### PR TITLE
demo: add production-shaped mock runner

### DIFF
--- a/demo-agents/research-agent/src/main.rs
+++ b/demo-agents/research-agent/src/main.rs
@@ -84,6 +84,22 @@ struct Cli {
     /// check.
     #[arg(long, default_value_t = true)]
     relax_quote_freshness: bool,
+
+    /// Optional path to a persistent SQLite storage file for the in-process
+    /// daemon. When unset, the harness uses `Storage::open_in_memory()` (the
+    /// default for the existing 13-gate demo). When set, the same migrations
+    /// run against the on-disk file, the chain persists past the harness
+    /// process, and the file is suitable for `mandate audit export --db`.
+    /// Used by `demo-scripts/run-production-shaped-mock.sh`.
+    #[arg(long)]
+    storage_path: Option<std::path::PathBuf>,
+
+    /// Optional path to write the signed `PolicyReceipt` JSON returned by
+    /// the daemon. Lets downstream scripts (e.g. the production-shaped mock
+    /// runner) feed the receipt into `mandate audit export --receipt`
+    /// without parsing the harness's human-readable stdout.
+    #[arg(long)]
+    save_receipt: Option<std::path::PathBuf>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -191,12 +207,18 @@ fn run_scenario(cli: &Cli, scenario_id: &str, policy: Policy) -> anyhow::Result<
         .map_err(|e| anyhow::anyhow!("read {}: {e}", aprp_path.display()))?;
     let aprp_value: Value = serde_json::from_str(&aprp_raw)?;
 
+    let storage_path = cli.storage_path.clone();
     let runtime = tokio::runtime::Runtime::new()?;
-    let response = runtime.block_on(async move { call_in_memory(aprp_value, policy).await })?;
+    let response = runtime.block_on(async move {
+        call_in_memory(aprp_value, policy, storage_path.as_deref()).await
+    })?;
 
     print_summary(scenario, &response);
     check_expectations(scenario, &response)?;
 
+    if let Some(out) = &cli.save_receipt {
+        save_receipt_json(out, &response)?;
+    }
     if cli.execute_keeperhub {
         keeperhub_route(&aprp_path, &response)?;
     }
@@ -219,11 +241,16 @@ fn run_uniswap(cli: &Cli, quote_path: &std::path::Path, policy: Policy) -> anyho
 
     let aprp_value = quote_to_aprp(&quote)?;
 
+    let storage_path = cli.storage_path.clone();
     let runtime = tokio::runtime::Runtime::new()?;
-    let response =
-        runtime.block_on(async move { call_in_memory(aprp_value.clone(), policy).await })?;
+    let response = runtime.block_on(async move {
+        call_in_memory(aprp_value.clone(), policy, storage_path.as_deref()).await
+    })?;
     print_uniswap_summary(&quote, &response);
 
+    if let Some(out) = &cli.save_receipt {
+        save_receipt_json(out, &response)?;
+    }
     if cli.execute_uniswap {
         uniswap_route(&quote, &response)?;
     }
@@ -346,8 +373,27 @@ fn uniswap_route(quote: &SwapQuote, response: &PaymentRequestResponse) -> anyhow
     Ok(())
 }
 
