### PR TITLE
feat: add verifiable audit export bundle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,12 +1033,14 @@ name = "mandate-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "mandate-core",
  "mandate-policy",
  "mandate-storage",
  "serde",
  "serde_json",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/mandate-cli/Cargo.toml
+++ b/crates/mandate-cli/Cargo.toml
@@ -19,5 +19,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
+chrono = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/mandate-cli/src/main.rs
+++ b/crates/mandate-cli/src/main.rs
@@ -3,6 +3,8 @@ use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
 use mandate_core::audit::{verify_chain, SignedAuditEvent};
+use mandate_core::audit_bundle::{self, AuditBundle};
+use mandate_core::receipt::PolicyReceipt;
 use mandate_core::{schema, SchemaError};
 
 #[derive(Parser, Debug)]
@@ -41,6 +43,55 @@ enum Command {
     Schema {
         /// One of: aprp | policy | decision-token | policy-receipt | audit-event | x402
         kind: String,
+    },
+    /// Verifiable audit export bundle commands.
+    ///
+    /// `mandate audit export` packages a signed receipt + the relevant audit
+    /// chain segment + the public verification keys into a single JSON file
+    /// that anyone can re-verify offline. `mandate audit verify-bundle`
+    /// re-derives every signature, hash and chain link in that file and
+    /// reports the result. Tagline: Mandate does not just decide. It leaves
+    /// behind verifiable proof.
+    Audit {
+        #[command(subcommand)]
+        op: AuditCmd,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum AuditCmd {
+    /// Build a verifiable bundle from a signed receipt + audit chain JSONL.
+    ///
+    /// The chain JSONL must include the genesis event (seq=1) through the
+    /// event referenced by the receipt's `audit_event_id`, in seq order.
+    Export {
+        /// Path to the signed PolicyReceipt JSON (the body returned by
+        /// `POST /v1/payment-requests`, field `receipt`).
+        #[arg(long)]
+        receipt: PathBuf,
+        /// Path to a JSONL audit chain (one SignedAuditEvent per line).
+        #[arg(long)]
+        chain: PathBuf,
+        /// Public verification key (hex) for the receipt signer (32 bytes).
+        #[arg(long)]
+        receipt_pubkey: String,
+        /// Public verification key (hex) for the audit signer (32 bytes).
+        #[arg(long)]
+        audit_pubkey: String,
+        /// Output path. If omitted, the bundle JSON is written to stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
+    /// Verify a previously-exported bundle.
+    ///
+    /// Re-derives every receipt + audit signature, every audit event_hash,
+    /// and the prev_event_hash linkage of the included chain segment. Exits
+    /// with code 0 on success, 1 on any verification failure, 2 on I/O or
+    /// JSON-parse errors.
+    VerifyBundle {
+        /// Path to a bundle JSON file produced by `mandate audit export`.
+        #[arg(long)]
+        path: PathBuf,
     },
 }
 
@@ -95,6 +146,25 @@ fn main() -> ExitCode {
             pubkey,
         } => cmd_verify_audit(&path, !skip_hash, pubkey.as_deref()),
         Command::Schema { kind } => cmd_schema(&kind),
+        Command::Audit {
+            op:
+                AuditCmd::Export {
+                    receipt,
+                    chain,
+                    receipt_pubkey,
+                    audit_pubkey,
+                    out,
+                },
+        } => cmd_audit_export(
+            &receipt,
+            &chain,
+            &receipt_pubkey,
+            &audit_pubkey,
+            out.as_deref(),
+        ),
+        Command::Audit {
+            op: AuditCmd::VerifyBundle { path },
+        } => cmd_audit_verify_bundle(&path),
     }
 }
 
@@ -266,6 +336,121 @@ fn cmd_verify_audit(path: &Path, verify_hashes: bool, pubkey: Option<&str>) -> E
         }
         Err(e) => {
             eprintln!("audit chain invalid: {e}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn read_audit_chain_jsonl(path: &Path) -> anyhow::Result<Vec<SignedAuditEvent>> {
+    let data = std::fs::read_to_string(path)?;
+    let mut events: Vec<SignedAuditEvent> = Vec::new();
+    for (i, line) in data.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let signed: SignedAuditEvent = serde_json::from_str(line).map_err(|e| {
+            anyhow::anyhow!("chain JSONL line {} is not a SignedAuditEvent: {e}", i + 1)
+        })?;
+        events.push(signed);
+    }
+    Ok(events)
+}
+
+fn cmd_audit_export(
+    receipt_path: &Path,
+    chain_path: &Path,
+    receipt_pubkey_hex: &str,
+    audit_pubkey_hex: &str,
+    out: Option<&Path>,
+) -> ExitCode {
+    let receipt: PolicyReceipt = match std::fs::read_to_string(receipt_path)
+        .map_err(anyhow::Error::from)
+        .and_then(|s| serde_json::from_str(&s).map_err(anyhow::Error::from))
+    {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error reading receipt {}: {e}", receipt_path.display());
+            return ExitCode::from(2);
+        }
+    };
+    let chain = match read_audit_chain_jsonl(chain_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error reading chain {}: {e}", chain_path.display());
+            return ExitCode::from(2);
+        }
+    };
+    let bundle = match audit_bundle::build(
+        receipt,
+        chain,
+        receipt_pubkey_hex.to_string(),
+        audit_pubkey_hex.to_string(),
+        chrono::Utc::now(),
+    ) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("error building bundle: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    // Pretty-print so humans can diff bundles visually; structure is the
+    // same as the compact form because field order is fixed by the derive.
+    let serialised = match serde_json::to_string_pretty(&bundle) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("error serialising bundle: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    match out {
+        Some(p) => {
+            if let Err(e) = std::fs::write(p, serialised.as_bytes()) {
+                eprintln!("error writing {}: {e}", p.display());
+                return ExitCode::from(2);
+            }
+            eprintln!(
+                "wrote bundle to {} (chain length: {}, audit_event_id: {})",
+                p.display(),
+                bundle.audit_chain_segment.len(),
+                bundle.audit_event.event.id
+            );
+        }
+        None => {
+            println!("{serialised}");
+        }
+    }
+    ExitCode::SUCCESS
+}
+
+fn cmd_audit_verify_bundle(path: &Path) -> ExitCode {
+    let data = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("error reading {}: {e}", path.display());
+            return ExitCode::from(2);
+        }
+    };
+    let bundle: AuditBundle = match serde_json::from_str(&data) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("invalid bundle JSON: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    match audit_bundle::verify(&bundle) {
+        Ok(summary) => {
+            println!(
+                "ok: bundle verified (decision={:?}, deny_code={:?}, chain_length={}, audit_event_id={})",
+                summary.decision,
+                summary.deny_code,
+                summary.audit_chain_length,
+                summary.audit_event_id
+            );
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("bundle invalid: {e}");
             ExitCode::from(1)
         }
     }

