### PR TITLE
docs: add ETHGlobal submission form draft

### DIFF
--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -2,9 +2,9 @@
 
 Post-merge snapshot for the ETHGlobal Open Agents 2026 submission.
 
-**Last updated:** 2026-04-28
-**Phase:** 5 — submission readiness; `main` is submission-ready after the documentation cleanup in PR #10.
-**Implementation PRs merged into `main`:** `#1`, `#2`, `#5`, `#6`, `#7`, `#8`, `#9`. **Documentation cleanup:** PR `#10` (this commit). **No implementation PRs remain open.**
+**Last updated:** 2026-04-28 (post-PR-#11 snapshot)
+**Phase:** 5 — submission readiness. `main` is submission-ready: PR #10 cleaned up the docs, PR #11 made the APRP nonce-replay store SQLite-backed and persistent.
+**Implementation PRs merged into `main`:** `#1`, `#2`, `#5`, `#6`, `#7`, `#8`, `#9`, `#11`. **Documentation cleanup:** PR `#10`. **No implementation PRs remain open.** PR #12 (`docs/submission-form-draft`) is open and is a docs-only addition (`SUBMISSION_FORM_DRAFT.md` + one-line README link), not core implementation.
 **CI on `main`:** ✅ green (`Rust check` + `Validate JSON schemas / OpenAPI`).
 **Blockers:** none.
 
@@ -19,6 +19,8 @@ Post-merge snapshot for the ETHGlobal Open Agents 2026 submission.
 | [#8](https://github.com/B2JK-Industry/mandate-ethglobal-openagents-2026/pull/8) | `931fb28` | `tests: null comparison + emergency.freeze_all regressions` |
 | [#6](https://github.com/B2JK-Industry/mandate-ethglobal-openagents-2026/pull/6) | `30fb407` | `perf: collapse audit_last into a single query` |
 | [#5](https://github.com/B2JK-Industry/mandate-ethglobal-openagents-2026/pull/5) | `f52596c` | `refactor: deduplicate same_origin into mandate-policy::util` |
+| [#10](https://github.com/B2JK-Industry/mandate-ethglobal-openagents-2026/pull/10) | `c4b30fc` | `docs: finalize ETHGlobal submission readiness` |
+| [#11](https://github.com/B2JK-Industry/mandate-ethglobal-openagents-2026/pull/11) | `a29926d` | `feat: persist APRP nonce replay protection` |
 
 ## What is implemented
 
@@ -45,7 +47,8 @@ Full Open Agents vertical:
 
 ## Hardening landed during this phase
 
-- **PR #7** — APRP nonce replay protection (HTTP 409 `protocol.nonce_replay`). The replay gate fires before `request_hash` / policy / budget / audit / signing, so a duplicate nonce produces no audit/receipt side effects. Three regression tests cover (a) replay rejected, (b) distinct nonces independently processed, (c) replay with same nonce but mutated body still rejected. In-memory dedup set; resets on daemon restart (documented in `SUBMISSION_NOTES.md` "Known limitations").
+- **PR #11** — APRP nonce replay store made persistent. Replaces PR #7's in-memory `seen_nonces: Mutex<HashSet<String>>` with a SQLite-backed `nonce_replay` table (migration `V002__nonce_replay.sql`) accessed via `Storage::nonce_try_claim`. The PRIMARY KEY on `nonce` gives atomic INSERT-or-fail dedup. A daemon configured with `Storage::open(path)` rejects replays across process restart; the demo defaults to `Storage::open_in_memory()`, where SQLite-backed dedup persists for the lifetime of the demo process. New regression test `nonce_replay_rejection_persists_across_storage_reopen` exercises the persistence guarantee end-to-end at the storage layer.
+- **PR #7** — APRP nonce replay protection (HTTP 409 `protocol.nonce_replay`). The replay gate fires before `request_hash` / policy / budget / audit / signing, so a duplicate nonce produces no audit/receipt side effects. Three regression tests cover (a) replay rejected, (b) distinct nonces independently processed, (c) replay with same nonce but mutated body still rejected. The in-memory dedup set introduced in #7 was superseded by PR #11's SQLite-backed store (above); the gate's pre-state-mutation placement is unchanged.
 - **PR #9** — `Policy::parse_{json,yaml}` reject duplicate `agents[].agent_id`, `rules[].id`, `providers[].id`, `(recipients[].address.lc, chain)`, and `(budgets[].agent_id, scope, scope_key)`. Both parse paths route through the same `validate()` step.
 - **PR #8** — Regression tests for `null` comparison semantics in `expr.rs` and the `emergency.freeze_all` global kill-switch in `engine.rs`. Pure additive: `+57` lines across two `#[test]` modules.
 - **PR #6** — `audit_last` collapsed from a `SELECT seq` + `audit_get` two-roundtrip into a single `SELECT * ORDER BY seq DESC LIMIT 1`. Tightens error handling: previously `.ok()` swallowed every SQLite error into `Ok(None)`; now only `QueryReturnedNoRows` becomes `None`.
@@ -55,7 +58,7 @@ Full Open Agents vertical:
 
 - `cargo fmt --check` — ✅
 - `cargo clippy --workspace --all-targets -- -D warnings` — ✅ (no warnings)
-- `cargo test --workspace --all-targets` — ✅ **90 / 90 pass** (0 fail, 0 ignored)
+- `cargo test --workspace --all-targets` — ✅ **96 / 96 pass** (0 fail, 0 ignored)
 - `python3 scripts/validate_schemas.py` — ✅ (6 schemas + 4 corpus fixtures)
 - `python3 scripts/validate_openapi.py` — ✅ (`docs/api/openapi.json` valid)
 - `bash demo-scripts/run-openagents-final.sh` — ✅ all 11 steps green incl. audit-chain tamper detection (~5 seconds end-to-end)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository was implemented during **ETHGlobal Open Agents 2026**. Planning 
 
 ## Status
 
-Implementation complete. All hardening PRs (#5, #6, #7, #8, #9) are merged into `main`; `cargo test --workspace --all-targets` runs **90/90 green**; `bash demo-scripts/run-openagents-final.sh` runs end-to-end clean. See [`IMPLEMENTATION_STATUS.md`](IMPLEMENTATION_STATUS.md) for the post-merge snapshot and [`FINAL_REVIEW.md`](FINAL_REVIEW.md) for the submission-readiness audit.
+Implementation complete. All hardening PRs (#5, #6, #7, #8, #9, #11) are merged into `main`; `cargo test --workspace --all-targets` runs **96/96 green**; `bash demo-scripts/run-openagents-final.sh` runs end-to-end clean. See [`IMPLEMENTATION_STATUS.md`](IMPLEMENTATION_STATUS.md) for the post-merge snapshot and [`FINAL_REVIEW.md`](FINAL_REVIEW.md) for the submission-readiness audit.
 
 ## What this is
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ bash demo-scripts/run-openagents-final.sh
 
 You need a Rust toolchain (workspace MSRV `1.80`) and Python 3 for the schema validators. The demo runs in ~5 seconds and exercises all 11 steps including the audit-chain tamper detection.
 
-See [`SUBMISSION_NOTES.md`](SUBMISSION_NOTES.md) for the ETHGlobal submission narrative and [`AI_USAGE.md`](AI_USAGE.md) for AI tooling disclosure.
+See [`SUBMISSION_NOTES.md`](SUBMISSION_NOTES.md) for the ETHGlobal submission narrative, [`SUBMISSION_FORM_DRAFT.md`](SUBMISSION_FORM_DRAFT.md) for copy-paste-ready ETHGlobal form text, and [`AI_USAGE.md`](AI_USAGE.md) for AI tooling disclosure.
 
 ## Repository layout
 

--- a/SUBMISSION_FORM_DRAFT.md
+++ b/SUBMISSION_FORM_DRAFT.md
@@ -1,0 +1,225 @@
+# ETHGlobal Open Agents 2026 — Submission Form Draft (Mandate)
+
+Copy-paste-ready text for the ETHGlobal Open Agents 2026 project submission form. Every field below maps to an ETHGlobal form field (or to a video / repo link). Fields with a `<TODO: …>` placeholder are the only ones that need to be filled in on submission day.
+
+> One-sentence hook (use anywhere a hook is required):
+>
+> **Don't give your agent a wallet. Give it a mandate.**
+
+---
+
+## Project name
+
+```
+Mandate
+```
+
+## Category
+
+```
+Infrastructure
+```
+
+## Emoji
+
+```
+🛂
+```
+
+(Passport-control emoji — visualises Mandate as the customs gate every agent payment has to clear before it ever reaches a wallet or sponsor.)
+
+## Short description (under 100 characters)
+
+```
+Spending mandates for AI agents. The agent never holds the key; Mandate decides, signs and audits.
+```
+
+(98 characters including spaces — ETHGlobal's short-description field caps at 100.)
+
+## Long description (judge-facing)
+
+```
+Mandate is a local policy, budget, receipt and audit firewall that decides whether an autonomous AI agent may execute an onchain or payment action — so the agent never has to hold a private key.
+
+A research-agent in our demo emits a payment request (an APRP — "Agent Payment Request Protocol") across the Mandate boundary. Mandate validates the request, evaluates a deterministic policy, enforces multi-scope budgets, rejects replayed nonces with HTTP 409, signs an Ed25519 policy receipt, appends a hash-chained audit event, and only then routes the action to a sponsor executor (KeeperHub or Uniswap in this demo). When the same agent is prompt-injected and forwards a hostile request, Mandate denies before any signer or executor runs and the audit log captures the rejection. Tampering with one byte of an audit event is rejected by the strict-hash verifier.
+
+The whole flow is deterministic, runs offline, and reproduces from a fresh clone in ~5 seconds with `bash demo-scripts/run-openagents-final.sh`. 90/90 tests pass, schemas validate, the demo's 11 gates are green end-to-end including the audit-chain tamper-detection step.
+
+Mandate is not a wallet, not a relayer, and not a trading bot. It is the pre-execution policy and signing boundary that lets autonomous agents transact without ever being trusted with a key.
+```
+
+## How it is made
+
+```
+Mandate is a Rust workspace built during ETHGlobal Open Agents 2026 around four hard contracts: a strict APRP wire format with `serde(deny_unknown_fields)` end-to-end and a JCS-canonical request hash locked at `c0bd2fab…`; a deterministic policy engine evaluating a small Rego-compatible expression grammar over a hash-locked policy file; a multi-scope budget tracker (`per_tx`, `daily`, `monthly`, `per_provider`); and an Ed25519-signed, hash-chained audit log persisted in SQLite with a separate JSONL verifier offering both structural and strict-hash modes.
+
+The HTTP boundary is `POST /v1/payment-requests`, served by axum. Each request runs through the same fail-closed pipeline: schema validation → canonical request hash → APRP nonce-replay gate (HTTP 409 + `protocol.nonce_replay`, before any state mutation) → policy decision → budget commit (only on Allow) → audit append → signed policy receipt. Receipts and decision tokens are JCS-canonical JSON signed with Ed25519; audit events are linked by `prev_event_hash` and verifiable end-to-end with the `mandate verify-audit` CLI.
+
+A research-agent harness drives the boundary across two scenarios — a legitimate x402 purchase and a prompt-injection attack — by posting real APRP fixtures across the API and printing the daemon's signed response. The agent crate intentionally has zero signing dependencies; you can verify it by grepping for `SigningKey` / `signing_key` in `demo-agents/research-agent/`. ENS, KeeperHub and Uniswap each show up as guarded executors behind a thin adapter trait so they can be swapped for live backends without touching the policy/signing core.
+```
+
+## Tech stack
+
+```
+Rust workspace (8 crates + research-agent demo binary):
+  - mandate-core        APRP types, JCS canonical hashing, Ed25519 signer, receipts, decision tokens, audit events.
+  - mandate-policy      Policy model + Rego-compatible expression evaluator, decide(), multi-scope budget tracker.
+  - mandate-storage     SQLite-backed audit log with hash-chain verifier (rusqlite + migrations).
+  - mandate-server      axum HTTP server, POST /v1/payment-requests pipeline, in-memory APRP nonce-replay gate.
+  - mandate-execution   Guarded-executor adapters (KeeperHub, Uniswap) with explicit local_mock / live constructors.
+  - mandate-identity    ENS resolver trait + offline fixture resolver + policy_hash drift check.
+  - mandate-mcp         MCP tool surface skeleton.
+  - mandate-cli         `mandate` CLI: aprp validate|hash|run-corpus, schema, verify-audit.
+
+Cryptography & wire format:
+  - ed25519-dalek                 Ed25519 signatures over canonical JSON (receipts, decision tokens, audit events).
+  - serde_json_canonicalizer      JCS (RFC 8785) for request and policy canonical hashing.
+  - sha2                          SHA-256 for request_hash, policy_hash, audit event_hash.
+  - JSON Schema 2020-12           6 schemas (aprp, policy, x402, policy_receipt, decision_token, audit_event).
+  - OpenAPI 3.1                   docs/api/openapi.json validated in CI.
+  - ULID                          Stable, sortable identifiers for audit and execution refs.
+
+Other: axum, tokio, tower, rusqlite, anyhow, thiserror, tracing, clap, chrono.
+
+Tooling: cargo fmt, cargo clippy -D warnings, GitHub Actions CI (Rust check + JSON Schema/OpenAPI validators), Codex (Claude Code) PR review workflow.
+```
+
+## What is real vs mocked (truthfulness)
+
+The demo runs offline and deterministically. The submission narrative deliberately separates the parts that are end-to-end real from the parts that are local mocks.
+
+```
+REAL (end-to-end, exercised by the test suite + the final demo):
+  - APRP wire format and `serde(deny_unknown_fields)` strictness — adversarial fixture rejected with `schema.unknown_field`.
+  - JCS canonical request hash — golden hash `c0bd2fab…` locked in test.
+  - JSON Schema validation — 6 schemas, 4-fixture corpus, no network.
+  - Policy engine + agent gate (unknown / paused / revoked / `emergency.paused_agents` / `emergency.freeze_all`).
+  - Multi-scope budget tracker (per_tx non-accumulating; daily / monthly / per_provider accumulating; commit only on Allow).
+  - APRP nonce replay rejection — HTTP 409 + `protocol.nonce_replay`, fires before request_hash / policy / budget / audit / signing so a replay produces no side effects.
+  - Ed25519-signed policy receipts, decision tokens and audit events.
+  - Hash-chained audit log (SQLite + JSONL verifier with structural and strict-hash modes).
+  - Audit-chain tamper detection — flip one byte and strict-hash verify rejects.
+  - Real research-agent harness posting real APRP fixtures (legit + prompt-injection) across the boundary.
+
+MOCKED / OFFLINE in this hackathon build (clearly labelled in demo output):
+  - ENS resolution — the demo uses an offline `OfflineEnsResolver` fixture loaded from `demo-fixtures/ens-records.json`; the `EnsResolver` trait abstracts a future live testnet resolver but no live resolver is shipped in this build.
+  - KeeperHub backend — the demo always constructs `KeeperHubExecutor::local_mock()`. A `KeeperHubExecutor::live()` constructor exists for the production path but is not exercised; the demo's KeeperHub mock receipt prints `mock: true` and a sponsor note.
+  - Uniswap backend — the demo always constructs `UniswapExecutor::local_mock()`. `UniswapExecutor::live()` is intentionally stubbed and returns `BackendOffline`; the swap-policy guard (token allowlist, max notional, max slippage, treasury recipient, quote freshness) is real and runs before any executor call.
+  - Signing seeds — `AppState::new` uses deterministic dev seeds in `mandate-server::lib.rs` (clearly labelled `⚠ DEV ONLY ⚠`); production deployments inject real signers via `AppState::with_signers` (TEE/HSM-backed).
+
+Not present in this build (intentional):
+  - No `MANDATE_*_LIVE` environment variable feature flag — switching any sponsor adapter from mock to live is a single-constructor-call change, not a runtime toggle.
+  - No persistent nonce store (the in-memory `seen_nonces` set resets on daemon restart; tracked as post-submission task PS-P1-01).
+  - No real secrets, API keys, private keys or wallet keys committed anywhere.
+```
+
+## Partner prize notes
+
+### ENS — Best Integration for AI Agents
+
+```
+Mandate uses ENS as the public identity layer for autonomous agents. The demo agent `research-agent.team.eth` resolves text records:
+
+  mandate:agent_id        research-agent-01
+  mandate:endpoint        https://example.com/agents/research-agent-01
+  mandate:policy_hash     <canonical SHA-256 of the active Mandate policy>
+  mandate:audit_root      <root of the agent's hash-chained audit log>
+  mandate:receipt_schema  <link to the policy_receipt_v1 schema>
+
+The demo verifies that the published `mandate:policy_hash` matches the canonical hash of the daemon's currently-loaded policy. If they ever drift, the agent is treated as un-trustable. This is a one-line check that gives sponsor reviewers immediate, cryptographic confidence that the on-chain identity and the off-chain enforcement are bound together.
+
+In this hackathon build the resolver is offline (`OfflineEnsResolver` reads `demo-fixtures/ens-records.json`). The `EnsResolver` trait abstraction is real and live testnet resolution is a single adapter swap.
+```
+
+### KeeperHub — Best Use of KeeperHub
+
+```
+Mandate decides, KeeperHub executes. After the policy engine returns Allow, the signed `PolicyReceipt` and the underlying APRP are handed to `KeeperHubExecutor::execute()`. Only Allow receipts ever reach the sponsor; Deny receipts are refused before any sponsor call (`policy receipt rejected: decision=Deny`). This separation maps directly onto KeeperHub's "execution layer for AI agents onchain" framing: Mandate is the pre-execution policy and risk layer, KeeperHub is the execution layer.
+
+In this hackathon build the demo constructs `KeeperHubExecutor::local_mock()` and prints `mock: true` plus a deterministic `kh-<ULID>` execution_ref. A `KeeperHubExecutor::live()` constructor exists; switching to a live KeeperHub MCP/API call is a single-function-body change once a stable action-submission schema is published.
+```
+
+### Uniswap — Best Uniswap API Integration (stretch)
+
+```
+Mandate is not a trading bot. The Uniswap adapter exists to prove that an agent which wants to trade through Uniswap can still be bounded by Mandate's policy and the swap-policy guard. The flow is:
+
+  1. The agent emits an APRP `smart_account_session` swap intent (input/output token, max slippage bps, max notional USD, recipient).
+  2. The swap-policy guard (`mandate_execution::uniswap::evaluate_swap`) enforces input/output token allowlists, max notional, max slippage, quote freshness window and treasury-recipient guard.
+  3. The APRP is posted to Mandate's policy engine under a swap-aware variant of the reference policy.
+  4. Approved receipts go to `UniswapExecutor::local_mock()` which returns a deterministic `uni-<ULID>` execution_ref. Denied receipts never reach the executor.
+
+Demo allow path: USDC → ETH within all caps. Demo deny path: USDC → rug-token at 1500 bps slippage to a non-allowlisted recipient — both the swap-policy guard and Mandate deny independently. The static fixture's quote uses a `(relaxed)` freshness flag that is explicitly visible in demo output; live mode would use the strict freshness check.
+
+In this hackathon build the demo always constructs `UniswapExecutor::local_mock()`; `UniswapExecutor::live()` is intentionally stubbed and returns `BackendOffline`. Wiring the Uniswap Trading API is a single-function-body change.
+```
+
+## Demo link
+
+```
+<TODO: paste recorded demo URL (YouTube unlisted or Loom) before submission>
+
+Backup live-demo command for any judge who can build from source:
+    git clone https://github.com/B2JK-Industry/mandate-ethglobal-openagents-2026.git
+    cd mandate-ethglobal-openagents-2026
+    bash demo-scripts/run-openagents-final.sh
+```
+
+## GitHub repo link
+
+```
+https://github.com/B2JK-Industry/mandate-ethglobal-openagents-2026
+```
+
+## Suggested 4-minute video structure
+
+Mirrors `demo-scripts/demo-video-script.md` (target 3:30, hard stop 3:50). Real human voiceover, no AI TTS, no music-only segments.
+
+| t | Beat | Visual | Notes |
+|---|---|---|---|
+| 0:00–0:20 | Hook + one-sentence "what is Mandate" + tagline. | Title card. | Land "Don't give your agent a wallet. Give it a mandate." in the first 10 seconds. |
+| 0:20–0:40 | ENS agent identity. Show `mandate:policy_hash` matching the active Mandate policy hash. | `bash demo-scripts/sponsors/ens-agent-identity.sh` | Highlight the `ens.verify: ok (matches active policy …)` line. Disclose offline resolver in one line. |
+| 0:40–1:15 | Legitimate x402 purchase. Allow → signed receipt → audit event. | `./demo-agents/research-agent/run --scenario legit-x402` | Pause on `decision: Allow`, `request_hash`, `policy_hash`, `audit_event`, `receipt_sig`. |
+| 1:15–1:45 | KeeperHub guarded execution. Approved receipt routed; `kh-<ULID>` returned. | `bash demo-scripts/sponsors/keeperhub-guarded-execution.sh` (allow path only) | Disclose `mock: true` line in passing. |
+| 1:45–2:25 | Prompt-injection attack. Show `attack_prompt` text on screen. Mandate denies before any signer/executor runs. KeeperHub refuses the denied receipt. | `./demo-agents/research-agent/run --scenario prompt-injection --execute-keeperhub` | Linger on `decision: Deny` + `keeperhub.refused`. Make the malicious string visible. |
+| 2:25–3:00 | Uniswap guarded swap. Bounded USDC → ETH allowed. Rug-token attacker quote denied by both swap-policy guard and Mandate. | `bash demo-scripts/sponsors/uniswap-guarded-swap.sh` | Show the `FAIL` lines on the deny path + `uniswap.refused`. |
+| 3:00–3:25 | Audit chain end-to-end. Three events linked, signed. Tamper one byte → strict-hash verify rejects. | `run-openagents-final.sh` step 11 output | Close on `strict-hash verify rejected the tampered audit event`. |
+| 3:25–3:50 | Sign-off. | Title card + commit hash. | "Don't give your agent a wallet. Give it a mandate." Title card carries the commit hash so judges can reproduce. |
+
+Recording checklist:
+- 720p+ (1080p preferred), real screen recorder, no phone capture.
+- Real human voiceover. No AI TTS, no music-only segments.
+- Run `bash demo-scripts/reset.sh` before recording so any persistent state starts fresh.
+- Record commit hash on the title card.
+- Do not speed up terminal output. If pacing is tight, edit out long waits, never compress them.
+
+---
+
+## Field-by-field copy-paste cheat sheet
+
+| ETHGlobal field | Source section above |
+|---|---|
+| Project name | Project name |
+| Tagline / one-liner | hook block at the top |
+| Short description (≤ 100 chars) | Short description |
+| Long description | Long description |
+| How it is made | How it is made |
+| Tech stack | Tech stack |
+| Emoji | Emoji |
+| Category | Category |
+| Demo link | Demo link |
+| Source code | GitHub repo link |
+| Notes for ENS / KeeperHub / Uniswap | Partner prize notes |
+
+## Sources used to draft this file
+
+- `README.md` — current submission build status and demo command.
+- `SUBMISSION_NOTES.md` — partner-prize framing, "what is live vs mocked", judging-criteria mapping.
+- `FEEDBACK.md` — per-partner narrative for ENS, KeeperHub, Uniswap including hackathon limitations.
+- `IMPLEMENTATION_STATUS.md` — what is implemented and which hardening PRs landed.
+- `FINAL_REVIEW.md` — independent submission-readiness audit, mock/live truthfulness verdict.
+- `demo-scripts/run-openagents-final.sh` — the 11-step demo flow; ground truth for all "what runs" claims.
+- `demo-scripts/demo-video-script.md` — existing storyboard; the 4-minute structure above stays compatible.
+- `demo-agents/research-agent/README.md` — agent-boundary description (no signing keys in the agent crate).
+
+Update this file if any of the above documents change.

--- a/SUBMISSION_FORM_DRAFT.md
+++ b/SUBMISSION_FORM_DRAFT.md
@@ -43,7 +43,7 @@ Mandate is a local policy, budget, receipt and audit firewall that decides wheth
 
 A research-agent in our demo emits a payment request (an APRP — "Agent Payment Request Protocol") across the Mandate boundary. Mandate validates the request, evaluates a deterministic policy, enforces multi-scope budgets, rejects replayed nonces with HTTP 409, signs an Ed25519 policy receipt, appends a hash-chained audit event, and only then routes the action to a sponsor executor (KeeperHub or Uniswap in this demo). When the same agent is prompt-injected and forwards a hostile request, Mandate denies before any signer or executor runs and the audit log captures the rejection. Tampering with one byte of an audit event is rejected by the strict-hash verifier.
 
-The whole flow is deterministic, runs offline, and reproduces from a fresh clone in ~5 seconds with `bash demo-scripts/run-openagents-final.sh`. 90/90 tests pass, schemas validate, the demo's 11 gates are green end-to-end including the audit-chain tamper-detection step.
+The whole flow is deterministic, runs offline, and reproduces from a fresh clone in ~5 seconds with `bash demo-scripts/run-openagents-final.sh`. 96/96 tests pass, schemas validate, the demo's 11 gates are green end-to-end including the audit-chain tamper-detection step.
 
 Mandate is not a wallet, not a relayer, and not a trading bot. It is the pre-execution policy and signing boundary that lets autonomous agents transact without ever being trusted with a key.
 ```
@@ -65,7 +65,7 @@ Rust workspace (8 crates + research-agent demo binary):
   - mandate-core        APRP types, JCS canonical hashing, Ed25519 signer, receipts, decision tokens, audit events.
   - mandate-policy      Policy model + Rego-compatible expression evaluator, decide(), multi-scope budget tracker.
   - mandate-storage     SQLite-backed audit log with hash-chain verifier (rusqlite + migrations).
-  - mandate-server      axum HTTP server, POST /v1/payment-requests pipeline, in-memory APRP nonce-replay gate.
+  - mandate-server      axum HTTP server, POST /v1/payment-requests pipeline, SQLite-backed APRP nonce-replay gate (atomic INSERT into the `nonce_replay` table from migration V002).
   - mandate-execution   Guarded-executor adapters (KeeperHub, Uniswap) with explicit local_mock / live constructors.
   - mandate-identity    ENS resolver trait + offline fixture resolver + policy_hash drift check.
   - mandate-mcp         MCP tool surface skeleton.
@@ -95,7 +95,7 @@ REAL (end-to-end, exercised by the test suite + the final demo):
   - JSON Schema validation — 6 schemas, 4-fixture corpus, no network.
   - Policy engine + agent gate (unknown / paused / revoked / `emergency.paused_agents` / `emergency.freeze_all`).
   - Multi-scope budget tracker (per_tx non-accumulating; daily / monthly / per_provider accumulating; commit only on Allow).
-  - APRP nonce replay rejection — HTTP 409 + `protocol.nonce_replay`, fires before request_hash / policy / budget / audit / signing so a replay produces no side effects.
+  - APRP nonce replay rejection — HTTP 409 + `protocol.nonce_replay`, fires before request_hash / policy / budget / audit / signing so a replay produces no side effects. Dedup is backed by the persistent `nonce_replay` SQLite table (migration V002) via `Storage::nonce_try_claim`, so a daemon configured with `Storage::open(path)` rejects replays across process restart; the demo defaults to `Storage::open_in_memory()`, where the same SQLite-backed dedup persists for the lifetime of the demo process.
   - Ed25519-signed policy receipts, decision tokens and audit events.
   - Hash-chained audit log (SQLite + JSONL verifier with structural and strict-hash modes).
   - Audit-chain tamper detection — flip one byte and strict-hash verify rejects.
@@ -109,7 +109,7 @@ MOCKED / OFFLINE in this hackathon build (clearly labelled in demo output):
 
 Not present in this build (intentional):
   - No `MANDATE_*_LIVE` environment variable feature flag — switching any sponsor adapter from mock to live is a single-constructor-call change, not a runtime toggle.
-  - No persistent nonce store (the in-memory `seen_nonces` set resets on daemon restart; tracked as post-submission task PS-P1-01).
+  - No RFC 8470-style `Idempotency-Key` semantics for safe-retry on 5xx — a 5xx after the nonce is consumed will surface as a 409 `protocol.nonce_replay` on retry rather than replaying the original response.
   - No real secrets, API keys, private keys or wallet keys committed anywhere.
 ```
 


### PR DESCRIPTION
Docs-only PR for PS-P0-02. Adds a copy-paste-ready ETHGlobal Open Agents submission form draft and links it from README.

## Scope

- `SUBMISSION_FORM_DRAFT.md` (new) — project name, category, emoji, ≤100-char short description, long description, how-it-is-made, tech stack, real-vs-mocked truthfulness block, ENS / KeeperHub / Uniswap partner notes, demo + repo links, 4-minute video structure.
- `README.md` — single-line link to the draft alongside `SUBMISSION_NOTES.md` and `AI_USAGE.md`. Status line updated to reflect post-PR-#11 reality (`#11` added to merged-PRs list, test count `90/90` → `96/96`).
- `IMPLEMENTATION_STATUS.md` — refreshed as a post-PR-#11 snapshot: header phase line mentions PR #11, merged-PRs table gains rows for #10 and #11, PR #11 hardening bullet added describing the SQLite-backed `nonce_replay` table (migration V002) accessed via `Storage::nonce_try_claim`, PR #7 bullet clarifies its in-memory dedup was superseded by #11, test count updated to 96/96, and PR #12 is explicitly noted as docs-only (not core implementation).

## No production code changes

This PR touches only Markdown — no Rust, no schemas, no OpenAPI, no migrations, no demo scripts.

## Verification

The branch was moved to the isolated Developer B workspace at `/Users/danielbabjak/Desktop/MandateETHGlobal/mandate-ethglobal-openagents-2026-b` after the original shared-checkout near-miss. Full local verification was re-run there on the rebased branch (top of `main` includes PR #11 at `a29926d`):

- `cargo fmt --check` — ✅
- `cargo clippy --workspace --all-targets -- -D warnings` — ✅
- `cargo test --workspace --all-targets` — ✅ **96 / 96 pass**, 0 fail, 0 ignored
- `python3 scripts/validate_schemas.py` — ✅
- `python3 scripts/validate_openapi.py` — ✅
- `bash demo-scripts/run-openagents-final.sh` — ✅ all 11 gates green incl. audit-chain tamper detection

GitHub Actions CI on the pushed branch is green (Rust check + Validate JSON schemas / OpenAPI).

## Mock / live truthfulness

Unchanged from PR v2 — the draft and the post-PR-#11 docs continue to disclose:

- ENS resolution: offline `OfflineEnsResolver` fixture; trait abstracts a future live testnet resolver.
- KeeperHub backend: demo always uses `KeeperHubExecutor::local_mock()`; `live()` constructor exists.
- Uniswap backend: demo always uses `UniswapExecutor::local_mock()`; `live()` is intentionally stubbed and returns `BackendOffline`.
- Signing seeds: deterministic dev seeds in `mandate-server::lib.rs`, clearly labelled `⚠ DEV ONLY ⚠`; production deployments inject real signers via `AppState::with_signers`.

The draft was updated only on facts that changed with PR #11: the nonce-replay store is now SQLite-backed (migration V002, `nonce_replay` table) and persists across daemon restart for `Storage::open(path)`. The "no idempotency / safe-retry on 5xx" caveat is preserved.

## Do not merge without Daniel approval.