### PR TITLE
feat: export audit bundle from sqlite storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,7 @@ dependencies = [
  "mandate-core",
  "mandate-policy",
  "mandate-storage",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/mandate-cli/Cargo.toml
+++ b/crates/mandate-cli/Cargo.toml
@@ -25,3 +25,4 @@ tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+rusqlite = { workspace = true }

--- a/crates/mandate-cli/src/main.rs
+++ b/crates/mandate-cli/src/main.rs
@@ -60,18 +60,34 @@ enum Command {
 
 #[derive(Subcommand, Debug)]
 enum AuditCmd {
-    /// Build a verifiable bundle from a signed receipt + audit chain JSONL.
+    /// Build a verifiable bundle from a signed receipt + audit chain.
     ///
-    /// The chain JSONL must include the genesis event (seq=1) through the
-    /// event referenced by the receipt's `audit_event_id`, in seq order.
+    /// Exactly one chain source must be supplied:
+    ///   --chain <jsonl-path>  reads SignedAuditEvent[] from a JSONL file
+    ///                         (one event per line, genesis through the
+    ///                         receipt's `audit_event_id`, in seq order).
+    ///   --db    <sqlite-path> reads the chain directly from a Mandate
+    ///                         daemon's SQLite storage (`mandate-storage`),
+    ///                         slicing the prefix through the receipt's
+    ///                         `audit_event_id`. Performs a pre-flight
+    ///                         `verify_chain` and a receipt-signature
+    ///                         check before writing the bundle.
     Export {
         /// Path to the signed PolicyReceipt JSON (the body returned by
         /// `POST /v1/payment-requests`, field `receipt`).
         #[arg(long)]
         receipt: PathBuf,
         /// Path to a JSONL audit chain (one SignedAuditEvent per line).
-        #[arg(long)]
-        chain: PathBuf,
+        /// Mutually exclusive with `--db`; exactly one must be supplied.
+        #[arg(long, conflicts_with = "db", required_unless_present = "db")]
+        chain: Option<PathBuf>,
+        /// Path to a Mandate SQLite storage file (the `MANDATE_DB` the
+        /// daemon writes to). Mutually exclusive with `--chain`; exactly
+        /// one must be supplied. Reads the audit chain prefix through
+        /// the receipt's `audit_event_id` directly from the daemon's
+        /// persisted log — no out-of-band JSONL export required.
+        #[arg(long, conflicts_with = "chain", required_unless_present = "chain")]
+        db: Option<PathBuf>,
         /// Public verification key (hex) for the receipt signer (32 bytes).
         #[arg(long)]
         receipt_pubkey: String,
@@ -151,13 +167,15 @@ fn main() -> ExitCode {
                 AuditCmd::Export {
                     receipt,
                     chain,
+                    db,
                     receipt_pubkey,
                     audit_pubkey,
                     out,
                 },
         } => cmd_audit_export(
             &receipt,
-            &chain,
+            chain.as_deref(),
+            db.as_deref(),
             &receipt_pubkey,
             &audit_pubkey,
             out.as_deref(),
@@ -357,9 +375,42 @@ fn read_audit_chain_jsonl(path: &Path) -> anyhow::Result<Vec<SignedAuditEvent>> 
     Ok(events)
 }
 
+/// Open a Mandate SQLite store and slice the audit chain prefix through
+/// the receipt's `audit_event_id`. Pre-flights the chain segment with
+/// `verify_chain` against the supplied audit pubkey AND verifies the
+/// receipt signature against the supplied receipt pubkey, so a DB-backed
+/// export with mismatched keys or a corrupt chain fails immediately
+/// with a clear message instead of producing an unverifiable bundle.
+fn read_audit_chain_from_db(
+    db_path: &Path,
+    receipt: &PolicyReceipt,
+    receipt_pubkey_hex: &str,
+    audit_pubkey_hex: &str,
+) -> anyhow::Result<Vec<SignedAuditEvent>> {
+    if !db_path.exists() {
+        anyhow::bail!("db path does not exist: {}", db_path.display());
+    }
+    let storage = mandate_storage::Storage::open(db_path)
+        .map_err(|e| anyhow::anyhow!("opening db {}: {e}", db_path.display()))?;
+    let chain = storage
+        .audit_chain_prefix_through(&receipt.audit_event_id)
+        .map_err(|e| anyhow::anyhow!("reading chain prefix from db: {e}"))?;
+    // Pre-flight: chain integrity under the supplied audit pubkey. Catches
+    // (a) a tampered DB, (b) a wrong --audit-pubkey, (c) a malformed pubkey
+    // hex string — all surface here, not later in verify-bundle.
+    verify_chain(&chain, true, Some(audit_pubkey_hex))
+        .map_err(|e| anyhow::anyhow!("audit chain pre-flight failed: {e}"))?;
+    // Pre-flight: receipt signature under the supplied receipt pubkey.
+    receipt
+        .verify(receipt_pubkey_hex)
+        .map_err(|e| anyhow::anyhow!("receipt signature pre-flight failed: {e:?}"))?;
+    Ok(chain)
+}
+
 fn cmd_audit_export(
     receipt_path: &Path,
-    chain_path: &Path,
+    chain_path: Option<&Path>,
+    db_path: Option<&Path>,
     receipt_pubkey_hex: &str,
     audit_pubkey_hex: &str,
     out: Option<&Path>,
@@ -374,10 +425,27 @@ fn cmd_audit_export(
             return ExitCode::from(2);
         }
     };
-    let chain = match read_audit_chain_jsonl(chain_path) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("error reading chain {}: {e}", chain_path.display());
+    // Clap enforces "exactly one of --chain / --db"; this match is a guard
+    // against future flag rearrangements that would break that invariant.
+    let chain = match (chain_path, db_path) {
+        (Some(p), None) => match read_audit_chain_jsonl(p) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("error reading chain {}: {e}", p.display());
+                return ExitCode::from(2);
+            }
+        },
+        (None, Some(p)) => {
+            match read_audit_chain_from_db(p, &receipt, receipt_pubkey_hex, audit_pubkey_hex) {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("error reading chain from db {}: {e}", p.display());
+                    return ExitCode::from(1);
+                }
+            }
+        }
+        _ => {
+            eprintln!("internal error: exactly one of --chain or --db must be supplied");
             return ExitCode::from(2);
         }
     };

--- a/crates/mandate-cli/tests/audit_bundle.rs
+++ b/crates/mandate-cli/tests/audit_bundle.rs
@@ -277,3 +277,297 @@ fn verify_bundle_rejects_broken_chain_linkage() {
         "verify-bundle must reject broken linkage"
     );
 }
