### PR TITLE
feat: add mock kms signer backend

### DIFF
--- a/crates/mandate-core/src/audit.rs
+++ b/crates/mandate-core/src/audit.rs
@@ -10,7 +10,7 @@ use crate::error::Result;
 use crate::hashing::{canonical_json, sha256_hex};
 use crate::receipt::EmbeddedSignature as Signature;
 use crate::receipt::SignatureAlgorithm;
-use crate::signer::{verify_hex, DevSigner, VerifyError};
+use crate::signer::{verify_hex, SignerBackend, VerifyError};
 
 pub const ZERO_HASH: &str = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -73,8 +73,11 @@ impl AuditEvent {
 impl SignedAuditEvent {
     /// Sign an `AuditEvent` and return the signed envelope. The signature is
     /// computed over the canonical JSON of the inner event; the same bytes are
-    /// used to derive `event_hash`.
-    pub fn sign(event: AuditEvent, signer: &DevSigner) -> Result<Self> {
+    /// used to derive `event_hash`. Accepts any [`SignerBackend`] — the
+    /// envelope's `signature.key_id` records the backend's
+    /// `current_key_id()` so a verifier can route the public-key lookup
+    /// (especially after a `MockKmsSigner` rotation).
+    pub fn sign<S: SignerBackend + ?Sized>(event: AuditEvent, signer: &S) -> Result<Self> {
         let v = serde_json::to_value(&event)?;
         let bytes = canonical_json(&v)?;
         let event_hash = sha256_hex(&bytes);
@@ -84,7 +87,7 @@ impl SignedAuditEvent {
             event_hash,
             signature: Signature {
                 algorithm: SignatureAlgorithm::Ed25519,
-                key_id: signer.key_id.clone(),
+                key_id: signer.current_key_id().to_string(),
                 signature_hex: sig_hex,
             },
         })
@@ -152,6 +155,7 @@ pub fn verify_chain(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::signer::DevSigner;
     use serde_json::json;
 
     fn ev(seq: u64, prev: &str, ts: &str) -> AuditEvent {

--- a/crates/mandate-core/src/decision_token.rs
+++ b/crates/mandate-core/src/decision_token.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::Result;
 use crate::hashing::canonical_json;
 use crate::receipt::Decision;
-use crate::signer::{verify_hex, DevSigner, VerifyError};
+use crate::signer::{verify_hex, SignerBackend, VerifyError};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -55,14 +55,17 @@ pub struct DecisionToken {
 }
 
 impl DecisionPayload {
-    pub fn sign(self, signer: &DevSigner) -> Result<DecisionToken> {
+    /// Sign the payload with any [`SignerBackend`]. The token records
+    /// the backend's *current* public key in `signing_pubkey_hex`, so a
+    /// verifier doesn't need access to the backend after the fact.
+    pub fn sign<S: SignerBackend + ?Sized>(self, signer: &S) -> Result<DecisionToken> {
         let value = serde_json::to_value(&self)?;
         let bytes = canonical_json(&value)?;
         let sig_hex = signer.sign_hex(&bytes);
         Ok(DecisionToken {
             payload: self,
             signature_hex: sig_hex,
-            signing_pubkey_hex: signer.verifying_key_hex(),
+            signing_pubkey_hex: signer.current_public_hex(),
         })
     }
 }
@@ -78,6 +81,7 @@ impl DecisionToken {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::signer::DevSigner;
 
     fn sample_payload() -> DecisionPayload {
         DecisionPayload {

--- a/crates/mandate-core/src/lib.rs
+++ b/crates/mandate-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod audit_bundle;
 pub mod decision_token;
 pub mod error;
 pub mod hashing;
+pub mod mock_kms;
 pub mod receipt;
 pub mod schema;
 pub mod signer;

--- a/crates/mandate-core/src/mock_kms.rs
+++ b/crates/mandate-core/src/mock_kms.rs
@@ -1,0 +1,509 @@
+//! Production-shaped **mock** KMS signer.
+//!
+//! `MockKmsSigner` looks and behaves like a key-managed signing service: it
+//! has stable `key_id`s, explicit `key_version`s, public-key metadata, and
+//! supports rotation while keeping historical keys verifiable. It is
+//! deliberately **mock** — keys are derived deterministically from a local
+//! root seed (no HSM, no TEE, no remote KMS, no network). The only thing
+//! it shares with a real KMS is the *shape* of the API and the lifecycle
+//! semantics (rotation, version-by-version verification).
+//!
+//! Truthfulness rules (do not violate):
+//! - Every public artefact must say "mock" explicitly.
+//! - The struct's seeds, public keys, and key_ids are derived from a local
+//!   value; they are **not** secrets in the production sense and must not
+//!   be presented as such.
+//! - This is not a stepping stone "you flip one bit and it's production".
+//!   A real KMS implementation would replace the `derive_signing_key`
+//!   call with a call to the KMS API, AND change the trust model in many
+//!   other places (key custody, audit, attestation, recovery, etc).
+//!
+//! What `MockKmsSigner` does provide:
+//! - A versioned keyring under a stable role name (e.g. `audit-mock`).
+//! - Each version has a `key_id` like `audit-mock-v1`, `audit-mock-v2`, …
+//!   recorded verbatim in `EmbeddedSignature.key_id` on the receipts/
+//!   audit events / decision tokens it signs.
+//! - `rotate()` advances the current version. Past versions stay available
+//!   for verifying earlier receipts.
+//! - The signing path goes through the same `SignerBackend` trait used by
+//!   `DevSigner`, so swapping backends is a one-line change at the call
+//!   site.
+
+use chrono::{DateTime, Utc};
+use ed25519_dalek::SigningKey;
+use sha2::Digest;
+
+use crate::signer::{verify_hex, DevSigner, SignerBackend, VerifyError};
+
+/// Metadata describing one version of a mock-KMS key. Exposed via
+/// `MockKmsSigner::versions()` so callers (CLI, tests, docs) can enumerate
+/// the keyring without reaching into private state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MockKmsKeyMeta {
+    pub role: String,
+    pub version: u32,
+    pub key_id: String,
+    pub public_hex: String,
+    /// When this version was added to the keyring. Deterministic from the
+    /// caller-supplied clock so tests and demos stay reproducible.
+    pub created_at: DateTime<Utc>,
+    /// Always `true` — this struct only represents mock keys. Surfaced as
+    /// a field so JSON/CLI output cannot accidentally drop the disclosure.
+    pub mock: bool,
+}
+
+/// Mock KMS-shaped Ed25519 signer with rotation.
+///
+/// Construct with a stable `role` (e.g. `"audit-mock"` or
+/// `"decision-mock"`) and a 32-byte `root_seed`. Rotations are pure
+/// in-memory state — persistence (so `mandate key rotate --mock` can
+/// outlive a CLI invocation) is a follow-up wired in `mandate-storage`.
+#[derive(Debug, Clone)]
+pub struct MockKmsSigner {
+    role: String,
+    root_seed: [u8; 32],
+    /// Genesis timestamp for v1; subsequent versions are spaced by one
+    /// nanosecond so `created_at` is monotonically increasing without
+    /// pulling in a real clock.
+    genesis: DateTime<Utc>,
+    versions: Vec<MockKmsKeyMeta>,
+    current_index: usize,
+}
+
+impl MockKmsSigner {
+    /// Build a fresh keyring with v1 derived from `(root_seed, role, 1)`.
+    /// `genesis` is the deterministic "created_at" anchor for v1.
+    pub fn new(role: impl Into<String>, root_seed: [u8; 32], genesis: DateTime<Utc>) -> Self {
+        let role = role.into();
+        let v1 = Self::build_meta(&role, 1, &root_seed, genesis);
+        Self {
+            role,
+            root_seed,
+            genesis,
+            versions: vec![v1],
+            current_index: 0,
+        }
+    }
+
+    /// Reconstruct a keyring with `current_version` already advanced. Used
+    /// by callers that persist the rotation state externally and want to
+    /// rebuild the in-memory keyring on startup.
+    pub fn from_versions(
+        role: impl Into<String>,
+        root_seed: [u8; 32],
+        genesis: DateTime<Utc>,
+        current_version: u32,
+    ) -> Self {
+        assert!(current_version >= 1, "version numbering starts at 1");
+        let role = role.into();
+        let versions: Vec<_> = (1..=current_version)
+            .map(|v| Self::build_meta(&role, v, &root_seed, genesis))
+            .collect();
+        let current_index = (current_version as usize) - 1;
+        Self {
+            role,
+            root_seed,
+            genesis,
+            versions,
+            current_index,
+        }
+    }
+
+    fn build_meta(
+        role: &str,
+        version: u32,
+        root_seed: &[u8; 32],
+        genesis: DateTime<Utc>,
+    ) -> MockKmsKeyMeta {
+        let signing_key = derive_signing_key(role, version, root_seed);
+        let public_hex = hex::encode(signing_key.verifying_key().to_bytes());
+        let key_id = format!("{role}-v{version}");
+        // Space versions by one nanosecond so the timeline is strictly
+        // monotonic but still derives only from the caller's `genesis`.
+        let created_at =
+            genesis + chrono::Duration::nanoseconds(((version as i64).saturating_sub(1)).max(0));
+        MockKmsKeyMeta {
+            role: role.to_string(),
+            version,
+            key_id,
+            public_hex,
+            created_at,
+            mock: true,
+        }
+    }
+
+    pub fn role(&self) -> &str {
+        &self.role
+    }
+
+    pub fn current_version(&self) -> u32 {
+        self.versions[self.current_index].version
+    }
+
+    /// Metadata for the current (active for new signatures) version.
+    pub fn current(&self) -> &MockKmsKeyMeta {
+        &self.versions[self.current_index]
+    }
+
+    /// All keyring entries from v1 through the current version, in order.
+    pub fn versions(&self) -> &[MockKmsKeyMeta] {
+        &self.versions
+    }
+
+    /// Look up a keyring entry by its full `key_id` (e.g. `audit-mock-v2`).
+    /// Returns `None` if the id is unknown.
+    pub fn key_by_id(&self, key_id: &str) -> Option<&MockKmsKeyMeta> {
+        self.versions.iter().find(|m| m.key_id == key_id)
+    }
+
+    /// Look up a keyring entry by `version` (1-indexed).
+    pub fn key_by_version(&self, version: u32) -> Option<&MockKmsKeyMeta> {
+        self.versions.iter().find(|m| m.version == version)
+    }
+
+    /// Add a new version. The new version becomes the current signing
+    /// key; previous versions remain available for verification of
+    /// earlier signatures via `verify(...)`.
+    pub fn rotate(&mut self) -> &MockKmsKeyMeta {
+        let next_version = self.current_version() + 1;
+        let meta = Self::build_meta(&self.role, next_version, &self.root_seed, self.genesis);
+        self.versions.push(meta);
+        self.current_index = self.versions.len() - 1;
+        self.current()
+    }
+
+    fn current_signing_key(&self) -> SigningKey {
+        derive_signing_key(&self.role, self.current_version(), &self.root_seed)
+    }
+
+    /// Verify a signature claimed to be produced under `key_id`. Resolves
+    /// the keyring entry, then runs the standard Ed25519 verify.
+    pub fn verify(
+        &self,
+        key_id: &str,
+        message: &[u8],
+        signature_hex: &str,
+    ) -> Result<(), VerifyError> {
+        let meta = self.key_by_id(key_id).ok_or(VerifyError::BadPublicKey)?;
+        verify_hex(&meta.public_hex, message, signature_hex)
+    }
+
+    /// Convenience: derive a `DevSigner` for the *current* version. Useful
+    /// when a caller wants to interoperate with code that holds onto a
+    /// `DevSigner` directly (e.g. existing `audit_append` paths) without
+    /// committing to the keyring lifecycle.
+    pub fn current_as_dev_signer(&self) -> DevSigner {
+        DevSigner::from_seed(
+            self.current().key_id.clone(),
+            seed_for(&self.role, self.current_version(), &self.root_seed),
+        )
+    }
+}
+
+impl SignerBackend for MockKmsSigner {
+    fn current_key_id(&self) -> &str {
+        &self.current().key_id
+    }
+    fn sign_hex(&self, message: &[u8]) -> String {
+        use ed25519_dalek::Signer as _;
+        let sk = self.current_signing_key();
+        let sig = sk.sign(message);
+        hex::encode(sig.to_bytes())
+    }
+    fn current_public_hex(&self) -> String {
+        self.current().public_hex.clone()
+    }
+}
+
+/// Deterministic per-version seed. **Not** a production KDF — a real KMS
+/// would never derive private keys from a public-ish role+version tuple.
+/// This is sufficient for reproducible local testing where the same
+/// (root_seed, role, version) triple yields the same Ed25519 keypair.
+fn seed_for(role: &str, version: u32, root_seed: &[u8; 32]) -> [u8; 32] {
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(b"mandate.mock_kms.v1");
+    hasher.update(root_seed);
+    hasher.update((role.len() as u32).to_be_bytes());
+    hasher.update(role.as_bytes());
+    hasher.update(version.to_be_bytes());
+    let digest = hasher.finalize();
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&digest);
+    out
+}
+
+fn derive_signing_key(role: &str, version: u32, root_seed: &[u8; 32]) -> SigningKey {
+    SigningKey::from_bytes(&seed_for(role, version, root_seed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ts(s: &str) -> DateTime<Utc> {
+        chrono::DateTime::parse_from_rfc3339(s).unwrap().into()
+    }
+
+    #[test]
+    fn fresh_signer_starts_at_v1() {
+        let s = MockKmsSigner::new("audit-mock", [42u8; 32], ts("2026-04-28T00:00:00Z"));
+        assert_eq!(s.current_version(), 1);
+        assert_eq!(s.current_key_id(), "audit-mock-v1");
+        assert_eq!(s.versions().len(), 1);
+        assert!(s.current().mock, "metadata must surface mock = true");
+    }
+
+    #[test]
+    fn key_metadata_is_deterministic() {
+        // Same (role, root_seed, genesis) → same keyring exactly. This is
+        // the property tests, fixtures and demos rely on.
+        let a = MockKmsSigner::new("audit-mock", [42u8; 32], ts("2026-04-28T00:00:00Z"));
+        let b = MockKmsSigner::new("audit-mock", [42u8; 32], ts("2026-04-28T00:00:00Z"));
+        assert_eq!(a.versions(), b.versions());
+    }
+
+    #[test]
+    fn different_roots_yield_different_keys() {
+        let a = MockKmsSigner::new("audit-mock", [42u8; 32], ts("2026-04-28T00:00:00Z"));
+        let b = MockKmsSigner::new("audit-mock", [99u8; 32], ts("2026-04-28T00:00:00Z"));
+        assert_ne!(a.current().public_hex, b.current().public_hex);
+    }
+
+    #[test]
+    fn signer_backend_round_trip() {
+        // Sign through the trait; verify through the keyring's own verify
+        // (which looks up the public key by key_id).
+        let s = MockKmsSigner::new("decision-mock", [7u8; 32], ts("2026-04-28T00:00:00Z"));
+        let msg = b"some canonical payload";
+        let sig = SignerBackend::sign_hex(&s, msg);
+        s.verify(s.current_key_id(), msg, &sig)
+            .expect("self-verify must succeed");
+    }
+
+    #[test]
+    fn signer_backend_reports_consistent_metadata() {
+        let s = MockKmsSigner::new("audit-mock", [42u8; 32], ts("2026-04-28T00:00:00Z"));
+        // current_key_id and current_public_hex must agree with the
+        // keyring's metadata, otherwise verifiers and signers would
+        // disagree about what just got signed.
+        assert_eq!(s.current_key_id(), s.current().key_id);
+        assert_eq!(s.current_public_hex(), s.current().public_hex);
+    }
+
+    #[test]
+    fn rotate_advances_current_version() {
+        let mut s = MockKmsSigner::new("audit-mock", [42u8; 32], ts("2026-04-28T00:00:00Z"));
+        let before = s.current().clone();
+        let after = s.rotate().clone();
+        assert_eq!(after.version, 2);
+        assert_eq!(after.key_id, "audit-mock-v2");
+        assert_ne!(
+            after.public_hex, before.public_hex,
+            "rotation must change public key"
+        );
+        assert_eq!(s.current_version(), 2);
+        assert_eq!(s.versions().len(), 2);
+    }
+
+    #[test]
+    fn old_signature_still_verifies_after_rotation() {
+        // The whole point of carrying historical keys: an audit event
+        // signed before a rotation must remain verifiable after.
+        let mut s = MockKmsSigner::new("audit-mock", [42u8; 32], ts("2026-04-28T00:00:00Z"));
+        let v1_key_id = s.current_key_id().to_string();
+        let msg = b"pre-rotation message";
+        let sig = SignerBackend::sign_hex(&s, msg);
+
+        s.rotate();
+        assert_eq!(s.current_version(), 2);
+
+        // v1 signature still verifies under the v1 keyring entry.
+        s.verify(&v1_key_id, msg, &sig)
+            .expect("v1 signature must still verify under v1 pubkey after rotation");
+        // And the v2 pubkey must NOT verify the v1 signature.
+        let v2_key_id = s.current_key_id().to_string();
+        let res = s.verify(&v2_key_id, msg, &sig);
+        assert!(matches!(res, Err(VerifyError::Invalid)));
+    }
+
+    #[test]
+    fn wrong_key_id_returns_bad_public_key() {
+        let s = MockKmsSigner::new("audit-mock", [42u8; 32], ts("2026-04-28T00:00:00Z"));
+        let msg = b"x";
+        let sig = SignerBackend::sign_hex(&s, msg);
+        let res = s.verify("audit-mock-v999", msg, &sig);
+        assert!(matches!(res, Err(VerifyError::BadPublicKey)));
+    }
+
+    #[test]
+    fn from_versions_reconstructs_same_keyring_after_rotations() {
+        // Persistence story (when the rotation count is stored elsewhere
+        // and we rebuild the in-memory keyring at startup): reconstructing
+        // with `current_version=N` produces the same N entries as
+        // `new(...)` followed by `N-1` rotations.
+        let mut grown = MockKmsSigner::new("audit-mock", [42u8; 32], ts("2026-04-28T00:00:00Z"));
+        for _ in 0..3 {
+            grown.rotate();
+        }
+        let restored =
+            MockKmsSigner::from_versions("audit-mock", [42u8; 32], ts("2026-04-28T00:00:00Z"), 4);
+        assert_eq!(grown.versions(), restored.versions());
+        assert_eq!(grown.current_version(), restored.current_version());
+    }
+
+    #[test]
+    fn current_as_dev_signer_produces_compatible_signatures() {
+        // The compat shim lets MockKmsSigner interoperate with code that
+        // still takes `&DevSigner`. The DevSigner it returns must produce
+        // signatures verifiable under the keyring's current public key.
+        let s = MockKmsSigner::new("audit-mock", [42u8; 32], ts("2026-04-28T00:00:00Z"));
+        let dev = s.current_as_dev_signer();
+        assert_eq!(dev.current_key_id(), s.current_key_id());
+        let msg = b"compat";
+        let sig = dev.sign_hex(msg);
+        s.verify(s.current_key_id(), msg, &sig)
+            .expect("DevSigner-produced signature must verify under MockKms keyring");
+    }
+
+    // -- Cross-cutting integration tests ------------------------------------
+    //
+    // The point of `SignerBackend` is that the three Mandate signing
+    // surfaces (receipts, audit events, decision tokens) work with any
+    // backend without code changes. Below: sign through MockKmsSigner,
+    // then verify using the same code paths the daemon uses today.
+
+    use crate::audit::{AuditEvent, SignedAuditEvent, ZERO_HASH};
+    use crate::decision_token::{DecisionPayload, TxTemplate};
+    use crate::receipt::{Decision, UnsignedReceipt};
+
+    fn unsigned_receipt(audit_event_id: &str) -> UnsignedReceipt {
+        UnsignedReceipt {
+            agent_id: "research-agent-01".to_string(),
+            decision: Decision::Allow,
+            deny_code: None,
+            request_hash: "1111111111111111111111111111111111111111111111111111111111111111"
+                .to_string(),
+            policy_hash: "2222222222222222222222222222222222222222222222222222222222222222"
+                .to_string(),
+            policy_version: Some(1),
+            audit_event_id: audit_event_id.to_string(),
+            execution_ref: None,
+            issued_at: ts("2026-04-27T12:00:01.500Z"),
+            expires_at: None,
+        }
+    }
+
+    fn audit_event(seq: u64) -> AuditEvent {
+        AuditEvent {
+            version: 1,
+            seq,
+            id: format!("evt-mock-kms-{seq:03}"),
+            ts: ts("2026-04-27T12:00:01Z"),
+            event_type: "policy_decided".to_string(),
+            actor: "policy_engine".to_string(),
+            subject_id: format!("pr-mock-{seq:03}"),
+            payload_hash: ZERO_HASH.to_string(),
+            metadata: serde_json::Map::new(),
+            policy_version: Some(1),
+            policy_hash: None,
+            attestation_ref: None,
+            prev_event_hash: ZERO_HASH.to_string(),
+        }
+    }
+
+    fn decision_payload(request_hash: &str) -> DecisionPayload {
+        DecisionPayload {
+            version: 1,
+            request_hash: request_hash.to_string(),
+            decision: Decision::Allow,
+            deny_code: None,
+            policy_version: 1,
+            policy_hash: "2222222222222222222222222222222222222222222222222222222222222222"
+                .to_string(),
+            tx_template: TxTemplate {
+                chain_id: 8453,
+                to: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".to_string(),
+                value: "0".to_string(),
+                data: "0x".to_string(),
+                gas_limit: 100_000,
+                max_fee_per_gas: None,
+                max_priority_fee_per_gas: None,
+                nonce_hint: None,
+            },
+            key_id: "agent-research-01-key".to_string(),
+            decision_id: "dec-mock-kms-001".to_string(),
+            issued_at: ts("2026-04-27T12:00:00Z"),
+            expires_at: ts("2026-04-27T12:05:00Z"),
+            attestation_ref: None,
+        }
+    }
+
+    #[test]
+    fn receipt_round_trip_through_mock_kms() {
+        // The receipt's signature.key_id MUST be the keyring's current
+        // key_id (so a verifier can resolve which version produced it),
+        // and verifying with the matching public key MUST succeed.
+        let s = MockKmsSigner::new("decision-mock", [7u8; 32], ts("2026-04-28T00:00:00Z"));
+        let receipt = unsigned_receipt("evt-mock-kms-001").sign(&s).unwrap();
+        assert_eq!(receipt.signature.key_id, s.current_key_id());
+        receipt
+            .verify(&s.current_public_hex())
+            .expect("receipt must verify under the MockKms keyring's current pubkey");
+    }
+
+    #[test]
+    fn audit_event_round_trip_through_mock_kms() {
+        let s = MockKmsSigner::new("audit-mock", [11u8; 32], ts("2026-04-28T00:00:00Z"));
+        let signed = SignedAuditEvent::sign(audit_event(1), &s).unwrap();
+        assert_eq!(signed.signature.key_id, s.current_key_id());
+        signed
+            .verify_signature(&s.current_public_hex())
+            .expect("audit event must verify under MockKms keyring");
+    }
+
+    #[test]
+    fn decision_token_round_trip_through_mock_kms() {
+        // DecisionToken records signing_pubkey_hex inline, so the
+        // verifier doesn't need keyring access at all.
+        let s = MockKmsSigner::new("decision-mock", [9u8; 32], ts("2026-04-28T00:00:00Z"));
+        let payload =
+            decision_payload("c0bd2fab4a7d4686d686edcc9c8356315cd66b820a2072493bf758a1eeb500db");
+        let token = payload.sign(&s).unwrap();
+        assert_eq!(token.signing_pubkey_hex, s.current_public_hex());
+        token.verify().expect("decision token must verify");
+    }
+
+    #[test]
+    fn pre_rotation_receipt_still_verifies_after_rotation() {
+        // End-to-end version of the keyring's
+        // `old_signature_still_verifies_after_rotation` — but exercised
+        // through the receipt code path. A receipt signed by v1 must keep
+        // verifying after the keyring rotates to v2, as long as the
+        // verifier uses the *v1* pubkey resolved via key_id.
+        let mut s = MockKmsSigner::new("decision-mock", [7u8; 32], ts("2026-04-28T00:00:00Z"));
+        let v1_pub = s.current_public_hex();
+        let receipt_v1 = unsigned_receipt("evt-mock-kms-001").sign(&s).unwrap();
+        assert_eq!(receipt_v1.signature.key_id, "decision-mock-v1");
+
+        s.rotate();
+        let v2_pub = s.current_public_hex();
+        assert_ne!(v1_pub, v2_pub);
+
+        // Resolve the historic pubkey via the keyring; verify succeeds.
+        let resolved = s
+            .key_by_id(&receipt_v1.signature.key_id)
+            .expect("keyring still knows about v1");
+        receipt_v1
+            .verify(&resolved.public_hex)
+            .expect("pre-rotation receipt must verify under the resolved v1 pubkey");
+
+        // And new receipts signed after rotation embed the v2 key_id.
+        let receipt_v2 = unsigned_receipt("evt-mock-kms-002").sign(&s).unwrap();
+        assert_eq!(receipt_v2.signature.key_id, "decision-mock-v2");
+        receipt_v2
+            .verify(&v2_pub)
+            .expect("v2 receipt must verify under v2 pubkey");
+        // Cross-pollination must fail: v1 receipt MUST NOT verify under v2.
+        assert!(receipt_v1.verify(&v2_pub).is_err());
+    }
+}

--- a/crates/mandate-core/src/receipt.rs
+++ b/crates/mandate-core/src/receipt.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
 use crate::hashing::canonical_json;
-use crate::signer::{verify_hex, DevSigner, VerifyError};
+use crate::signer::{verify_hex, SignerBackend, VerifyError};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -75,7 +75,11 @@ pub struct UnsignedReceipt {
 }
 
 impl UnsignedReceipt {
-    pub fn sign(self, signer: &DevSigner) -> Result<PolicyReceipt> {
+    /// Sign the receipt with any [`SignerBackend`] — `DevSigner` for
+    /// the existing demo path, `MockKmsSigner` for the production-shaped
+    /// path. The receipt's `signature.key_id` is taken from the
+    /// backend's `current_key_id()` so verifiers can route the lookup.
+    pub fn sign<S: SignerBackend + ?Sized>(self, signer: &S) -> Result<PolicyReceipt> {
         // Build the receipt with a placeholder signature so we can compute the
         // canonical body bytes by stripping the `signature` key from the JSON.
         let placeholder = PolicyReceipt {
@@ -93,7 +97,7 @@ impl UnsignedReceipt {
             expires_at: self.expires_at,
             signature: EmbeddedSignature {
                 algorithm: SignatureAlgorithm::Ed25519,
-                key_id: signer.key_id.clone(),
+                key_id: signer.current_key_id().to_string(),
                 signature_hex: "placeholder".to_string(),
             },
         };
@@ -102,7 +106,7 @@ impl UnsignedReceipt {
         Ok(PolicyReceipt {
             signature: EmbeddedSignature {
                 algorithm: SignatureAlgorithm::Ed25519,
-                key_id: signer.key_id.clone(),
+                key_id: signer.current_key_id().to_string(),
                 signature_hex: sig_hex,
             },
             ..placeholder
@@ -128,6 +132,7 @@ fn canonicalize_body(receipt: &PolicyReceipt) -> Result<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::signer::DevSigner;
 
     fn unsigned() -> UnsignedReceipt {
         UnsignedReceipt {

--- a/crates/mandate-core/src/signer.rs
+++ b/crates/mandate-core/src/signer.rs
@@ -1,8 +1,14 @@
-//! Local dev Ed25519 signer.
+//! Local dev Ed25519 signer + signer-backend trait.
 //!
 //! Production deployments use a TEE/HSM-backed signer (see
-//! `docs/spec/17_interface_contracts.md` §1). This module is the developer-mode
-//! backend used by demos and CI.
+//! `docs/spec/17_interface_contracts.md` §1). This module hosts:
+//!
+//! - `DevSigner`: the developer-mode Ed25519 signer used by demos and CI.
+//! - `SignerBackend`: the trait that decouples Mandate's signing code paths
+//!   (`UnsignedReceipt::sign`, `SignedAuditEvent::sign`, `DecisionPayload::sign`)
+//!   from any specific backend. `DevSigner` and the production-shaped
+//!   `MockKmsSigner` (in `crate::mock_kms`) both implement it. **Neither is a
+//!   real KMS or HSM.**
 
 use ed25519_dalek::{Signature, Signer as _, SigningKey, Verifier as _, VerifyingKey};
 use rand::rngs::OsRng;
@@ -57,6 +63,46 @@ impl DevSigner {
 
     pub fn sign_hex(&self, message: &[u8]) -> String {
         hex::encode(self.sign(message).to_bytes())
+    }
+}
+
+/// Backend abstraction for the three Mandate signing surfaces (policy
+/// receipt, audit event, decision token). Implementors must:
+///
+/// - report a stable `current_key_id()` that uniquely identifies the
+///   key version that produced a signature — verifiers carry this back
+///   in the `EmbeddedSignature.key_id` field;
+/// - produce hex-encoded Ed25519 signatures over the supplied bytes;
+/// - report the verifying key (hex) that corresponds to the
+///   *current* signing key, so a verifier can reconstruct trust without
+///   reaching into backend internals.
+///
+/// A backend that supports rotation (e.g. `MockKmsSigner`) MAY also
+/// expose historical keys via its own concrete API; the trait itself
+/// is intentionally minimal so callers don't depend on lifecycle
+/// details that don't apply to every backend.
+///
+/// **Truthfulness:** implementing this trait does NOT make a backend
+/// production-grade. `DevSigner` and `MockKmsSigner` are both local,
+/// non-HSM, non-KMS Ed25519 signers; production would replace them
+/// with a TEE/HSM-backed implementation behind the same trait.
+pub trait SignerBackend {
+    fn current_key_id(&self) -> &str;
+    fn sign_hex(&self, message: &[u8]) -> String;
+    fn current_public_hex(&self) -> String;
+}
+
+impl SignerBackend for DevSigner {
+    fn current_key_id(&self) -> &str {
+        &self.key_id
+    }
+    fn sign_hex(&self, message: &[u8]) -> String {
+        // Inherent method; same body. Keeping the inherent method for
+        // direct callers that don't go through the trait.
+        DevSigner::sign_hex(self, message)
+    }
+    fn current_public_hex(&self) -> String {
+        self.verifying_key_hex()
     }
 }
 

--- a/docs/cli/mock-kms.md
+++ b/docs/cli/mock-kms.md
@@ -1,0 +1,96 @@
+# Mock KMS signer
+
+> *Production-shaped, not production-ready.*
+
+`MockKmsSigner` (in `crates/mandate-core/src/mock_kms.rs`) is a local Ed25519 signer that **mimics the lifecycle shape of a managed KMS** — versioned keys, stable role names, rotation, historical-key verification — without ever leaving the process or talking to a real KMS.
+
+## What it is, and what it is not
+
+| | Mock KMS (this module) | A real KMS / HSM |
+|---|---|---|
+| Key custody | Local process memory; private key derivable from a local root seed | Hardware-isolated; never leaves the device |
+| Rotation | `rotate()` advances an in-memory keyring version | Provider-managed; backed by audit + access control |
+| Network | None — fully offline, deterministic | API + auth required, with rate limits and SLAs |
+| Failure modes | Compile-time / `VerifyError` | Auth failures, unavailable, throttled, attestation mismatches |
+| Audit | None | Provider-side audit, plus your own |
+
+**This is not a stepping stone where flipping one flag turns it into a real KMS.** The function `derive_signing_key(role, version, root_seed)` is replaceable, but the trust model around custody, rotation policy, attestation, and recovery is not modelled here. A real implementation would replace the entire backend behind the `SignerBackend` trait and rebuild a different operational story around it.
+
+The deterministic mock IS useful for:
+
+- exercising rotation semantics in tests and demos without flakiness;
+- showing reviewers a signer-trait boundary (`SignerBackend`) that production-grade backends can plug into;
+- proving that `PolicyReceipt` / `SignedAuditEvent` / `DecisionToken` already verify *across* a key rotation, with the right `key_id` resolution.
+
+## API surface
+
+`mandate_core::signer::SignerBackend` — the trait every signing surface uses:
+
+```rust
+pub trait SignerBackend {
+    fn current_key_id(&self) -> &str;
+    fn sign_hex(&self, message: &[u8]) -> String;
+    fn current_public_hex(&self) -> String;
+}
+```
+
+Both `DevSigner` and `MockKmsSigner` implement it. `UnsignedReceipt::sign`, `SignedAuditEvent::sign`, and `DecisionPayload::sign` all accept `&impl SignerBackend`, so swapping backends is a one-line change at the construction site.
+
+`mandate_core::mock_kms::MockKmsSigner`:
+
+```rust
+let mut s = MockKmsSigner::new(
+    /* role        */ "audit-mock",
+    /* root_seed   */ [42u8; 32],
+    /* genesis     */ chrono::Utc::now(),
+);
+assert_eq!(s.current_key_id(), "audit-mock-v1");
+
+// Sign through the trait.
+let sig = SignerBackend::sign_hex(&s, b"some canonical bytes");
+
+// Rotate.
+let v2 = s.rotate();
+assert_eq!(v2.version, 2);
+assert_eq!(v2.key_id, "audit-mock-v2");
+
+// Old signatures stay verifiable via key_id resolution.
+let v1 = s.key_by_id("audit-mock-v1").unwrap();
+mandate_core::signer::verify_hex(&v1.public_hex, b"some canonical bytes", &sig).unwrap();
+```
+
+`MockKmsKeyMeta` exposes:
+
+- `role`, `version`, `key_id`, `public_hex`, `created_at`,
+- a `mock: bool` field that is **always `true`** so JSON / CLI output cannot drop the disclosure.
+
+## CLI
+
+The CLI commands `mandate key list --mock` and `mandate key rotate --mock` are tracked separately. They require a small storage table to persist rotation state across CLI invocations; see the production-shaped mock backlog (item PSM-A1.9) for follow-up.
+
+For now, callers use `MockKmsSigner` programmatically (tests, in-process daemons, fixtures).
+
+## Tests
+
+`crates/mandate-core/src/mock_kms.rs::tests` covers:
+
+- v1 keyring metadata is deterministic;
+- different root seeds yield different keys;
+- `SignerBackend` round-trip;
+- `current_key_id()` / `current_public_hex()` agree with the keyring;
+- `rotate()` advances the version and changes the public key;
+- pre-rotation signatures still verify via resolved historical pubkey;
+- post-rotation pubkey rejects pre-rotation signatures;
+- unknown `key_id` → `VerifyError::BadPublicKey`;
+- `from_versions(N)` reconstructs the same keyring as `new(...) + N-1 rotations`;
+- `current_as_dev_signer()` produces compatible signatures (compat shim);
+- end-to-end: receipt / audit event / decision token sign + verify through `MockKmsSigner`;
+- end-to-end: a pre-rotation receipt verifies under the resolved v1 pubkey after the keyring rotates to v2; a v2 pubkey rejects the v1 receipt.
+
+## Limitations carried forward (truthful disclosure)
+
+- No persistence of rotation state across processes (programmatic only).
+- No CLI surface yet — see PSM-A1.9.
+- No live KMS / HSM backend implements `SignerBackend` in this build.
+- `derive_signing_key` is a deterministic seed-stretch, **not** a production KDF; do not adopt it for any non-mock context.
+- The daemon (`mandate-server`) still constructs `DevSigner` for receipts and audit events; wiring the daemon to use `MockKmsSigner` (and persisting rotation state) is also future work.


### PR DESCRIPTION
## Summary

Backlog item **A1** from the production-shaped mock backlog (`38_production_shaped_mock_backlog.md`). Adds a production-shaped **mock** signer that mimics KMS lifecycle (versioned keys, stable role names, rotation, historical-key verification) — **without** ever leaving the process or talking to a real KMS. Documented exhaustively in the module header and the new `docs/cli/mock-kms.md`. **Mock — not production-grade.**

## What's real vs mocked

**Real (kept identical):**
- Ed25519 signing primitives (same as `DevSigner`).
- Receipt / audit-event / decision-token signing pipeline — bytes are identical, the `key_id` string is the only thing that differs (`audit-mock-v1` vs `audit-signer-v1`).
- Verification path: `verify_hex(...)` is unchanged.

**Mocked (clearly labelled):**
- Key custody: keys are derived deterministically from a local `root_seed` via `seed_for(role, version, root_seed) = SHA256("mandate.mock_kms.v1" || root_seed || role || version)`. Documented as **NOT a production KDF**.
- Rotation lifecycle: pure in-memory state on `MockKmsSigner`. No KMS API call. No audit on the rotation event itself in this PR.
- `MockKmsKeyMeta.mock: bool` is **always `true`** and exists specifically so JSON / CLI output cannot accidentally drop the disclosure.

## Files changed (7)

| File | Change |
|---|---|
| `crates/mandate-core/src/signer.rs` | New `SignerBackend` trait + `impl SignerBackend for DevSigner`. Module header rewritten to disclose neither backend is HSM/KMS. |
| `crates/mandate-core/src/mock_kms.rs` (new) | `MockKmsSigner` keyring + `MockKmsKeyMeta` + `SignerBackend` impl + 14 tests. |
| `crates/mandate-core/src/lib.rs` | `pub mod mock_kms;` |
| `crates/mandate-core/src/receipt.rs` | `UnsignedReceipt::sign` is now generic `<S: SignerBackend + ?Sized>(self, signer: &S)`. Reads `signer.current_key_id()`. |
| `crates/mandate-core/src/audit.rs` | `SignedAuditEvent::sign` made generic over `&impl SignerBackend`. |
| `crates/mandate-core/src/decision_token.rs` | `DecisionPayload::sign` made generic; reads `signer.current_public_hex()` for `signing_pubkey_hex`. |
| `docs/cli/mock-kms.md` (new) | Production-shaped/not-production-ready disclosure, API surface, what-is-not-modelled table, deferred-CLI explanation. |

## Test count

✅ **135 / 135 pass** (was 121; +14 new — 10 keyring + 4 cross-cutting integration).

### Test breakdown

**`mock_kms::tests` (10 keyring tests):**
- `fresh_signer_starts_at_v1`
- `key_metadata_is_deterministic`
- `different_roots_yield_different_keys`
- `signer_backend_round_trip`
- `signer_backend_reports_consistent_metadata`
- `rotate_advances_current_version`
- `old_signature_still_verifies_after_rotation`
- `wrong_key_id_returns_bad_public_key`
- `from_versions_reconstructs_same_keyring_after_rotations`
- `current_as_dev_signer_produces_compatible_signatures`

**`mock_kms::tests` (4 cross-cutting integration):**
- `receipt_round_trip_through_mock_kms`
- `audit_event_round_trip_through_mock_kms`
- `decision_token_round_trip_through_mock_kms`
- `pre_rotation_receipt_still_verifies_after_rotation` — signs receipt under v1, rotates to v2, asserts v1 receipt still verifies via the resolved v1 pubkey AND v2 pubkey rejects the v1 receipt

## Command results (local, on this branch)

- [x] `cargo fmt --check` — ✅
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — ✅ (no warnings)
- [x] `cargo test --workspace --all-targets` — ✅ 135 / 135
- [x] `python3 scripts/validate_schemas.py` — ✅
- [x] `python3 scripts/validate_openapi.py` — ✅
- [x] `bash demo-scripts/run-openagents-final.sh` — ✅ all 13 / 13 gates green
- [x] `python3 trust-badge/build.py` — ✅
- [x] `python3 trust-badge/test_build.py` — ✅ PASS: 31 checks ok

## Schemas / OpenAPI changed?

**No.** Receipts / audit events / decision tokens produced by `MockKmsSigner` are byte-identical in shape to those produced by `DevSigner`; only the `key_id` string differs.

## Demo affected?

**No.** The 13-step `run-openagents-final.sh` is unaffected; the daemon still constructs `DevSigner` directly. `MockKmsSigner` is opt-in via the new trait.

## Limitations / deferred follow-ups

Documented openly in the module header + `docs/cli/mock-kms.md`:

- **No CLI** (`mandate key list --mock` / `mandate key rotate --mock`) — PSM-A1.9 requires a small `mock_kms_keys` storage table to persist rotation state across CLI invocations; tracked separately so this PR stays focused on the signer + trait boundary.
- **Daemon still uses `DevSigner` directly.** Wiring `mandate-server` to use `MockKmsSigner` (and persisting rotation state) is follow-up.
- **Not a stepping stone.** Documented explicitly: replacing `derive_signing_key` with a real KMS call would NOT make this production-grade. Custody / attestation / recovery / audit are not modelled here.
- **No persistence** — `rotate()` is in-memory only. Tests use `from_versions(N)` to simulate restart-after-N-rotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)