### PR TITLE
docs: polish final QA wording

### DIFF
--- a/FINAL_REVIEW.md
+++ b/FINAL_REVIEW.md
@@ -6,6 +6,8 @@
 **Review verdict before this docs cleanup:** `READY_AFTER_FIXES` — no code/security/demo blockers; only doc staleness issues.
 **After the fixes in PR #10:** **`READY_FOR_SUBMISSION`** — all medium and low findings (M1–M4, L1, L2) are resolved by PR #10, as marked in §6 below.
 
+> **Note:** this review was originally captured after PR #10. Post-PR #11/#12 current status is tracked in [`IMPLEMENTATION_STATUS.md`](IMPLEMENTATION_STATUS.md) and is **96/96 tests** with persistent SQLite-backed APRP nonce-replay protection.
+
 ---
 
 ## 1. Repository state

--- a/SUBMISSION_NOTES.md
+++ b/SUBMISSION_NOTES.md
@@ -18,14 +18,14 @@ All implementation code in this repository:
 - Policy engine (hackathon-grade custom expression evaluator over the locked rule grammar in `mandate-policy/src/expr.rs`; Rego via `regorus` is the production target per `docs/spec/17_interface_contracts.md`) + multi-scope budget checks + fail-closed agent gate (unknown / paused / revoked / `emergency.paused_agents`).
 - SQLite-backed storage with hash-chained audit log.
 - Real research-agent harness with `legit-x402` and `prompt-injection` scenarios.
-- ENS identity proof adapter (resolves agent → vault endpoint + policy hash + audit root).
+- ENS identity proof adapter (resolves agent → Mandate endpoint + policy hash + audit root).
 - KeeperHub guarded-execution adapter (`mandate-execution::keeperhub`).
 - Uniswap guarded-swap adapter (`mandate-execution::uniswap`): swap-policy guard (token allowlist, max notional, max slippage, quote freshness, treasury recipient) + `UniswapExecutor::local_mock()`.
 - Sponsor demo scripts: `ens-agent-identity.sh`, `keeperhub-guarded-execution.sh`, `uniswap-guarded-swap.sh`.
 - Standalone red-team gate: `demo-scripts/red-team/prompt-injection.sh`.
 - `demo-scripts/run-openagents-final.sh` — single-command demo runner with audit-chain tamper detection.
 - `demo-scripts/demo-video-script.md` — 3:30 storyboard with recording checklist.
-- CI: fmt, clippy, tests (90 passing), schema validation.
+- CI: fmt, clippy, tests (96 passing), schema validation.
 
 ## What was reused as planning material
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -550,7 +550,7 @@
     "securitySchemes": {
       "agentMtls": {
         "type": "mutualTLS",
-        "description": "Agent certificate issued by the vault CA; certificate CN/SAN carries agent_id."
+        "description": "Agent certificate issued by the Mandate CA; certificate CN/SAN carries agent_id."
       },
       "adminMtls": {
         "type": "mutualTLS",

--- a/test-corpus/README.md
+++ b/test-corpus/README.md
@@ -15,7 +15,7 @@ This directory is normative input for implementation and CI.
 |---|---|---|
 | `aprp/golden_001_minimal.json` | Minimal valid APRP x402 request | accepted |
 | `aprp/adversarial_unknown_field.json` | Strict schema guard | `schema.unknown_field` |
-| `aprp/deny_prompt_injection_request.json` | ETHPrague hero attack request | valid schema, policy denies with `policy.deny_recipient_not_allowlisted` |
+| `aprp/deny_prompt_injection_request.json` | Open Agents hero attack request | valid schema, policy denies with `policy.deny_recipient_not_allowlisted` |
 | `policy/reference_low_risk.json` | Reference low-risk policy | accepted by policy linter |
 | `x402/challenge_001.json` | Minimal x402 challenge | accepted |
 | `audit/chain_v1.jsonl` | Three-event audit chain shape | accepted after implementation locks hashes/signatures |


### PR DESCRIPTION
Docs-only PR. Fixes QA PASS_WITH_NOTES findings on stale wording across the user-facing submission docs and the OpenAPI spec.

## Scope

- `SUBMISSION_NOTES.md` — `tests (90 passing)` → `tests (96 passing)`; `vault endpoint` → `Mandate endpoint`.
- `FINAL_REVIEW.md` — adds a one-line preamble note clarifying that the audit body is the post-PR-#10 snapshot and pointing at `IMPLEMENTATION_STATUS.md` for the post-PR-#11/#12 current 96/96 state. The historical body is left intact.
- `docs/api/openapi.json` — `vault CA` → `Mandate CA` (description-only change to the `agentMtls` securityScheme).
- `test-corpus/README.md` — `ETHPrague hero attack request` → `Open Agents hero attack request`.

## No production code changes

Markdown + a single OpenAPI description string. No Rust, no schemas, no migrations, no demo scripts, no error codes, no receipt fields, no decision/audit semantics.

## Verification (isolated Developer B workspace)

- `cargo fmt --check` — ✅
- `cargo clippy --workspace --all-targets -- -D warnings` — ✅
- `cargo test --workspace --all-targets` — ✅ **96 / 96 pass**, 0 fail, 0 ignored
- `python3 scripts/validate_schemas.py` — ✅
- `python3 scripts/validate_openapi.py` — ✅ (`docs/api/openapi.json` still valid after the description edit)
- `bash demo-scripts/run-openagents-final.sh` — ✅ all 11 gates green incl. audit-chain tamper detection

## Mock / live truthfulness

Unchanged.

## Do not merge without Daniel approval.