### PR TITLE
tests: null comparison + emergency.freeze_all regressions (rebased)

### DIFF
--- a/crates/mandate-policy/src/engine.rs
+++ b/crates/mandate-policy/src/engine.rs
@@ -450,6 +450,9 @@ mod tests {
     fn emergency_freeze_all_denies_any_request() {
         let mut p = policy();
         p.emergency.freeze_all = true;
+        // `golden_aprp()` is the request that *normally* passes (active agent,
+        // trusted provider, allowed recipient, small amount). Using it here
+        // proves the kill switch overrides an otherwise-allowed request.
         let outcome = decide(&p, &golden_aprp()).unwrap();
         assert_eq!(outcome.decision, Decision::Deny);
         assert_eq!(

--- a/crates/mandate-policy/src/engine.rs
+++ b/crates/mandate-policy/src/engine.rs
@@ -447,6 +447,23 @@ mod tests {
     }
 
     #[test]
+    fn emergency_freeze_all_denies_any_request() {
+        let mut p = policy();
+        p.emergency.freeze_all = true;
+        let outcome = decide(&p, &golden_aprp()).unwrap();
+        assert_eq!(outcome.decision, Decision::Deny);
+        assert_eq!(
+            outcome.deny_code.as_deref(),
+            Some("policy.deny_emergency_frozen"),
+            "global kill switch must fire from the deny-emergency-freeze rule"
+        );
+        assert_eq!(
+            outcome.matched_rule_id.as_deref(),
+            Some("deny-emergency-freeze")
+        );
+    }
+
+    #[test]
     fn safe_amount_f64_round_trips_small_values() {
         // The reference fixtures use small values; these must NOT be punted.
         assert_eq!(super::safe_amount_f64("0.05"), 0.05);

--- a/crates/mandate-policy/src/expr.rs
+++ b/crates/mandate-policy/src/expr.rs
@@ -509,4 +509,24 @@ mod tests {
         // Sanity: well-formed expressions still evaluate.
         assert!(evaluate_bool("true == true", &c).unwrap());
     }
+
+    #[test]
+    fn null_comparisons_match_intuitive_semantics() {
+        let c = json!({
+            "input": {
+                "addr_set":   "0x1111111111111111111111111111111111111111",
+                "addr_unset": null
+            }
+        });
+        // null == null is true; null != null is false (identity).
+        assert!(evaluate_bool("input.addr_unset == null", &c).unwrap());
+        assert!(!evaluate_bool("input.addr_unset != null", &c).unwrap());
+        // string vs null returns the obvious identity answer the reviewer flagged
+        // (`input.recipient.address != null` should be true when address is set).
+        assert!(evaluate_bool("input.addr_set != null", &c).unwrap());
+        assert!(!evaluate_bool("input.addr_set == null", &c).unwrap());
+        // Ordered comparisons on null still error (no obvious meaning).
+        let err = evaluate_bool("input.addr_unset < null", &c).expect_err("ordered null must fail");
+        assert!(matches!(err, ExprError::TypeMismatch(_)), "got {err:?}");
+    }
 }

--- a/crates/mandate-policy/src/expr.rs
+++ b/crates/mandate-policy/src/expr.rs
@@ -526,7 +526,24 @@ mod tests {
         assert!(evaluate_bool("input.addr_set != null", &c).unwrap());
         assert!(!evaluate_bool("input.addr_set == null", &c).unwrap());
         // Ordered comparisons on null still error (no obvious meaning).
-        let err = evaluate_bool("input.addr_unset < null", &c).expect_err("ordered null must fail");
-        assert!(matches!(err, ExprError::TypeMismatch(_)), "got {err:?}");
+        // Both branches in cmp() must reject ordering: null-vs-null AND null-vs-T.
+        let err_null_null =
+            evaluate_bool("input.addr_unset < null", &c).expect_err("null < null must fail");
+        assert!(
+            matches!(err_null_null, ExprError::TypeMismatch(_)),
+            "got {err_null_null:?}"
+        );
+        let err_string_null =
+            evaluate_bool("input.addr_set < null", &c).expect_err("string < null must fail");
+        assert!(
+            matches!(err_string_null, ExprError::TypeMismatch(_)),
+            "got {err_string_null:?}"
+        );
+        let err_null_string =
+            evaluate_bool("null > input.addr_set", &c).expect_err("null > string must fail");
+        assert!(
+            matches!(err_null_string, ExprError::TypeMismatch(_)),
+            "got {err_null_string:?}"
+        );
     }
 }


### PR DESCRIPTION
Replaces PR #4 (closed for conflict against the post-squash main; same content cherry-picked onto a fresh branch off main).

Adds the two regression tests Claude flagged on the most recent re-review of merged PR #1 — both behaviours are already correct in the codebase; these tests pin them so a future regression is caught immediately.

### Tests added
- `crates/mandate-policy/src/expr.rs::tests::null_comparisons_match_intuitive_semantics` — covers `null == null` (true), `null != null` (false), `string == null` (false), `string != null` (true), and three variants of ordered-on-null still error (null < null, string < null, null > string).
- `crates/mandate-policy/src/engine.rs::tests::emergency_freeze_all_denies_any_request` — sets `policy.emergency.freeze_all = true` and asserts `decide()` returns `Decision::Deny` with deny_code `policy.deny_emergency_frozen` from rule `deny-emergency-freeze`. Guards the global kill switch.

### Doc sync
- `SUBMISSION_NOTES.md`: bump test count 69 → 71.
- `IMPLEMENTATION_STATUS.md`: same bump and 62 + 9 new P1/P3 regression tests.

@codex review please.