### PR TITLE
feat: validate policy uniqueness invariants in Policy::parse_{json,yaml}

### DIFF
--- a/crates/mandate-policy/src/lib.rs
+++ b/crates/mandate-policy/src/lib.rs
@@ -8,6 +8,7 @@ pub mod model;
 pub use budget::{BudgetDeny, BudgetTracker};
 pub use engine::{decide, Decision, EngineError, Outcome};
 pub use model::{
-    AgentSelector, AgentStatus, Budget, BudgetScope, DefaultDecision, Emergency, Policy, Provider,
-    ProviderStatus, Recipient, RecipientStatus, Rule, RuleEffect,
+    AgentSelector, AgentStatus, Budget, BudgetScope, DefaultDecision, Emergency, Policy,
+    PolicyParseError, PolicyValidationError, Provider, ProviderStatus, Recipient, RecipientStatus,
+    Rule, RuleEffect,
 };

--- a/crates/mandate-policy/src/model.rs
+++ b/crates/mandate-policy/src/model.rs
@@ -165,6 +165,33 @@ pub enum PolicyValidationError {
     DuplicateProviderId(String),
     #[error("recipients[] must be unique by (address, chain); '{address}@{chain}' duplicated")]
     DuplicateRecipient { address: String, chain: String },
+    /// `Budget` has no explicit `id` field, but the engine looks budgets up by
+    /// the tuple `(agent_id, scope, scope_key)` (see `BudgetTracker::check` in
+    /// `crates/mandate-policy/src/budget.rs`). Two entries with the same tuple
+    /// would silently shadow each other — the first one found via `iter()`
+    /// wins — so we reject that ambiguity at parse time. `scope_key` is
+    /// rendered as `<none>` when absent so the message is deterministic
+    /// regardless of which order the duplicates appear.
+    #[error(
+        "budgets[] must be unique by (agent_id, scope, scope_key); \
+         '{agent_id}/{scope}/{scope_key}' duplicated"
+    )]
+    DuplicateBudgetTuple {
+        agent_id: String,
+        scope: String,
+        scope_key: String,
+    },
+}
+
+fn budget_scope_label(s: BudgetScope) -> &'static str {
+    // Match the `serde(rename_all = "snake_case")` form on `BudgetScope` so
+    // error messages quote scopes the same way users wrote them in YAML/JSON.
+    match s {
+        BudgetScope::PerTx => "per_tx",
+        BudgetScope::Daily => "daily",
+        BudgetScope::Monthly => "monthly",
+        BudgetScope::PerProvider => "per_provider",
+    }
 }
 
 impl Policy {
@@ -215,6 +242,26 @@ impl Policy {
                 return Err(PolicyValidationError::DuplicateRecipient {
                     address: normalised,
                     chain: r.chain.clone(),
+                });
+            }
+        }
+        let mut budgets = HashSet::with_capacity(self.budgets.len());
+        for b in &self.budgets {
+            // The engine indexes budgets by (agent_id, scope, scope_key) — see
+            // the bucket key in `BudgetTracker::check`. Treat `None` and
+            // `Some("")` as distinct from every named key but equal to each
+            // other (both mean "no scope key"); the ord-stable representation
+            // is `Option::as_deref().unwrap_or("")`.
+            let key = (
+                b.agent_id.as_str(),
+                b.scope,
+                b.scope_key.as_deref().unwrap_or(""),
+            );
+            if !budgets.insert(key) {
+                return Err(PolicyValidationError::DuplicateBudgetTuple {
+                    agent_id: b.agent_id.clone(),
+                    scope: budget_scope_label(b.scope).to_string(),
+                    scope_key: b.scope_key.clone().unwrap_or_else(|| "<none>".to_string()),
                 });
             }
         }