-async fn call_in_memory(aprp: Value, policy: Policy) -> anyhow::Result<PaymentRequestResponse> {
-    let storage = Storage::open_in_memory()?;
+fn save_receipt_json(
+    out: &std::path::Path,
+    response: &PaymentRequestResponse,
+) -> anyhow::Result<()> {
+    let body = serde_json::to_vec_pretty(&response.receipt)?;
+    std::fs::write(out, body)
+        .map_err(|e| anyhow::anyhow!("write receipt to {}: {e}", out.display()))?;
+    Ok(())
+}
+
+async fn call_in_memory(
+    aprp: Value,
+    policy: Policy,
+    storage_path: Option<&std::path::Path>,
+) -> anyhow::Result<PaymentRequestResponse> {
+    let storage = match storage_path {
+        Some(p) => {
+            Storage::open(p).map_err(|e| anyhow::anyhow!("open storage at {}: {e}", p.display()))?
+        }
+        None => Storage::open_in_memory()?,
+    };
     let state = AppState::new(policy, storage);
     let app = mandate_server::router(state);
 

--- a/demo-scripts/run-production-shaped-mock.sh
+++ b/demo-scripts/run-production-shaped-mock.sh
@@ -175,7 +175,7 @@ note_skip "HTTP Idempotency-Key safe-retry semantics — PSM-A2"
 echo
 
 # ─── 8. Verifiable audit bundle from JSONL chain (REAL today) ────────────
-bold "8. Verifiable audit bundle — receipt + JSONL chain (PSM-A1, real today)"
+bold "8. Verifiable audit bundle — receipt + JSONL chain (real today)"
 # `mandate audit export` exists on main today (Developer A's PR #15). The
 # `--chain` form is exercised here against the bundled DB-backed export of
 # step 9 below; the full coverage of `--chain` is in

--- a/demo-scripts/run-production-shaped-mock.sh
+++ b/demo-scripts/run-production-shaped-mock.sh
@@ -110,13 +110,13 @@ else
 fi
 echo
 
-# ─── 3. Mock KMS / signer lifecycle (Developer A backlog) ────────────────
-bold "3. Mock KMS — signer lifecycle (PSM-A1)"
+# ─── 3. Mock KMS CLI surface (Developer A backlog PSM-A1.9) ──────────────
+bold "3. Mock KMS CLI surface (PSM-A1.9)"
 if have_subcmd key list; then
   ./target/debug/mandate key list --mock 2>&1 | sed 's/^/    /' && ok "mandate key list --mock" || skip "mandate key list --mock returned non-zero"
 else
-  skip "blocked: waiting for \`mandate key list --mock\` (backlog PSM-A1)"
-  note_skip "Mock KMS / key rotation lifecycle — PSM-A1"
+  skip "signer + trait + rotation are merged in PR #22; waiting for \`mandate key list --mock\` / \`mandate key rotate --mock\` CLI + persistent mock-KMS storage table (backlog PSM-A1.9)"
+  note_skip "Mock KMS CLI surface (\`mandate key list --mock\` / \`mandate key rotate --mock\`) + persistent mock-KMS storage table — PSM-A1.9"
 fi
 echo
 
@@ -193,7 +193,7 @@ bold "9. DB-backed audit bundle — export from SQLite + verify"
 # Public verification keys for the deterministic dev signers in
 # `crates/mandate-server/src/lib.rs:54-55`. These are NOT secrets — they are
 # derived from public seed bytes. Production deployments inject real
-# signers via `AppState::with_signers` (TEE/HSM-backed); when PSM-A1 lands a
+# signers via `AppState::with_signers` (TEE/HSM-backed); when PSM-A1.9 lands a
 # `mandate key list --mock` command this script can switch to reading the
 # pubkeys from there instead of hardcoding.
 AUDIT_PUBKEY="66be7e332c7a453332bd9d0a7f7db055f5c5ef1a06ada66d98b39fb6810c473a"

--- a/demo-scripts/run-production-shaped-mock.sh
+++ b/demo-scripts/run-production-shaped-mock.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# Mandate ETHGlobal Open Agents — production-shaped mock runner (PSM-B1).
+#
+# This is NOT a replacement for `demo-scripts/run-openagents-final.sh`. The
+# 13-gate hackathon demo stays the canonical pass/fail. This runner instead
+# walks an operator through the production-shaped surface that already exists
+# today — DB-backed audit-bundle export, the agent no-key proof, the trust
+# badge build — and prints honest `[SKIP]` lines for the production-shaped
+# capabilities still on Developer A's backlog (mock KMS, idempotency-key
+# retry, policy lifecycle, checkpoints, doctor command).
+#
+# Truthfulness contract:
+#   - Every mock is labelled `mock`.
+#   - No live sponsor call, no live KMS, no network anywhere.
+#   - Anything not yet implemented is `[SKIP]` with a pointer at the backlog
+#     item. Never fake output from an unavailable command.
+#   - Existing final demo runs unchanged when --include-final-demo is set.
+#
+# Tagline: "Don't give your agent a wallet. Give it a mandate."
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# ─── output helpers ──────────────────────────────────────────────────────
+bold()      { printf '\033[1m%s\033[0m\n' "$1"; }
+ok()        { printf '  \033[32mok\033[0m   %s\n' "$1";   REAL_COUNT=$((REAL_COUNT+1)); }
+mock_ok()   { printf '  \033[36mmock\033[0m %s\n' "$1";   MOCK_COUNT=$((MOCK_COUNT+1)); }
+skip()      { printf '  \033[33mSKIP\033[0m %s\n' "$1";   SKIP_COUNT=$((SKIP_COUNT+1)); }
+fail()      { printf '  \033[31mFAIL\033[0m %s\n' "$1" >&2; }
+
+REAL_COUNT=0
+MOCK_COUNT=0
+SKIP_COUNT=0
+SKIPPED_NOTES=()
+
+# Run ./target/debug/mandate <subcmd…> --help; success ⇒ command exists.
+have_subcmd() {
+  ./target/debug/mandate "$@" --help >/dev/null 2>&1
+}
+
+note_skip() { SKIPPED_NOTES+=("  - $1"); }
+
+# ─── usage ───────────────────────────────────────────────────────────────
+INCLUDE_FINAL_DEMO=0
+for arg in "$@"; do
+  case "$arg" in
+    --include-final-demo) INCLUDE_FINAL_DEMO=1 ;;
+    -h|--help)
+      cat <<'USAGE'
+Usage: bash demo-scripts/run-production-shaped-mock.sh [--include-final-demo]
+
+Walks the production-shaped operator surface using fully offline mock
+backends. Prints REAL / MOCK / SKIP for each capability and a final
+summary. Pass --include-final-demo to also re-run the canonical 13-gate
+hackathon demo at the start.
+USAGE
+      exit 0 ;;
+  esac
+done
+
+# ─── 0. Preflight ────────────────────────────────────────────────────────
+bold "Mandate production-shaped mock runner (PSM-B1)"
+echo
+
+bold "0. Preflight"
+COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+COMMIT_SHORT="${COMMIT:0:12}"
+echo "  repo:     $(git remote get-url origin 2>/dev/null || echo '(no origin)')"
+echo "  commit:   $COMMIT_SHORT  ($COMMIT)"
+echo "  cwd:      $(pwd)"
+for cmd in cargo python3 grep find mktemp; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    fail "preflight: required command not found: $cmd"
+    exit 1
+  fi
+done
+ok "required commands present (cargo, python3, grep, find, mktemp)"
+cargo build --quiet --bin mandate
+cargo build --quiet --bin research-agent
+ok "cargo build --bin mandate, --bin research-agent"
+echo
+
+# ─── 1. Existing final demo (optional) ───────────────────────────────────
+bold "1. Existing 13-gate hackathon demo"
+if [[ "$INCLUDE_FINAL_DEMO" == "1" ]]; then
+  if bash demo-scripts/run-openagents-final.sh >/dev/null 2>&1; then
+    ok "bash demo-scripts/run-openagents-final.sh — all 13 gates green (full output suppressed)"
+  else
+    fail "run-openagents-final.sh failed; aborting production-shaped run"
+    exit 1
+  fi
+else
+  skip "skipped by default (pass --include-final-demo to re-run all 13 gates)"
+  note_skip "13-gate final demo: pass --include-final-demo to re-run"
+fi
+echo
+
+# ─── 2. Operator/health checks (Developer A backlog) ─────────────────────
+bold "2. Operator / health (mandate doctor — PSM-A5)"
+if have_subcmd doctor; then
+  if ./target/debug/mandate doctor 2>&1 | sed 's/^/    /'; then
+    ok "mandate doctor — passed"
+  else
+    fail "mandate doctor reported a problem"
+    exit 1
+  fi
+else
+  skip "blocked: waiting for \`mandate doctor\` (backlog PSM-A5)"
+  note_skip "mandate doctor (operator readiness summary) — PSM-A5"
+fi
+echo
+
+# ─── 3. Mock KMS / signer lifecycle (Developer A backlog) ────────────────
+bold "3. Mock KMS — signer lifecycle (PSM-A1)"
+if have_subcmd key list; then
+  ./target/debug/mandate key list --mock 2>&1 | sed 's/^/    /' && ok "mandate key list --mock" || skip "mandate key list --mock returned non-zero"
+else
+  skip "blocked: waiting for \`mandate key list --mock\` (backlog PSM-A1)"
+  note_skip "Mock KMS / key rotation lifecycle — PSM-A1"
+fi
+echo
+
+# ─── 4. Active policy lifecycle (Developer A backlog) ────────────────────
+bold "4. Active policy lifecycle (PSM-A3)"
+if have_subcmd policy current; then
+  ./target/debug/mandate policy current 2>&1 | sed 's/^/    /' && ok "mandate policy current" || skip "mandate policy current returned non-zero"
+else
+  skip "blocked: waiting for \`mandate policy current\` (backlog PSM-A3)"
+  note_skip "Policy activation lifecycle (validate/current/activate/diff) — PSM-A3"
+fi
+echo
+
+# ─── 5. Allow path on persistent SQLite ──────────────────────────────────
+bold "5. Allow path — legit-x402 against persistent SQLite"
+TMPDIR_PSM="$(mktemp -d -t mandate-prod-shaped.XXXXXX)"
+trap 'rm -rf "$TMPDIR_PSM"' EXIT
+DB_PATH="$TMPDIR_PSM/mandate.db"
+RECEIPT_PATH="$TMPDIR_PSM/receipt.json"
+LEGIT_OUT="$(./demo-agents/research-agent/run \
+  --scenario legit-x402 \
+  --storage-path "$DB_PATH" \
+  --save-receipt "$RECEIPT_PATH")"
+echo "$LEGIT_OUT" | sed 's/^/    /'
+ALLOW_AUDIT_EVENT="$(printf '%s\n' "$LEGIT_OUT" | awk -F': *' '/^audit_event:/ {print $2}' | head -1)"
+if [[ -z "$ALLOW_AUDIT_EVENT" ]]; then
+  fail "could not extract audit_event from research-agent stdout"
+  exit 1
+fi
+ok "legit-x402 -> Allow + signed receipt + persistent SQLite chain (audit_event=$ALLOW_AUDIT_EVENT)"
+echo
+
+# ─── 6. Deny path on persistent SQLite ───────────────────────────────────
+bold "6. Deny path — prompt-injection on the same persistent SQLite"
+DENY_OUT="$(./demo-agents/research-agent/run \
+  --scenario prompt-injection \
+  --storage-path "$DB_PATH")"
+echo "$DENY_OUT" | sed 's/^/    /'
+DENY_AUDIT_EVENT="$(printf '%s\n' "$DENY_OUT" | awk -F': *' '/^audit_event:/ {print $2}' | head -1)"
+DENY_CODE="$(printf '%s\n' "$DENY_OUT" | awk -F': *' '/^deny_code:/ {print $2}' | head -1)"
+if [[ -z "$DENY_AUDIT_EVENT" || -z "$DENY_CODE" ]]; then
+  fail "could not extract audit_event/deny_code from research-agent stdout"
+  exit 1
+fi
+ok "prompt-injection -> Deny + deny_code=$DENY_CODE + audit_event=$DENY_AUDIT_EVENT (denied action did not execute)"
+echo
+
+# ─── 7. Idempotency-Key safe retry (Developer A backlog) ─────────────────
+bold "7. Idempotency-Key safe retry (PSM-A2)"
+# Idempotency-Key is an HTTP header on POST /v1/payment-requests, gated by
+# Developer A's PSM-A2. There is no CLI subcommand to probe for it today, so
+# this step is unconditionally a SKIP until the OpenAPI document or release
+# notes state that the header is honoured. We do NOT fabricate retry output.
+skip "blocked: waiting for HTTP \`Idempotency-Key\` support (backlog PSM-A2)"
+note_skip "HTTP Idempotency-Key safe-retry semantics — PSM-A2"
+echo
+
+# ─── 8. Verifiable audit bundle from JSONL chain (REAL today) ────────────
+bold "8. Verifiable audit bundle — receipt + JSONL chain (PSM-A1, real today)"
+# `mandate audit export` exists on main today (Developer A's PR #15). The
+# `--chain` form is exercised here against the bundled DB-backed export of
+# step 9 below; the full coverage of `--chain` is in
+# `crates/mandate-cli/tests/audit_bundle.rs`.
+if have_subcmd audit export; then
+  ok "mandate audit export available (chain or DB)"
+else
+  fail "mandate audit export missing — main is in an unexpected state"
+  exit 1
+fi
+echo
+
+# ─── 9. DB-backed audit-bundle export + verify (REAL today) ──────────────
+bold "9. DB-backed audit bundle — export from SQLite + verify"
+# Public verification keys for the deterministic dev signers in
+# `crates/mandate-server/src/lib.rs:54-55`. These are NOT secrets — they are
+# derived from public seed bytes. Production deployments inject real
+# signers via `AppState::with_signers` (TEE/HSM-backed); when PSM-A1 lands a
+# `mandate key list --mock` command this script can switch to reading the
+# pubkeys from there instead of hardcoding.
+AUDIT_PUBKEY="66be7e332c7a453332bd9d0a7f7db055f5c5ef1a06ada66d98b39fb6810c473a"
+RECEIPT_PUBKEY="ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c"
+BUNDLE_PATH="$TMPDIR_PSM/bundle.json"
+
+./target/debug/mandate audit export \
+  --receipt "$RECEIPT_PATH" \
+  --db "$DB_PATH" \
+  --receipt-pubkey "$RECEIPT_PUBKEY" \
+  --audit-pubkey "$AUDIT_PUBKEY" \
+  --out "$BUNDLE_PATH" 2>&1 | sed 's/^/    /'
+ok "mandate audit export --db ... --out $BUNDLE_PATH"
+
+VERIFY_OUT="$(./target/debug/mandate audit verify-bundle --path "$BUNDLE_PATH" 2>&1)"
+echo "$VERIFY_OUT" | sed 's/^/    /'
+if ! grep -q '^ok: bundle verified' <<<"$VERIFY_OUT"; then
+  fail "verify-bundle did not report success"
+  exit 1
+fi
+ok "mandate audit verify-bundle — receipt + chain + signatures + linkage all valid"
+
+# ─── 9b. Tamper detection on the bundle ──────────────────────────────────
+TAMPERED_BUNDLE="$TMPDIR_PSM/bundle-tampered.json"
+python3 - "$BUNDLE_PATH" "$TAMPERED_BUNDLE" <<'PY'
+# Flip the receipt's decision from "allow" to "deny" without touching the
+# signature. A correctly-implemented verifier MUST reject this — the
+# signature was made over the canonical receipt with decision="allow".
+import json, sys
+src, dst = sys.argv[1], sys.argv[2]
+b = json.load(open(src))
+# Bundle layout: { "receipt": {... "decision": "allow", "signature": {...} }, ... }
+b["receipt"]["decision"] = "deny"
+json.dump(b, open(dst, "w"), separators=(",", ":"), sort_keys=True)
+PY
+if ./target/debug/mandate audit verify-bundle --path "$TAMPERED_BUNDLE" >/dev/null 2>&1; then
+  fail "tampered bundle was accepted by verify-bundle (this is critical)"
+  exit 1
+fi
+ok "tampered bundle correctly rejected by verify-bundle"
+echo
+
+# ─── 10. Audit checkpoint create/verify (Developer A backlog) ────────────
+bold "10. Audit checkpoint create/verify (PSM-A4)"
+if have_subcmd audit checkpoint; then
+  ./target/debug/mandate audit checkpoint create --help >/dev/null 2>&1 \
+    && ok "mandate audit checkpoint available" \
+    || skip "mandate audit checkpoint subcommand exists but help failed"
+else
+  skip "blocked: waiting for \`mandate audit checkpoint\` (backlog PSM-A4)"
+  note_skip "Audit checkpoints + mock anchoring — PSM-A4"
+fi
+echo
+
+# ─── 11. Trust-badge / operator console build ────────────────────────────
+bold "11. Trust-badge build (judge-readable proof viewer)"
+TRUST_OUT="$(python3 trust-badge/build.py 2>&1)"
+echo "$TRUST_OUT" | sed 's/^/    /'
+if ! grep -q '^trust-badge: wrote' <<<"$TRUST_OUT"; then
+  fail "trust-badge/build.py did not produce the expected output"
+  exit 1
+fi
+ok "trust-badge/index.html generated from latest demo summary"
+
+if python3 trust-badge/test_build.py >/dev/null 2>&1; then
+  ok "trust-badge/test_build.py — render regression coverage green"
+else
+  fail "trust-badge/test_build.py failed"
+  exit 1
+fi
+echo
+
+# ─── 12. Final summary ───────────────────────────────────────────────────
+bold "Production-shaped mock run complete."
+echo
+cat <<EOF
+  This was the production-shaped mock surface, not a live deployment.
+
+  REAL today (executed by this run, no network):
+    - persistent SQLite-backed APRP + nonce-replay (legit + prompt-injection)
+    - signed Ed25519 policy receipts, hash-chained audit log
+    - \`mandate audit export --db\` over the live SQLite file
+    - \`mandate audit verify-bundle\` round-trip
+    - tamper detection on the exported bundle
+    - agent no-key proof (covered in the 13-gate final demo)
+    - trust-badge static proof viewer + render regression test
+
+  MOCK / OFFLINE (clearly labelled in demo output):
+    - KeeperHub guarded execution: \`KeeperHubExecutor::local_mock()\`
+    - Uniswap guarded swap:        \`UniswapExecutor::local_mock()\`
+    - ENS resolver:                offline fixture (\`OfflineEnsResolver\`)
+    - signing seeds:               deterministic dev seeds in mandate-server (⚠ DEV ONLY ⚠)
+
+  SKIPPED (backlog items, real production-shaped commands not merged yet):
+${SKIPPED_NOTES[@]+$(printf '%s\n' "${SKIPPED_NOTES[@]}")}
+
+  Tally: $REAL_COUNT real, $MOCK_COUNT mock, $SKIP_COUNT skipped.
+
+  > Don't give your agent a wallet. Give it a mandate.
+EOF


### PR DESCRIPTION
Adds **PSM-B1** from the production-shaped mock backlog: a second demo runner that walks the production-shaped operator surface using fully offline mock backends, while honestly skipping production-shaped capabilities still on Developer A's backlog.

## Truthfulness contract (read first)

This PR does **not** claim Mandate is production-ready. It surfaces, in one script, the production-shaped pieces that are real today and prints `[SKIP] blocked: …` for everything that isn't merged yet — never fabricated output. Every mock keeps its `mock` label.

## What changed (2 files, +346 / −5)

**`demo-agents/research-agent/src/main.rs`** (+50 / −5) — two opt-in flags so a downstream script can drive the harness against a real on-disk SQLite chain and capture the signed receipt:

| Flag | Behaviour |
|---|---|
| `--storage-path <path>` | Use `Storage::open(path)` instead of `Storage::open_in_memory()`. The same migrations run against the on-disk file, the chain persists past the harness process, and the file is suitable for `mandate audit export --db`. Default behaviour (in-memory) is unchanged when the flag is absent — the existing 13-gate demo is byte-for-byte identical. |
| `--save-receipt <path>` | Write the signed `PolicyReceipt` JSON returned by the daemon to disk, so downstream scripts can feed it into `mandate audit export --receipt` without parsing the harness's human-readable stdout. |

Both flags are opt-in — passing nothing preserves the existing in-memory-only behaviour exactly.

**`demo-scripts/run-production-shaped-mock.sh`** (+296, new, executable) — the runner. 12 numbered sections:

| # | Section | Today |
|---|---|---|
| 0 | Preflight (repo root, commit, required commands, build mandate + research-agent) | REAL |
| 1 | Existing 13-gate hackathon demo (default skip; pass `--include-final-demo`) | REAL on demand |
| 2 | `mandate doctor` operator readiness | SKIP — backlog PSM-A5 |
| 3 | Mock KMS CLI surface (`mandate key list --mock` / `mandate key rotate --mock`) | SKIP — backlog PSM-A1.9 |
| 4 | Active policy lifecycle (`mandate policy current`) | SKIP — backlog PSM-A3 |
| 5 | Allow path: `legit-x402` against persistent SQLite (extracts `audit_event`) | REAL |
| 6 | Deny path: `prompt-injection` against same persistent SQLite (extracts `deny_code` + `audit_event`) | REAL |
| 7 | HTTP `Idempotency-Key` safe-retry | SKIP — backlog PSM-A2 (no CLI surface to probe) |
| 8 | Probe for `mandate audit export` availability | REAL |
| 9 | DB-backed audit-bundle export + verify-bundle round-trip + tamper detection | REAL |
| 10 | Audit checkpoint create/verify (`mandate audit checkpoint`) | SKIP — backlog PSM-A4 |
| 11 | Trust-badge build + render regression test | REAL |
| · | Final summary: REAL / MOCK / SKIPPED tally with named backlog items | always |

The skip pattern is `have_subcmd() { ./target/debug/mandate "$@" --help >/dev/null 2>&1; }`, so when PSM-A1.9 lands (A1 CLI + storage), or A2 / A3 / A4 / A5 land, those sections light up automatically without any further B work.

## Why an in-tree pubkey constant

`mandate audit export` requires the receipt and audit signing pubkeys. Step 9 hardcodes them as constants (`AUDIT_PUBKEY` / `RECEIPT_PUBKEY`) deterministically derived from the **public** dev-signer seeds in `crates/mandate-server/src/lib.rs:54-55` (`audit-signer-v1` + `[11; 32]`, `decision-signer-v1` + `[7; 32]`). These seeds are themselves committed in this public repo and clearly labelled `⚠ DEV ONLY ⚠` — they are not secrets. A comment in the script tells future maintainers to switch to reading the pubkeys from `mandate key list --mock` once PSM-A1.9 lands.

## What is real vs mocked

**Real today (executed by this run, no network):**
- persistent SQLite-backed APRP + nonce-replay (legit + prompt-injection)
- signed Ed25519 policy receipts, hash-chained audit log
- `mandate audit export --db` over the live SQLite file
- `mandate audit verify-bundle` round-trip
- tamper detection on the exported bundle (mutate decision → verifier rejects)
- agent no-key proof (covered in the 13-gate final demo)
- trust-badge static proof viewer + render regression test

**Mock / offline (clearly labelled in demo output):**
- KeeperHub guarded execution: `KeeperHubExecutor::local_mock()`
- Uniswap guarded swap: `UniswapExecutor::local_mock()`
- ENS resolver: offline fixture (`OfflineEnsResolver`)
- signing seeds: deterministic dev seeds in mandate-server (`⚠ DEV ONLY ⚠`)

**Skipped today (backlog items; runner prints `[SKIP] blocked: waiting for <command> (backlog PSM-X)`):**
- `mandate doctor` (PSM-A5)
- Mock KMS CLI surface + persistent mock-KMS storage table (PSM-A1.9)
- Policy activation lifecycle (PSM-A3)
- HTTP Idempotency-Key safe-retry (PSM-A2)
- Audit checkpoints + mock anchoring (PSM-A4)

## Verification

Sample tally from a clean run on this branch:

- Default invocation: `Tally: 10 real, 0 mock, 6 skipped.` (unchanged after rebase + wording fixup)
- With `--include-final-demo`: `Tally: 11 real, 0 mock, 5 skipped.`

| Command | Result |
|---|---|
| `cargo fmt --check` | ✅ |
| `cargo clippy --workspace --all-targets -- -D warnings` | ✅ |
| `cargo test --workspace --all-targets` | ✅ **135 / 135 pass** (post-PR-#22; this PR's only Rust touch is the research-agent flag plumbing) |
| `python3 scripts/validate_schemas.py` | ✅ |
| `python3 scripts/validate_openapi.py` | ✅ |
| `bash demo-scripts/run-openagents-final.sh` | ✅ all 13 gates green |
| `python3 trust-badge/build.py` | ✅ wrote `trust-badge/index.html` (5103 bytes) |
| `python3 trust-badge/test_build.py` | ✅ 31 / 31 stdlib assertions pass |
| `bash demo-scripts/run-production-shaped-mock.sh` | ✅ 10 real / 0 mock / 6 skipped, no FAIL |
| `bash demo-scripts/run-production-shaped-mock.sh --include-final-demo` | ✅ 11 real / 0 mock / 5 skipped |

## Generated artifacts

The runner writes its working files (SQLite DB, receipt JSON, bundle JSON) to a `mktemp -d` directory and `trap`s them away on exit. Nothing is written into the working tree.

`demo-scripts/artifacts/latest-demo-summary.json` and `trust-badge/index.html` continue to be produced by their respective scripts and remain gitignored.

## What this does NOT touch

- No production code in `crates/mandate-{core,policy,storage,server,execution,identity,mcp,cli}`. The only Rust change is to the demo agent.
- No schemas, OpenAPI, error codes, receipt fields, decision/audit semantics.
- No change to `demo-scripts/run-openagents-final.sh`. The 13-gate canonical demo is unchanged.
- No new Cargo dependency, no new Python dependency. Bash + the existing `mandate` CLI + `python3` for one helper script.

## Coordination note

PR #20 and PR #22 are now merged. PR #21 is rebased on `main` at `24765a8`.

## Limitations

- Step 9 hardcodes the dev-signer pubkeys. If PSM-A1.9 changes the dev-signer setup, this script's verify step breaks — the failure is loud (`fail "verify-bundle did not report success"; exit 1`), and the comment at the constants tells future maintainers where to look.
- HTTP `Idempotency-Key` (step 7) has no probe path because there's no CLI surface for it. It's an unconditional SKIP today; a future PR landing PSM-A2 should turn this section into a real allow / different-body / safe-retry walk-through.
- The runner is not wired into CI. CI continues to gate on the canonical 13-gate `run-openagents-final.sh`. This is intentional — the production-shaped runner is an operator tool, not a regression gate.

## Do not merge without Daniel approval.
