### PR TITLE
feat: add mandate doctor command

### DIFF
--- a/crates/mandate-cli/src/doctor.rs
+++ b/crates/mandate-cli/src/doctor.rs
@@ -1,0 +1,569 @@
+//! `mandate doctor` — operator readiness summary.
+//!
+//! Production-shaped, deliberately honest. Every feature shows up as one
+//! of:
+//!
+//! - **`ok`** — the feature is implemented and the database backs it.
+//! - **`skip`** — the feature is not implemented in this build (its table
+//!   doesn't exist yet, or its CLI/storage path is documented future work).
+//!   Skip is **never** silently presented as `ok`.
+//! - **`warn`** — implemented but the current state is anomalous (e.g. an
+//!   empty audit chain on a fresh DB is fine; an empty audit chain on a
+//!   db that has nonce rows is suspicious — but we don't currently
+//!   correlate those, so warn is reserved for future heuristics).
+//! - **`fail`** — implemented but the integrity check failed (e.g. audit
+//!   chain present but `prev_event_hash` linkage is broken). The doctor
+//!   exits non-zero in this case.
+//!
+//! The CLI is intended to be safe to run against a production-shape mock
+//! daemon's storage. It does not require live network, live KMS or
+//! sponsor credentials — every check is a local SQLite read.
+
+use std::path::Path;
+use std::process::ExitCode;
+
+use mandate_core::audit::verify_chain;
+use mandate_storage::Storage;
+use serde::Serialize;
+
+/// One row of the doctor report. Either a present-and-healthy `ok` row, a
+/// `skip` row for an optional/future feature, a `warn`, or a `fail`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "status", rename_all = "lowercase")]
+enum CheckStatus {
+    Ok {
+        detail: String,
+    },
+    Skip {
+        reason: String,
+    },
+    /// Reserved for future heuristics (see module docs). Currently no
+    /// runtime check produces a `Warn`; it stays in the enum so the
+    /// JSON envelope is forward-compatible and tests can construct it
+    /// to exercise `overall_verdict`.
+    #[allow(dead_code)]
+    Warn {
+        detail: String,
+    },
+    Fail {
+        error: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct Check {
+    name: &'static str,
+    #[serde(flatten)]
+    status: CheckStatus,
+}
+
+/// JSON envelope shape — stable across releases. The production-shaped
+/// runner (PSM-B1) can consume this to promote sections from SKIP.
+#[derive(Debug, Serialize)]
+struct DoctorReport {
+    /// Always `"mandate.doctor.v1"`. Stable identifier so consumers can
+    /// route to the right parser.
+    report_type: &'static str,
+    /// Aggregate verdict. `ok` if every check is `ok` or `skip`. `fail`
+    /// if any check is `fail`. `warn` if there's at least one `warn` and
+    /// no `fail`.
+    overall: &'static str,
+    /// Path the doctor opened. `:memory:` if `--db` was omitted.
+    db_path: String,
+    checks: Vec<Check>,
+}
+
+fn ok(name: &'static str, detail: impl Into<String>) -> Check {
+    Check {
+        name,
+        status: CheckStatus::Ok {
+            detail: detail.into(),
+        },
+    }
+}
+
+fn skip(name: &'static str, reason: impl Into<String>) -> Check {
+    Check {
+        name,
+        status: CheckStatus::Skip {
+            reason: reason.into(),
+        },
+    }
+}
+
+/// Constructor for warn rows. Reserved for future heuristics — exposed
+/// to tests so `overall_verdict` is exercised, but no runtime check
+/// produces a warn today.
+#[allow(dead_code)]
+fn warn_check(name: &'static str, detail: impl Into<String>) -> Check {
+    Check {
+        name,
+        status: CheckStatus::Warn {
+            detail: detail.into(),
+        },
+    }
+}
+
+fn fail(name: &'static str, error: impl Into<String>) -> Check {
+    Check {
+        name,
+        status: CheckStatus::Fail {
+            error: error.into(),
+        },
+    }
+}
+
+/// Run every check against `storage` and return the populated report.
+fn run_checks(storage: &Storage) -> Vec<Check> {
+    let mut checks = Vec::new();
+
+    // 1. migrations applied
+    match storage.applied_migrations() {
+        Ok(rows) if rows.is_empty() => {
+            checks.push(fail("migrations", "no migrations recorded"));
+        }
+        Ok(rows) => {
+            let summary = rows
+                .iter()
+                .map(|(v, d)| format!("V{v:03}:{d}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            checks.push(ok("migrations", summary));
+        }
+        Err(e) => checks.push(fail("migrations", e.to_string())),
+    }
+
+    // 2. nonce replay table (V002 — production-grade in current build)
+    match storage.optional_count("nonce_replay") {
+        Ok(Some(n)) => checks.push(ok("nonce_replay", format!("table present, rows={n}"))),
+        Ok(None) => checks.push(skip(
+            "nonce_replay",
+            "table not present — nonce replay protection unavailable in this DB",
+        )),
+        Err(e) => checks.push(fail("nonce_replay", e.to_string())),
+    }
+
+    // 3. idempotency table (V004 — present after PSM-A2 lands)
+    match storage.optional_count("idempotency_keys") {
+        Ok(Some(n)) => checks.push(ok("idempotency_keys", format!("table present, rows={n}"))),
+        Ok(None) => checks.push(skip(
+            "idempotency_keys",
+            "table not present — Idempotency-Key safe-retry unavailable in this DB \
+             (implemented in PSM-A2; ensure the daemon ran the V004 migration)",
+        )),
+        Err(e) => checks.push(fail("idempotency_keys", e.to_string())),
+    }
+
+    // 4. audit chain — present, structural verify if non-empty
+    match storage.audit_count() {
+        Ok(0) => checks.push(skip(
+            "audit_chain",
+            "no audit events yet — fresh DB; doctor cannot verify a chain that hasn't been written",
+        )),
+        Ok(n) => match storage.audit_list() {
+            Ok(events) => match verify_chain(&events, true, None) {
+                Ok(()) => checks.push(ok(
+                    "audit_chain",
+                    format!("{n} events; structural + hash verify ok (signatures not checked — pubkey not available to doctor)"),
+                )),
+                Err(e) => checks.push(fail("audit_chain", e.to_string())),
+            },
+            Err(e) => checks.push(fail("audit_chain", e.to_string())),
+        },
+        Err(e) => checks.push(fail("audit_chain", e.to_string())),
+    }
+
+    // 5. mock KMS keyring (PSM-A1 / future PSM-A1.9 storage)
+    match storage.optional_count("mock_kms_keys") {
+        Ok(Some(n)) => checks.push(ok(
+            "mock_kms_keys",
+            format!(
+                "table present, rows={n} — see docs/cli/mock-kms.md (mock, not production KMS)"
+            ),
+        )),
+        Ok(None) => checks.push(skip(
+            "mock_kms_keys",
+            "table not present — Mock KMS keyring persistence is tracked as PSM-A1.9; \
+             the in-process MockKmsSigner from PSM-A1 still works without it",
+        )),
+        Err(e) => checks.push(fail("mock_kms_keys", e.to_string())),
+    }
+
+    // 6. active policy (PSM-A3)
+    match storage.optional_count("active_policy") {
+        Ok(Some(n)) => checks.push(ok("active_policy", format!("table present, rows={n}"))),
+        Ok(None) => checks.push(skip(
+            "active_policy",
+            "table not present — policy lifecycle (PSM-A3) not implemented; \
+             daemon currently uses the embedded reference policy",
+        )),
+        Err(e) => checks.push(fail("active_policy", e.to_string())),
+    }
+
+    // 7. payment_requests (existing table from V001)
+    match storage.optional_count("payment_requests") {
+        Ok(Some(n)) => checks.push(ok("payment_requests", format!("table present, rows={n}"))),
+        Ok(None) => checks.push(fail(
+            "payment_requests",
+            "core table missing — V001 migration did not apply",
+        )),
+        Err(e) => checks.push(fail("payment_requests", e.to_string())),
+    }
+
+    checks
+}
+
+fn overall_verdict(checks: &[Check]) -> &'static str {
+    let mut has_warn = false;
+    for c in checks {
+        match c.status {
+            CheckStatus::Fail { .. } => return "fail",
+            CheckStatus::Warn { .. } => has_warn = true,
+            _ => {}
+        }
+    }
+    if has_warn {
+        "warn"
+    } else {
+        "ok"
+    }
+}
+
+fn render_human(report: &DoctorReport) -> String {
+    let mut out = String::new();
+    use std::fmt::Write;
+    let _ = writeln!(out, "mandate doctor — operator readiness summary");
+    let _ = writeln!(out, "  db:      {}", report.db_path);
+    let _ = writeln!(out, "  overall: {}", report.overall);
+    let _ = writeln!(out);
+    for c in &report.checks {
+        match &c.status {
+            CheckStatus::Ok { detail } => {
+                let _ = writeln!(out, "  ok    {:24}  {}", c.name, detail);
+            }
+            CheckStatus::Skip { reason } => {
+                let _ = writeln!(out, "  skip  {:24}  {}", c.name, reason);
+            }
+            CheckStatus::Warn { detail } => {
+                let _ = writeln!(out, "  warn  {:24}  {}", c.name, detail);
+            }
+            CheckStatus::Fail { error } => {
+                let _ = writeln!(out, "  FAIL  {:24}  {}", c.name, error);
+            }
+        }
+    }
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "  truthfulness note: skip means the feature is not yet implemented \
+         in this build, NOT that it silently passed. See docs/cli/doctor.md."
+    );
+    out
+}
+
+/// Entry point for `mandate doctor`. Returns a process exit code:
+/// `0` on `ok` / `warn`, `1` if any check failed, `2` if the database
+/// itself could not be opened.
+pub fn run(db: Option<&Path>, json: bool) -> ExitCode {
+    let storage_result = match db {
+        Some(p) => Storage::open(p),
+        None => Storage::open_in_memory(),
+    };
+    let storage = match storage_result {
+        Ok(s) => s,
+        Err(e) => {
+            let path = db
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| ":memory:".to_string());
+            if json {
+                let report = DoctorReport {
+                    report_type: "mandate.doctor.v1",
+                    overall: "fail",
+                    db_path: path.clone(),
+                    checks: vec![fail("storage_open", e.to_string())],
+                };
+                println!("{}", serde_json::to_string_pretty(&report).unwrap());
+            } else {
+                eprintln!("mandate doctor: failed to open db {path}: {e}");
+            }
+            return ExitCode::from(2);
+        }
+    };
+
+    let checks = run_checks(&storage);
+    let overall = overall_verdict(&checks);
+    let report = DoctorReport {
+        report_type: "mandate.doctor.v1",
+        overall,
+        db_path: db
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| ":memory:".to_string()),
+        checks,
+    };
+
+    if json {
+        match serde_json::to_string_pretty(&report) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                eprintln!("mandate doctor: failed to serialise report: {e}");
+                return ExitCode::from(2);
+            }
+        }
+    } else {
+        print!("{}", render_human(&report));
+    }
+
+    match overall {
+        "fail" => ExitCode::from(1),
+        _ => ExitCode::SUCCESS,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh_storage() -> Storage {
+        Storage::open_in_memory().unwrap()
+    }
+
+    /// Build a tempfile-backed `Storage` and then DROP `table` from
+    /// the underlying SQLite file, simulating an "older daemon DB"
+    /// that was migrated to current schema except for the named
+    /// optional table. We use this to test the doctor's `skip` path
+    /// independently of which migrations happen to be on `main` at
+    /// any given moment — so the test stays correct after future
+    /// migrations land.
+    ///
+    /// The migration system records `(version, sha256)` rows in
+    /// `schema_migrations`. After we drop the table, re-opening the
+    /// `Storage` does NOT re-create it: the migration loop sees the
+    /// existing `schema_migrations` row, skips re-applying. That
+    /// precisely models a daemon that was upgraded without re-running
+    /// the relevant migration — exactly the operational shape the
+    /// doctor's skip path is designed to surface.
+    fn storage_without_table(table: &str) -> (tempfile::TempDir, Storage) {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("doctor-older-db.sqlite");
+        // Apply all current migrations (V001/V002/V004 today, plus
+        // anything future). Drop the Storage so the file lock is
+        // released before the raw rusqlite handle takes over.
+        {
+            let _ = Storage::open(&path).unwrap();
+        }
+        {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            conn.execute(&format!("DROP TABLE IF EXISTS \"{table}\""), [])
+                .unwrap();
+        }
+        // Re-open via Storage. Migration loop sees `schema_migrations`
+        // already populated for this version → skips re-applying.
+        // The dropped table stays missing.
+        let s = Storage::open(&path).unwrap();
+        (tmp, s)
+    }
+
+    #[test]
+    fn fresh_in_memory_db_yields_ok_overall() {
+        // A fresh storage on current `main` has:
+        //   - migrations applied (V001 + V002 + V004),
+        //   - idempotency_keys table present (V004) — ok,
+        //   - nonce_replay table present (V002) — ok,
+        //   - mock_kms_keys, active_policy → skip (not on main yet),
+        //   - audit_chain → skip (no events yet),
+        //   - payment_requests → ok (V001).
+        // No fails, no warns → overall ok.
+        let s = fresh_storage();
+        let checks = run_checks(&s);
+        let overall = overall_verdict(&checks);
+        assert_eq!(overall, "ok", "got checks={checks:#?}");
+        // Sanity: at least one ok and at least one skip should be present.
+        let has_ok = checks
+            .iter()
+            .any(|c| matches!(c.status, CheckStatus::Ok { .. }));
+        let has_skip = checks
+            .iter()
+            .any(|c| matches!(c.status, CheckStatus::Skip { .. }));
+        assert!(has_ok, "doctor must surface at least one ok check");
+        assert!(
+            has_skip,
+            "doctor must surface skip rows for optional features (truthfulness rule)"
+        );
+    }
+
+    #[test]
+    fn nonce_replay_reports_ok_when_table_present() {
+        let s = fresh_storage();
+        let checks = run_checks(&s);
+        let nonce_check = checks
+            .iter()
+            .find(|c| c.name == "nonce_replay")
+            .expect("nonce_replay must be checked");
+        assert!(matches!(nonce_check.status, CheckStatus::Ok { .. }));
+    }
+
+    #[test]
+    fn idempotency_reports_ok_on_default_post_a2_db() {
+        // Post PSM-A2, V004 is part of the default migration set, so a
+        // fresh storage carries the `idempotency_keys` table. This
+        // pins the OK path so a future regression that silently
+        // dropped V004 from the migrations list would surface here.
+        let s = fresh_storage();
+        let checks = run_checks(&s);
+        let idem = checks
+            .iter()
+            .find(|c| c.name == "idempotency_keys")
+            .expect("idempotency_keys row must exist");
+        assert!(
+            matches!(idem.status, CheckStatus::Ok { .. }),
+            "idempotency_keys must be OK on a default post-A2 DB; got {:?}",
+            idem.status
+        );
+    }
+
+    #[test]
+    fn idempotency_skip_when_table_missing_on_older_db() {
+        // The skip path is ONLY for older databases that haven't run
+        // the V004 migration (e.g. a daemon that was upgraded but
+        // hasn't applied schema changes yet). We construct that shape
+        // explicitly by dropping the `idempotency_keys` table —
+        // independent of which migrations happen to be on main. The
+        // skip reason must reference PSM-A2 so an operator knows the
+        // upgrade path.
+        let (_tmp, s) = storage_without_table("idempotency_keys");
+        let checks = run_checks(&s);
+        let idem = checks
+            .iter()
+            .find(|c| c.name == "idempotency_keys")
+            .expect("idempotency_keys row must exist");
+        match &idem.status {
+            CheckStatus::Skip { reason } => {
+                assert!(
+                    reason.contains("PSM-A2"),
+                    "skip reason must reference PSM-A2 so operators know what to enable: {reason}"
+                );
+            }
+            other => panic!("expected skip on older DB without V004, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mock_kms_keys_skip_when_table_missing_on_older_db() {
+        // Same pattern as the idempotency skip test but for V005
+        // (PSM-A1.9). On main today the table doesn't exist by
+        // default, but once A1.9 lands it will — so we explicitly
+        // construct the skip shape via the table-drop helper. That
+        // keeps this test correct in BOTH worlds: pre-A1.9 the table
+        // is naturally absent, post-A1.9 we drop it to simulate an
+        // older daemon DB. The skip reason must reference PSM-A1.9
+        // so an operator knows the upgrade path.
+        let (_tmp, s) = storage_without_table("mock_kms_keys");
+        let checks = run_checks(&s);
+        let kms = checks
+            .iter()
+            .find(|c| c.name == "mock_kms_keys")
+            .expect("mock_kms_keys row");
+        match &kms.status {
+            CheckStatus::Skip { reason } => {
+                assert!(
+                    reason.contains("PSM-A1.9"),
+                    "skip reason must reference PSM-A1.9: {reason}"
+                );
+            }
+            other => panic!("expected skip, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn audit_chain_skip_on_empty_db() {
+        let s = fresh_storage();
+        let checks = run_checks(&s);
+        let chain = checks
+            .iter()
+            .find(|c| c.name == "audit_chain")
+            .expect("audit_chain row");
+        assert!(
+            matches!(chain.status, CheckStatus::Skip { .. }),
+            "empty chain must be skip, not fail or fake-ok; got {:?}",
+            chain.status
+        );
+    }
+
+    #[test]
+    fn audit_chain_ok_after_appending_events() {
+        // Append a couple of events through the existing storage path,
+        // then run the doctor — chain row should be ok with the count.
+        use mandate_core::signer::DevSigner;
+        use mandate_storage::audit_store::NewAuditEvent;
+        let mut s = fresh_storage();
+        let signer = DevSigner::from_seed("audit-doctor", [3u8; 32]);
+        s.audit_append(
+            NewAuditEvent::now("runtime_started", "doctor-test", "runtime"),
+            &signer,
+        )
+        .unwrap();
+        s.audit_append(
+            NewAuditEvent::now("policy_decided", "doctor-test", "pr-001"),
+            &signer,
+        )
+        .unwrap();
+        let checks = run_checks(&s);
+        let chain = checks.iter().find(|c| c.name == "audit_chain").unwrap();
+        match &chain.status {
+            CheckStatus::Ok { detail } => assert!(
+                detail.contains("2 events"),
+                "expected ok with 2 events, got {detail}"
+            ),
+            other => panic!("expected ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_envelope_serialises_with_stable_report_type() {
+        let s = fresh_storage();
+        let checks = run_checks(&s);
+        let overall = overall_verdict(&checks);
+        let report = DoctorReport {
+            report_type: "mandate.doctor.v1",
+            overall,
+            db_path: ":memory:".to_string(),
+            checks,
+        };
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&report).unwrap()).unwrap();
+        assert_eq!(v["report_type"], "mandate.doctor.v1");
+        assert!(v["checks"].is_array());
+        assert!(v["checks"].as_array().unwrap().len() >= 5);
+        // Each check carries a name + a status tag.
+        for c in v["checks"].as_array().unwrap() {
+            assert!(c["name"].is_string());
+            assert!(c["status"].is_string());
+        }
+    }
+
+    #[test]
+    fn overall_is_fail_if_any_check_fails() {
+        let checks = vec![
+            ok("a", "fine"),
+            fail("b", "broken"),
+            skip("c", "not implemented"),
+        ];
+        assert_eq!(overall_verdict(&checks), "fail");
+    }
+
+    #[test]
+    fn overall_is_warn_if_only_warns_no_fails() {
+        let checks = vec![
+            ok("a", "fine"),
+            warn_check("b", "anomalous"),
+            skip("c", "not implemented"),
+        ];
+        assert_eq!(overall_verdict(&checks), "warn");
+    }
+
+    #[test]
+    fn overall_is_ok_if_only_ok_and_skip() {
+        let checks = vec![ok("a", "fine"), skip("b", "not implemented")];
+        assert_eq!(overall_verdict(&checks), "ok");
+    }
+}

--- a/crates/mandate-cli/src/main.rs
+++ b/crates/mandate-cli/src/main.rs
@@ -7,6 +7,8 @@ use mandate_core::audit_bundle::{self, AuditBundle};
 use mandate_core::receipt::PolicyReceipt;
 use mandate_core::{schema, SchemaError};
 
+mod doctor;
+
 #[derive(Parser, Debug)]
 #[command(
     name = "mandate",
@@ -55,6 +57,26 @@ enum Command {
     Audit {
         #[command(subcommand)]
         op: AuditCmd,
+    },
+    /// Operator readiness summary.
+    ///
+    /// Inspects a Mandate SQLite database (or an in-memory fresh one) and
+    /// reports per-feature status: storage open, migrations applied, audit
+    /// chain integrity, nonce-replay table, idempotency table, mock KMS
+    /// keyring, active policy. Each check is **honest about scope** — a
+    /// feature that is not implemented yet surfaces as `skip`, never as
+    /// fake `ok`. Output is a human-readable summary by default; `--json`
+    /// emits a machine-readable envelope suitable for pipelines and the
+    /// production-shaped runner.
+    Doctor {
+        /// Path to a Mandate SQLite database. If omitted, opens a fresh
+        /// in-memory database (every check runs against a clean slate —
+        /// useful for verifying the binary itself works).
+        #[arg(long)]
+        db: Option<PathBuf>,
+        /// Emit JSON instead of human-readable text.
+        #[arg(long, default_value_t = false)]
+        json: bool,
     },
 }
 
@@ -183,6 +205,7 @@ fn main() -> ExitCode {
         Command::Audit {
             op: AuditCmd::VerifyBundle { path },
         } => cmd_audit_verify_bundle(&path),
+        Command::Doctor { db, json } => doctor::run(db.as_deref(), json),
     }
 }
 

--- a/crates/mandate-storage/src/db.rs
+++ b/crates/mandate-storage/src/db.rs
@@ -24,6 +24,49 @@ pub struct Storage {
 }
 
 impl Storage {
+    /// True if a table with the given name exists in the open database.
+    /// Used by `mandate doctor` to detect optional tables (e.g.
+    /// `idempotency_keys` from a future migration) without forcing a
+    /// migration order.
+    pub fn table_exists(&self, name: &str) -> StorageResult<bool> {
+        let n: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?1",
+            rusqlite::params![name],
+            |r| r.get(0),
+        )?;
+        Ok(n > 0)
+    }
+
+    /// List of `(version, description)` for every migration that has been
+    /// applied against this database. `mandate doctor` prints this to
+    /// reassure the operator that storage is current.
+    pub fn applied_migrations(&self) -> StorageResult<Vec<(i64, String)>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT version, description FROM schema_migrations ORDER BY version ASC")?;
+        let rows = stmt
+            .query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?)))?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Count rows in a table that may not exist. Returns `Ok(None)` when
+    /// the table is missing — handy for the doctor's optional-feature
+    /// reporting where a missing table is "skip", not "fail".
+    pub fn optional_count(&self, table: &str) -> StorageResult<Option<u64>> {
+        if !self.table_exists(table)? {
+            return Ok(None);
+        }
+        // We control `table` (called only with hard-coded names from the
+        // CLI), so direct interpolation is fine — SQLite parameter
+        // bindings can't substitute table identifiers anyway.
+        let sql = format!("SELECT COUNT(*) FROM \"{table}\"");
+        let n: i64 = self.conn.query_row(&sql, [], |r| r.get(0))?;
+        Ok(Some(n as u64))
+    }
+}
+
+impl Storage {
     pub fn open_in_memory() -> StorageResult<Self> {
         let conn = Connection::open_in_memory().map_err(StorageError::Sqlite)?;
         Self::configure(&conn)?;

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -1,0 +1,82 @@
+# `mandate doctor`
+
+> Operator readiness summary. Honest about scope: every check is `ok`, `skip`, `warn`, or `fail` — never silently `ok` on a missing feature.
+
+## Quick start
+
+```bash
+# Run against an in-memory fresh DB (verifies the binary itself works):
+mandate doctor
+
+# Run against a daemon's SQLite store:
+mandate doctor --db /var/lib/mandate/mandate.sqlite
+
+# Machine-readable, stable schema (production-shaped runner consumes this):
+mandate doctor --db /var/lib/mandate/mandate.sqlite --json
+```
+
+## What it checks
+
+| Row | Meaning |
+|---|---|
+| `migrations` | `schema_migrations` populated; lists `V<n>:<description>` for every applied migration. |
+| `nonce_replay` | V002 table present + row count. (Implemented today.) |
+| `idempotency_keys` | V004 table present + row count. **Skip** if the migration hasn't run — reason references **PSM-A2** so an operator knows what to enable. |
+| `audit_chain` | Count + structural verify (`prev_event_hash` linkage and `event_hash` recompute). Signatures are **not** verified — the doctor doesn't have access to the daemon's signer pubkey. **Skip** if the chain is empty. |
+| `mock_kms_keys` | **Skip** today — Mock KMS keyring persistence is tracked as **PSM-A1.9**. The in-process `MockKmsSigner` (PSM-A1) still works without persistence. |
+| `active_policy` | **Skip** today — policy lifecycle is **PSM-A3**. The daemon currently uses the embedded reference policy. |
+| `payment_requests` | Core V001 table present + row count. |
+
+## Status semantics
+
+- **`ok`** — feature implemented and DB backs it. Detail explains the row count or migration list.
+- **`skip`** — feature is **not implemented in this build** OR the optional table hasn't been migrated yet. Skip is **never** a fake `ok`. Skip rows always include a reason that references the backlog item that would promote them (PSM-A2, PSM-A1.9, PSM-A3).
+- **`warn`** — implemented but the current state is anomalous. Reserved for future heuristics.
+- **`fail`** — implemented and the integrity check failed (e.g. audit chain present but `prev_event_hash` linkage is broken). The doctor exits non-zero in this case.
+
+## Aggregate verdict
+
+The `overall` field at the top of the report is:
+
+- `ok` — every row is `ok` or `skip`.
+- `warn` — at least one `warn`, no `fail`.
+- `fail` — at least one `fail`. The doctor exits with code `1`.
+
+Code `2` is reserved for "DB itself could not be opened" (different error class — DB-level, not check-level).
+
+## JSON envelope
+
+The JSON shape is **stable** under `report_type: "mandate.doctor.v1"`. Consumers (especially the production-shaped runner) can rely on:
+
+```json
+{
+  "report_type": "mandate.doctor.v1",
+  "overall":     "ok|warn|fail",
+  "db_path":     "...",
+  "checks": [
+    { "name": "migrations",       "status": "ok",   "detail": "V001:init, V002:nonce_replay" },
+    { "name": "nonce_replay",     "status": "ok",   "detail": "table present, rows=0" },
+    { "name": "idempotency_keys", "status": "skip", "reason": "table not present — ... PSM-A2 ..." },
+    { "name": "audit_chain",      "status": "skip", "reason": "no audit events yet — ..." },
+    ...
+  ]
+}
+```
+
+`status` is the discriminator. `ok` and `warn` rows carry `detail`; `skip` rows carry `reason`; `fail` rows carry `error`.
+
+## What the doctor does NOT check
+
+- **Live network reachability.** The doctor is offline by design.
+- **KMS / HSM connectivity.** Mock KMS keyring is local; production KMS would be a separate diagnostic.
+- **Sponsor credentials.** ENS / KeeperHub / Uniswap connectivity is not part of the doctor's scope.
+- **Signer keypair correctness.** Audit chain verification skips signatures (it doesn't have the pubkey to verify against). Wire that up if you persist the daemon's signing pubkey somewhere the doctor can read.
+
+These omissions are deliberate — the doctor is for "is the local Mandate state internally consistent and migrations-current?", not "is every external dependency live?"
+
+## Truthfulness rules (for the people who read every doctor report)
+
+1. Skip means **not implemented yet**, never silently passing.
+2. Skip rows reference the backlog item that would promote them — so an operator can plan the upgrade path.
+3. The `overall` verdict deliberately treats `skip` as `ok` for the aggregate — a fresh production-shaped mock build is supposed to have skips, and we don't want to fail-loud on expected absences.
+4. The doctor never claims production readiness. The output makes it obvious which features are mock and which are absent.


### PR DESCRIPTION
## Summary

PSM-A5 from the production-shaped mock backlog. Adds `mandate doctor` — operator readiness summary that inspects a Mandate SQLite database and reports each feature as `ok` / `skip` / `warn` / `fail`. **Skip is never a fake `ok`** — every skip row references the backlog item that would promote it (PSM-A2, PSM-A1.9, PSM-A3) so an operator knows the upgrade path.

## Files changed (4)

| File | Change |
|---|---|
| `crates/mandate-cli/src/doctor.rs` (new) | Module: `CheckStatus` enum, `Check` row, `DoctorReport` envelope, `run_checks()`, `overall_verdict()`, `render_human()`, `run()` entry point. **11 unit tests.** |
| `crates/mandate-cli/src/main.rs` | New `Doctor { db, json }` subcommand + dispatch. |
| `crates/mandate-storage/src/db.rs` | 3 new helpers: `table_exists()`, `applied_migrations()`, `optional_count()` — used by the doctor to detect optional tables without forcing a migration order. |
| `docs/cli/doctor.md` (new) | Semantics, JSON shape, truthfulness rules. |

## Behaviour on a default current `main` DB (post-A2)

| Check | Status today | When promoted | When SKIP |
|---|---|---|---|
| `migrations` | `ok` — `V001:init, V002:nonce_replay, V004:idempotency_keys` | — | empty / unreadable |
| `nonce_replay` (V002) | **`ok`** — table present | always present on default DB | only on older DBs that haven't run V002 |
| `idempotency_keys` (V004) | **`ok`** — table present **(post-A2 default)** | always present on default DB | only on older DBs missing V004 |
| `audit_chain` | `skip` (empty chain) | non-empty + structural verify | empty fresh DB |
| `mock_kms_keys` (V005) | `skip` today | promotes to `ok` automatically once **PSM-A1.9 (PR #28)** lands and creates the table | only on older DBs missing V005 |
| `active_policy` | `skip` | promotes to `ok` once **PSM-A3** lands | only on older DBs missing the future migration |
| `payment_requests` (V001) | `ok` — core table present | always | (FAIL if missing — V001 is mandatory) |

The audit chain check intentionally does **not** verify signatures — the doctor doesn't have access to the daemon's signing pubkey. Documented in the `ok` detail string and in `docs/cli/doctor.md`.

## Output modes

**Human (default):**
```
mandate doctor — operator readiness summary
  db:      :memory:
  overall: ok

  ok    migrations                V001:init, V002:nonce_replay, V004:idempotency_keys
  ok    nonce_replay              table present, rows=0
  ok    idempotency_keys          table present, rows=0
  skip  audit_chain               no audit events yet — fresh DB; doctor cannot verify a chain that hasn't been written
  skip  mock_kms_keys             table not present — Mock KMS keyring persistence is tracked as PSM-A1.9; the in-process MockKmsSigner from PSM-A1 still works without it
  skip  active_policy             table not present — policy lifecycle (PSM-A3) not implemented; daemon currently uses the embedded reference policy
  ok    payment_requests          table present, rows=0

  truthfulness note: skip means the feature is not yet implemented in this build, NOT that it silently passed. See docs/cli/doctor.md.
```

**`--json`** (stable `mandate.doctor.v1` envelope, machine-readable for the production-shaped runner): same shape, machine-parseable.

## Exit codes

- `0` — overall `ok` or `warn`.
- `1` — overall `fail` (at least one check failed).
- `2` — DB itself could not be opened.

## Tests (11)

The two skip-path tests are **explicit** about constructing an older DB via the `storage_without_table(table)` helper — they drop the optional table from a tempfile-backed Storage and then re-open. This decouples the test correctness from "which migrations happen to be on `main` at any given moment" so:

- before A2/A1.9 lands → optional table absent naturally;
- after A2/A1.9 lands → default DB has the table; the test still constructs the older shape via DROP, exercising the skip path correctly.

| Test | What it pins |
|---|---|
| `fresh_in_memory_db_yields_ok_overall` | Default DB → overall `ok`, with at least one `ok` and one `skip` row |
| `nonce_replay_reports_ok_when_table_present` | V002 → `ok` |
| `idempotency_reports_ok_on_default_post_a2_db` | V004 → `ok` on the default post-A2 DB (would catch a regression that silently dropped V004) |
| `idempotency_skip_when_table_missing_on_older_db` | Older DB without V004 → `skip` with reason referencing PSM-A2 |
| `mock_kms_keys_skip_when_table_missing_on_older_db` | Older DB without V005 → `skip` with reason referencing PSM-A1.9 (forward-looking — stays correct after A1.9 lands) |
| `audit_chain_skip_on_empty_db` | Empty chain → `skip`, never fake-ok |
| `audit_chain_ok_after_appending_events` | Non-empty chain → `ok` with count + structural-verify message |
| `json_envelope_serialises_with_stable_report_type` | JSON envelope shape matches the documented contract |
| `overall_is_fail_if_any_check_fails` | Aggregate verdict logic |
| `overall_is_warn_if_only_warns_no_fails` | Aggregate verdict logic |
| `overall_is_ok_if_only_ok_and_skip` | Aggregate verdict logic |

## What is real vs mocked

**Real:** All the SQLite reads, structural audit-chain verification, exit-code semantics, JSON envelope.
**Mocked / not in scope:** No live network, no KMS connectivity check, no sponsor credentials, no signature verification (no pubkey access). Documented openly in `docs/cli/doctor.md`.

## Tradeoffs / what is NOT in this PR

- **Rebased onto post-A2 main** with `--force-with-lease`. Trivial / no main.rs conflict (A2 didn't touch the CLI command enum).
- **No mock_kms_keys migration in this PR.** Doctor reports it as `skip` referencing PSM-A1.9. PSM-A1.9 (PR #28) will add the table; doctor will pick it up automatically with no doctor-side change.
- **No active_policy migration in this PR.** Doctor reports `skip` referencing PSM-A3.
- **No CI integration of the doctor itself.** Could be a B-owned follow-up to add `mandate doctor --json` to the production-shaped runner section that currently reads SKIP for PSM-A5.

## Verification (local, on `01b01eb`, post-rebase)

- [x] `cargo fmt --check` ✅
- [x] `cargo clippy --workspace --all-targets -- -D warnings` ✅ (no warnings)
- [x] `cargo test --workspace --all-targets` ✅ **158 / 158 pass**
- [x] `python3 scripts/validate_schemas.py` ✅
- [x] `python3 scripts/validate_openapi.py` ✅
- [x] `bash demo-scripts/run-openagents-final.sh` ✅ all **13 / 13 gates green**
- [x] `python3 trust-badge/test_build.py` ✅ **PASS: 31 checks ok**

🤖 Generated with [Claude Code](https://claude.com/claude-code)