### PR TITLE
test: cover wrong receipt pubkey for db audit export

### DIFF
--- a/crates/mandate-cli/tests/audit_bundle.rs
+++ b/crates/mandate-cli/tests/audit_bundle.rs
@@ -571,3 +571,64 @@ fn db_backed_export_fails_when_db_chain_is_tampered() {
         "no bundle should be written when the DB chain doesn't verify"
     );
 }
+
+#[test]
+fn db_backed_export_fails_when_receipt_pubkey_is_wrong() {
+    // QA low finding follow-up: structurally the DB-backed export's
+    // pre-flight is `chain check (verify_chain) → receipt.verify(...)`,
+    // but until now we only had a direct test for the chain-side branch
+    // (`db_backed_export_fails_when_db_chain_is_tampered` and the
+    // wrong-audit-pubkey path it implicitly covers, since
+    // verify_chain also takes the audit pubkey). The receipt-side
+    // branch — `receipt signature pre-flight failed` — was reachable
+    // in code but not pinned by an integration test. This test
+    // closes that gap directly.
+    //
+    // Setup is the same well-formed DB fixture used by the happy-path
+    // test. The only thing wrong is `--receipt-pubkey`: we substitute
+    // a different DevSigner's pubkey, so the receipt's signature
+    // (made by the real receipt signer in the fixture) cannot verify
+    // under it. The export must exit non-zero with the receipt-side
+    // diagnostic on stderr, and crucially must not write the bundle
+    // file — a half-written bundle on a "wrong key" path would be a
+    // foot-gun for downstream consumers.
+    let (tmp, db, receipt, _rpk_correct, apk, _) = build_db_fixture();
+    let bundle_path = tmp.path().join("bundle.json");
+
+    // Pubkey of an unrelated signer — guaranteed not to match the
+    // receipt's signature.
+    let other_signer = DevSigner::from_seed("attacker-receipt-signer", [99u8; 32]);
+    let wrong_rpk = other_signer.verifying_key_hex();
+
+    let out = Command::new(cli_bin())
+        .args([
+            "audit",
+            "export",
+            "--receipt",
+            receipt.to_str().unwrap(),
+            "--db",
+            db.to_str().unwrap(),
+            "--receipt-pubkey",
+            &wrong_rpk,
+            "--audit-pubkey",
+            &apk,
+            "--out",
+            bundle_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "must reject wrong --receipt-pubkey; stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("receipt signature pre-flight failed"),
+        "expected receipt-side pre-flight diagnostic; got {stderr}"
+    );
+    assert!(
+        !bundle_path.exists(),
+        "no bundle should be written when the receipt pubkey doesn't match"
+    );
+}


### PR DESCRIPTION
## Summary

Closes the QA low finding on PR #17. The DB-backed export's pre-flight has two branches: `verify_chain` (already covered by `db_backed_export_fails_when_db_chain_is_tampered`) and then `receipt.verify(receipt_pubkey_hex)`. The receipt-side branch was reachable in code but not pinned by an integration test. This PR adds a single direct test for it.

**No production code change.** Touches only `crates/mandate-cli/tests/audit_bundle.rs`.

## Files changed (1)

| File | Change |
|---|---|
| `crates/mandate-cli/tests/audit_bundle.rs` | +61 lines: new `db_backed_export_fails_when_receipt_pubkey_is_wrong` integration test. |

## Test added

`db_backed_export_fails_when_receipt_pubkey_is_wrong`

- Reuses the existing `build_db_fixture()` helper — same well-formed on-disk SQLite DB and signed receipt as the happy-path test.
- The only thing wrong is `--receipt-pubkey`: substitutes a different `DevSigner`'s pubkey (deterministic seed `[99u8; 32]`, guaranteed not to match the real receipt signer).
- Asserts:
  - **Exit code is non-zero** (export refused, not silently downgraded).
  - **stderr contains `receipt signature pre-flight failed`** (matches the error string emitted by `read_audit_chain_from_db` in `crates/mandate-cli/src/main.rs`).
  - **The bundle file does NOT exist on disk** — a half-written bundle on a wrong-key path would be a foot-gun for downstream consumers.

## Final test count

✅ **121 / 121 pass** (was 120; +1 new test in this PR)

The 4 pre-existing DB-backed CLI tests + 4 storage prefix tests + 3 file-based CLI tests are all green and unchanged. Pre-existing `mandate-core::audit_bundle::tests::*` (13) still green.

## All command results (local, on this branch's HEAD `6932607`)

- [x] `cargo fmt --check` — ✅
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — ✅ (no warnings)
- [x] `cargo test --workspace --all-targets` — ✅ **121 / 121 pass**
- [x] `python3 scripts/validate_schemas.py` — ✅
- [x] `python3 scripts/validate_openapi.py` — ✅
- [x] `bash demo-scripts/run-openagents-final.sh` — ✅ all **13 / 13 gates green**

## Confirmation: no production code changed

`git diff --stat main..HEAD` shows a single touched file:

```
crates/mandate-cli/tests/audit_bundle.rs | 61 ++++++++++++++++++++++++++++++++
```

That file is `crates/mandate-cli/tests/` — i.e. an integration test under the `tests/` directory, not `src/`. No schema, OpenAPI, demo, doc or production-code changes. The receipt-side pre-flight implementation in `crates/mandate-cli/src/main.rs::read_audit_chain_from_db` (which already produces the exact `receipt signature pre-flight failed` string this test asserts on) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)