@@ -353,6 +400,94 @@ mod tests {
             matches!(
                 err,
                 PolicyParseError::Validation(PolicyValidationError::DuplicateAgentId(_))
+            ),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn duplicate_budget_tuple_is_rejected() {
+        // `Budget` has no `id`. The engine looks budgets up by
+        // `(agent_id, scope, scope_key)`; two entries with the same tuple
+        // would silently shadow each other (first one wins), producing
+        // ambiguous policy semantics. Reject at parse time.
+        let mut p = base();
+        // The reference policy's first budget is per_tx for research-agent-01
+        // with no scope_key — clone it and push a duplicate.
+        let dup = p.budgets[0].clone();
+        let expected_agent = dup.agent_id.clone();
+        p.budgets.push(dup);
+        let err = p
+            .validate()
+            .expect_err("must reject duplicate budget tuple");
+        match err {
+            PolicyValidationError::DuplicateBudgetTuple {
+                agent_id,
+                scope,
+                scope_key,
+            } => {
+                assert_eq!(agent_id, expected_agent);
+                assert_eq!(scope, "per_tx");
+                // No scope_key on a per_tx budget → rendered as "<none>".
+                assert_eq!(scope_key, "<none>");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn duplicate_per_provider_budget_tuple_with_same_scope_key_is_rejected() {
+        // Same agent + scope + scope_key duplicates → reject.
+        let mut p = base();
+        // Index 2 in the reference policy is the per_provider/api.example.com
+        // budget. Clone it to force a real (agent_id, scope, scope_key) tuple
+        // collision (i.e. not the easier "no scope_key" case).
+        let dup = p.budgets[2].clone();
+        let expected_key = dup
+            .scope_key
+            .clone()
+            .expect("per_provider budget has scope_key");
+        p.budgets.push(dup);
+        let err = p
+            .validate()
+            .expect_err("must reject duplicate per_provider budget tuple");
+        match err {
+            PolicyValidationError::DuplicateBudgetTuple {
+                scope, scope_key, ..
+            } => {
+                assert_eq!(scope, "per_provider");
+                assert_eq!(scope_key, expected_key);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn distinct_budget_scopes_for_same_agent_are_allowed() {
+        // The reference policy already has three distinct budgets for
+        // research-agent-01 (per_tx, daily, per_provider+api.example.com) —
+        // pin that the new tuple check does not regress that valid case.
+        let p = base();
+        assert_eq!(p.budgets.len(), 3);
+        p.validate().expect("reference policy must remain valid");
+    }
+
+    #[test]
+    fn parse_yaml_rejects_duplicate_budget_tuple() {
+        // YAML path symmetry: same invariant must fire when policies are
+        // loaded as YAML. Mirrors `parse_yaml_runs_validation` but for the
+        // budget tuple instead of `agent_id`.
+        let raw = include_str!("../../../test-corpus/policy/reference_low_risk.json");
+        let mut value: serde_json::Value = serde_json::from_str(raw).unwrap();
+        let extra = value["budgets"][0].clone();
+        value["budgets"].as_array_mut().unwrap().push(extra);
+        let bad_yaml = serde_yaml::to_string(&value).unwrap();
+        let err = Policy::parse_yaml(&bad_yaml)
+            .expect_err("YAML path must reject duplicate budget tuple");
+        assert!(
+            matches!(
+                err,
+                PolicyParseError::Validation(PolicyValidationError::DuplicateBudgetTuple { .. })
             ),
             "got {err:?}"
         );

--- a/crates/mandate-policy/src/model.rs
+++ b/crates/mandate-policy/src/model.rs
@@ -1,6 +1,9 @@
 //! Policy YAML/JSON model. Mirrors `schemas/policy_v1.json`.
 
+use std::collections::HashSet;
+
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -135,13 +138,84 @@ pub struct Emergency {
     pub paused_agents: Vec<String>,
 }
 
+/// Errors that can occur when parsing or validating a `Policy`.
+///
+/// `serde(deny_unknown_fields)` already protects every nested struct against
+/// unexpected JSON/YAML keys; the [`PolicyParseError::Validation`] variant
+/// covers semantic invariants that serde cannot express, such as uniqueness
+/// of `agents[].agent_id`.
+#[derive(Debug, Error)]
+pub enum PolicyParseError {
+    #[error("json: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("yaml: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+    #[error(transparent)]
+    Validation(#[from] PolicyValidationError),
+}
+
+/// Semantic validation failures detected after a policy has been deserialised.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum PolicyValidationError {
+    #[error("agents[].agent_id must be unique; '{0}' appears more than once")]
+    DuplicateAgentId(String),
+    #[error("rules[].id must be unique; '{0}' appears more than once")]
+    DuplicateRuleId(String),
+    #[error("providers[].id must be unique; '{0}' appears more than once")]
+    DuplicateProviderId(String),
+    #[error("recipients[] must be unique by (address, chain); '{address}@{chain}' duplicated")]
+    DuplicateRecipient { address: String, chain: String },
+}
+
 impl Policy {
-    pub fn parse_yaml(s: &str) -> Result<Self, serde_yaml::Error> {
-        serde_yaml::from_str(s)
+    pub fn parse_yaml(s: &str) -> Result<Self, PolicyParseError> {
+        let policy: Self = serde_yaml::from_str(s)?;
+        policy.validate()?;
+        Ok(policy)
     }
 
-    pub fn parse_json(s: &str) -> Result<Self, serde_json::Error> {
-        serde_json::from_str(s)
+    pub fn parse_json(s: &str) -> Result<Self, PolicyParseError> {
+        let policy: Self = serde_json::from_str(s)?;
+        policy.validate()?;
+        Ok(policy)
+    }
+
+    /// Run semantic validation that serde cannot express. Called automatically
+    /// by [`Policy::parse_json`] and [`Policy::parse_yaml`]; exposed publicly
+    /// so callers that build a `Policy` programmatically (tests, fuzzing) can
+    /// run the same checks.
+    pub fn validate(&self) -> Result<(), PolicyValidationError> {
+        let mut agent_ids = HashSet::with_capacity(self.agents.len());
+        for a in &self.agents {
+            if !agent_ids.insert(a.agent_id.as_str()) {
+                return Err(PolicyValidationError::DuplicateAgentId(a.agent_id.clone()));
+            }
+        }
+        let mut rule_ids = HashSet::with_capacity(self.rules.len());
+        for r in &self.rules {
+            if !rule_ids.insert(r.id.as_str()) {
+                return Err(PolicyValidationError::DuplicateRuleId(r.id.clone()));
+            }
+        }
+        let mut provider_ids = HashSet::with_capacity(self.providers.len());
+        for p in &self.providers {
+            if !provider_ids.insert(p.id.as_str()) {
+                return Err(PolicyValidationError::DuplicateProviderId(p.id.clone()));
+            }
+        }
+        let mut recipients = HashSet::with_capacity(self.recipients.len());
+        for r in &self.recipients {
+            // Addresses are case-insensitive on EVM chains; normalise before
+            // comparing so `0xAA…` and `0xaa…` are treated as the same.
+            let key = (r.address.to_ascii_lowercase(), r.chain.clone());
+            if !recipients.insert(key) {
+                return Err(PolicyValidationError::DuplicateRecipient {
+                    address: r.address.clone(),
+                    chain: r.chain.clone(),
+                });
+            }
+        }
+        Ok(())
     }
 
     /// Canonical SHA-256 hex of the policy. Computed over JCS-canonical JSON.
@@ -177,5 +251,78 @@ mod tests {
         let h2 = policy.canonical_hash().unwrap();
         assert_eq!(h1, h2);
         assert_eq!(h1.len(), 64);
+    }
+
+    fn base() -> Policy {
+        Policy::parse_json(include_str!(
+            "../../../test-corpus/policy/reference_low_risk.json"
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn duplicate_agent_id_is_rejected() {
+        let mut p = base();
+        let dup = p.agents[0].clone();
+        p.agents.push(dup);
+        let err = p.validate().expect_err("must reject duplicate agent_id");
+        assert!(
+            matches!(err, PolicyValidationError::DuplicateAgentId(ref id) if id == "research-agent-01"),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn duplicate_rule_id_is_rejected() {
+        let mut p = base();
+        let dup = p.rules[0].clone();
+        p.rules.push(dup);
+        let err = p.validate().expect_err("must reject duplicate rule id");
+        assert!(matches!(err, PolicyValidationError::DuplicateRuleId(_)));
+    }
+
+    #[test]
+    fn duplicate_provider_id_is_rejected() {
+        let mut p = base();
+        let dup = p.providers[0].clone();
+        p.providers.push(dup);
+        let err = p.validate().expect_err("must reject duplicate provider id");
+        assert!(matches!(err, PolicyValidationError::DuplicateProviderId(_)));
+    }
+
+    #[test]
+    fn duplicate_recipient_is_rejected_case_insensitively() {
+        let mut p = base();
+        // Mutate to upper-case to prove the check normalises before comparing.
+        let mut dup = p.recipients[0].clone();
+        dup.address = dup.address.to_ascii_uppercase();
+        p.recipients.push(dup);
+        let err = p
+            .validate()
+            .expect_err("must reject duplicate recipient regardless of address casing");
+        assert!(matches!(
+            err,
+            PolicyValidationError::DuplicateRecipient { .. }
+        ));
+    }
+
+    #[test]
+    fn parse_json_runs_validation() {
+        // Drop a manual duplicate into the raw JSON and confirm parse_json
+        // surfaces a `Validation` error rather than silently accepting it.
+        let raw = include_str!("../../../test-corpus/policy/reference_low_risk.json");
+        let mut value: serde_json::Value = serde_json::from_str(raw).unwrap();
+        let extra = value["agents"][0].clone();
+        value["agents"].as_array_mut().unwrap().push(extra);
+        let bad = serde_json::to_string(&value).unwrap();
+        let err =
+            Policy::parse_json(&bad).expect_err("must reject duplicate agent_id at parse time");
+        assert!(
+            matches!(
+                err,
+                PolicyParseError::Validation(PolicyValidationError::DuplicateAgentId(_))
+            ),
+            "got {err:?}"
+        );
     }
 }

--- a/crates/mandate-policy/src/model.rs
+++ b/crates/mandate-policy/src/model.rs
@@ -207,10 +207,13 @@ impl Policy {
         for r in &self.recipients {
             // Addresses are case-insensitive on EVM chains; normalise before
             // comparing so `0xAA…` and `0xaa…` are treated as the same.
-            let key = (r.address.to_ascii_lowercase(), r.chain.clone());
+            let normalised = r.address.to_ascii_lowercase();
+            let key = (normalised.clone(), r.chain.clone());
             if !recipients.insert(key) {
+                // Report the canonical (lowercase) form so the error message
+                // doesn't depend on which casing happens to be the duplicate.
                 return Err(PolicyValidationError::DuplicateRecipient {
-                    address: r.address.clone(),
+                    address: normalised,
                     chain: r.chain.clone(),
                 });
             }
@@ -276,9 +279,13 @@ mod tests {
     fn duplicate_rule_id_is_rejected() {
         let mut p = base();
         let dup = p.rules[0].clone();
+        let dup_id = dup.id.clone();
         p.rules.push(dup);
         let err = p.validate().expect_err("must reject duplicate rule id");
-        assert!(matches!(err, PolicyValidationError::DuplicateRuleId(_)));
+        assert!(
+            matches!(err, PolicyValidationError::DuplicateRuleId(ref id) if id == &dup_id),
+            "got {err:?}"
+        );
     }
 
     #[test]
@@ -295,15 +302,20 @@ mod tests {
         let mut p = base();
         // Mutate to upper-case to prove the check normalises before comparing.
         let mut dup = p.recipients[0].clone();
+        let original_lc = dup.address.to_ascii_lowercase();
         dup.address = dup.address.to_ascii_uppercase();
         p.recipients.push(dup);
         let err = p
             .validate()
             .expect_err("must reject duplicate recipient regardless of address casing");
-        assert!(matches!(
-            err,
-            PolicyValidationError::DuplicateRecipient { .. }
-        ));
+        // Error must surface the canonical lowercase form, not the raw casing
+        // of whichever entry happened to be the duplicate.
+        match err {
+            PolicyValidationError::DuplicateRecipient { address, .. } => {
+                assert_eq!(address, original_lc, "address must be reported lowercase");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 
     #[test]
@@ -317,6 +329,26 @@ mod tests {
         let bad = serde_json::to_string(&value).unwrap();
         let err =
             Policy::parse_json(&bad).expect_err("must reject duplicate agent_id at parse time");
+        assert!(
+            matches!(
+                err,
+                PolicyParseError::Validation(PolicyValidationError::DuplicateAgentId(_))
+            ),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_yaml_runs_validation() {
+        // Symmetric coverage to `parse_json_runs_validation`. The duplicate is
+        // identical in YAML and JSON; this test pins that the YAML path also
+        // routes through `validate()` rather than just `serde_yaml::from_str`.
+        let raw = include_str!("../../../test-corpus/policy/reference_low_risk.json");
+        let mut value: serde_json::Value = serde_json::from_str(raw).unwrap();
+        let extra = value["agents"][0].clone();
+        value["agents"].as_array_mut().unwrap().push(extra);
+        let bad_yaml = serde_yaml::to_string(&value).unwrap();
+        let err = Policy::parse_yaml(&bad_yaml).expect_err("YAML path must run validate() too");
         assert!(
             matches!(
                 err,


### PR DESCRIPTION
Closes the third bullet under "Refactors (post-hackathon)" / P3-C in the second @claude review of merged PR #1: `Policy::parse_json` accepted policies with duplicate `agents[].agent_id`, `rules[].id`, etc. Engine and budget code use `policy.agents.iter().find(...)` and only see the first match — a duplicate later in the array would silently change behaviour depending on insertion order.

### Why this matters
`serde(deny_unknown_fields)` blocks unexpected JSON keys, but cannot express semantic invariants like uniqueness. The reference policy never tripped this because it has one of each, but a hand-edited policy or a fuzz-generated one could ship a duplicate `agent_id` and produce an inconsistent decision (e.g. `agents[0].status = active`, `agents[1].status = revoked` — the agent gate sees "active" and lets the request through).

### Changes
- `crates/mandate-policy/src/model.rs`:
  - New `PolicyParseError` enum that wraps `serde_json::Error` / `serde_yaml::Error` and the new `PolicyValidationError`.
  - New `PolicyValidationError` enum with one variant per invariant: `DuplicateAgentId`, `DuplicateRuleId`, `DuplicateProviderId`, `DuplicateRecipient { address, chain }`.
  - `Policy::parse_json` and `Policy::parse_yaml` now return `Result<Self, PolicyParseError>` and run `validate()` after deserialisation.
  - `Policy::validate()` is also exposed publicly so callers that build a `Policy` programmatically (tests, fuzzing) get the same guarantees.
  - Recipient uniqueness is keyed by `(address.to_ascii_lowercase(), chain)` because EVM addresses are case-insensitive.
- `crates/mandate-policy/src/lib.rs`: re-export the new types.

### API impact
`parse_json` / `parse_yaml` previously returned `Result<Self, serde_json::Error>` / `serde_yaml::Error`. Now they return `Result<Self, PolicyParseError>`. All in-tree call sites use `.unwrap()` or `.expect()` and compile unchanged.

### Tests
- `duplicate_agent_id_is_rejected` — clones an existing agent, expects `PolicyValidationError::DuplicateAgentId`.
- `duplicate_rule_id_is_rejected`
- `duplicate_provider_id_is_rejected`
- `duplicate_recipient_is_rejected_case_insensitively` — uppercases the duplicate address to prove the lowercase normalisation.
- `parse_json_runs_validation` — injects the duplicate at the JSON level and confirms `Policy::parse_json` surfaces `PolicyParseError::Validation(...)` rather than silently accepting it.

### Verification
```
cargo fmt --all -- --check                                          ok
cargo clippy --workspace --all-targets -- -D warnings               ok
cargo test --workspace --all-targets                                ok — 74 tests pass on this base (69 + 5 new validation tests)
```

@codex review please — focus on whether the new validation belongs in `Policy` (vs a separate validator) and whether the recipient lowercase normalisation is consistent with what `engine.rs` already does at line 195 (it uses `eq_ignore_ascii_case`).