### PR TITLE
feat: persist mock kms keyring + add mandate key cli (PSM-A1.9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,6 +1035,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "hex",
  "mandate-core",
  "mandate-policy",
  "mandate-storage",

--- a/crates/mandate-cli/Cargo.toml
+++ b/crates/mandate-cli/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
+hex = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 

--- a/crates/mandate-cli/src/key.rs
+++ b/crates/mandate-cli/src/key.rs
@@ -188,15 +188,19 @@ pub fn cmd_list(mock: bool, role: Option<&str>, db: &Path) -> ExitCode {
         }
         return ExitCode::SUCCESS;
     }
+    // Codex P2 on PR #28: every output line — header, column line,
+    // each row — must start with the `mock-kms:` disclosure so a human
+    // skimming a copy-pasted slice of the output cannot mistake any
+    // single line for production KMS material.
     println!(
-        "mock-kms keyring ({} row{}):",
+        "mock-kms: keyring ({} row{}):",
         rows.len(),
         if rows.len() == 1 { "" } else { "s" }
     );
-    println!("  role                  ver  key_id                 public_hex                                                                          created_at");
+    println!("mock-kms:   role                  ver  key_id                 public_hex                                                                          created_at");
     for r in rows {
         println!(
-            "  {role:<22}{version:<5}{key_id:<23}{public_hex}  {ts}",
+            "mock-kms:   {role:<22}{version:<5}{key_id:<23}{public_hex}  {ts}",
             role = r.role,
             version = r.version,
             key_id = r.key_id,
@@ -250,6 +254,49 @@ pub fn cmd_rotate(mock: bool, role: &str, root_seed_hex: &str, db: &Path) -> Exi
             return ExitCode::from(1);
         }
     };