+
+// ----- DB-backed export ---------------------------------------------------
+//
+// The DB-backed export reads the audit chain directly from a Mandate
+// daemon's SQLite store via `mandate_storage::Storage`. The fixture below
+// builds a real on-disk DB by appending three events with the same
+// deterministic dev signers used by `build_fixture_files`, then writes a
+// signed receipt that points at the middle event. This is the realistic
+// shape: a long-running daemon's storage + a receipt the agent kept.
+
+use mandate_storage::audit_store::NewAuditEvent;
+use mandate_storage::Storage;
+
+fn build_db_fixture() -> (
+    tempfile::TempDir,
+    PathBuf, // db path
+    PathBuf, // receipt path
+    String,  // receipt pubkey hex
+    String,  // audit pubkey hex
+    String,  // audit_event_id the receipt references
+) {
+    let tmp = tempfile::tempdir().unwrap();
+    let db_path = tmp.path().join("mandate.sqlite");
+    let audit_signer = DevSigner::from_seed("audit-signer-v1", [11u8; 32]);
+    let receipt_signer = DevSigner::from_seed("decision-signer-v1", [7u8; 32]);
+
+    let middle_event_id;
+    {
+        let mut storage = Storage::open(&db_path).unwrap();
+        storage
+            .audit_append(
+                NewAuditEvent::now("runtime_started", "mandate-server", "runtime"),
+                &audit_signer,
+            )
+            .unwrap();
+        let middle = storage
+            .audit_append(
+                NewAuditEvent::now("policy_decided", "policy_engine", "pr-test-001"),
+                &audit_signer,
+            )
+            .unwrap();
+        storage
+            .audit_append(
+                NewAuditEvent::now("policy_decided", "policy_engine", "pr-test-002"),
+                &audit_signer,
+            )
+            .unwrap();
+        middle_event_id = middle.event.id.clone();
+    } // Drop the Storage handle so the CLI can open its own connection.
+
+    let unsigned = UnsignedReceipt {
+        agent_id: "research-agent-01".to_string(),
+        decision: Decision::Allow,
+        deny_code: None,
+        request_hash: "1111111111111111111111111111111111111111111111111111111111111111"
+            .to_string(),
+        policy_hash: "2222222222222222222222222222222222222222222222222222222222222222".to_string(),
+        policy_version: Some(1),
+        audit_event_id: middle_event_id.clone(),
+        execution_ref: None,
+        issued_at: chrono::DateTime::parse_from_rfc3339("2026-04-27T12:00:01.500Z")
+            .unwrap()
+            .into(),
+        expires_at: None,
+    };
+    let receipt = unsigned.sign(&receipt_signer).unwrap();
+    let receipt_path = tmp.path().join("receipt.json");
+    std::fs::write(&receipt_path, serde_json::to_vec_pretty(&receipt).unwrap()).unwrap();
+
+    (
+        tmp,
+        db_path,
+        receipt_path,
+        receipt_signer.verifying_key_hex(),
+        audit_signer.verifying_key_hex(),
+        middle_event_id,
+    )
+}
+
+#[test]
+fn db_backed_export_then_verify_bundle_succeeds() {
+    // Happy path: a real on-disk daemon DB + a signed receipt → export
+    // assembles a bundle without ever touching a JSONL file → verify
+    // round-trips clean. This is the "Mandate leaves behind verifiable
+    // proof directly from its daemon storage" claim end-to-end.
+    let (tmp, db, receipt, rpk, apk, target_id) = build_db_fixture();
+    let bundle_path = tmp.path().join("bundle.json");
+
+    let out = Command::new(cli_bin())
+        .args([
+            "audit",
+            "export",
+            "--receipt",
+            receipt.to_str().unwrap(),
+            "--db",
+            db.to_str().unwrap(),
+            "--receipt-pubkey",
+            &rpk,
+            "--audit-pubkey",
+            &apk,
+            "--out",
+            bundle_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "db-backed export must succeed; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(bundle_path.exists());
+
+    let out = Command::new(cli_bin())
+        .args([
+            "audit",
+            "verify-bundle",
+            "--path",
+            bundle_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "verify-bundle must succeed; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("ok: bundle verified"),
+        "unexpected stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains(&target_id),
+        "verify summary must name the audit_event_id; stdout={stdout}"
+    );
+
+    // Bundle's chain segment must be exactly genesis through the receipt's
+    // referenced event (length 2), not the entire DB chain (length 3).
+    let bundle: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&bundle_path).unwrap()).unwrap();
+    let segment = bundle["audit_chain_segment"].as_array().unwrap();
+    assert_eq!(segment.len(), 2, "DB-backed export must slice prefix");
+}
+
+#[test]
+fn db_backed_export_fails_when_db_path_missing() {
+    let (tmp, _db, receipt, rpk, apk, _) = build_db_fixture();
+    let bundle_path = tmp.path().join("bundle.json");
+    let nonexistent = tmp.path().join("does-not-exist.sqlite");
+
+    let out = Command::new(cli_bin())
+        .args([
+            "audit",
+            "export",
+            "--receipt",
+            receipt.to_str().unwrap(),
+            "--db",
+            nonexistent.to_str().unwrap(),
+            "--receipt-pubkey",
+            &rpk,
+            "--audit-pubkey",
+            &apk,
+            "--out",
+            bundle_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "must reject missing db path; stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("does not exist"),
+        "expected diagnostic naming the missing db; got {stderr}"
+    );
+    assert!(
+        !bundle_path.exists(),
+        "no bundle file should be written when export fails"
+    );
+}
+
+#[test]
+fn db_backed_export_fails_when_audit_event_id_not_in_db() {
+    // Receipt points at an audit_event_id the DB never wrote (typical
+    // cause: receipt and DB belong to different daemons). The error
+    // message must echo the missing id verbatim so the operator can
+    // diagnose it without re-reading the receipt.
+    let (tmp, db, _good_receipt, rpk, apk, _) = build_db_fixture();
+    let bundle_path = tmp.path().join("bundle.json");
+
+    // Build a fresh receipt that points at a bogus audit_event_id.
+    let receipt_signer = DevSigner::from_seed("decision-signer-v1", [7u8; 32]);
+    let bogus_id = "evt-DOES-NOT-EXIST-IN-DB-XX".to_string();
+    let unsigned = UnsignedReceipt {
+        agent_id: "research-agent-01".to_string(),
+        decision: Decision::Allow,
+        deny_code: None,
+        request_hash: "1111111111111111111111111111111111111111111111111111111111111111"
+            .to_string(),
+        policy_hash: "2222222222222222222222222222222222222222222222222222222222222222".to_string(),
+        policy_version: Some(1),
+        audit_event_id: bogus_id.clone(),
+        execution_ref: None,
+        issued_at: chrono::DateTime::parse_from_rfc3339("2026-04-27T12:00:01.500Z")
+            .unwrap()
+            .into(),
+        expires_at: None,
+    };
+    let receipt = unsigned.sign(&receipt_signer).unwrap();
+    let receipt_path = tmp.path().join("bad-receipt.json");
+    std::fs::write(&receipt_path, serde_json::to_vec_pretty(&receipt).unwrap()).unwrap();
+
+    let out = Command::new(cli_bin())
+        .args([
+            "audit",
+            "export",
+            "--receipt",
+            receipt_path.to_str().unwrap(),
+            "--db",
+            db.to_str().unwrap(),
+            "--receipt-pubkey",
+            &rpk,
+            "--audit-pubkey",
+            &apk,
+            "--out",
+            bundle_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "must reject receipt pointing at unknown audit_event_id"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains(&bogus_id),
+        "diagnostic must echo the missing id; got {stderr}"
+    );
+    assert!(!bundle_path.exists(), "no bundle on failure");
+}
+
+#[test]
+fn db_backed_export_fails_when_db_chain_is_tampered() {
+    // Manually rewrite a row in the SQLite audit_events table to break
+    // the hash chain. The export's pre-flight `verify_chain` must catch
+    // this BEFORE writing any bundle, so a downstream consumer never
+    // sees an unverifiable bundle from a corrupted DB.
+    let (tmp, db, receipt, rpk, apk, _) = build_db_fixture();
+    let bundle_path = tmp.path().join("bundle.json");
+
+    // Mutate seq=2's actor — this changes its canonical hash, so the
+    // recorded event_hash and the chain's prev_event_hash linkage no
+    // longer match what `verify_chain` recomputes.
+    let conn = rusqlite::Connection::open(&db).unwrap();
+    conn.execute(
+        "UPDATE audit_events SET actor = 'tampered-actor' WHERE seq = 2",
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    let out = Command::new(cli_bin())
+        .args([
+            "audit",
+            "export",
+            "--receipt",
+            receipt.to_str().unwrap(),
+            "--db",
+            db.to_str().unwrap(),
+            "--receipt-pubkey",
+            &rpk,
+            "--audit-pubkey",
+            &apk,
+            "--out",
+            bundle_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "must reject tampered DB chain at export time"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("audit chain pre-flight failed"),
+        "expected pre-flight diagnostic; got {stderr}"
+    );
+    assert!(
+        !bundle_path.exists(),
+        "no bundle should be written when the DB chain doesn't verify"
+    );
+}

--- a/crates/mandate-storage/src/audit_store.rs
+++ b/crates/mandate-storage/src/audit_store.rs
@@ -137,6 +137,31 @@ impl Storage {
         Ok(rows)
     }
 
+    /// Fetch the chain prefix from genesis (seq=1) up to and including the
+    /// event with the given `event_id`, in seq order. Returns
+    /// `StorageError::AuditEventNotFound` if no such event exists in the log.
+    ///
+    /// The slice this returns is exactly what an `audit_bundle::AuditBundle`
+    /// needs as its `audit_chain_segment` for a receipt that points at
+    /// `event_id` — it includes every prev_event_hash predecessor needed for
+    /// chain verification, and stops at the receipt's referenced event so
+    /// the bundle is no larger than the proof requires.
+    pub fn audit_chain_prefix_through(
+        &self,
+        event_id: &str,
+    ) -> StorageResult<Vec<SignedAuditEvent>> {
+        let chain = self.audit_list()?;
+        let position = chain
+            .iter()
+            .position(|e| e.event.id == event_id)
+            .ok_or_else(|| StorageError::AuditEventNotFound {
+                id: event_id.to_string(),
+            })?;
+        let mut prefix = chain;
+        prefix.truncate(position + 1);
+        Ok(prefix)
+    }
+
     pub fn audit_append(
         &mut self,
         new_event: NewAuditEvent,
@@ -262,5 +287,63 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM schema_migrations", [], |r| r.get(0))
             .unwrap();
         assert!(n >= 1, "at least one migration applied");
+    }
+
+    #[test]
+    fn audit_chain_prefix_through_returns_correct_slice() {
+        // The audit-bundle DB-backed export needs everything from genesis
+        // through the receipt's referenced event — no more, no less. Pin
+        // the slice contents by id and length on a 3-event chain.
+        let mut s = Storage::open_in_memory().unwrap();
+        let signer = DevSigner::from_seed("audit-signer-v1", [11u8; 32]);
+        let e1 = s
+            .audit_append(
+                NewAuditEvent::now("runtime_started", "mandate-server", "runtime"),
+                &signer,
+            )
+            .unwrap();
+        let e2 = s
+            .audit_append(
+                NewAuditEvent::now("policy_decided", "policy_engine", "pr-001"),
+                &signer,
+            )
+            .unwrap();
+        let _e3 = s
+            .audit_append(
+                NewAuditEvent::now("policy_decided", "policy_engine", "pr-002"),
+                &signer,
+            )
+            .unwrap();
+
+        // Slice through the middle event must be exactly [genesis, middle].
+        let prefix = s.audit_chain_prefix_through(&e2.event.id).unwrap();
+        assert_eq!(prefix.len(), 2);
+        assert_eq!(prefix[0].event.id, e1.event.id);
+        assert_eq!(prefix[1].event.id, e2.event.id);
+
+        // Slicing through the last event returns the entire chain.
+        let full = s.audit_chain_prefix_through(&_e3.event.id).unwrap();
+        assert_eq!(full.len(), 3);
+    }
+
+    #[test]
+    fn audit_chain_prefix_through_returns_not_found_for_unknown_id() {
+        // The DB-backed export must fail clearly when a receipt points at
+        // an event id the daemon never wrote. Carries the bad id in the
+        // error so the CLI can echo it back to the user verbatim.
+        let mut s = Storage::open_in_memory().unwrap();
+        let signer = DevSigner::from_seed("audit-signer-v1", [11u8; 32]);
+        s.audit_append(
+            NewAuditEvent::now("runtime_started", "mandate-server", "runtime"),
+            &signer,
+        )
+        .unwrap();
+        let err = s
+            .audit_chain_prefix_through("evt-DOES-NOT-EXIST")
+            .expect_err("must fail when id is missing");
+        match err {
+            StorageError::AuditEventNotFound { id } => assert_eq!(id, "evt-DOES-NOT-EXIST"),
+            other => panic!("unexpected: {other:?}"),
+        }
     }
 }

--- a/crates/mandate-storage/src/audit_store.rs
+++ b/crates/mandate-storage/src/audit_store.rs
@@ -25,6 +25,13 @@ const SELECT_AUDIT_LAST: &str =
      policy_hash, attestation_ref, prev_event_hash, event_hash, signature_alg, \
      signature_key_id, signature_hex FROM audit_events ORDER BY seq DESC LIMIT 1";
 
+const SELECT_AUDIT_PREFIX_BY_SEQ: &str =
+    "SELECT seq, id, ts, type, actor, subject_id, payload_hash, metadata_json, policy_version, \
+     policy_hash, attestation_ref, prev_event_hash, event_hash, signature_alg, \
+     signature_key_id, signature_hex FROM audit_events WHERE seq <= ?1 ORDER BY seq ASC";
+
+const SELECT_AUDIT_SEQ_BY_ID: &str = "SELECT seq FROM audit_events WHERE id = ?1";
+
 fn row_to_signed_audit_event(r: &rusqlite::Row<'_>) -> rusqlite::Result<SignedAuditEvent> {
     let metadata_json: String = r.get(7)?;
     let metadata: serde_json::Map<String, serde_json::Value> = serde_json::from_str(&metadata_json)
@@ -146,20 +153,44 @@ impl Storage {
     /// `event_id` — it includes every prev_event_hash predecessor needed for
     /// chain verification, and stops at the receipt's referenced event so
     /// the bundle is no larger than the proof requires.
+    ///
+    /// This is implemented as two scoped SQL queries — first an `id → seq`
+    /// lookup (the audit_events.id UNIQUE index makes this O(log n)), then
+    /// a `WHERE seq <= ?1 ORDER BY seq ASC` over only the prefix rows.
+    /// Rows with `seq > target_seq` are never deserialised, so:
+    ///
+    ///   * the cost scales with the proof prefix size, not the total log
+    ///     size — exporting an old receipt's bundle does not pay for every
+    ///     event written since;
+    ///   * a malformed or tampered row past the target event cannot break
+    ///     a proof for an earlier event whose own prefix is intact.
+    ///
+    /// A malformed row *inside* the prefix still surfaces (either through
+    /// the row mapper or, downstream, via `verify_chain` on the returned
+    /// segment) — that is the correct outcome, since the proof depends on
+    /// every preceding event being well-formed.
     pub fn audit_chain_prefix_through(
         &self,
         event_id: &str,
     ) -> StorageResult<Vec<SignedAuditEvent>> {
-        let chain = self.audit_list()?;
-        let position = chain
-            .iter()
-            .position(|e| e.event.id == event_id)
-            .ok_or_else(|| StorageError::AuditEventNotFound {
-                id: event_id.to_string(),
-            })?;
-        let mut prefix = chain;
-        prefix.truncate(position + 1);
-        Ok(prefix)
+        let target_seq: i64 =
+            match self
+                .conn
+                .query_row(SELECT_AUDIT_SEQ_BY_ID, params![event_id], |r| r.get(0))
+            {
+                Ok(seq) => seq,
+                Err(rusqlite::Error::QueryReturnedNoRows) => {
+                    return Err(StorageError::AuditEventNotFound {
+                        id: event_id.to_string(),
+                    });
+                }
+                Err(e) => return Err(e.into()),
+            };
+        let mut stmt = self.conn.prepare(SELECT_AUDIT_PREFIX_BY_SEQ)?;
+        let rows = stmt
+            .query_map(params![target_seq], row_to_signed_audit_event)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(rows)
     }
 
     pub fn audit_append(
@@ -345,5 +376,111 @@ mod tests {
             StorageError::AuditEventNotFound { id } => assert_eq!(id, "evt-DOES-NOT-EXIST"),
             other => panic!("unexpected: {other:?}"),
         }
+    }
+
+    #[test]
+    fn audit_chain_prefix_through_does_not_read_rows_after_target_seq() {
+        // Codex P2: the prefix query MUST NOT pay for rows past the
+        // target event. We prove that by writing a well-formed prefix
+        // (seq=1 + seq=2) and then injecting a row at seq=3 whose
+        // `metadata_json` is not valid JSON. If the implementation read
+        // the whole table and truncated in memory, the row mapper would
+        // run on seq=3 and return an Err. Because we use `WHERE seq <=
+        // target_seq`, seq=3 is never even loaded — exporting through
+        // seq=2 succeeds.
+        let mut s = Storage::open_in_memory().unwrap();
+        let signer = DevSigner::from_seed("audit-signer-v1", [11u8; 32]);
+        let _e1 = s
+            .audit_append(
+                NewAuditEvent::now("runtime_started", "mandate-server", "runtime"),
+                &signer,
+            )
+            .unwrap();
+        let target = s
+            .audit_append(
+                NewAuditEvent::now("policy_decided", "policy_engine", "pr-test-001"),
+                &signer,
+            )
+            .unwrap();
+        // Inject a malformed seq=3 row directly. We don't go through
+        // `audit_append` because that would refuse to write malformed
+        // JSON; the test specifically simulates a corrupted future row.
+        s.conn
+            .execute(
+                "INSERT INTO audit_events
+                    (seq, id, ts, type, actor, subject_id, payload_hash, metadata_json,
+                     policy_version, policy_hash, attestation_ref, prev_event_hash,
+                     event_hash, signature_alg, signature_key_id, signature_hex)
+                 VALUES (3, 'evt-MALFORMED-FUTURE', '2026-04-27T12:00:02Z', 'policy_decided',
+                         'policy_engine', 'pr-test-002', '{}', 'NOT JSON',
+                         NULL, NULL, NULL,
+                         '0000000000000000000000000000000000000000000000000000000000000000',
+                         '0000000000000000000000000000000000000000000000000000000000000000',
+                         'ed25519', 'audit-signer-v1', 'aaaa')",
+                [],
+            )
+            .unwrap();
+
+        let prefix = s
+            .audit_chain_prefix_through(&target.event.id)
+            .expect("prefix must load even with a malformed row at higher seq");
+        assert_eq!(prefix.len(), 2);
+        assert_eq!(prefix[1].event.id, target.event.id);
+    }
+
+    #[test]
+    fn audit_chain_prefix_through_propagates_malformed_row_inside_prefix() {
+        // Symmetric guarantee: a malformed row *inside* the prefix MUST
+        // surface — a proof needs every predecessor to be well-formed.
+        // Inject a malformed seq=2 row, then export through seq=3. The
+        // row mapper on seq=2 fails when parsing `metadata_json`, which
+        // surfaces as a SQLite conversion error.
+        let mut s = Storage::open_in_memory().unwrap();
+        let signer = DevSigner::from_seed("audit-signer-v1", [11u8; 32]);
+        let _e1 = s
+            .audit_append(
+                NewAuditEvent::now("runtime_started", "mandate-server", "runtime"),
+                &signer,
+            )
+            .unwrap();
+        // Inject malformed row at seq=2 directly.
+        s.conn
+            .execute(
+                "INSERT INTO audit_events
+                    (seq, id, ts, type, actor, subject_id, payload_hash, metadata_json,
+                     policy_version, policy_hash, attestation_ref, prev_event_hash,
+                     event_hash, signature_alg, signature_key_id, signature_hex)
+                 VALUES (2, 'evt-MALFORMED-PREFIX', '2026-04-27T12:00:01Z', 'policy_decided',
+                         'policy_engine', 'pr-test-001', '{}', 'NOT JSON',
+                         NULL, NULL, NULL,
+                         '0000000000000000000000000000000000000000000000000000000000000000',
+                         '0000000000000000000000000000000000000000000000000000000000000000',
+                         'ed25519', 'audit-signer-v1', 'aaaa')",
+                [],
+            )
+            .unwrap();
+        // And a valid-looking seq=3 the test will try to export through.
+        s.conn
+            .execute(
+                "INSERT INTO audit_events
+                    (seq, id, ts, type, actor, subject_id, payload_hash, metadata_json,
+                     policy_version, policy_hash, attestation_ref, prev_event_hash,
+                     event_hash, signature_alg, signature_key_id, signature_hex)
+                 VALUES (3, 'evt-OK-SEQ3', '2026-04-27T12:00:02Z', 'policy_decided',
+                         'policy_engine', 'pr-test-002', '{}', '{}',
+                         NULL, NULL, NULL,
+                         '0000000000000000000000000000000000000000000000000000000000000000',
+                         '0000000000000000000000000000000000000000000000000000000000000000',
+                         'ed25519', 'audit-signer-v1', 'bbbb')",
+                [],
+            )
+            .unwrap();
+
+        let err = s
+            .audit_chain_prefix_through("evt-OK-SEQ3")
+            .expect_err("must fail when a row inside the prefix is malformed");
+        // The row mapper turns the bad metadata_json into a SQLite
+        // conversion error, which our error type wraps as Sqlite(_).
+        assert!(matches!(err, StorageError::Sqlite(_)), "got {err:?}");
     }
 }

--- a/crates/mandate-storage/src/error.rs
+++ b/crates/mandate-storage/src/error.rs
@@ -18,6 +18,8 @@ pub enum StorageError {
     Json(#[from] serde_json::Error),
     #[error("io: {0}")]
     Io(#[from] std::io::Error),
+    #[error("audit_event id '{id}' not found in chain")]
+    AuditEventNotFound { id: String },
 }
 
 pub type StorageResult<T> = Result<T, StorageError>;

--- a/docs/cli/audit-bundle.md
+++ b/docs/cli/audit-bundle.md
@@ -1,10 +1,27 @@
 # `mandate audit export` / `verify-bundle`
 
-> *Mandate does not just decide. It leaves behind verifiable proof.*
+> *Mandate does not just decide. It leaves behind verifiable proof — directly from its daemon storage.*
 
 A Mandate decision already produces three signed artefacts: the **policy receipt** (returned in the `POST /v1/payment-requests` response), the **audit event** (appended to the hash-chained log), and the **chain linkage** between successive events. The bundle commands package those artefacts into a single self-contained JSON file that anyone can re-verify offline.
 
 ## Export
+
+The export command takes a signed receipt plus an audit chain source. **Exactly one** of `--chain` or `--db` must be supplied:
+
+### From SQLite storage (production-style)
+
+```bash
+mandate audit export \
+  --receipt   path/to/receipt.json \
+  --db        path/to/mandate.sqlite \
+  --receipt-pubkey <hex> \
+  --audit-pubkey   <hex> \
+  --out       path/to/bundle.json
+```
+
+This is the realistic path: a Mandate daemon writes its audit log to SQLite (`MANDATE_DB`); the receipt comes back to the agent in the `POST /v1/payment-requests` response. The CLI opens the same SQLite file, slices the chain prefix from genesis through `receipt.audit_event_id`, **pre-flights the chain integrity** with `verify_chain` against `--audit-pubkey`, **pre-flights the receipt signature** against `--receipt-pubkey`, and only then writes the bundle. A failure on any of those checks aborts before the bundle file is created — so a downstream consumer never sees an unverifiable bundle.
+
+### From a JSONL chain file
 
 ```bash
 mandate audit export \
@@ -15,10 +32,25 @@ mandate audit export \
   --out       path/to/bundle.json
 ```
 
+Use this when you already have an exported chain JSONL (for example, from a fixture or an air-gapped environment without the live daemon).
+
+### Common flags
+
 - `--receipt` — the `receipt` field from a `POST /v1/payment-requests` response, saved as JSON.
-- `--chain` — the audit log as JSONL (one `SignedAuditEvent` per line). Must include the genesis event (seq=1) through the event referenced by `receipt.audit_event_id`, in seq order.
+- `--chain` — the audit log as JSONL (one `SignedAuditEvent` per line). Must include the genesis event (seq=1) through the event referenced by `receipt.audit_event_id`, in seq order. **Mutually exclusive with `--db`.**
+- `--db` — path to the Mandate daemon's SQLite store. The CLI reads the chain prefix through `receipt.audit_event_id` directly. **Mutually exclusive with `--chain`.**
 - `--receipt-pubkey` / `--audit-pubkey` — 32-byte Ed25519 public keys (hex). For the hackathon dev signers these are the deterministic seeds wired into `AppState::new`; production deployments substitute via `AppState::with_signers(...)`.
 - `--out` — output file. If omitted, the bundle is written to stdout (good for piping into `jq`).
+
+### Failure modes (DB-backed export)
+
+| Condition | Behaviour |
+|---|---|
+| `--db` path does not exist | Exits non-zero, error names the missing path; no bundle written. |
+| `receipt.audit_event_id` not present in DB | Exits non-zero, error echoes the missing id; no bundle written. |
+| Audit chain in DB is tampered (e.g. a row was rewritten outside `audit_append`) | Pre-flight `verify_chain` rejects; exits non-zero with `audit chain pre-flight failed: …`; no bundle written. |
+| Wrong `--audit-pubkey` (does not match the daemon's audit signer) | Same path as tampered chain — pre-flight signature check fails. |
+| Wrong `--receipt-pubkey` | Pre-flight receipt-signature check fails before the bundle is written. |
 
 ## Verify
 
@@ -70,3 +102,4 @@ Exit codes:
 - The chain segment must be the full prefix from genesis. Pruned / Merkle-proof variants are tracked separately.
 - The bundle does not include the original APRP payload — it includes the canonical `request_hash` only, which is enough to *re-verify* a request the verifier already has but not enough to *reconstruct* the request from the bundle alone. (Future revision: optional embedded APRP.)
 - No revocation / expiry semantics on the bundle itself; if you need expiring proofs, set `PolicyReceipt.expires_at` upstream.
+- The `--db` mode opens the SQLite file in normal mode (not read-only). Concurrent access against a running daemon is safe in WAL mode but the CLI does not enforce read-only; running it against a live daemon is fine but document it as such for production audits.


### PR DESCRIPTION
## Summary

Adds a `--db <path>` source flag to `mandate audit export` so the CLI can produce a verifiable bundle **directly from a Mandate daemon's SQLite store**, with pre-flight chain + receipt verification. The existing `--chain <jsonl>` flag is unchanged and remains backward compatible. Strengthens the product claim: **Mandate leaves behind verifiable proof directly from its daemon storage.**

## Files changed (7)

| File | Change |
|---|---|
| `crates/mandate-storage/src/audit_store.rs` | New `Storage::audit_chain_prefix_through(event_id)`. **Implemented as two scoped SQL queries** (Codex P2 follow-up `63b8533`): first an `id → seq` lookup using the `audit_events.id UNIQUE` index, then `WHERE seq <= ?1 ORDER BY seq ASC` loading only the prefix rows. Cost scales with proof prefix size, not total log size. **4 unit tests** including 2 new tests pinning that rows past the target seq are never deserialised. |
| `crates/mandate-storage/src/error.rs` | New `StorageError::AuditEventNotFound { id }` variant. |
| `crates/mandate-cli/src/main.rs` | `Audit::Export` now accepts `--chain` OR `--db` (clap-enforced mutually exclusive, exactly one required). New `read_audit_chain_from_db()` helper that opens storage, slices the prefix via the scoped SQL, and pre-flights chain integrity + receipt signature before the bundle is written. |
| `crates/mandate-cli/tests/audit_bundle.rs` | 4 new DB-backed integration tests (happy path + 3 failure modes); reuses the existing `cli_bin()` machinery. |
| `crates/mandate-cli/Cargo.toml` | `rusqlite` added as a dev-dep so the tampering test can mutate `audit_events` directly. |
| `docs/cli/audit-bundle.md` | New "From SQLite storage (production-style)" section + a "Failure modes (DB-backed export)" table. |
| `Cargo.lock` | Regenerated. |

## Command syntax

```bash
mandate audit export \
  --receipt        path/to/receipt.json \
  --db             path/to/mandate.sqlite \
  --receipt-pubkey <hex> \
  --audit-pubkey   <hex> \
  --out            path/to/bundle.json
```

`--chain <jsonl>` (the previous source mode) is unchanged. Clap rejects calls that pass both or neither.

## Scoped SQL behaviour for DB-backed export

`Storage::audit_chain_prefix_through(event_id)` runs two scoped queries against the `audit_events` table:

```sql
-- step 1: targeted lookup, uses the `id UNIQUE` index from V001 (O(log n))
SELECT seq FROM audit_events WHERE id = ?1

-- step 2: only the proof prefix
SELECT <full row columns>
FROM   audit_events
WHERE  seq <= ?1
ORDER BY seq ASC
```

**Rows with `seq > target_seq` are never selected, never streamed, never deserialised.** That means:
- exporting an old receipt's bundle does NOT pay for every event written to the daemon since;
- a malformed or tampered row past the target event cannot break a proof for an earlier event whose own prefix is intact.

A malformed row *inside* the prefix still surfaces (either through the row mapper or, downstream, via the pre-flight `verify_chain`) — that is the correct outcome, since the proof depends on every preceding event being well-formed.

## DB-backed flow

1. Verifies `--db` path exists.
2. Opens `Storage::open(db_path)` (real SQLite, same one the daemon writes to).
3. Slices chain prefix through `receipt.audit_event_id` via the new helper (the two scoped queries above).
4. **Pre-flight `verify_chain`** against `--audit-pubkey`. Catches tampered rows, broken `prev_event_hash` linkage, wrong/malformed audit pubkey — surfaces as a clear error before any bundle is written.
5. **Pre-flight receipt signature** against `--receipt-pubkey`. Wrong receipt key → fail before write.
6. Builds + serialises the bundle exactly like the JSONL path (same `audit_bundle::build` codepath).

Failure modes (DB-backed export only — JSONL path keeps its previous semantics for backward compat):

| Condition | Behaviour |
|---|---|
| `--db` path does not exist | Exit 1, error names the missing path; no bundle file written. |
| `receipt.audit_event_id` not in DB | Exit 1, error echoes the missing id verbatim; no bundle file written. |
| Audit chain in DB tampered (within prefix) | Exit 1, `audit chain pre-flight failed: …`; no bundle file written. |
| Wrong `--audit-pubkey` | Same path as tampered chain — pre-flight signature check fails. |
| Wrong `--receipt-pubkey` | Exit 1, `receipt signature pre-flight failed: …`. |

## Final test count

✅ **120 / 120 pass** (was 112 baseline; **+8 new tests added by this PR**)

### Test breakdown

**`mandate-storage::audit_store::tests` — 4 new unit tests:**
- `audit_chain_prefix_through_returns_correct_slice` — happy path: 3-event chain, slice through middle returns `[genesis, middle]`; slice through last returns the full chain.
- `audit_chain_prefix_through_returns_not_found_for_unknown_id` — exercises the new SQL `id → seq` lookup's `QueryReturnedNoRows` arm; error carries the bad id verbatim.
- *(Codex P2 follow-up)* `audit_chain_prefix_through_does_not_read_rows_after_target_seq` — writes well-formed seq=1 + seq=2, injects a malformed seq=3 row directly via SQL with `metadata_json = 'NOT JSON'`, asserts that exporting through seq=2 still succeeds. **Pins the SQL `WHERE seq <= ?1` scoping**: if the implementation read the whole table and truncated in memory, the row mapper would error on seq=3.
- *(Codex P2 follow-up)* `audit_chain_prefix_through_propagates_malformed_row_inside_prefix` — symmetric guarantee: a malformed row at seq=2 must surface when exporting through seq=3, since a proof depends on every preceding event being well-formed.

**`mandate-cli/tests/audit_bundle.rs` — 4 new integration tests** (invoke the real `mandate` binary via `env!("CARGO_BIN_EXE_mandate")`, populate a real on-disk SQLite DB via `mandate-storage`):
- `db_backed_export_then_verify_bundle_succeeds` — happy path: real DB, signed receipt, export → verify-bundle round-trips clean. Also pins that the segment is sliced to a 2-event prefix from a 3-event DB chain.
- `db_backed_export_fails_when_db_path_missing` — `Exit ≠ 0`, stderr contains "does not exist", no bundle file.
- `db_backed_export_fails_when_audit_event_id_not_in_db` — `Exit ≠ 0`, stderr echoes the bogus id verbatim.
- `db_backed_export_fails_when_db_chain_is_tampered` — uses a raw `rusqlite::Connection` to mutate `actor` on seq=2, asserts pre-flight rejects with `audit chain pre-flight failed: …` and no bundle file is written.

The 3 pre-existing JSONL-source CLI tests still pass unchanged. Pre-existing `mandate-core::audit_bundle::tests::*` (13) still green.

## All command results (local, on `63b8533`)

- [x] `cargo fmt --check` — ✅
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — ✅ (no warnings)
- [x] `cargo test --workspace --all-targets` — ✅ **120 / 120 pass**
- [x] `python3 scripts/validate_schemas.py` — ✅
- [x] `python3 scripts/validate_openapi.py` — ✅
- [x] `bash demo-scripts/run-openagents-final.sh` — ✅ all **13 / 13 gates green**

## Schemas / OpenAPI changed?

**No.** APRP, policy receipt, decision token, audit event JSON Schemas are untouched. OpenAPI is untouched. The new `--db` flag is purely a CLI-side addition, and the new SQL-level prefix query reuses the existing `audit_events.id UNIQUE` index — no migration needed.

## Demo affected?

**No.** The 13-step `run-openagents-final.sh` is unaffected. The new flag is additive.

## Limitations

- **Backward-compat asymmetry on purpose:** the JSONL path (`--chain`) does NOT pre-verify (its behaviour is unchanged from before this PR). Only the DB-backed path adds the pre-flight checks. Rationale: avoid changing the existing path's contract; pre-flight on `--db` matches its "production-grade" framing.
- **Full prefix only:** `--db` reads the chain from genesis through the receipt's referenced event. Pruned/Merkle subset bundles are not yet supported.
- **No read-only mode:** `Storage::open` opens the SQLite file in normal mode (WAL is safe under concurrent access against a running daemon, but the CLI does not enforce read-only). Documented in `docs/cli/audit-bundle.md`.
- **No `--latest-receipt` / `--receipt-id` shortcut:** the CLI still requires the caller to supply the receipt JSON. A "fetch the most recent allow receipt for agent X" CLI is plausible future work but out of scope for this PR.
- **No retroactive bundle generation against the demo runner:** the new `latest-demo-summary.json` transcript artifact is unchanged — DB-backed export is for production daemons, not the in-memory demo path.

## Commits

- `d04d8e2` `feat: export audit bundle from sqlite storage`
- `63b8533` `perf: scope audit_chain_prefix_through to seq <= target via SQL` (Codex P2 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)