--- a/crates/mandate-cli/tests/audit_bundle.rs
+++ b/crates/mandate-cli/tests/audit_bundle.rs
@@ -1,0 +1,279 @@
+//! Integration smoke test for `mandate audit export` → `mandate audit verify-bundle`.
+//!
+//! Exercises the real CLI binary end-to-end: deterministic dev signers
+//! produce a receipt and an audit chain, the export command writes a
+//! bundle JSON file, and the verify-bundle command must reject any
+//! tampering with the bundle's cryptographic claims.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
+use mandate_core::audit::{AuditEvent, SignedAuditEvent, ZERO_HASH};
+use mandate_core::receipt::{Decision, UnsignedReceipt};
+use mandate_core::signer::DevSigner;
+
+fn cli_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_mandate"))
+}
+
+fn write_chain_jsonl(path: &std::path::Path, events: &[SignedAuditEvent]) {
+    let mut f = std::fs::File::create(path).unwrap();
+    for e in events {
+        let line = serde_json::to_string(e).unwrap();
+        writeln!(f, "{line}").unwrap();
+    }
+}
+
+/// Build a small but realistic chain (3 events) plus a receipt that
+/// references the middle event, signed by deterministic dev signers so
+/// the bundle is reproducible across test runs.
+fn build_fixture_files() -> (
+    tempfile::TempDir,
+    PathBuf, // receipt path
+    PathBuf, // chain JSONL path
+    String,  // receipt pubkey hex
+    String,  // audit pubkey hex
+    String,  // audit event id (the receipt's referent — used by negative tests)
+) {
+    let tmp = tempfile::tempdir().unwrap();
+
+    let audit_signer = DevSigner::from_seed("audit-signer-v1", [11u8; 32]);
+    let receipt_signer = DevSigner::from_seed("decision-signer-v1", [7u8; 32]);
+
+    let mk = |seq: u64, prev: &str, ts: &str, id: &str, ty: &str| {
+        let event = AuditEvent {
+            version: 1,
+            seq,
+            id: id.to_string(),
+            ts: chrono::DateTime::parse_from_rfc3339(ts).unwrap().into(),
+            event_type: ty.to_string(),
+            actor: "policy_engine".to_string(),
+            subject_id: format!("pr-test-{seq:03}"),
+            payload_hash: ZERO_HASH.to_string(),
+            metadata: serde_json::Map::new(),
+            policy_version: Some(1),
+            policy_hash: None,
+            attestation_ref: None,
+            prev_event_hash: prev.to_string(),
+        };
+        SignedAuditEvent::sign(event, &audit_signer).unwrap()
+    };
+    let e1 = mk(
+        1,
+        ZERO_HASH,
+        "2026-04-27T12:00:00Z",
+        "evt-01HTAWX5K3R8YV9NQB7C6P2DGQ",
+        "runtime_started",
+    );
+    let e2 = mk(
+        2,
+        &e1.event_hash,
+        "2026-04-27T12:00:01Z",
+        "evt-01HTAWX5K3R8YV9NQB7C6P2DGR",
+        "policy_decided",
+    );
+    let e3 = mk(
+        3,
+        &e2.event_hash,
+        "2026-04-27T12:00:02Z",
+        "evt-01HTAWX5K3R8YV9NQB7C6P2DGS",
+        "policy_decided",
+    );
+
+    let chain_path = tmp.path().join("chain.jsonl");
+    write_chain_jsonl(&chain_path, &[e1.clone(), e2.clone(), e3.clone()]);
+
+    let unsigned = UnsignedReceipt {
+        agent_id: "research-agent-01".to_string(),
+        decision: Decision::Allow,
+        deny_code: None,
+        request_hash: "1111111111111111111111111111111111111111111111111111111111111111"
+            .to_string(),
+        policy_hash: "2222222222222222222222222222222222222222222222222222222222222222".to_string(),
+        policy_version: Some(1),
+        audit_event_id: e2.event.id.clone(),
+        execution_ref: None,
+        issued_at: chrono::DateTime::parse_from_rfc3339("2026-04-27T12:00:01.500Z")
+            .unwrap()
+            .into(),
+        expires_at: None,
+    };
+    let receipt = unsigned.sign(&receipt_signer).unwrap();
+    let receipt_path = tmp.path().join("receipt.json");
+    std::fs::write(&receipt_path, serde_json::to_vec_pretty(&receipt).unwrap()).unwrap();
+
+    let receipt_pk = receipt_signer.verifying_key_hex();
+    let audit_pk = audit_signer.verifying_key_hex();
+    let target_id = e2.event.id;
+    (
+        tmp,
+        receipt_path,
+        chain_path,
+        receipt_pk,
+        audit_pk,
+        target_id,
+    )
+}
+
+#[test]
+fn export_then_verify_bundle_succeeds() {
+    let (tmp, receipt, chain, rpk, apk, target_id) = build_fixture_files();
+    let bundle_path = tmp.path().join("bundle.json");
+
+    let out = Command::new(cli_bin())
+        .args([
+            "audit",
+            "export",
+            "--receipt",
+            receipt.to_str().unwrap(),
+            "--chain",
+            chain.to_str().unwrap(),
+            "--receipt-pubkey",
+            &rpk,
+            "--audit-pubkey",
+            &apk,
+            "--out",
+            bundle_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "export must succeed; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(bundle_path.exists());
+
+    let out = Command::new(cli_bin())
+        .args([
+            "audit",
+            "verify-bundle",
+            "--path",
+            bundle_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "verify-bundle must succeed; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("ok: bundle verified"),
+        "unexpected verify stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains(&target_id),
+        "verify summary must name the audit_event_id; stdout={stdout}"
+    );
+}
+
+#[test]
+fn verify_bundle_rejects_tampered_receipt_signature() {
+    // Tamper with the bundle's receipt signature bytes after export. The
+    // verify command must exit non-zero; the daemon-style signature check
+    // protects every receipt-covered field (request_hash, policy_hash,
+    // decision, etc.) by extension.
+    let (tmp, receipt, chain, rpk, apk, _) = build_fixture_files();
+    let bundle_path = tmp.path().join("bundle.json");
+    let status = Command::new(cli_bin())
+        .args([
+            "audit",
+            "export",
+            "--receipt",
+            receipt.to_str().unwrap(),
+            "--chain",
+            chain.to_str().unwrap(),
+            "--receipt-pubkey",
+            &rpk,
+            "--audit-pubkey",
+            &apk,
+            "--out",
+            bundle_path.to_str().unwrap(),
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let raw = std::fs::read_to_string(&bundle_path).unwrap();
+    let mut bundle: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    let sig = bundle["receipt"]["signature"]["signature_hex"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let mut chars: Vec<char> = sig.chars().collect();
+    let last = chars.pop().unwrap();
+    chars.push(if last == '0' { '1' } else { '0' });
+    bundle["receipt"]["signature"]["signature_hex"] =
+        serde_json::Value::String(chars.into_iter().collect());
+    std::fs::write(&bundle_path, serde_json::to_vec_pretty(&bundle).unwrap()).unwrap();
+
+    let out = Command::new(cli_bin())
+        .args([
+            "audit",
+            "verify-bundle",
+            "--path",
+            bundle_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "verify-bundle must reject tampered signature"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("bundle invalid"),
+        "expected diagnostic on stderr; got {stderr}"
+    );
+}
+
+#[test]
+fn verify_bundle_rejects_broken_chain_linkage() {
+    // Mutate prev_event_hash on an event after export — chain verification
+    // must catch the broken linkage even though signatures are still
+    // present.
+    let (tmp, receipt, chain, rpk, apk, _) = build_fixture_files();
+    let bundle_path = tmp.path().join("bundle.json");
+    let status = Command::new(cli_bin())
+        .args([
+            "audit",
+            "export",
+            "--receipt",
+            receipt.to_str().unwrap(),
+            "--chain",
+            chain.to_str().unwrap(),
+            "--receipt-pubkey",
+            &rpk,
+            "--audit-pubkey",
+            &apk,
+            "--out",
+            bundle_path.to_str().unwrap(),
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let raw = std::fs::read_to_string(&bundle_path).unwrap();
+    let mut bundle: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    bundle["audit_chain_segment"][2]["event"]["prev_event_hash"] = serde_json::Value::String(
+        "0000000000000000000000000000000000000000000000000000000000000001".to_string(),
+    );
+    std::fs::write(&bundle_path, serde_json::to_vec_pretty(&bundle).unwrap()).unwrap();
+
+    let out = Command::new(cli_bin())
+        .args([
+            "audit",
+            "verify-bundle",
+            "--path",
+            bundle_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "verify-bundle must reject broken linkage"
+    );
+}

--- a/crates/mandate-core/src/audit_bundle.rs
+++ b/crates/mandate-core/src/audit_bundle.rs
@@ -93,6 +93,10 @@ pub struct VerifySummary {
     pub audit_chain_length: usize,
 }
 
+/// The single supported bundle format identity. Both fields are checked
+/// in `verify()`; either mismatching is a fail-closed format-confusion guard.
+const SUPPORTED_BUNDLE_VERSION: u32 = 1;
+
 #[derive(Debug, Error)]
 pub enum BundleError {
     #[error("bundle is missing a receipt's audit_event_id from the chain segment")]
@@ -115,6 +119,10 @@ pub enum BundleError {
     Signer(#[from] VerifyError),
     #[error("serde error: {0}")]
     Serde(#[from] serde_json::Error),
+    #[error("unsupported bundle version: {0} (this build supports v1)")]
+    UnsupportedVersion(u32),
+    #[error("unsupported bundle_type: only mandate.audit_bundle.v1 is accepted in this build")]
+    UnsupportedBundleType,
 }
 
 /// Build a bundle from already-signed pieces. Both signer public keys must
@@ -178,6 +186,23 @@ pub fn build(
 /// or chain. (The acceptance test for this is
 /// `verify_fails_when_summary_lies_about_decision`.)
 pub fn verify(bundle: &AuditBundle) -> Result<VerifySummary, BundleError> {
+    // 0. Format-confusion guard. A bundle with `version: 2` (or any other
+    //    value) MUST NOT verify as if it were v1, even if every signature
+    //    inside still happens to round-trip — a future v2 may carry
+    //    different fields, different canonical-body rules, or different
+    //    semantics, and silently accepting it under v1 rules would let an
+    //    attacker present a v2 bundle to a v1 verifier. Same reasoning for
+    //    `bundle_type`: serde already rejects unknown enum variants at
+    //    parse time, but the explicit `matches!` here is defence-in-depth
+    //    against future enum additions and against callers who construct
+    //    a bundle programmatically (bypassing serde).
+    if !matches!(bundle.bundle_type, BundleType::AuditBundleV1) {
+        return Err(BundleError::UnsupportedBundleType);
+    }
+    if bundle.version != SUPPORTED_BUNDLE_VERSION {
+        return Err(BundleError::UnsupportedVersion(bundle.version));
+    }
+
     // 1. Receipt signature — covers request_hash, policy_hash, decision,
     //    deny_code, audit_event_id, etc. via canonical-body signing.
     bundle
@@ -505,5 +530,70 @@ mod tests {
         bundle.verification_keys.receipt_signer_pubkey_hex = other.verifying_key_hex();
         let err = verify(&bundle).expect_err("must reject wrong receipt pubkey");
         assert!(matches!(err, BundleError::ReceiptSignatureInvalid));
+    }
+
+    #[test]
+    fn verify_fails_when_version_field_is_not_one() {
+        // Format-confusion guard: a bundle that claims to be v2 (or any
+        // value other than 1) must NOT verify under v1 rules even if every
+        // signature inside still happens to round-trip. This fires before
+        // any signature/chain check so a malicious v2 bundle never reaches
+        // the v1 verification path.
+        let (mut bundle, _, _) = fixture();
+        bundle.version = 2;
+        let err = verify(&bundle).expect_err("must reject unsupported bundle version");
+        assert!(
+            matches!(err, BundleError::UnsupportedVersion(2)),
+            "got {err:?}"
+        );
+
+        // Sanity: a fresh v1 bundle still verifies, so the gate isn't a
+        // false positive.
+        let (good, _, _) = fixture();
+        assert_eq!(good.version, 1);
+        verify(&good).expect("valid v1 bundle must still verify");
+    }
+
+    #[test]
+    fn verify_fails_when_version_is_unsupported_via_json_round_trip() {
+        // Same property as above, but exercised through the JSON path: the
+        // serde derive happily round-trips arbitrary u32 values for
+        // `version`, so a tampered exported bundle reaches `verify()` with
+        // a non-1 version. The gate must reject it.
+        let (bundle, _, _) = fixture();
+        let mut value: serde_json::Value = serde_json::to_value(&bundle).unwrap();
+        value["version"] = serde_json::Value::Number(serde_json::Number::from(2));
+        let tampered: AuditBundle = serde_json::from_value(value).expect(
+            "serde must deserialise an arbitrary u32; the format gate runs in verify(), not parse",
+        );
+        let err = verify(&tampered).expect_err("must reject v2 on disk");
+        assert!(matches!(err, BundleError::UnsupportedVersion(2)));
+    }
+
+    #[test]
+    fn unknown_bundle_type_string_is_rejected_by_serde_at_parse_time() {
+        // Belt-and-braces evidence that the bundle_type field is not a
+        // confusion vector. `BundleType` is a single-variant enum mapped
+        // to the literal `"mandate.audit_bundle.v1"`; serde refuses any
+        // other string before `verify()` is even called.
+        //
+        // The defensive `matches!` check inside `verify()` (covered by
+        // `verify_fails_when_bundle_type_is_unsupported_variant_in_future`
+        // would catch additions to the enum) is therefore unreachable
+        // through normal JSON paths today, but pins fail-closed semantics
+        // for the day a v2 variant is added.
+        let (bundle, _, _) = fixture();
+        let mut value: serde_json::Value = serde_json::to_value(&bundle).unwrap();
+        value["bundle_type"] = serde_json::Value::String("mandate.audit_bundle.v2".to_string());
+        let parse_err = serde_json::from_value::<AuditBundle>(value)
+            .expect_err("serde must reject an unknown bundle_type string before reaching verify()");
+        // The exact serde error message isn't part of the contract; we
+        // just assert that the parse fails so a v2 string never reaches
+        // the v1 verifier.
+        let msg = parse_err.to_string();
+        assert!(
+            msg.contains("bundle_type") || msg.contains("variant"),
+            "expected a serde enum-variant error mentioning bundle_type; got {msg}"
+        );
     }
 }

--- a/crates/mandate-core/src/audit_bundle.rs
+++ b/crates/mandate-core/src/audit_bundle.rs
@@ -1,0 +1,509 @@
+//! Verifiable audit export bundle (v1).
+//!
+//! A self-contained, machine-readable proof that a Mandate decision happened
+//! and is internally consistent. The bundle pulls together everything a
+//! third party (or a future you) needs to verify that:
+//!
+//! - the policy receipt was signed by the recorded receipt-signer key,
+//! - the audit event referenced by the receipt was signed by the recorded
+//!   audit-signer key,
+//! - the audit event sits in a hash-chained log whose `prev_event_hash`
+//!   linkage and per-event `event_hash` reproduce from the canonical event
+//!   bytes,
+//! - and the receipt's `audit_event_id` actually maps to the supplied
+//!   audit event.
+//!
+//! The bundle is *not* an oracle of legitimacy — it does not say "Mandate
+//! issued this receipt"; only the public keys you decide to trust can do
+//! that. The bundle says "given that you trust these two public keys,
+//! every signature, hash and link in this proof is valid".
+//!
+//! Tagline: **Mandate does not just decide. It leaves behind verifiable proof.**
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::audit::{verify_chain, ChainError, SignedAuditEvent};
+use crate::receipt::{Decision, PolicyReceipt};
+use crate::signer::VerifyError;
+
+/// Top-level bundle envelope. See module docs.
+///
+/// `audit_chain_segment` MUST start at the genesis event (seq=1) and run
+/// in seq order through the event referenced by `receipt.audit_event_id`.
+/// A future revision can carry a Merkle proof instead of the full segment.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuditBundle {
+    pub bundle_type: BundleType,
+    pub version: u32,
+    pub exported_at: DateTime<Utc>,
+    pub receipt: PolicyReceipt,
+    pub audit_event: SignedAuditEvent,
+    pub audit_chain_segment: Vec<SignedAuditEvent>,
+    pub verification_keys: VerificationKeys,
+    pub summary: BundleSummary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BundleType {
+    #[serde(rename = "mandate.audit_bundle.v1")]
+    AuditBundleV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct VerificationKeys {
+    pub receipt_signer_pubkey_hex: String,
+    pub audit_signer_pubkey_hex: String,
+}
+
+/// Pre-extracted convenience fields. Always derived from the other bundle
+/// fields; `verify` re-derives and asserts equality, so a tampered summary
+/// cannot lie about the receipt or chain.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BundleSummary {
+    pub decision: Decision,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deny_code: Option<String>,
+    pub request_hash: String,
+    pub policy_hash: String,
+    pub audit_event_id: String,
+    pub audit_event_hash: String,
+    pub audit_chain_root: String,
+    pub audit_chain_latest: String,
+}
+
+/// Result of a successful verification. Mirrors the bundle summary plus a
+/// few derived counters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifySummary {
+    pub receipt_signature_ok: bool,
+    pub audit_event_signature_ok: bool,
+    pub audit_chain_ok: bool,
+    pub receipt_audit_link_ok: bool,
+    pub decision: Decision,
+    pub deny_code: Option<String>,
+    pub request_hash: String,
+    pub policy_hash: String,
+    pub audit_event_id: String,
+    pub audit_event_hash: String,
+    pub audit_chain_length: usize,
+}
+
+#[derive(Debug, Error)]
+pub enum BundleError {
+    #[error("bundle is missing a receipt's audit_event_id from the chain segment")]
+    AuditEventNotInChain,
+    #[error("receipt.audit_event_id does not match audit_event.event.id")]
+    ReceiptAuditMismatch,
+    #[error("audit_event hash in chain does not match standalone audit_event")]
+    AuditEventHashMismatch,
+    #[error("summary field '{0}' does not match the bundle body")]
+    SummaryMismatch(&'static str),
+    #[error("receipt signature does not verify under verification_keys.receipt_signer_pubkey_hex")]
+    ReceiptSignatureInvalid,
+    #[error(
+        "audit_event signature does not verify under verification_keys.audit_signer_pubkey_hex"
+    )]
+    AuditEventSignatureInvalid,
+    #[error("audit chain invalid: {0}")]
+    Chain(#[from] ChainError),
+    #[error("signer error: {0}")]
+    Signer(#[from] VerifyError),
+    #[error("serde error: {0}")]
+    Serde(#[from] serde_json::Error),
+}
+
+/// Build a bundle from already-signed pieces. Both signer public keys must
+/// be supplied — the bundle records who you intend the verifier to trust,
+/// not who actually signed (signatures themselves prove that).
+///
+/// `audit_chain_segment` must include the receipt's audit event and every
+/// preceding event back to seq=1, in seq order.
+pub fn build(
+    receipt: PolicyReceipt,
+    audit_chain_segment: Vec<SignedAuditEvent>,
+    receipt_signer_pubkey_hex: String,
+    audit_signer_pubkey_hex: String,
+    exported_at: DateTime<Utc>,
+) -> Result<AuditBundle, BundleError> {
+    let audit_event = audit_chain_segment
+        .iter()
+        .find(|e| e.event.id == receipt.audit_event_id)
+        .cloned()
+        .ok_or(BundleError::AuditEventNotInChain)?;
+    let chain_root = audit_chain_segment
+        .first()
+        .map(|e| e.event_hash.clone())
+        .ok_or(BundleError::AuditEventNotInChain)?;
+    let chain_latest = audit_chain_segment
+        .last()
+        .map(|e| e.event_hash.clone())
+        .ok_or(BundleError::AuditEventNotInChain)?;
+    let summary = BundleSummary {
+        decision: receipt.decision.clone(),
+        deny_code: receipt.deny_code.clone(),
+        request_hash: receipt.request_hash.clone(),
+        policy_hash: receipt.policy_hash.clone(),
+        audit_event_id: audit_event.event.id.clone(),
+        audit_event_hash: audit_event.event_hash.clone(),
+        audit_chain_root: chain_root,
+        audit_chain_latest: chain_latest,
+    };
+    Ok(AuditBundle {
+        bundle_type: BundleType::AuditBundleV1,
+        version: 1,
+        exported_at,
+        receipt,
+        audit_event,
+        audit_chain_segment,
+        verification_keys: VerificationKeys {
+            receipt_signer_pubkey_hex,
+            audit_signer_pubkey_hex,
+        },
+        summary,
+    })
+}
+
+/// Verify every claim the bundle makes. Returns a populated `VerifySummary`
+/// on success or the first invariant violation as an error. We deliberately
+/// fail fast — partial-success reporting would let a tampered bundle pick
+/// which checks the verifier sees pass.
+///
+/// The summary block carried inside the bundle is re-derived and compared
+/// against the body, so a tampered summary cannot misrepresent the receipt
+/// or chain. (The acceptance test for this is
+/// `verify_fails_when_summary_lies_about_decision`.)
+pub fn verify(bundle: &AuditBundle) -> Result<VerifySummary, BundleError> {
+    // 1. Receipt signature — covers request_hash, policy_hash, decision,
+    //    deny_code, audit_event_id, etc. via canonical-body signing.
+    bundle
+        .receipt
+        .verify(&bundle.verification_keys.receipt_signer_pubkey_hex)
+        .map_err(|_| BundleError::ReceiptSignatureInvalid)?;
+
+    // 2. Standalone audit_event signature.
+    bundle
+        .audit_event
+        .verify_signature(&bundle.verification_keys.audit_signer_pubkey_hex)
+        .map_err(|_| BundleError::AuditEventSignatureInvalid)?;
+
+    // 3. Chain integrity — recomputes every event_hash, walks prev_event_hash,
+    //    re-verifies every signature with the same audit signer key.
+    verify_chain(
+        &bundle.audit_chain_segment,
+        true,
+        Some(&bundle.verification_keys.audit_signer_pubkey_hex),
+    )?;
+
+    // 4. The receipt must point at an event that actually exists in the
+    //    chain segment, and the standalone audit_event must match the chain
+    //    member with the same id (id, hash, signature, prev pointer all the
+    //    same — equality on the SignedAuditEvent struct).
+    if bundle.receipt.audit_event_id != bundle.audit_event.event.id {
+        return Err(BundleError::ReceiptAuditMismatch);
+    }
+    let chain_member = bundle
+        .audit_chain_segment
+        .iter()
+        .find(|e| e.event.id == bundle.audit_event.event.id)
+        .ok_or(BundleError::AuditEventNotInChain)?;
+    if chain_member != &bundle.audit_event {
+        // Same id but different signed contents — the standalone event
+        // disagrees with the chain member.
+        return Err(BundleError::AuditEventHashMismatch);
+    }
+
+    // 5. Summary block must agree with the body. Cheap protection against
+    //    a tampered summary that contradicts what the (signed) receipt says.
+    let s = &bundle.summary;
+    if s.decision != bundle.receipt.decision {
+        return Err(BundleError::SummaryMismatch("decision"));
+    }
+    if s.deny_code != bundle.receipt.deny_code {
+        return Err(BundleError::SummaryMismatch("deny_code"));
+    }
+    if s.request_hash != bundle.receipt.request_hash {
+        return Err(BundleError::SummaryMismatch("request_hash"));
+    }
+    if s.policy_hash != bundle.receipt.policy_hash {
+        return Err(BundleError::SummaryMismatch("policy_hash"));
+    }
+    if s.audit_event_id != bundle.audit_event.event.id {
+        return Err(BundleError::SummaryMismatch("audit_event_id"));
+    }
+    if s.audit_event_hash != bundle.audit_event.event_hash {
+        return Err(BundleError::SummaryMismatch("audit_event_hash"));
+    }
+    let expected_root = &bundle
+        .audit_chain_segment
+        .first()
+        .ok_or(BundleError::AuditEventNotInChain)?
+        .event_hash;
+    if &s.audit_chain_root != expected_root {
+        return Err(BundleError::SummaryMismatch("audit_chain_root"));
+    }
+    let expected_latest = &bundle
+        .audit_chain_segment
+        .last()
+        .ok_or(BundleError::AuditEventNotInChain)?
+        .event_hash;
+    if &s.audit_chain_latest != expected_latest {
+        return Err(BundleError::SummaryMismatch("audit_chain_latest"));
+    }
+
+    Ok(VerifySummary {
+        receipt_signature_ok: true,
+        audit_event_signature_ok: true,
+        audit_chain_ok: true,
+        receipt_audit_link_ok: true,
+        decision: bundle.receipt.decision.clone(),
+        deny_code: bundle.receipt.deny_code.clone(),
+        request_hash: bundle.receipt.request_hash.clone(),
+        policy_hash: bundle.receipt.policy_hash.clone(),
+        audit_event_id: bundle.audit_event.event.id.clone(),
+        audit_event_hash: bundle.audit_event.event_hash.clone(),
+        audit_chain_length: bundle.audit_chain_segment.len(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::{AuditEvent, ZERO_HASH};
+    use crate::receipt::UnsignedReceipt;
+    use crate::signer::DevSigner;
+
+    /// Build a small but realistic bundle covering the receipt for seq=2
+    /// in a 3-event chain. Exposes the two signers so tampering tests can
+    /// flip pieces and re-verify.
+    fn fixture() -> (AuditBundle, DevSigner, DevSigner) {
+        let audit_signer = DevSigner::from_seed("audit-signer-v1", [11u8; 32]);
+        let receipt_signer = DevSigner::from_seed("decision-signer-v1", [7u8; 32]);
+
+        let e1_event = AuditEvent {
+            version: 1,
+            seq: 1,
+            id: "evt-01HTAWX5K3R8YV9NQB7C6P2DGQ".to_string(),
+            ts: chrono::DateTime::parse_from_rfc3339("2026-04-27T12:00:00Z")
+                .unwrap()
+                .into(),
+            event_type: "runtime_started".to_string(),
+            actor: "mandate-server".to_string(),
+            subject_id: "runtime".to_string(),
+            payload_hash: ZERO_HASH.to_string(),
+            metadata: serde_json::Map::new(),
+            policy_version: None,
+            policy_hash: None,
+            attestation_ref: None,
+            prev_event_hash: ZERO_HASH.to_string(),
+        };
+        let e1 = SignedAuditEvent::sign(e1_event, &audit_signer).unwrap();
+
+        let e2_event = AuditEvent {
+            version: 1,
+            seq: 2,
+            id: "evt-01HTAWX5K3R8YV9NQB7C6P2DGR".to_string(),
+            ts: chrono::DateTime::parse_from_rfc3339("2026-04-27T12:00:01Z")
+                .unwrap()
+                .into(),
+            event_type: "policy_decided".to_string(),
+            actor: "policy_engine".to_string(),
+            subject_id: "pr-test-001".to_string(),
+            payload_hash: "1111111111111111111111111111111111111111111111111111111111111111"
+                .to_string(),
+            metadata: serde_json::Map::new(),
+            policy_version: Some(1),
+            policy_hash: Some(
+                "2222222222222222222222222222222222222222222222222222222222222222".to_string(),
+            ),
+            attestation_ref: None,
+            prev_event_hash: e1.event_hash.clone(),
+        };
+        let e2 = SignedAuditEvent::sign(e2_event, &audit_signer).unwrap();
+
+        let e3_event = AuditEvent {
+            version: 1,
+            seq: 3,
+            id: "evt-01HTAWX5K3R8YV9NQB7C6P2DGS".to_string(),
+            ts: chrono::DateTime::parse_from_rfc3339("2026-04-27T12:00:02Z")
+                .unwrap()
+                .into(),
+            event_type: "policy_decided".to_string(),
+            actor: "policy_engine".to_string(),
+            subject_id: "pr-test-002".to_string(),
+            payload_hash: "3333333333333333333333333333333333333333333333333333333333333333"
+                .to_string(),
+            metadata: serde_json::Map::new(),
+            policy_version: Some(1),
+            policy_hash: Some(
+                "2222222222222222222222222222222222222222222222222222222222222222".to_string(),
+            ),
+            attestation_ref: None,
+            prev_event_hash: e2.event_hash.clone(),
+        };
+        let e3 = SignedAuditEvent::sign(e3_event, &audit_signer).unwrap();
+
+        let unsigned = UnsignedReceipt {
+            agent_id: "research-agent-01".to_string(),
+            decision: Decision::Allow,
+            deny_code: None,
+            request_hash: "1111111111111111111111111111111111111111111111111111111111111111"
+                .to_string(),
+            policy_hash: "2222222222222222222222222222222222222222222222222222222222222222"
+                .to_string(),
+            policy_version: Some(1),
+            audit_event_id: e2.event.id.clone(),
+            execution_ref: None,
+            issued_at: chrono::DateTime::parse_from_rfc3339("2026-04-27T12:00:01.500Z")
+                .unwrap()
+                .into(),
+            expires_at: None,
+        };
+        let receipt = unsigned.sign(&receipt_signer).unwrap();
+        let exported_at: DateTime<Utc> =
+            chrono::DateTime::parse_from_rfc3339("2026-04-28T08:00:00Z")
+                .unwrap()
+                .into();
+        let bundle = build(
+            receipt,
+            vec![e1, e2, e3],
+            receipt_signer.verifying_key_hex(),
+            audit_signer.verifying_key_hex(),
+            exported_at,
+        )
+        .unwrap();
+        (bundle, receipt_signer, audit_signer)
+    }
+
+    #[test]
+    fn happy_path_round_trip_verifies() {
+        let (bundle, _, _) = fixture();
+        let summary = verify(&bundle).expect("bundle must verify");
+        assert!(summary.receipt_signature_ok);
+        assert!(summary.audit_event_signature_ok);
+        assert!(summary.audit_chain_ok);
+        assert!(summary.receipt_audit_link_ok);
+        assert_eq!(summary.audit_chain_length, 3);
+        assert_eq!(summary.decision, Decision::Allow);
+    }
+
+    #[test]
+    fn bundle_canonical_export_is_deterministic() {
+        // Two identical inputs must produce byte-identical JSON. We use the
+        // standard serde_json::to_vec because the bundle's serde derives
+        // serialise fields in a fixed declaration order.
+        let (bundle, _, _) = fixture();
+        let a = serde_json::to_vec(&bundle).unwrap();
+        let b = serde_json::to_vec(&bundle).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn verify_fails_when_request_hash_mutated() {
+        // Mutating any signature-covered field on the receipt invalidates
+        // the receipt signature. This pins the security claim: a tampered
+        // request_hash cannot pass verification even if the signature bytes
+        // are kept intact.
+        let (mut bundle, _, _) = fixture();
+        bundle.receipt.request_hash =
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string();
+        // Note: we deliberately do NOT touch the summary here; the receipt-
+        // signature check fails before the summary mismatch check would run.
+        let err = verify(&bundle).expect_err("must reject mutated request_hash");
+        assert!(matches!(err, BundleError::ReceiptSignatureInvalid));
+    }
+
+    #[test]
+    fn verify_fails_when_policy_hash_mutated() {
+        let (mut bundle, _, _) = fixture();
+        bundle.receipt.policy_hash =
+            "cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe".to_string();
+        let err = verify(&bundle).expect_err("must reject mutated policy_hash");
+        assert!(matches!(err, BundleError::ReceiptSignatureInvalid));
+    }
+
+    #[test]
+    fn verify_fails_when_receipt_signature_bytes_mutated() {
+        let (mut bundle, _, _) = fixture();
+        // Flip one nibble in the signature — must invalidate it without
+        // changing any field the signature covers.
+        let sig = &mut bundle.receipt.signature.signature_hex;
+        let last = sig.pop().unwrap();
+        sig.push(if last == '0' { '1' } else { '0' });
+        let err = verify(&bundle).expect_err("must reject mutated signature");
+        assert!(matches!(err, BundleError::ReceiptSignatureInvalid));
+    }
+
+    #[test]
+    fn verify_fails_when_audit_event_hash_mutated() {
+        // The standalone audit_event must match the chain member of the
+        // same id. Mutating the standalone event's hash makes the standalone
+        // and the chain disagree — caught by the AuditEventHashMismatch
+        // check before chain verification would even matter.
+        let (mut bundle, _, _) = fixture();
+        bundle.audit_event.event_hash =
+            "0000000000000000000000000000000000000000000000000000000000000001".to_string();
+        let err = verify(&bundle).expect_err("must reject mutated audit_event hash");
+        // Standalone audit_event signature is computed over the *event*, not
+        // event_hash; flipping event_hash alone passes signature verify but
+        // breaks the standalone vs chain equality check.
+        assert!(matches!(err, BundleError::AuditEventHashMismatch));
+    }
+
+    #[test]
+    fn verify_fails_when_audit_chain_linkage_broken() {
+        let (mut bundle, _, _) = fixture();
+        // Flip prev_event_hash on seq=3 — verify_chain detects PrevHashMismatch.
+        bundle.audit_chain_segment[2].event.prev_event_hash =
+            "0000000000000000000000000000000000000000000000000000000000000001".to_string();
+        let err = verify(&bundle).expect_err("must reject broken chain linkage");
+        assert!(matches!(err, BundleError::Chain(_)));
+    }
+
+    #[test]
+    fn verify_fails_when_audit_event_not_in_chain() {
+        let (mut bundle, _, _) = fixture();
+        // Drop the receipt's referenced event from the chain segment.
+        bundle.audit_chain_segment.retain(|e| e.event.seq != 2);
+        // Patch summary's chain endpoints to keep the summary self-consistent
+        // so we exercise the audit-link check, not the summary check.
+        bundle.summary.audit_chain_root = bundle.audit_chain_segment[0].event_hash.clone();
+        bundle.summary.audit_chain_latest = bundle
+            .audit_chain_segment
+            .last()
+            .unwrap()
+            .event_hash
+            .clone();
+        let err = verify(&bundle).expect_err("must reject missing audit_event");
+        // The chain segment now skips seq=2, so prev_event_hash on the
+        // remaining seq=3 no longer matches its predecessor — chain verify
+        // catches that first. (If the receipt's audit_event_id had pointed
+        // outside any plausible chain, the AuditEventNotInChain branch
+        // would fire instead. This test pins the realistic path.)
+        assert!(matches!(err, BundleError::Chain(_)));
+    }
+
+    #[test]
+    fn verify_fails_when_summary_lies_about_decision() {
+        // Independent property: the summary cannot disagree with the body.
+        let (mut bundle, _, _) = fixture();
+        bundle.summary.decision = Decision::Deny;
+        let err = verify(&bundle).expect_err("must reject summary that lies");
+        assert!(matches!(err, BundleError::SummaryMismatch("decision")));
+    }
+
+    #[test]
+    fn verify_fails_when_wrong_pubkey_supplied() {
+        // If the caller swaps the verification key (e.g. pretends a
+        // different signer issued the receipt), receipt verification fails.
+        let (mut bundle, _, _) = fixture();
+        let other = DevSigner::from_seed("attacker", [99u8; 32]);
+        bundle.verification_keys.receipt_signer_pubkey_hex = other.verifying_key_hex();
+        let err = verify(&bundle).expect_err("must reject wrong receipt pubkey");
+        assert!(matches!(err, BundleError::ReceiptSignatureInvalid));
+    }
+}

--- a/crates/mandate-core/src/lib.rs
+++ b/crates/mandate-core/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod aprp;
 pub mod audit;
+pub mod audit_bundle;
 pub mod decision_token;
 pub mod error;
 pub mod hashing;

--- a/docs/cli/audit-bundle.md
+++ b/docs/cli/audit-bundle.md
@@ -1,0 +1,72 @@
+# `mandate audit export` / `verify-bundle`
+
+> *Mandate does not just decide. It leaves behind verifiable proof.*
+
+A Mandate decision already produces three signed artefacts: the **policy receipt** (returned in the `POST /v1/payment-requests` response), the **audit event** (appended to the hash-chained log), and the **chain linkage** between successive events. The bundle commands package those artefacts into a single self-contained JSON file that anyone can re-verify offline.
+
+## Export
+
+```bash
+mandate audit export \
+  --receipt   path/to/receipt.json \
+  --chain     path/to/chain.jsonl \
+  --receipt-pubkey <hex> \
+  --audit-pubkey   <hex> \
+  --out       path/to/bundle.json
+```
+
+- `--receipt` — the `receipt` field from a `POST /v1/payment-requests` response, saved as JSON.
+- `--chain` — the audit log as JSONL (one `SignedAuditEvent` per line). Must include the genesis event (seq=1) through the event referenced by `receipt.audit_event_id`, in seq order.
+- `--receipt-pubkey` / `--audit-pubkey` — 32-byte Ed25519 public keys (hex). For the hackathon dev signers these are the deterministic seeds wired into `AppState::new`; production deployments substitute via `AppState::with_signers(...)`.
+- `--out` — output file. If omitted, the bundle is written to stdout (good for piping into `jq`).
+
+## Verify
+
+```bash
+mandate audit verify-bundle --path path/to/bundle.json
+```
+
+Re-derives every claim in the bundle:
+1. Verifies the receipt signature under the recorded receipt-signer public key.
+2. Verifies the standalone audit event signature.
+3. Re-runs `verify_chain` over `audit_chain_segment` (recomputes every `event_hash`, walks `prev_event_hash`, re-verifies every signature).
+4. Confirms `receipt.audit_event_id` matches the standalone event and is present in the chain.
+5. Re-derives the bundle's `summary` block and compares it field-by-field to the body, so a tampered summary cannot misrepresent what the receipt or chain actually says.
+
+Exit codes:
+- `0` — bundle verified.
+- `1` — verification failed (signature, chain linkage, or summary mismatch). A short diagnostic is printed to stderr.
+- `2` — I/O or JSON-parse error.
+
+## Bundle shape
+
+```json
+{
+  "bundle_type": "mandate.audit_bundle.v1",
+  "version": 1,
+  "exported_at": "2026-04-28T...Z",
+  "receipt":            { /* PolicyReceipt with embedded Ed25519 signature */ },
+  "audit_event":        { /* SignedAuditEvent referenced by receipt.audit_event_id */ },
+  "audit_chain_segment":[ /* SignedAuditEvent[] from genesis through audit_event */ ],
+  "verification_keys":  { "receipt_signer_pubkey_hex": "...", "audit_signer_pubkey_hex": "..." },
+  "summary":            { /* decision, deny_code, request_hash, policy_hash, audit_event_id, audit_event_hash, chain root + latest */ }
+}
+```
+
+## What the bundle does and does not prove
+
+**Proves**, given that you trust the two recorded public keys:
+- the receipt's `request_hash`, `policy_hash`, `decision`, `deny_code` and `audit_event_id` were signed by the receipt-signer key (any tampering breaks the signature);
+- the standalone audit event was signed by the audit-signer key, has a matching `event_hash`, and sits at a specific position in the audit chain;
+- every event in the chain segment links cleanly to its predecessor and was signed by the same audit-signer key.
+
+**Does not prove** (out of scope for the v1 bundle):
+- *who* the recorded public keys belong to — that is an identity question handled separately by the ENS adapter (`mandate-identity`);
+- the absence of audit events past `audit_chain_segment.last()` — exporting a partial chain is fine for "this decision happened", but completeness proofs need a Merkle commitment that we have not built yet;
+- agent reasoning before the request reached Mandate — APRP is a wire-level contract, not a behavioural one.
+
+## Limitations
+
+- The chain segment must be the full prefix from genesis. Pruned / Merkle-proof variants are tracked separately.
+- The bundle does not include the original APRP payload — it includes the canonical `request_hash` only, which is enough to *re-verify* a request the verifier already has but not enough to *reconstruct* the request from the bundle alone. (Future revision: optional embedded APRP.)
+- No revocation / expiry semantics on the bundle itself; if you need expiring proofs, set `PolicyReceipt.expires_at` upstream.


### PR DESCRIPTION
## Summary

Adds `mandate audit export` and `mandate audit verify-bundle` CLI subcommands plus a small `audit_bundle` core module. Together they package a signed `PolicyReceipt`, the standalone `SignedAuditEvent` it references, and the audit chain segment up to that event into a single JSON file that anyone can re-verify offline. Strengthens the product claim: **Mandate does not just decide. It leaves behind verifiable proof.**

## Files changed (7)

| File | Change |
|---|---|
| `crates/mandate-core/src/audit_bundle.rs` (new) | `AuditBundle` data type, `build()` constructor, `verify()` with format-confusion guard + signature/chain verification, `BundleError` taxonomy. **13 unit tests** (10 round-trip / tampering + 3 version/bundle_type gate after Codex P2). |
| `crates/mandate-core/src/lib.rs` | `pub mod audit_bundle;` |
| `crates/mandate-cli/src/main.rs` | New `Audit` subcommand with `Export { --receipt --chain --receipt-pubkey --audit-pubkey [--out] }` and `VerifyBundle { --path }`. Reads receipt JSON + audit chain JSONL, calls `audit_bundle::build`/`verify`, exits 0/1/2. |
| `crates/mandate-cli/Cargo.toml` | `chrono` regular dep (used by export's `exported_at`); `tempfile` dev-dep for the integration test. |
| `crates/mandate-cli/tests/audit_bundle.rs` (new) | **3 integration tests** invoking the real `mandate` binary via `env!("CARGO_BIN_EXE_mandate")` — happy path + tampered-signature rejection + broken-chain-linkage rejection. |
| `docs/cli/audit-bundle.md` (new) | User-facing reference: command shape, bundle structure, what the bundle does and does not prove, current limitations. |
| `Cargo.lock` | Regenerated. |

## Security rationale

- **Format-confusion guard (after Codex P2 — `d4a8bc8`).** `verify()` starts with a step 0 that asserts both `bundle.bundle_type == BundleType::AuditBundleV1` and `bundle.version == 1` (`SUPPORTED_BUNDLE_VERSION`). Both checks run before any signature/chain check, so a malicious bundle claiming `version: 2` (or any other value) cannot reach the v1 verification path even if every signature inside still happens to round-trip. The `bundle_type` `matches!` is also defence-in-depth against future enum additions and against callers who construct an `AuditBundle` programmatically (bypassing serde).
- **Receipt signature covers the security-critical claims** (`request_hash`, `policy_hash`, `decision`, `deny_code`, `audit_event_id`) via canonical-body signing — so the existing `PolicyReceipt::verify()` is enough to detect tampering with any of those fields without needing extra checks in the bundle.
- **Audit chain integrity** is delegated to the existing `verify_chain(events, true, Some(pubkey))` — recomputes every `event_hash`, walks `prev_event_hash`, re-verifies every signature.
- **Receipt → audit linkage** is checked twice: by id (`receipt.audit_event_id == audit_event.event.id`) and by byte equality (`chain_member == audit_event`). Standalone signature verification doesn't catch a swapped-out `event_hash` because the audit signature covers the event body, not the hash — so we explicitly assert standalone-vs-chain equality.
- **Summary cannot lie**: `verify()` re-derives the summary block from the body and compares field-by-field. A tampered summary that contradicts the (signed) receipt is rejected.
- **Fail-fast**: a single `Result` return so a tampered bundle cannot pick which checks the verifier sees pass.

## Tests run (local, on the latest commit `d4a8bc8`)

- [x] `cargo fmt --check` — ✅
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — ✅ (no warnings)
- [x] `cargo test --workspace --all-targets` — ✅ **112 / 112 pass** (was 96 baseline; **+16 new tests** added by this PR — see breakdown below)
- [x] `python3 scripts/validate_schemas.py` — ✅
- [x] `python3 scripts/validate_openapi.py` — ✅
- [x] `bash demo-scripts/run-openagents-final.sh` — ✅ all 11 steps green incl. tamper detection

### Test breakdown (16 new tests)

**`mandate-core::audit_bundle::tests` — 13 unit tests:**
- `happy_path_round_trip_verifies` — valid bundle verifies; chain length, decision, all four `*_ok` flags asserted
- `bundle_canonical_export_is_deterministic` — two exports of identical input → byte-identical JSON
- `verify_fails_when_request_hash_mutated` — `BundleError::ReceiptSignatureInvalid`
- `verify_fails_when_policy_hash_mutated` — `BundleError::ReceiptSignatureInvalid`
- `verify_fails_when_receipt_signature_bytes_mutated` — `BundleError::ReceiptSignatureInvalid`
- `verify_fails_when_audit_event_hash_mutated` — `BundleError::AuditEventHashMismatch`
- `verify_fails_when_audit_chain_linkage_broken` — `BundleError::Chain(_)` (PrevHashMismatch)
- `verify_fails_when_audit_event_not_in_chain` — `BundleError::Chain(_)` (chain segment skips the receipt's referenced event)
- `verify_fails_when_summary_lies_about_decision` — `BundleError::SummaryMismatch("decision")`
- `verify_fails_when_wrong_pubkey_supplied` — `BundleError::ReceiptSignatureInvalid`
- *(Codex P2 follow-up)* `verify_fails_when_version_field_is_not_one` — mutates `bundle.version = 2`, asserts `BundleError::UnsupportedVersion(2)`; re-runs verify on a fresh v1 bundle to pin "valid v1 bundle still verifies"
- *(Codex P2 follow-up)* `verify_fails_when_version_is_unsupported_via_json_round_trip` — same property exercised through serde end-to-end (serialise → patch JSON `version: 2` → deserialise → reject)
- *(Codex P2 follow-up)* `unknown_bundle_type_string_is_rejected_by_serde_at_parse_time` — pins serde's parse-time defence on `bundle_type`; documents why the in-`verify()` `matches!` is unreachable today but kept as belt-and-braces

**`mandate-cli/tests/audit_bundle.rs` — 3 integration tests** (invoke the real `mandate` binary via `env!("CARGO_BIN_EXE_mandate")`):
- `export_then_verify_bundle_succeeds` — happy path: export writes a bundle file, verify-bundle exits 0 with a summary that names the audit_event_id
- `verify_bundle_rejects_tampered_receipt_signature` — flip the receipt signature in the exported JSON, verify-bundle must exit non-zero with "bundle invalid" on stderr
- `verify_bundle_rejects_broken_chain_linkage` — mutate `prev_event_hash` mid-chain, verify-bundle must reject

## Acceptance-criteria coverage

- ✅ Export produces deterministic, machine-readable output (`bundle_canonical_export_is_deterministic`)
- ✅ Verification succeeds for a valid bundle (`happy_path_round_trip_verifies`, `export_then_verify_bundle_succeeds`)
- ✅ Verification fails on `request_hash` mutation, `policy_hash` mutation, receipt-signature mutation, audit-event-hash mutation, audit-chain-linkage break, audit-event-not-in-chain, summary lying, wrong pubkey, **unsupported version**, **unknown bundle_type**
- ✅ Existing tests unchanged + still pass
- ✅ No security invariant weakened (only adds verification surface)
- ✅ Format-confusion guard added after Codex P2 — `verify()` rejects non-v1 versions and any non-`AuditBundleV1` bundle_type before any cryptographic check runs

## Schemas / OpenAPI changed?

**No.** The bundle is a CLI artefact, not on the wire. APRP, policy receipt, decision token, audit event JSON Schemas are all untouched. OpenAPI is untouched.

## Demo affected?

**No.** New CLI commands are additive; the 11-step `run-openagents-final.sh` is unaffected.

## Example bundle shape

```json
{
  "bundle_type": "mandate.audit_bundle.v1",
  "version": 1,
  "exported_at": "2026-04-28T...Z",
  "receipt": {
    "receipt_type": "mandate.policy_receipt.v1",
    "version": 1,
    "agent_id": "research-agent-01",
    "decision": "allow",
    "request_hash": "1111...",
    "policy_hash":  "2222...",
    "policy_version": 1,
    "audit_event_id": "evt-01HTAWX5K3R8YV9NQB7C6P2DGR",
    "issued_at": "2026-04-27T12:00:01.500Z",
    "signature": { "algorithm": "ed25519", "key_id": "decision-signer-v1", "signature_hex": "..." }
  },
  "audit_event": {
    "event": { "version": 1, "seq": 2, "id": "evt-01HTAWX5K3R8YV9NQB7C6P2DGR", "ts": "...", "type": "policy_decided", "actor": "policy_engine", "subject_id": "pr-test-002", "payload_hash": "...", "metadata": {}, "policy_version": 1, "prev_event_hash": "..." },
    "event_hash": "...",
    "signature": { "algorithm": "ed25519", "key_id": "audit-signer-v1", "signature_hex": "..." }
  },
  "audit_chain_segment": [ /* SignedAuditEvent for seq=1 */, /* seq=2 (== audit_event above) */, /* seq=3 */ ],
  "verification_keys": {
    "receipt_signer_pubkey_hex": "<32-byte hex>",
    "audit_signer_pubkey_hex":   "<32-byte hex>"
  },
  "summary": {
    "decision": "allow",
    "request_hash": "1111...",
    "policy_hash":  "2222...",
    "audit_event_id":   "evt-01HTAWX5K3R8YV9NQB7C6P2DGR",
    "audit_event_hash": "...",
    "audit_chain_root":   "<event_hash of seq=1>",
    "audit_chain_latest": "<event_hash of seq=3>"
  }
}
```

Verify with:
```bash
mandate audit verify-bundle --path bundle.json
# ok: bundle verified (decision=Allow, deny_code=None, chain_length=3, audit_event_id=evt-01HTAWX5K3R8YV9NQB7C6P2DGR)
```

## Known limitations

- **Chain segment must be the full prefix from genesis.** Pruned/Merkle-proof variants are not yet supported. For demo/hackathon-scale chains (3 events) this is fine.
- **No embedded APRP.** The bundle includes the canonical `request_hash` — enough to *re-verify* a request the verifier already has, not enough to *reconstruct* it from the bundle alone. Optional embedded APRP is a future revision.
- **No bundle-level expiry/revocation.** If you need expiring proofs, set `PolicyReceipt.expires_at` upstream.
- **No automatic chain-source resolver in the CLI.** The current `mandate audit export` reads chain JSONL from a file path. A future `--db` flag could pull directly from the SQLite audit log; not implemented here to keep this PR focused.
- **The bundle does not say who the recorded public keys belong to.** That is an identity question handled separately by the ENS adapter (`mandate-identity`). The bundle says "given that you trust these two pubkeys, every claim verifies."

## Commits

- `0670bbe` `feat: add verifiable audit export bundle`
- `d4a8bc8` `feat: gate audit-bundle verify on supported version + bundle_type` (Codex P2 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)