+
+    // Codex P2 on PR #28: refuse to rotate when the supplied --root-seed
+    // doesn't match the seed that produced the existing v(current_version).
+    // Without this check, a typo or mismatched secret silently inserts a
+    // v(n+1) row that the daemon's keyring can't actually re-derive — the
+    // keyring would diverge from the operator's notion of "the rotation
+    // seed", which is the entire authentication contract for the mock
+    // KMS surface. We compare both `key_id` and `public_hex` because
+    // either alone would already reveal a seed mismatch.
+    let stored_current = match storage.mock_kms_list(Some(role)) {
+        Ok(rows) => rows.into_iter().find(|r| r.version == current_version),
+        Err(e) => {
+            eprintln!("mandate key rotate: failed to read existing keyring: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    let stored_current = match stored_current {
+        Some(r) => r,
+        None => {
+            // current_version came back Some(v) but the row vanished —
+            // means another process raced us between the two queries.
+            // Treat as a transient inconsistency, not a seed mismatch.
+            eprintln!(
+                "mandate key rotate: db inconsistency: current_version={current_version} \
+                 reported for role={role} but no matching row found"
+            );
+            return ExitCode::from(1);
+        }
+    };
+    let (expected_current_key_id, expected_current_public_hex) =
+        mock_kms::derive_key_metadata(role, current_version, &root_seed);
+    if stored_current.key_id != expected_current_key_id
+        || stored_current.public_hex != expected_current_public_hex
+    {
+        eprintln!(
+            "mandate key rotate: --root-seed does not match the seed that produced \
+             the stored v{current_version} for role={role}; refusing to rotate. \
+             Pass the same --root-seed used at `mandate key init` (or the most \
+             recent `mandate key rotate`)."
+        );
+        return ExitCode::from(2);
+    }
+
     let next_version = current_version + 1;
     let (key_id, public_hex) = mock_kms::derive_key_metadata(role, next_version, &root_seed);
     let now = Utc::now();

--- a/crates/mandate-cli/src/key.rs
+++ b/crates/mandate-cli/src/key.rs
@@ -1,0 +1,287 @@
+//! `mandate key {init,list,rotate} --mock` — production-shaped mock KMS
+//! keyring CLI (PSM-A1.9).
+//!
+//! These commands operate on the `mock_kms_keys` SQLite table (V005)
+//! that stores per-version public-key metadata for the
+//! `MockKmsSigner` keyring shipped in PSM-A1. They never touch private
+//! key material on disk: the deterministic root-seed is supplied on
+//! every CLI invocation; only the resulting public metadata is
+//! persisted.
+//!
+//! The required `--mock` flag is an explicit acknowledgement that this
+//! is mock infrastructure. A real KMS keyring CLI would never be
+//! plug-compatible with these commands; documented in
+//! `docs/cli/mock-kms.md`.
+
+use std::path::Path;
+use std::process::ExitCode;
+
+use chrono::Utc;
+use mandate_core::mock_kms;
+use mandate_storage::mock_kms_store::MockKmsKeyRecord;
+use mandate_storage::Storage;
+
+const ROOT_SEED_HEX_LEN: usize = 64;
+
+fn open_db(db: &Path) -> Result<Storage, String> {
+    Storage::open(db).map_err(|e| format!("failed to open db {}: {e}", db.display()))
+}
+
+fn parse_root_seed(hex_str: &str) -> Result<[u8; 32], String> {
+    if hex_str.len() != ROOT_SEED_HEX_LEN {
+        return Err(format!(
+            "--root-seed must be {ROOT_SEED_HEX_LEN} hex chars (32 bytes), got {}",
+            hex_str.len()
+        ));
+    }
+    let bytes = hex::decode(hex_str).map_err(|e| format!("--root-seed is not valid hex: {e}"))?;
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes);
+    Ok(out)
+}
+
+fn require_mock_flag(mock: bool) -> Result<(), String> {
+    if !mock {
+        return Err(
+            "this command operates on the mock KMS keyring; pass --mock to acknowledge \
+             (production KMS backends are not implemented in this build)"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+/// `mandate key init --mock --role <name> --root-seed <hex64> [--genesis <ts>] --db <path>`
+///
+/// Creates the v1 row of a fresh keyring for `role`. Idempotent: if a
+/// row for `(role, 1)` already exists (e.g. previous run with the same
+/// args), the command no-ops with exit 0 and prints the existing meta.
+pub fn cmd_init(
+    mock: bool,
+    role: &str,
+    root_seed_hex: &str,
+    genesis: Option<&str>,
+    db: &Path,
+) -> ExitCode {
+    if let Err(e) = require_mock_flag(mock) {
+        eprintln!("mandate key init: {e}");
+        return ExitCode::from(2);
+    }
+    let root_seed = match parse_root_seed(root_seed_hex) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("mandate key init: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    let genesis_ts = match genesis {
+        Some(g) => match chrono::DateTime::parse_from_rfc3339(g) {
+            Ok(t) => t.with_timezone(&Utc),
+            Err(e) => {
+                eprintln!("mandate key init: --genesis must be RFC3339: {e}");
+                return ExitCode::from(2);
+            }
+        },
+        None => Utc::now(),
+    };
+
+    let mut storage = match open_db(db) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("mandate key init: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let (key_id, public_hex) = mock_kms::derive_key_metadata(role, 1, &root_seed);
+    let record = MockKmsKeyRecord {
+        role: role.to_string(),
+        version: 1,
+        key_id: key_id.clone(),
+        public_hex: public_hex.clone(),
+        created_at: genesis_ts,
+    };
+    match storage.mock_kms_insert(&record) {
+        Ok(true) => {
+            println!(
+                "mock-kms: initialised role={role} version=1 key_id={key_id} \
+                 public_hex={public_hex} created_at={}",
+                genesis_ts.to_rfc3339()
+            );
+            ExitCode::SUCCESS
+        }
+        Ok(false) => {
+            // Row already existed — surface the existing meta so the
+            // caller can confirm idempotence without consulting `list`.
+            match storage.mock_kms_list(Some(role)) {
+                Ok(rows) if !rows.is_empty() => {
+                    let v1 = rows.iter().find(|r| r.version == 1);
+                    match v1 {
+                        Some(r) => {
+                            println!(
+                                "mock-kms: role={} v1 already initialised; key_id={} \
+                                 public_hex={} created_at={}",
+                                r.role,
+                                r.key_id,
+                                r.public_hex,
+                                r.created_at.to_rfc3339()
+                            );
+                            ExitCode::SUCCESS
+                        }
+                        None => {
+                            eprintln!(
+                                "mandate key init: existing rows for role={role} but no v1; \
+                                 db may have been hand-edited"
+                            );
+                            ExitCode::from(1)
+                        }
+                    }
+                }
+                Ok(_) => {
+                    eprintln!(
+                        "mandate key init: insert was rejected as duplicate but no rows \
+                         found for role={role}; db inconsistency"
+                    );
+                    ExitCode::from(1)
+                }
+                Err(e) => {
+                    eprintln!("mandate key init: {e}");
+                    ExitCode::from(1)
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("mandate key init: {e}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+/// `mandate key list --mock [--role <name>] --db <path>`
+///
+/// Dumps the keyring (or only one role's worth) in `(role, version)`
+/// order. Output explicitly prefixes every line with `mock-kms:` so a
+/// human skimming the output cannot mistake it for production KMS.
+pub fn cmd_list(mock: bool, role: Option<&str>, db: &Path) -> ExitCode {
+    if let Err(e) = require_mock_flag(mock) {
+        eprintln!("mandate key list: {e}");
+        return ExitCode::from(2);
+    }
+    let storage = match open_db(db) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("mandate key list: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    let rows = match storage.mock_kms_list(role) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("mandate key list: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    if rows.is_empty() {
+        match role {
+            Some(r) => println!("mock-kms: no keyring entries for role={r}"),
+            None => println!("mock-kms: no keyring entries"),
+        }
+        return ExitCode::SUCCESS;
+    }
+    println!(
+        "mock-kms keyring ({} row{}):",
+        rows.len(),
+        if rows.len() == 1 { "" } else { "s" }
+    );
+    println!("  role                  ver  key_id                 public_hex                                                                          created_at");
+    for r in rows {
+        println!(
+            "  {role:<22}{version:<5}{key_id:<23}{public_hex}  {ts}",
+            role = r.role,
+            version = r.version,
+            key_id = r.key_id,
+            public_hex = r.public_hex,
+            ts = r.created_at.to_rfc3339()
+        );
+    }
+    ExitCode::SUCCESS
+}
+
+/// `mandate key rotate --mock --role <name> --root-seed <hex64> --db <path>`
+///
+/// Reads the highest existing version for `role`, derives the next
+/// version's public material from `(role, n+1, root_seed)`, and
+/// inserts the new row. The previous version is retained — receipts
+/// signed under it stay verifiable via the keyring.
+pub fn cmd_rotate(mock: bool, role: &str, root_seed_hex: &str, db: &Path) -> ExitCode {
+    if let Err(e) = require_mock_flag(mock) {
+        eprintln!("mandate key rotate: {e}");
+        return ExitCode::from(2);
+    }
+    let root_seed = match parse_root_seed(root_seed_hex) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("mandate key rotate: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    let mut storage = match open_db(db) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("mandate key rotate: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    let current = match storage.mock_kms_current_version(role) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("mandate key rotate: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    let current_version = match current {
+        Some(v) => v,
+        None => {
+            eprintln!(
+                "mandate key rotate: no keyring exists for role={role}. Run \
+                 `mandate key init --mock --role {role} --root-seed <hex64> --db {} ` first.",
+                db.display()
+            );
+            return ExitCode::from(1);
+        }
+    };
+    let next_version = current_version + 1;
+    let (key_id, public_hex) = mock_kms::derive_key_metadata(role, next_version, &root_seed);
+    let now = Utc::now();
+    let record = MockKmsKeyRecord {
+        role: role.to_string(),
+        version: next_version,
+        key_id: key_id.clone(),
+        public_hex: public_hex.clone(),
+        created_at: now,
+    };
+    match storage.mock_kms_insert(&record) {
+        Ok(true) => {
+            println!(
+                "mock-kms: rotated role={role}: v{current_version} → v{next_version} \
+                 key_id={key_id} public_hex={public_hex} created_at={}",
+                now.to_rfc3339()
+            );
+            ExitCode::SUCCESS
+        }
+        Ok(false) => {
+            eprintln!(
+                "mandate key rotate: insert rejected — likely a parallel rotate \
+                 already inserted v{next_version} for role={role}"
+            );
+            ExitCode::from(1)
+        }
+        Err(e) => {
+            eprintln!("mandate key rotate: {e}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+// Integration tests live in `crates/mandate-cli/tests/key_cli.rs` so they
+// can reach the cargo-built binary via `env!("CARGO_BIN_EXE_mandate")`.

--- a/crates/mandate-cli/src/main.rs
+++ b/crates/mandate-cli/src/main.rs
@@ -8,6 +8,7 @@ use mandate_core::receipt::PolicyReceipt;
 use mandate_core::{schema, SchemaError};
 
 mod doctor;
+mod key;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -77,6 +78,64 @@ enum Command {
         /// Emit JSON instead of human-readable text.
         #[arg(long, default_value_t = false)]
         json: bool,
+    },
+    /// Mock KMS keyring commands (PSM-A1.9).
+    ///
+    /// Operate on the persistent `mock_kms_keys` SQLite table (V005).
+    /// Every operation requires `--mock` for explicit disclosure — these
+    /// commands are NOT plug-compatible with a production KMS. See
+    /// `docs/cli/mock-kms.md`.
+    Key {
+        #[command(subcommand)]
+        op: KeyCmd,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum KeyCmd {
+    /// Initialise a mock keyring's v1 row for the given `--role`.
+    /// Idempotent: running again with the same args is a no-op.
+    Init {
+        /// Required acknowledgement that this is mock KMS infrastructure.
+        #[arg(long)]
+        mock: bool,
+        /// Stable role name (e.g. `audit-mock`, `decision-mock`).
+        #[arg(long)]
+        role: String,
+        /// 32-byte deterministic root seed, hex-encoded (64 chars). The
+        /// seed never enters the SQLite database — only its derived
+        /// public keys do.
+        #[arg(long)]
+        root_seed: String,
+        /// Optional v1 timestamp (RFC3339). Defaults to "now()".
+        #[arg(long)]
+        genesis: Option<String>,
+        /// SQLite database path (the same one the daemon writes to).
+        #[arg(long)]
+        db: PathBuf,
+    },
+    /// List keyring rows in `(role, version)` order.
+    List {
+        #[arg(long)]
+        mock: bool,
+        /// Restrict to a single role.
+        #[arg(long)]
+        role: Option<String>,
+        #[arg(long)]
+        db: PathBuf,
+    },
+    /// Add the next version of `--role` to the keyring. Reads the
+    /// existing maximum version, derives the new version's public
+    /// material from `(role, n+1, root_seed)`, inserts the row.
+    Rotate {
+        #[arg(long)]
+        mock: bool,
+        #[arg(long)]
+        role: String,
+        #[arg(long)]
+        root_seed: String,
+        #[arg(long)]
+        db: PathBuf,
     },
 }
 
@@ -206,6 +265,28 @@ fn main() -> ExitCode {
             op: AuditCmd::VerifyBundle { path },
         } => cmd_audit_verify_bundle(&path),
         Command::Doctor { db, json } => doctor::run(db.as_deref(), json),
+        Command::Key {
+            op:
+                KeyCmd::Init {
+                    mock,
+                    role,
+                    root_seed,
+                    genesis,
+                    db,
+                },
+        } => key::cmd_init(mock, &role, &root_seed, genesis.as_deref(), &db),
+        Command::Key {
+            op: KeyCmd::List { mock, role, db },
+        } => key::cmd_list(mock, role.as_deref(), &db),
+        Command::Key {
+            op:
+                KeyCmd::Rotate {
+                    mock,
+                    role,
+                    root_seed,
+                    db,
+                },
+        } => key::cmd_rotate(mock, &role, &root_seed, &db),
     }
 }
 

--- a/crates/mandate-cli/tests/key_cli.rs
+++ b/crates/mandate-cli/tests/key_cli.rs
@@ -15,6 +15,10 @@ fn cli_bin() -> PathBuf {
 /// **Mock** — never used outside the test suite.
 const TEST_ROOT_SEED: &str = "2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a";
 
+/// A different deterministic seed used to exercise the
+/// "mismatched-seed rejected at rotate" path.
+const OTHER_ROOT_SEED: &str = "5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b";
+
 #[test]
 fn init_writes_v1_row_then_list_shows_it() {
     let tmp = tempfile::tempdir().unwrap();
@@ -299,5 +303,163 @@ fn list_filters_by_role_when_given() {
     assert!(
         !stdout.contains("decision-mock-v1"),
         "filtered listing must not leak other roles; got: {stdout}"
+    );
+}
+
+/// Codex P2 on PR #28: every output line of the non-empty `key list`
+/// path must carry the `mock-kms:` disclosure prefix. Previously only
+/// the header announced "mock-kms keyring", but the column header and
+/// row lines started with whitespace — so a single copy-pasted row
+/// could be misread as production KMS output. We seed two roles, run
+/// list, and assert that **every non-blank stdout line** begins with
+/// `mock-kms:` (including the column header and each data row).
+#[test]
+fn list_prefixes_every_line_with_mock_kms_disclosure() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = tmp.path().join("mandate.sqlite");
+    for role in ["audit-mock", "decision-mock"] {
+        let s = Command::new(cli_bin())
+            .args([
+                "key",
+                "init",
+                "--mock",
+                "--role",
+                role,
+                "--root-seed",
+                TEST_ROOT_SEED,
+                "--db",
+                db.to_str().unwrap(),
+            ])
+            .status()
+            .unwrap();
+        assert!(s.success(), "init for role {role} must succeed");
+    }
+    let list = Command::new(cli_bin())
+        .args(["key", "list", "--mock", "--db", db.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(list.status.success());
+    let stdout = String::from_utf8_lossy(&list.stdout);
+
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert!(
+        lines.len() >= 4,
+        "non-empty list must produce at least header + col-header + 2 row lines; got: {stdout}"
+    );
+    for (i, line) in lines.iter().enumerate() {
+        assert!(
+            line.starts_with("mock-kms:"),
+            "line {i} ({line:?}) does not start with `mock-kms:`; full stdout:\n{stdout}"
+        );
+    }
+    // And confirm both roles' rows are still present (regression
+    // guard: changing the prefix must not have broken the data).
+    assert!(stdout.contains("audit-mock-v1"));
+    assert!(stdout.contains("decision-mock-v1"));
+}
+
+/// Codex P2 on PR #28: rotating with the wrong `--root-seed` must
+/// refuse, exit non-zero (we use `2` for "operator passed bad input"),
+/// and leave the keyring untouched. Without this check, a typo would
+/// silently insert a v2 row whose keys can't be re-derived from the
+/// "real" rotation seed — irrecoverable drift in the mock keyring's
+/// only authentication assumption.
+#[test]
+fn rotate_with_wrong_root_seed_refuses_and_does_not_advance() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = tmp.path().join("mandate.sqlite");
+
+    // init v1 with the canonical test seed.
+    let init = Command::new(cli_bin())
+        .args([
+            "key",
+            "init",
+            "--mock",
+            "--role",
+            "audit-mock",
+            "--root-seed",
+            TEST_ROOT_SEED,
+            "--db",
+            db.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(init.status.success());
+
+    // attempt rotate with the OTHER seed — must fail with exit 2.
+    let bad_rotate = Command::new(cli_bin())
+        .args([
+            "key",
+            "rotate",
+            "--mock",
+            "--role",
+            "audit-mock",
+            "--root-seed",
+            OTHER_ROOT_SEED,
+            "--db",
+            db.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !bad_rotate.status.success(),
+        "rotate with wrong --root-seed must fail; stdout={} stderr={}",
+        String::from_utf8_lossy(&bad_rotate.stdout),
+        String::from_utf8_lossy(&bad_rotate.stderr),
+    );
+    assert_eq!(
+        bad_rotate.status.code(),
+        Some(2),
+        "wrong-seed rotate should return exit 2 (bad operator input)"
+    );
+    let stderr = String::from_utf8_lossy(&bad_rotate.stderr);
+    assert!(
+        stderr.contains("--root-seed") && stderr.contains("does not match"),
+        "stderr must explain seed mismatch; got: {stderr}"
+    );
+
+    // list must still show only v1 — no v2 leaked through.
+    let list = Command::new(cli_bin())
+        .args([
+            "key",
+            "list",
+            "--mock",
+            "--role",
+            "audit-mock",
+            "--db",
+            db.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(list.status.success());
+    let list_stdout = String::from_utf8_lossy(&list.stdout);
+    assert!(
+        list_stdout.contains("audit-mock-v1"),
+        "v1 must still be present; got: {list_stdout}"
+    );
+    assert!(
+        !list_stdout.contains("audit-mock-v2"),
+        "rejected rotate must NOT have inserted v2; got: {list_stdout}"
+    );
+
+    // and a follow-up rotate WITH the correct seed must still succeed.
+    let good_rotate = Command::new(cli_bin())
+        .args([
+            "key",
+            "rotate",
+            "--mock",
+            "--role",
+            "audit-mock",
+            "--root-seed",
+            TEST_ROOT_SEED,
+            "--db",
+            db.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        good_rotate.status.success(),
+        "rotate with the right seed must succeed after a rejected attempt; stderr={}",
+        String::from_utf8_lossy(&good_rotate.stderr)
     );
 }

--- a/crates/mandate-cli/tests/key_cli.rs
+++ b/crates/mandate-cli/tests/key_cli.rs
@@ -1,0 +1,303 @@
+//! Integration tests for `mandate key {init,list,rotate} --mock` (PSM-A1.9).
+//!
+//! Exercises the real `mandate` binary end-to-end: each test builds a
+//! tempfile-backed SQLite db, drives the CLI with `Command::new(cli_bin())`,
+//! and asserts on stdout/stderr/exit-status of the actual process.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn cli_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_mandate"))
+}
+
+/// 32-byte deterministic seed used across all CLI integration tests here.
+/// **Mock** — never used outside the test suite.
+const TEST_ROOT_SEED: &str = "2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a";
+
+#[test]
+fn init_writes_v1_row_then_list_shows_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = tmp.path().join("mandate.sqlite");
+
+    let init = Command::new(cli_bin())
+        .args([
+            "key",
+            "init",
+            "--mock",
+            "--role",
+            "audit-mock",
+            "--root-seed",
+            TEST_ROOT_SEED,
+            "--db",
+            db.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        init.status.success(),
+        "init must succeed; stderr={}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+    let init_out = String::from_utf8_lossy(&init.stdout);
+    assert!(
+        init_out.contains("mock-kms"),
+        "init output must lead with `mock-kms` disclosure; got: {init_out}"
+    );
+
+    let list = Command::new(cli_bin())
+        .args(["key", "list", "--mock", "--db", db.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(list.status.success());
+    let stdout = String::from_utf8_lossy(&list.stdout);
+    assert!(
+        stdout.contains("audit-mock"),
+        "list should show audit-mock; got: {stdout}"
+    );
+    assert!(
+        stdout.contains("audit-mock-v1"),
+        "list should show key_id; got: {stdout}"
+    );
+}
+
+#[test]
+fn init_is_idempotent_on_repeat() {
+    // Running the same init twice should NOT fail. The second run
+    // reports the existing row; both runs exit 0. Catches a regression
+    // where the duplicate-row path returned non-zero.
+    let tmp = tempfile::tempdir().unwrap();
+    let db = tmp.path().join("mandate.sqlite");
+    let args = [
+        "key",
+        "init",
+        "--mock",
+        "--role",
+        "audit-mock",
+        "--root-seed",
+        TEST_ROOT_SEED,
+        "--db",
+        db.to_str().unwrap(),
+    ];
+    let first = Command::new(cli_bin()).args(args).output().unwrap();
+    assert!(first.status.success());
+    let second = Command::new(cli_bin()).args(args).output().unwrap();
+    assert!(
+        second.status.success(),
+        "second init must be idempotent; stderr={}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&second.stdout);
+    assert!(
+        stdout.contains("already initialised"),
+        "expected idempotency message; got: {stdout}"
+    );
+}
+
+#[test]
+fn rotate_advances_version_and_old_version_remains_listed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = tmp.path().join("mandate.sqlite");
+
+    // init v1
+    let init = Command::new(cli_bin())
+        .args([
+            "key",
+            "init",
+            "--mock",
+            "--role",
+            "audit-mock",
+            "--root-seed",
+            TEST_ROOT_SEED,
+            "--db",
+            db.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(init.status.success());
+
+    // rotate → v2
+    let rotate = Command::new(cli_bin())
+        .args([
+            "key",
+            "rotate",
+            "--mock",
+            "--role",
+            "audit-mock",
+            "--root-seed",
+            TEST_ROOT_SEED,
+            "--db",
+            db.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        rotate.status.success(),
+        "rotate must succeed; stderr={}",
+        String::from_utf8_lossy(&rotate.stderr)
+    );
+    let rotate_out = String::from_utf8_lossy(&rotate.stdout);
+    assert!(
+        rotate_out.contains("v1 → v2"),
+        "rotate should announce version change; got: {rotate_out}"
+    );
+
+    // list shows both v1 and v2
+    let list = Command::new(cli_bin())
+        .args([
+            "key",
+            "list",
+            "--mock",
+            "--role",
+            "audit-mock",
+            "--db",
+            db.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(list.status.success());
+    let stdout = String::from_utf8_lossy(&list.stdout);
+    assert!(stdout.contains("audit-mock-v1"));
+    assert!(stdout.contains("audit-mock-v2"));
+}
+
+#[test]
+fn rotate_without_init_fails_with_clear_message() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = tmp.path().join("mandate.sqlite");
+    let out = Command::new(cli_bin())
+        .args([
+            "key",
+            "rotate",
+            "--mock",
+            "--role",
+            "audit-mock",
+            "--root-seed",
+            TEST_ROOT_SEED,
+            "--db",
+            db.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "rotate without init must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("no keyring exists") || stderr.contains("init"),
+        "stderr must point at `init`; got: {stderr}"
+    );
+}
+
+#[test]
+fn list_with_no_keyring_prints_friendly_message() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = tmp.path().join("mandate.sqlite");
+    let out = Command::new(cli_bin())
+        .args(["key", "list", "--mock", "--db", db.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("no keyring entries"),
+        "should friendly-message; got: {stdout}"
+    );
+}
+
+#[test]
+fn missing_mock_flag_is_required_by_clap() {
+    // Without `--mock` clap itself rejects the call (the bool is a
+    // required arg via the always-set default semantics; we accept
+    // either clap's "required" message or our own runtime "--mock"
+    // disclosure check).
+    let tmp = tempfile::tempdir().unwrap();
+    let db = tmp.path().join("mandate.sqlite");
+    let out = Command::new(cli_bin())
+        .args([
+            "key",
+            "init",
+            "--role",
+            "audit-mock",
+            "--root-seed",
+            TEST_ROOT_SEED,
+            "--db",
+            db.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "init without --mock must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--mock") || stderr.contains("required") || stderr.contains("acknowledge"),
+        "stderr should explain --mock; got: {stderr}"
+    );
+}
+
+#[test]
+fn root_seed_with_wrong_length_returns_clear_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = tmp.path().join("mandate.sqlite");
+    let out = Command::new(cli_bin())
+        .args([
+            "key",
+            "init",
+            "--mock",
+            "--role",
+            "audit-mock",
+            "--root-seed",
+            "abcd", // 4 chars
+            "--db",
+            db.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("64 hex chars"),
+        "stderr should explain length; got: {stderr}"
+    );
+}
+
+#[test]
+fn list_filters_by_role_when_given() {
+    // Init two roles, list with --role only one, assert only that
+    // one's rows appear.
+    let tmp = tempfile::tempdir().unwrap();
+    let db = tmp.path().join("mandate.sqlite");
+    for role in ["audit-mock", "decision-mock"] {
+        let s = Command::new(cli_bin())
+            .args([
+                "key",
+                "init",
+                "--mock",
+                "--role",
+                role,
+                "--root-seed",
+                TEST_ROOT_SEED,
+                "--db",
+                db.to_str().unwrap(),
+            ])
+            .status()
+            .unwrap();
+        assert!(s.success());
+    }
+    let list = Command::new(cli_bin())
+        .args([
+            "key",
+            "list",
+            "--mock",
+            "--role",
+            "audit-mock",
+            "--db",
+            db.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(list.status.success());
+    let stdout = String::from_utf8_lossy(&list.stdout);
+    assert!(stdout.contains("audit-mock-v1"));
+    assert!(
+        !stdout.contains("decision-mock-v1"),
+        "filtered listing must not leak other roles; got: {stdout}"
+    );
+}

--- a/crates/mandate-core/src/mock_kms.rs
+++ b/crates/mandate-core/src/mock_kms.rs
@@ -215,6 +215,19 @@ impl SignerBackend for MockKmsSigner {
     }
 }
 
+/// Build the `(key_id, public_hex)` pair that
+/// `MockKmsSigner::new` / `rotate` would produce for `(role, version,
+/// root_seed)`. Useful for callers that store keyring metadata
+/// externally (e.g. SQLite via `mandate-storage::mock_kms_store`) and
+/// need to derive the next version's public material without holding
+/// a `MockKmsSigner` instance.
+pub fn derive_key_metadata(role: &str, version: u32, root_seed: &[u8; 32]) -> (String, String) {
+    let signing_key = derive_signing_key(role, version, root_seed);
+    let public_hex = hex::encode(signing_key.verifying_key().to_bytes());
+    let key_id = format!("{role}-v{version}");
+    (key_id, public_hex)
+}
+
 /// Deterministic per-version seed. **Not** a production KDF — a real KMS
 /// would never derive private keys from a public-ish role+version tuple.
 /// This is sufficient for reproducible local testing where the same

--- a/crates/mandate-storage/src/db.rs
+++ b/crates/mandate-storage/src/db.rs
@@ -10,13 +10,17 @@ use crate::error::{StorageError, StorageResult};
 pub const V001_SQL: &str = include_str!("../../../migrations/V001__init.sql");
 pub const V002_SQL: &str = include_str!("../../../migrations/V002__nonce_replay.sql");
 pub const V004_SQL: &str = include_str!("../../../migrations/V004__idempotency_keys.sql");
+pub const V005_SQL: &str = include_str!("../../../migrations/V005__mock_kms_keys.sql");
 
-// V003 was reserved for a separate experiment that did not land; numbering
-// stays sparse intentionally so future migrations don't have to renumber.
+// V003 reserved for an experiment that did not land. V004 = PSM-A2
+// (idempotency_keys, merged in PR #23). V005 = PSM-A1.9
+// (mock_kms_keys, this PR). Sparse numbering kept intentional so
+// parallel branches don't collide on the same number.
 const MIGRATIONS: &[(i64, &str, &str)] = &[
     (1, "init", V001_SQL),
     (2, "nonce_replay", V002_SQL),
     (4, "idempotency_keys", V004_SQL),
+    (5, "mock_kms_keys", V005_SQL),
 ];
 
 pub struct Storage {

--- a/crates/mandate-storage/src/lib.rs
+++ b/crates/mandate-storage/src/lib.rs
@@ -4,6 +4,7 @@ pub mod audit_store;
 pub mod db;
 pub mod error;
 pub mod idempotency_store;
+pub mod mock_kms_store;
 pub mod nonce_store;
 
 pub use audit_store::NewAuditEvent;

--- a/crates/mandate-storage/src/mock_kms_store.rs
+++ b/crates/mandate-storage/src/mock_kms_store.rs
@@ -1,0 +1,238 @@
+//! Persistence for the **mock** KMS keyring (PSM-A1.9).
+//!
+//! Holds *only* public-key material — no seeds, no private keys. The
+//! `mandate key {init,list,rotate} --mock` CLI supplies the
+//! deterministic `--root-seed` on every operation; this module records
+//! the resulting per-version public key plus stable metadata
+//! (`role`, `version`, `key_id`, `public_hex`, `created_at`).
+//!
+//! Truthfulness rules:
+//! - Every row is mock. The CLI surface enforces a `--mock` flag for
+//!   loud disclosure.
+//! - A real KMS keyring would store an opaque KMS handle/ARN per
+//!   version, NOT a deterministic public key. This is mock-shape, not
+//!   production-shape.
+//! - Rotation never advances backwards: the unique `(role, version)`
+//!   primary key prevents rollback / collision.
+
+use chrono::{DateTime, Utc};
+use rusqlite::params;
+
+use crate::error::{StorageError, StorageResult};
+use crate::Storage;
+
+/// One row of the `mock_kms_keys` table. Mirrors what
+/// `mandate_core::mock_kms::MockKmsKeyMeta` carries, minus the
+/// always-true `mock: bool` field (the table itself implies mock).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MockKmsKeyRecord {
+    pub role: String,
+    pub version: u32,
+    pub key_id: String,
+    pub public_hex: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl Storage {
+    /// Insert a keyring entry. Returns:
+    /// - `Ok(true)`  — row was new and stored;
+    /// - `Ok(false)` — row already existed for this (role, version) or
+    ///   (key_id) — caller may treat as a no-op;
+    /// - `Err(...)` — any other SQLite error.
+    pub fn mock_kms_insert(&mut self, record: &MockKmsKeyRecord) -> StorageResult<bool> {
+        match self.conn.execute(
+            "INSERT INTO mock_kms_keys (role, version, key_id, public_hex, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                record.role,
+                record.version as i64,
+                record.key_id,
+                record.public_hex,
+                record.created_at.to_rfc3339(),
+            ],
+        ) {
+            Ok(_) => Ok(true),
+            Err(rusqlite::Error::SqliteFailure(err, _))
+                if err.code == rusqlite::ErrorCode::ConstraintViolation =>
+            {
+                Ok(false)
+            }
+            Err(e) => Err(StorageError::Sqlite(e)),
+        }
+    }
+
+    /// List keyring rows in ascending `(role, version)` order. If
+    /// `role` is supplied, restrict to that role.
+    pub fn mock_kms_list(&self, role: Option<&str>) -> StorageResult<Vec<MockKmsKeyRecord>> {
+        let mut rows = Vec::new();
+        match role {
+            Some(r) => {
+                let mut stmt = self.conn.prepare(
+                    "SELECT role, version, key_id, public_hex, created_at
+                     FROM mock_kms_keys WHERE role = ?1
+                     ORDER BY role ASC, version ASC",
+                )?;
+                let iter = stmt.query_map(params![r], row_to_record)?;
+                for row in iter {
+                    rows.push(row?);
+                }
+            }
+            None => {
+                let mut stmt = self.conn.prepare(
+                    "SELECT role, version, key_id, public_hex, created_at
+                     FROM mock_kms_keys ORDER BY role ASC, version ASC",
+                )?;
+                let iter = stmt.query_map([], row_to_record)?;
+                for row in iter {
+                    rows.push(row?);
+                }
+            }
+        }
+        Ok(rows)
+    }
+
+    /// Highest existing version for `role`, or `None` if no keyring
+    /// has been initialised.
+    pub fn mock_kms_current_version(&self, role: &str) -> StorageResult<Option<u32>> {
+        let n: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT MAX(version) FROM mock_kms_keys WHERE role = ?1",
+                params![role],
+                |r| r.get(0),
+            )
+            .ok();
+        match n {
+            // SQLite returns NULL via Option<i64>=Some(0)? Actually it
+            // returns Ok(NULL) which serde-rusqlite maps to None when
+            // you ask for Option<i64>. The .ok() above swallows
+            // QueryReturnedNoRows; for COUNT-like selects there's
+            // always one row returning either NULL or a value.
+            None => Ok(None),
+            // version=0 should never exist (we start at 1) — but defend
+            // against a tampered DB by treating it as no initialised
+            // keyring rather than overflowing into u32::MAX.
+            Some(0) => Ok(None),
+            Some(v) => Ok(Some(v as u32)),
+        }
+    }
+}
+
+fn row_to_record(r: &rusqlite::Row<'_>) -> rusqlite::Result<MockKmsKeyRecord> {
+    let ts: String = r.get(4)?;
+    let created_at = chrono::DateTime::parse_from_rfc3339(&ts)
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(4, rusqlite::types::Type::Text, Box::new(e))
+        })?
+        .with_timezone(&Utc);
+    Ok(MockKmsKeyRecord {
+        role: r.get(0)?,
+        version: r.get::<_, i64>(1)? as u32,
+        key_id: r.get(2)?,
+        public_hex: r.get(3)?,
+        created_at,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(role: &str, version: u32, suffix: &str) -> MockKmsKeyRecord {
+        MockKmsKeyRecord {
+            role: role.to_string(),
+            version,
+            key_id: format!("{role}-v{version}"),
+            public_hex: format!("aaaa{suffix}"),
+            created_at: chrono::DateTime::parse_from_rfc3339("2026-04-28T00:00:00Z")
+                .unwrap()
+                .into(),
+        }
+    }
+
+    #[test]
+    fn insert_then_list_round_trip() {
+        let mut s = Storage::open_in_memory().unwrap();
+        let r = rec("audit-mock", 1, "01");
+        assert!(s.mock_kms_insert(&r).unwrap());
+        let got = s.mock_kms_list(None).unwrap();
+        assert_eq!(got, vec![r]);
+    }
+
+    #[test]
+    fn duplicate_role_version_returns_false() {
+        let mut s = Storage::open_in_memory().unwrap();
+        let r1 = rec("audit-mock", 1, "01");
+        let r2 = MockKmsKeyRecord {
+            public_hex: "different-pubkey".to_string(),
+            ..rec("audit-mock", 1, "02")
+        };
+        // PRIMARY KEY is (role, version) AND key_id is UNIQUE — two
+        // different attempts to insert at the same coordinate must
+        // surface as Ok(false), not silent overwrite.
+        assert!(s.mock_kms_insert(&r1).unwrap());
+        assert!(!s.mock_kms_insert(&r2).unwrap());
+        // The first record wins.
+        let got = s.mock_kms_list(None).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].public_hex, "aaaa01");
+    }
+
+    #[test]
+    fn duplicate_key_id_across_roles_is_rejected() {
+        // key_id has a UNIQUE constraint regardless of role — keeps the
+        // mapping `key_id -> public_hex` injective across the keyring.
+        let mut s = Storage::open_in_memory().unwrap();
+        let mut r1 = rec("audit-mock", 1, "01");
+        let mut r2 = rec("decision-mock", 1, "02");
+        // Force the key_ids to collide (would only happen via a misuse
+        // of the CLI; the test pins the storage-level guarantee).
+        r1.key_id = "shared-id".to_string();
+        r2.key_id = "shared-id".to_string();
+        assert!(s.mock_kms_insert(&r1).unwrap());
+        assert!(!s.mock_kms_insert(&r2).unwrap());
+    }
+
+    #[test]
+    fn current_version_returns_max_per_role() {
+        let mut s = Storage::open_in_memory().unwrap();
+        s.mock_kms_insert(&rec("audit-mock", 1, "01")).unwrap();
+        s.mock_kms_insert(&rec("audit-mock", 2, "02")).unwrap();
+        s.mock_kms_insert(&rec("audit-mock", 3, "03")).unwrap();
+        s.mock_kms_insert(&rec("decision-mock", 1, "11")).unwrap();
+        assert_eq!(s.mock_kms_current_version("audit-mock").unwrap(), Some(3));
+        assert_eq!(
+            s.mock_kms_current_version("decision-mock").unwrap(),
+            Some(1)
+        );
+        assert_eq!(s.mock_kms_current_version("never-seen").unwrap(), None);
+    }
+
+    #[test]
+    fn list_can_filter_by_role() {
+        let mut s = Storage::open_in_memory().unwrap();
+        s.mock_kms_insert(&rec("audit-mock", 1, "01")).unwrap();
+        s.mock_kms_insert(&rec("decision-mock", 1, "11")).unwrap();
+        s.mock_kms_insert(&rec("audit-mock", 2, "02")).unwrap();
+        let only_audit = s.mock_kms_list(Some("audit-mock")).unwrap();
+        assert_eq!(only_audit.len(), 2);
+        assert!(only_audit.iter().all(|r| r.role == "audit-mock"));
+        let all = s.mock_kms_list(None).unwrap();
+        assert_eq!(all.len(), 3);
+    }
+
+    #[test]
+    fn keyring_persists_across_storage_reopen() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        {
+            let mut s = Storage::open(&path).unwrap();
+            s.mock_kms_insert(&rec("audit-mock", 1, "01")).unwrap();
+            s.mock_kms_insert(&rec("audit-mock", 2, "02")).unwrap();
+        }
+        let s = Storage::open(&path).unwrap();
+        let got = s.mock_kms_list(Some("audit-mock")).unwrap();
+        assert_eq!(got.len(), 2);
+        assert_eq!(s.mock_kms_current_version("audit-mock").unwrap(), Some(2));
+    }
+}

--- a/crates/mandate-storage/src/mock_kms_store.rs
+++ b/crates/mandate-storage/src/mock_kms_store.rs
@@ -93,21 +93,21 @@ impl Storage {
 
     /// Highest existing version for `role`, or `None` if no keyring
     /// has been initialised.
+    ///
+    /// `SELECT MAX(...)` always returns exactly one row (a value or
+    /// SQL NULL), so `QueryReturnedNoRows` cannot happen here — `?`
+    /// propagates only real errors (schema drift, IO, corruption).
+    /// Codex P2 on PR #28 caught that the previous `.ok()` swallowed
+    /// every error as `None`, which would have made `cmd_rotate`
+    /// silently behave as if the keyring did not exist when in fact
+    /// the table was missing or unreadable.
     pub fn mock_kms_current_version(&self, role: &str) -> StorageResult<Option<u32>> {
-        let n: Option<i64> = self
-            .conn
-            .query_row(
-                "SELECT MAX(version) FROM mock_kms_keys WHERE role = ?1",
-                params![role],
-                |r| r.get(0),
-            )
-            .ok();
+        let n: Option<i64> = self.conn.query_row(
+            "SELECT MAX(version) FROM mock_kms_keys WHERE role = ?1",
+            params![role],
+            |r| r.get(0),
+        )?;
         match n {
-            // SQLite returns NULL via Option<i64>=Some(0)? Actually it
-            // returns Ok(NULL) which serde-rusqlite maps to None when
-            // you ask for Option<i64>. The .ok() above swallows
-            // QueryReturnedNoRows; for COUNT-like selects there's
-            // always one row returning either NULL or a value.
             None => Ok(None),
             // version=0 should never exist (we start at 1) — but defend
             // against a tampered DB by treating it as no initialised
@@ -219,6 +219,39 @@ mod tests {
         assert!(only_audit.iter().all(|r| r.role == "audit-mock"));
         let all = s.mock_kms_list(None).unwrap();
         assert_eq!(all.len(), 3);
+    }
+
+    #[test]
+    fn current_version_propagates_query_errors() {
+        // Codex P2 on PR #28: `mock_kms_current_version` previously
+        // converted every rusqlite error into `Ok(None)` via `.ok()`,
+        // which made schema drift / IO failure indistinguishable from
+        // "no keyring initialised yet". After the fix, propagation via
+        // `?` means a missing/broken table surfaces as `Err(Sqlite)`
+        // and callers (e.g. `mandate key rotate`) refuse to advance.
+        //
+        // We construct the failure shape by opening Storage normally
+        // (so migrations apply), then dropping the table out from
+        // under it via raw rusqlite. Re-opening Storage skips the
+        // already-recorded V005 migration, so the table stays gone.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        {
+            let _ = Storage::open(&path).unwrap();
+        }
+        {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            conn.execute("DROP TABLE mock_kms_keys", []).unwrap();
+        }
+        let s = Storage::open(&path).unwrap();
+        let err = s
+            .mock_kms_current_version("audit-mock")
+            .expect_err("missing table must propagate as Err, not silently report None");
+        let msg = err.to_string();
+        assert!(
+            msg.to_lowercase().contains("mock_kms_keys") || msg.to_lowercase().contains("no such"),
+            "expected the error to mention the missing table; got: {msg}"
+        );
     }
 
     #[test]

--- a/docs/cli/mock-kms.md
+++ b/docs/cli/mock-kms.md
@@ -64,11 +64,34 @@ mandate_core::signer::verify_hex(&v1.public_hex, b"some canonical bytes", &sig).
 - `role`, `version`, `key_id`, `public_hex`, `created_at`,
 - a `mock: bool` field that is **always `true`** so JSON / CLI output cannot drop the disclosure.
 
-## CLI
+## CLI (PSM-A1.9)
 
-The CLI commands `mandate key list --mock` and `mandate key rotate --mock` are tracked separately. They require a small storage table to persist rotation state across CLI invocations; see the production-shaped mock backlog (item PSM-A1.9) for follow-up.
+`mandate key {init,list,rotate}` operate on the persistent `mock_kms_keys` SQLite table (migration **V005**). Every operation requires `--mock` for explicit disclosure — these commands are NOT plug-compatible with a production KMS.
 
-For now, callers use `MockKmsSigner` programmatically (tests, in-process daemons, fixtures).
+```bash
+# Initialise role=audit-mock at v1, deterministic seed, in-process db.
+mandate key init --mock \
+  --role      audit-mock \
+  --root-seed 2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a \
+  --db        /var/lib/mandate/mandate.sqlite
+
+# List the keyring (filter by --role optional).
+mandate key list --mock --db /var/lib/mandate/mandate.sqlite
+
+# Rotate to next version. Reads max(version) for the role, derives v(n+1)
+# from (role, n+1, root_seed), inserts the row. Old version stays listed
+# so a verifier can resolve historical key_ids back to public keys.
+mandate key rotate --mock \
+  --role      audit-mock \
+  --root-seed 2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a \
+  --db        /var/lib/mandate/mandate.sqlite
+```
+
+The `--root-seed` is **never** stored in the SQLite database — only the resulting public-key metadata is persisted. The seed is supplied on every operation; rotation requires the same seed used at init (otherwise the derived public key wouldn't match what `MockKmsSigner` would produce).
+
+`init` is idempotent: re-running with the same args reports the existing v1 row and exits 0.
+
+`mandate doctor` automatically promotes the `mock_kms_keys` row from `skip` to `ok` once V005 has run and at least one keyring exists.
 
 ## Tests
 

--- a/migrations/V005__mock_kms_keys.sql
+++ b/migrations/V005__mock_kms_keys.sql
@@ -1,0 +1,32 @@
+-- Mandate V005: persistent **mock** KMS keyring metadata.
+--
+-- Backs `Storage::mock_kms_*` and the `mandate key {init,list,rotate} --mock`
+-- CLI surface (PSM-A1.9). Holds *only* public-key material — no seeds,
+-- no private keys. Callers supply the deterministic `--root-seed` to the
+-- CLI on every operation; this table stores the resulting per-version
+-- public key so:
+--   * `mandate key list` can dump the keyring without re-deriving;
+--   * the doctor can confirm a keyring exists and report its size;
+--   * a future B-owned demo step can show the keyring on the production-
+--     shaped runner without having to run a Rust binary.
+--
+-- This is mock infrastructure. A real KMS keyring would live behind a
+-- key-management API; the per-version row would carry an opaque KMS key
+-- ARN/handle, NOT a deterministic public key derived from a local seed.
+-- Documented in `docs/cli/mock-kms.md`.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS mock_kms_keys (
+    role        TEXT NOT NULL,
+    version     INTEGER NOT NULL,
+    key_id      TEXT NOT NULL UNIQUE,
+    public_hex  TEXT NOT NULL,
+    created_at  TEXT NOT NULL,
+    PRIMARY KEY (role, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mock_kms_keys_role ON mock_kms_keys(role);
+CREATE INDEX IF NOT EXISTS idx_mock_kms_keys_created_at ON mock_kms_keys(created_at);
+
+COMMIT;


### PR DESCRIPTION
## PSM-A1.9 — persist mock KMS keyring + `mandate key` CLI

> Status: head `9ac45c3` (one commit on top of `dd6a220` carrying the Codex P2 follow-ups). MERGEABLE / CLEAN against `main` at `13a69cb` (post #32 + #33).

Adds an SQLite-backed keyring for the **mock** KMS surface introduced by PSM-A1, plus the operator-facing `mandate key {init,list,rotate} --mock` CLI to manage it. The keyring stores **only public-key metadata** — `role`, `version`, `key_id`, `public_hex`, `created_at`. Private material is never persisted; the deterministic 32-byte `--root-seed` is supplied on every CLI invocation and used to re-derive `(key_id, public_hex)` for the requested version.

The required `--mock` flag is loud disclosure: a real KMS keyring CLI would never be plug-compatible with these commands. Documented in `docs/cli/mock-kms.md`.

## What landed (head `9ac45c3` = `dd6a220` + Codex P2 follow-ups)

### PSM-A1.9 core (commit `dd6a220`)
- `migrations/V005__mock_kms_keys.sql` — new table, primary key `(role, version)`, unique `key_id`.
- `crates/mandate-storage/src/mock_kms_store.rs` — `MockKmsKeyRecord` + `mock_kms_insert` / `mock_kms_list` / `mock_kms_current_version`.
- `crates/mandate-storage/src/{lib,db}.rs` — module wiring + V005 in the migration registry.
- `crates/mandate-core/src/mock_kms.rs` — exported `derive_key_metadata(role, version, &root_seed) -> (key_id, public_hex)` (already present from PSM-A1; surface change only).
- `crates/mandate-cli/src/key.rs` — `cmd_init`, `cmd_list`, `cmd_rotate` plus `parse_root_seed` + `require_mock_flag`.
- `crates/mandate-cli/src/main.rs` — `Key { op: KeyCmd }` clap subcommand wiring.
- `crates/mandate-cli/tests/key_cli.rs` — integration tests against the real `mandate` binary.
- `docs/cli/mock-kms.md` — operator docs (when to use, **why mock, never production**, full `init`/`list`/`rotate` examples).

### Codex P2 follow-ups (commit `9ac45c3`) — all three threads addressed in current head

| Thread | Fix landed at | Test pinning the fix |
| --- | --- | --- |
| **P2 #1** Validate root-seed consistency before rotate | `crates/mandate-cli/src/key.rs` lines 270–298 — `cmd_rotate` loads the stored v(current) row, recomputes `(key_id, public_hex)` from `(role, current_version, --root-seed)`, and aborts with exit 2 on mismatch | `crates/mandate-cli/tests/key_cli.rs::rotate_with_wrong_root_seed_refuses_and_does_not_advance` (init with seed A → rotate with seed B fails exit 2 with explanatory stderr → list still shows only v1 → rotate with seed A succeeds) |
| **P2 #2** Prefix every non-empty `key list` output line with `mock-kms:` | `crates/mandate-cli/src/key.rs` lines 196–207 — header, column line, and every row line now start with the disclosure | `crates/mandate-cli/tests/key_cli.rs::list_prefixes_every_line_with_mock_kms_disclosure` (seeds two roles, asserts every non-blank stdout line begins with `mock-kms:`, regression-checks both rows still present) |
| **P2 #3** Propagate `mock_kms_current_version` query failures instead of swallowing them as `None` | `crates/mandate-storage/src/mock_kms_store.rs` line 105 — `query_row(...)?` replaces the prior `.ok()` (SELECT MAX always returns one row, so QueryReturnedNoRows is structurally impossible) | `crates/mandate-storage/src/mock_kms_store.rs::current_version_propagates_query_errors` (drop `mock_kms_keys` from a migrated DB → reopen → `mock_kms_current_version` returns `Err(Sqlite)`, not `Ok(None)`) |

The two outdated Codex threads (list-prefix, current_version) were re-located by GitHub once the surrounding code shifted; the current-line thread (root-seed) is still anchored at the live region. UI "Resolve conversation" click is left to the reviewer — the underlying fixes are present in the diff and pinned by tests.

## Files changed (relative to `main` @ `13a69cb`)

| File | Change |
| --- | --- |
| `migrations/V005__mock_kms_keys.sql` | new |
| `crates/mandate-storage/src/mock_kms_store.rs` | new (storage API + 7 unit tests including P2 #3) |
| `crates/mandate-storage/src/lib.rs` | `pub mod mock_kms_store;` |
| `crates/mandate-storage/src/db.rs` | register V005 in `MIGRATIONS` |
| `crates/mandate-core/src/mock_kms.rs` | export `derive_key_metadata` |
| `crates/mandate-cli/src/key.rs` | new (3 subcommands + P2 #1 + P2 #2) |
| `crates/mandate-cli/src/main.rs` | wire `Key` subcommand |
| `crates/mandate-cli/Cargo.toml` | `hex` dep for seed parsing |
| `crates/mandate-cli/tests/key_cli.rs` | new (10 integration tests including the two P2-pinning tests) |
| `docs/cli/mock-kms.md` | operator docs |
| `Cargo.lock` | resolver update |

## Local verification (run against head `9ac45c3` + main `13a69cb`)

| Command | Result |
| --- | --- |
| `cargo fmt --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo test --workspace --all-targets` | **all green** — mandate-storage 25/25 (incl. `current_version_propagates_query_errors`), mandate-cli unit 11/11 + audit_bundle 8/8 + key_cli **10/10** (incl. `list_prefixes_every_line_with_mock_kms_disclosure` and `rotate_with_wrong_root_seed_refuses_and_does_not_advance`) |
| `python3 scripts/validate_schemas.py` | pass — 4 schemas + 4 corpus files |
| `python3 scripts/validate_openapi.py` | `openapi: ok (docs/api/openapi.json)` |
| `python3 trust-badge/test_build.py` | `PASS: 31 checks ok` |
| `python3 operator-console/test_build.py` | `PASS: 46 checks ok` |
| `bash demo-scripts/run-openagents-final.sh` | green — 13/13 demo phases (ENS verify → x402 allow → Uniswap allow/deny → prompt-injection deny → audit tamper detection → no-key proof → transcript artefact) |

## CI

| Workflow | Result |
| --- | --- |
| Rust check | ✅ SUCCESS |
| Validate JSON schemas / OpenAPI | ✅ SUCCESS |

## Out of scope on this PR

- Daemon-side keyring loading (PSM-B1 — the daemon will read this table via a `load_active_keyring` helper).
- Real KMS backend — explicitly NOT covered. `--mock` is a hard requirement on every subcommand.
- Policy lifecycle (PSM-A3) — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)