### PR TITLE
chore: add Codex (Claude Code) PR review workflow

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -40,6 +40,6 @@ jobs:
       - name: Run Codex (Claude Code Action)
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           trigger_phrase: "@codex"
           claude_args: --model claude-sonnet-4-6

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,45 @@
+name: Codex Review
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  codex:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@codex')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@codex')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@codex')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@codex') || contains(github.event.issue.title, '@codex')))
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+
+    concurrency:
+      group: codex-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 20
+
+      - name: Run Codex (Claude Code Action)
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          trigger_phrase: "@codex"
+          claude_args: --model claude-sonnet-4-6


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/codex-review.yml` so the bot replies whenever someone mentions `@codex` on issues, PR comments, review comments, or review bodies
- Uses the official `anthropics/claude-code-action@v1` with `claude-sonnet-4-6`
- Concurrency group keyed by issue/PR number so spam mentions don't fan out into parallel jobs

## Required before merge
1. Install the **Claude** GitHub App on this repo: https://github.com/apps/claude
2. Add the `ANTHROPIC_API_KEY` repository secret (Settings → Secrets and variables → Actions)

After merge, test by commenting `@codex review` on PR #1.

## Notes
- Workflow triggers on default-branch version, so it will only fire on PR #1 once this is merged to `main`
- Fork PRs from external contributors are intentionally limited by GitHub's `GITHUB_TOKEN` rules — fine for hackathon repo
- Model can be swapped to `claude-opus-4-7` in `claude_args` for heavier reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)