### PR TITLE
refactor: deduplicate same_origin into mandate-policy::util

### DIFF
--- a/crates/mandate-policy/src/budget.rs
+++ b/crates/mandate-policy/src/budget.rs
@@ -15,6 +15,7 @@ use thiserror::Error;
 use mandate_core::aprp::PaymentRequest;
 
 use crate::model::{Budget, BudgetScope, Policy};
+use crate::util::same_origin;
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum BudgetError {
@@ -161,8 +162,6 @@ fn applies_to_request(budget: &Budget, request: &PaymentRequest, policy: &Policy
         },
     }
 }
-
-use crate::util::same_origin;
 
 #[cfg(test)]
 mod tests {

--- a/crates/mandate-policy/src/budget.rs
+++ b/crates/mandate-policy/src/budget.rs
@@ -162,11 +162,7 @@ fn applies_to_request(budget: &Budget, request: &PaymentRequest, policy: &Policy
     }
 }
 
-fn same_origin(a: &str, b: &str) -> bool {
-    let a = a.trim_end_matches('/');
-    let b = b.trim_end_matches('/');
-    a == b || b.starts_with(&format!("{a}/")) || a.starts_with(&format!("{b}/"))
-}
+use crate::util::same_origin;
 
 #[cfg(test)]
 mod tests {

--- a/crates/mandate-policy/src/engine.rs
+++ b/crates/mandate-policy/src/engine.rs
@@ -19,6 +19,7 @@ use mandate_core::aprp::{Destination, PaymentRequest};
 
 use crate::expr;
 use crate::model::{AgentStatus, Policy, ProviderStatus, RecipientStatus, Rule, RuleEffect};
+use crate::util::same_origin;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -316,8 +317,6 @@ fn safe_amount_f64(s: &str) -> f64 {
         _ => AMOUNT_FAILSAFE_USD,
     }
 }
-
-use crate::util::same_origin;
 
 #[cfg(test)]
 mod tests {

--- a/crates/mandate-policy/src/engine.rs
+++ b/crates/mandate-policy/src/engine.rs
@@ -317,19 +317,7 @@ fn safe_amount_f64(s: &str) -> f64 {
     }
 }
 
-fn same_origin(a: &str, b: &str) -> bool {
-    let normalize = |u: &str| u.trim_end_matches('/').to_string();
-    let a = normalize(a);
-    let b = normalize(b);
-    if a == b {
-        return true;
-    }
-    // Match by host: if `b` starts with `a/`, a is the origin.
-    if b.starts_with(&format!("{a}/")) || a.starts_with(&format!("{b}/")) {
-        return true;
-    }
-    false
-}
+use crate::util::same_origin;
 
 #[cfg(test)]
 mod tests {

--- a/crates/mandate-policy/src/lib.rs
+++ b/crates/mandate-policy/src/lib.rs
@@ -4,6 +4,7 @@ pub mod budget;
 pub mod engine;
 pub mod expr;
 pub mod model;
+mod util;
 
 pub use budget::{BudgetDeny, BudgetTracker};
 pub use engine::{decide, Decision, EngineError, Outcome};

--- a/crates/mandate-policy/src/util.rs
+++ b/crates/mandate-policy/src/util.rs
@@ -1,0 +1,61 @@
+//! Shared helpers used by `engine` and `budget`.
+
+/// Returns `true` if two URLs refer to the same origin (host + scheme +
+/// optional port). Trailing slashes are ignored, and either URL is accepted as
+/// a prefix of the other (so `https://api.example.com` matches both
+/// `https://api.example.com/v1/foo` and bare `https://api.example.com`).
+///
+/// This is intentionally permissive — it accepts `https://a.com` as the same
+/// origin as `https://a.com/path` because Mandate's `provider.url` config can
+/// be either form. A stricter origin comparator would parse with the `url`
+/// crate; that is overkill for the per-tx hot path.
+pub(crate) fn same_origin(a: &str, b: &str) -> bool {
+    let a = a.trim_end_matches('/');
+    let b = b.trim_end_matches('/');
+    a == b || b.starts_with(&format!("{a}/")) || a.starts_with(&format!("{b}/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::same_origin;
+
+    #[test]
+    fn same_origin_exact_match() {
+        assert!(same_origin(
+            "https://api.example.com",
+            "https://api.example.com"
+        ));
+    }
+
+    #[test]
+    fn same_origin_normalises_trailing_slash() {
+        assert!(same_origin(
+            "https://api.example.com/",
+            "https://api.example.com"
+        ));
+    }
+
+    #[test]
+    fn same_origin_accepts_either_as_prefix() {
+        assert!(same_origin(
+            "https://api.example.com",
+            "https://api.example.com/v1/inference"
+        ));
+        assert!(same_origin(
+            "https://api.example.com/v1/inference",
+            "https://api.example.com"
+        ));
+    }
+
+    #[test]
+    fn same_origin_rejects_different_hosts() {
+        assert!(!same_origin(
+            "https://api.example.com",
+            "https://malicious.example"
+        ));
+        assert!(!same_origin(
+            "https://api.example.com",
+            "https://api.example.com.attacker.com"
+        ));
+    }
+}


### PR DESCRIPTION
Closes the third bullet under "Refactors (post-hackathon)" in issue #3.

Both `engine.rs` and `budget.rs` had independent copies of `same_origin(a, b)` with the same logic but slightly different formatting. Any future fix to URL-origin matching had to be replicated in both places.

This PR moves `same_origin` into a new internal module `mandate-policy::util` (private with `pub(crate)` visibility) and replaces both call sites with `use crate::util::same_origin;`. No behaviour change.

### Tests

Added 4 unit tests for the helper itself in `crates/mandate-policy/src/util.rs`:
- exact match
- trailing-slash normalisation
- prefix match in either direction
- different-host rejection (including the `example.com.attacker.com` substring trap)

```
cargo fmt --all -- --check                                          ok
cargo clippy --workspace --all-targets -- -D warnings               ok
cargo test --workspace --all-targets                                ok — 73 tests pass on this base (69 + 4 new util tests)
```

@claude small refactor — just confirm there is no remaining duplication and no behaviour change vs the originals.