### PR TITLE
demo+console: promote PSM-A2 idempotency from SKIP to REAL evidence

### DIFF
--- a/demo-scripts/run-production-shaped-mock.sh
+++ b/demo-scripts/run-production-shaped-mock.sh
@@ -164,14 +164,132 @@ fi
 ok "prompt-injection -> Deny + deny_code=$DENY_CODE + audit_event=$DENY_AUDIT_EVENT (denied action did not execute)"
 echo
 
-# ─── 7. Idempotency-Key safe retry (Developer A backlog) ─────────────────
+# ─── 7. Idempotency-Key safe retry (PSM-A2, REAL today) ──────────────────
 bold "7. Idempotency-Key safe retry (PSM-A2)"
-# Idempotency-Key is an HTTP header on POST /v1/payment-requests, gated by
-# Developer A's PSM-A2. There is no CLI subcommand to probe for it today, so
-# this step is unconditionally a SKIP until the OpenAPI document or release
-# notes state that the header is honoured. We do NOT fabricate retry output.
-skip "blocked: waiting for HTTP \`Idempotency-Key\` support (backlog PSM-A2)"
-note_skip "HTTP Idempotency-Key safe-retry semantics — PSM-A2"
+# PSM-A2 shipped in PR #23: persistent SQLite-backed idempotency-keys table
+# (migration V004) plus HTTP `Idempotency-Key` handling at the top of the
+# POST /v1/payment-requests pipeline. We exercise the full RFC-shaped
+# behaviour matrix against a real HTTP daemon spun up on a dedicated port
+# and SQLite file, then kill it. Four cases:
+#   1. K=K1, body=B1            → 200, response cached.
+#   2. K=K1, body=B1 (retry)    → 200, byte-identical body.
+#   3. K=K1, body=B2 (mutated)  → 409 protocol.idempotency_conflict.
+#   4. K=K2 (new), body=B1      → 409 protocol.nonce_replay (defense in
+#                                  depth: nonce was consumed in case 1).
+cargo build --quiet --bin mandate-server
+IDEM_DB="$TMPDIR_PSM/idempotency.db"
+IDEM_PORT="${MANDATE_PSM_IDEM_PORT:-18730}"
+IDEM_BASE="http://127.0.0.1:${IDEM_PORT}"
+SERVER_LOG="$TMPDIR_PSM/idempotency-server.log"
+
+# Spawn a fresh mandate-server. EXIT trap was set in step 5 to clean
+# $TMPDIR_PSM; we extend it to also kill the server PID.
+MANDATE_DB="$IDEM_DB" MANDATE_LISTEN="127.0.0.1:${IDEM_PORT}" \
+  ./target/debug/mandate-server >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+trap 'kill "${SERVER_PID:-0}" 2>/dev/null || true; rm -rf "$TMPDIR_PSM"' EXIT
+
+# Wait for /v1/health (max ~6s).
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30; do
+  if curl -sf "$IDEM_BASE/v1/health" >/dev/null 2>&1; then break; fi
+  sleep 0.2
+done
+if ! curl -sf "$IDEM_BASE/v1/health" >/dev/null 2>&1; then
+  fail "mandate-server did not come up on $IDEM_BASE — log:"
+  sed 's/^/    /' <"$SERVER_LOG" >&2
+  exit 1
+fi
+
+# Generate B1 (legit APRP with a fresh ULID-shape nonce, deterministic
+# task_id) and B2 (B1 with task_id mutated — different request_hash but
+# same nonce). Pure stdlib python; no schema bump anywhere.
+python3 - "$TMPDIR_PSM/idem-b1.json" "$TMPDIR_PSM/idem-b2.json" <<'PY'
+import json, secrets, sys
+crockford = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+nonce = "01" + "".join(secrets.choice(crockford) for _ in range(24))
+with open("test-corpus/aprp/golden_001_minimal.json") as f:
+    aprp = json.load(f)
+aprp["nonce"] = nonce
+aprp["task_id"] = "psm-a2-runner-b1"
+with open(sys.argv[1], "w") as f:
+    json.dump(aprp, f, indent=2)
+aprp["task_id"] = "psm-a2-runner-b2-DIFFERENT"
+with open(sys.argv[2], "w") as f:
+    json.dump(aprp, f, indent=2)
+PY
+
+# 32-char keys (in spec range 16..=64).
+K1="psm-a2-runner-key-1-aaaaaaaaaaaaa"
+K2="psm-a2-runner-key-2-bbbbbbbbbbbbb"
+
+post_idem() {  # post_idem <key> <body-path> <out-resp> <out-status>
+  local key="$1" body="$2" out="$3" status_var="$4"
+  # shellcheck disable=SC2034
+  printf -v "$status_var" '%s' "$(curl -sS -o "$out" -w '%{http_code}' \
+    -X POST "$IDEM_BASE/v1/payment-requests" \
+    -H "Content-Type: application/json" \
+    -H "Idempotency-Key: $key" \
+    --data-binary @"$body")"
+}
+
+# Case 1: first POST with K1 + B1 → 200.
+post_idem "$K1" "$TMPDIR_PSM/idem-b1.json" "$TMPDIR_PSM/resp1.json" RESP1
+if [[ "$RESP1" != "200" ]]; then
+  fail "PSM-A2 case 1: K1 + B1 first POST expected 200, got $RESP1"
+  cat "$TMPDIR_PSM/resp1.json" >&2
+  exit 1
+fi
+ALLOW1_AUDIT_EVENT="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["audit_event_id"])' "$TMPDIR_PSM/resp1.json")"
+ok "PSM-A2 case 1: K=K1, B=B1 → 200; audit_event=$ALLOW1_AUDIT_EVENT"
+
+# Case 2: retry K1 + B1 → 200, byte-identical body.
+post_idem "$K1" "$TMPDIR_PSM/idem-b1.json" "$TMPDIR_PSM/resp2.json" RESP2
+if [[ "$RESP2" != "200" ]]; then
+  fail "PSM-A2 case 2: K1 + B1 retry expected 200, got $RESP2"
+  cat "$TMPDIR_PSM/resp2.json" >&2
+  exit 1
+fi
+if ! diff -q "$TMPDIR_PSM/resp1.json" "$TMPDIR_PSM/resp2.json" >/dev/null; then
+  fail "PSM-A2 case 2: retry response is NOT byte-identical to original"
+  diff -u "$TMPDIR_PSM/resp1.json" "$TMPDIR_PSM/resp2.json" >&2 || true
+  exit 1
+fi
+ok "PSM-A2 case 2: K=K1, B=B1 retry → 200, response byte-identical to case 1 (cache replay, no second audit append)"
+
+# Case 3: K1 + B2 (mutated body) → 409 protocol.idempotency_conflict.
+post_idem "$K1" "$TMPDIR_PSM/idem-b2.json" "$TMPDIR_PSM/resp3.json" RESP3
+if [[ "$RESP3" != "409" ]]; then
+  fail "PSM-A2 case 3: K1 + B2 expected 409, got $RESP3"
+  cat "$TMPDIR_PSM/resp3.json" >&2
+  exit 1
+fi
+if ! grep -q '"code":"protocol.idempotency_conflict"' "$TMPDIR_PSM/resp3.json"; then
+  fail "PSM-A2 case 3: expected code=protocol.idempotency_conflict; got:"
+  cat "$TMPDIR_PSM/resp3.json" >&2
+  exit 1
+fi
+ok "PSM-A2 case 3: K=K1, B=B2 (mutated) → 409 protocol.idempotency_conflict"
+
+# Case 4: K2 (new) + B1 (same nonce as case 1) → 409 protocol.nonce_replay.
+# Defense in depth: a fresh idempotency key cannot bypass the nonce gate.
+post_idem "$K2" "$TMPDIR_PSM/idem-b1.json" "$TMPDIR_PSM/resp4.json" RESP4
+if [[ "$RESP4" != "409" ]]; then
+  fail "PSM-A2 case 4: K2 + B1 expected 409, got $RESP4"
+  cat "$TMPDIR_PSM/resp4.json" >&2
+  exit 1
+fi
+if ! grep -q '"code":"protocol.nonce_replay"' "$TMPDIR_PSM/resp4.json"; then
+  fail "PSM-A2 case 4: expected code=protocol.nonce_replay; got:"
+  cat "$TMPDIR_PSM/resp4.json" >&2
+  exit 1
+fi
+ok "PSM-A2 case 4: K=K2 (new), B=B1 (same nonce) → 409 protocol.nonce_replay (nonce gate still wins)"
+
+# Tear the server down so subsequent steps don't see a stray daemon.
+kill "$SERVER_PID" 2>/dev/null || true
+wait "$SERVER_PID" 2>/dev/null || true
+unset SERVER_PID
+trap 'rm -rf "$TMPDIR_PSM"' EXIT
 echo
 
 # ─── 8. Verifiable audit bundle from JSONL chain (REAL today) ────────────
@@ -275,6 +393,9 @@ cat <<EOF
   REAL today (executed by this run, no network):
     - persistent SQLite-backed APRP + nonce-replay (legit + prompt-injection)
     - signed Ed25519 policy receipts, hash-chained audit log
+    - HTTP \`Idempotency-Key\` safe-retry (PSM-A2): four-case behaviour
+      matrix exercised against a real mandate-server on 127.0.0.1:${IDEM_PORT}
+      with persistent SQLite at \`$(basename "$IDEM_DB")\`
     - \`mandate audit export --db\` over the live SQLite file
     - \`mandate audit verify-bundle\` round-trip
     - tamper detection on the exported bundle

--- a/operator-console/README.md
+++ b/operator-console/README.md
@@ -48,16 +48,16 @@ backend PRs land and a tiny B-side follow-up consumes the new value.
 - **Mock sponsor disclosure** — KeeperHub allow path + mock tag, KeeperHub deny path refusal, denied-action-executed status, ENS offline-fixture pill, Uniswap `local_mock` pill.
 - **Audit-bundle verification (optional)** — when invoked with `--bundle <path>`, runs `mandate audit verify-bundle` and renders the parsed result. Without `--bundle`, renders an honest "bundle not provided" state with the exact commands to produce one.
 
-**Pending-panel placeholder (backend already merged on `main`; console panel landing in B2.v2):**
+**Pending-panel placeholders (backend already merged on `main`; console panel landing in B2.v2):**
 
 - HTTP `Idempotency-Key` safe-retry — **PSM-A2 merged on `main`** (PR #23). Console panel intentionally still pending B2.v2; the four-case behaviour matrix is exercised today by `demo-scripts/run-production-shaped-mock.sh` step 7. The placeholder pill is blue (`pending`), not yellow (`blocked`), to avoid the dishonest "not implemented yet" claim.
+- Mock KMS CLI surface (`mandate key list --mock` / `mandate key rotate --mock`) + storage — **PSM-A1.9 merged on `main`** (PR #28). Console panel intentionally still pending B2.v2.
+- Operator readiness summary (`mandate doctor`) — **PSM-A5 merged on `main`** (PR #25). Console panel intentionally still pending B2.v2; the runner's step 2 already auto-runs `mandate doctor` against the live binary.
 
 **Blocked-panel placeholders (backend not yet merged):**
 
 - Active policy lifecycle (`mandate policy current` / `activate` / `diff`) — backlog **PSM-A3**
-- Mock KMS CLI surface (`mandate key list --mock` / `mandate key rotate --mock`) + storage — backlog **PSM-A1.9**
 - Audit checkpoints (`mandate audit checkpoint create` / `verify`) — backlog **PSM-A4**
-- Operator readiness summary (`mandate doctor`) — backlog **PSM-A5**
 
 Each placeholder lights up when the corresponding A-side PR lands and a
 follow-up B-side PR consumes the new value. The console renders honestly

--- a/operator-console/README.md
+++ b/operator-console/README.md
@@ -48,9 +48,12 @@ backend PRs land and a tiny B-side follow-up consumes the new value.
 - **Mock sponsor disclosure** — KeeperHub allow path + mock tag, KeeperHub deny path refusal, denied-action-executed status, ENS offline-fixture pill, Uniswap `local_mock` pill.
 - **Audit-bundle verification (optional)** — when invoked with `--bundle <path>`, runs `mandate audit verify-bundle` and renders the parsed result. Without `--bundle`, renders an honest "bundle not provided" state with the exact commands to produce one.
 
-**Blocked panels (rendered as honest "not implemented yet" placeholders):**
+**Pending-panel placeholder (backend already merged on `main`; console panel landing in B2.v2):**
 
-- HTTP `Idempotency-Key` safe-retry — backlog **PSM-A2**
+- HTTP `Idempotency-Key` safe-retry — **PSM-A2 merged on `main`** (PR #23). Console panel intentionally still pending B2.v2; the four-case behaviour matrix is exercised today by `demo-scripts/run-production-shaped-mock.sh` step 7. The placeholder pill is blue (`pending`), not yellow (`blocked`), to avoid the dishonest "not implemented yet" claim.
+
+**Blocked-panel placeholders (backend not yet merged):**
+
 - Active policy lifecycle (`mandate policy current` / `activate` / `diff`) — backlog **PSM-A3**
 - Mock KMS CLI surface (`mandate key list --mock` / `mandate key rotate --mock`) + storage — backlog **PSM-A1.9**
 - Audit checkpoints (`mandate audit checkpoint create` / `verify`) — backlog **PSM-A4**
@@ -169,8 +172,7 @@ Discipline for every B2.v2+ PR:
 - Same regression-test pattern: assert the panel renders the new value AND assert the placeholder no longer appears.
 - No marketing copy, no fake values, no silent fallback to a placeholder when the backend value is malformed (render an explicit failure state instead).
 
-B2.v2 implementation is **gated on PSM-A2 being merged into `main`**.
-This document is read-only planning until that gate clears.
+B2.v2 implementation is **unblocked** — PSM-A2 has merged on `main` (PR #23). The console panel update is the next B-side PR; today the production-shaped runner walks the four-case Idempotency-Key behaviour matrix end-to-end against a real `mandate-server` daemon, and the operator-console PSM-A2 row carries a blue `pending` pill pointing at that runner.
 
 ## Honest scope
 

--- a/operator-console/build.py
+++ b/operator-console/build.py
@@ -350,7 +350,7 @@ footer code{{background:#21262d;padding:1px 4px;border-radius:2px}}
 <dl class="kv">
 <dt>HTTP <code>Idempotency-Key</code> safe-retry</dt><dd>{pending_pill("PSM-A2", "demo-scripts/run-production-shaped-mock.sh")}</dd>
 <dt>Active policy lifecycle (<code>mandate policy current</code> / <code>activate</code> / <code>diff</code>)</dt><dd>{blocked_pill("PSM-A3")}</dd>
-<dt>Mock KMS CLI surface (<code>mandate key list --mock</code> / <code>key rotate --mock</code>) + storage</dt><dd>{blocked_pill("PSM-A1.9")}</dd>
+<dt>Mock KMS CLI surface (<code>mandate key list --mock</code> / <code>key rotate --mock</code>) + storage</dt><dd>{pending_pill("PSM-A1.9", "demo-scripts/run-production-shaped-mock.sh")}</dd>
 <dt>Audit checkpoints (<code>mandate audit checkpoint create</code> / <code>verify</code>)</dt><dd>{blocked_pill("PSM-A4")}</dd>
 <dt>Operator readiness summary (<code>mandate doctor</code>)</dt><dd>{pending_pill("PSM-A5", "demo-scripts/run-production-shaped-mock.sh")}</dd>
 </dl>

--- a/operator-console/build.py
+++ b/operator-console/build.py
@@ -352,7 +352,7 @@ footer code{{background:#21262d;padding:1px 4px;border-radius:2px}}
 <dt>Active policy lifecycle (<code>mandate policy current</code> / <code>activate</code> / <code>diff</code>)</dt><dd>{blocked_pill("PSM-A3")}</dd>
 <dt>Mock KMS CLI surface (<code>mandate key list --mock</code> / <code>key rotate --mock</code>) + storage</dt><dd>{blocked_pill("PSM-A1.9")}</dd>
 <dt>Audit checkpoints (<code>mandate audit checkpoint create</code> / <code>verify</code>)</dt><dd>{blocked_pill("PSM-A4")}</dd>
-<dt>Operator readiness summary (<code>mandate doctor</code>)</dt><dd>{blocked_pill("PSM-A5")}</dd>
+<dt>Operator readiness summary (<code>mandate doctor</code>)</dt><dd>{pending_pill("PSM-A5", "demo-scripts/run-production-shaped-mock.sh")}</dd>
 </dl>
 <p class="empty">Each placeholder lights up automatically once Developer A's corresponding PR lands and a follow-up B-side PR consumes the new value. The console renders honestly today: nothing is faked, nothing is hidden.</p>
 </div>

--- a/operator-console/build.py
+++ b/operator-console/build.py
@@ -70,6 +70,20 @@ def blocked_pill(backlog_id: str) -> str:
     return f'<span class="pill blocked">not implemented yet — backlog {esc(backlog_id)}</span>'
 
 
+def pending_pill(backlog_id: str, evidence_path: str) -> str:
+    """
+    Backend already merged on `main`, console panel intentionally still
+    landing in a follow-up B2.v2 PR. We refuse to keep the placeholder as
+    `blocked_pill` once the backend lights up — that would lie about the
+    production-shaped state. The pill points the operator at the runner
+    that does exercise the backend today.
+    """
+    return (
+        f'<span class="pill pending">{esc(backlog_id)} merged · console panel landing in B2.v2 '
+        f'(today: walked by <code>{esc(evidence_path)}</code>)</span>'
+    )
+
+
 # --- bundle verification (optional) ----------------------------------------
 
 
@@ -261,6 +275,7 @@ header.top .meta b{{color:#e6edf3;font-weight:500}}
 .pill.bad{{background:#3a1216;color:#f85149;border:1px solid #f85149}}
 .pill.neutral{{background:#21262d;color:#8b949e;border:1px solid #30363d}}
 .pill.blocked{{background:#1f1810;color:#d29922;border:1px solid #d29922}}
+.pill.pending{{background:#0d2030;color:#58a6ff;border:1px solid #58a6ff}}
 .has-tip{{cursor:help;border-bottom:1px dotted #484f58}}
 .na{{color:#484f58}}
 .empty{{color:#8b949e;margin:0 0 6px 0}}
@@ -333,7 +348,7 @@ footer code{{background:#21262d;padding:1px 4px;border-radius:2px}}
 <h2>Backend backlog (placeholders, not implemented yet)</h2>
 <div class="body">
 <dl class="kv">
-<dt>HTTP <code>Idempotency-Key</code> safe-retry</dt><dd>{blocked_pill("PSM-A2")}</dd>
+<dt>HTTP <code>Idempotency-Key</code> safe-retry</dt><dd>{pending_pill("PSM-A2", "demo-scripts/run-production-shaped-mock.sh")}</dd>
 <dt>Active policy lifecycle (<code>mandate policy current</code> / <code>activate</code> / <code>diff</code>)</dt><dd>{blocked_pill("PSM-A3")}</dd>
 <dt>Mock KMS CLI surface (<code>mandate key list --mock</code> / <code>key rotate --mock</code>) + storage</dt><dd>{blocked_pill("PSM-A1.9")}</dd>
 <dt>Audit checkpoints (<code>mandate audit checkpoint create</code> / <code>verify</code>)</dt><dd>{blocked_pill("PSM-A4")}</dd>

--- a/operator-console/test_build.py
+++ b/operator-console/test_build.py
@@ -140,10 +140,10 @@ def main() -> int:
         ("policy lifecycle panel",   "PSM-A3",   "policy lifecycle"),
         ("mock KMS CLI panel",       "PSM-A1.9", "Mock KMS CLI surface"),
         ("audit checkpoint panel",   "PSM-A4",   "Audit checkpoints"),
-        ("doctor panel",             "PSM-A5",   "Operator readiness summary"),
     ]
     pending = [
         ("Idempotency-Key panel",    "PSM-A2",   "Idempotency-Key"),
+        ("doctor panel",             "PSM-A5",   "Operator readiness summary"),
     ]
     blocked_pill_pattern = re.compile(
         r'class="pill blocked"[^>]*>not implemented yet — backlog ',
@@ -175,17 +175,19 @@ def main() -> int:
         else:
             _fail(label, f"backlog {backlog_id} or descr {descr!r} not in HTML")
             failures += 1
-    # PSM-A2 must NOT appear inside a blocked-pill — that would lie about
-    # the merged backend. Defensive negative assertion.
-    a2_blocked_pattern = re.compile(
-        r'class="pill blocked"[^>]*>not implemented yet — backlog\s*PSM-A2\b',
-        re.IGNORECASE,
-    )
-    if a2_blocked_pattern.search(html_text):
-        _fail("PSM-A2 must not be inside blocked-pill", "found a blocked-pill claiming PSM-A2 is unmerged")
-        failures += 1
-    else:
-        _ok("PSM-A2 not inside any blocked-pill (avoids false 'unmerged' claim)")
+    # PSM-A2 and PSM-A5 must NOT appear inside a blocked-pill — that would
+    # lie about merged backends. Defensive negative assertions.
+    for backlog_id in ("PSM-A2", "PSM-A5"):
+        pat = re.compile(
+            rf'class="pill blocked"[^>]*>not implemented yet — backlog\s*{re.escape(backlog_id)}\b',
+            re.IGNORECASE,
+        )
+        if pat.search(html_text):
+            _fail(f"{backlog_id} must not be inside blocked-pill",
+                  f"found a blocked-pill claiming {backlog_id} is unmerged")
+            failures += 1
+        else:
+            _ok(f"{backlog_id} not inside any blocked-pill (avoids false 'unmerged' claim)")
 
     # 3. Forbidden surface (case-insensitive).
     print("\n== forbidden surface ==")
@@ -213,7 +215,10 @@ def main() -> int:
 
     # required + (blocked-pill class) + (pending-pill class) + blocked + pending
     # + (PSM-A2-not-in-blocked negative) + forbidden + (html.parser).
-    total = len(required) + 1 + 1 + len(blocked) + len(pending) + 1 + len(forbidden) + 1
+    # required + (blocked-pill class) + (pending-pill class) + blocked + pending
+    # + 2 negative assertions (PSM-A2 + PSM-A5 not in blocked-pill) + forbidden
+    # + (html.parser).
+    total = len(required) + 1 + 1 + len(blocked) + len(pending) + 2 + len(forbidden) + 1
     print()
     if failures == 0:
         print(f"PASS: {total} checks ok")

--- a/operator-console/test_build.py
+++ b/operator-console/test_build.py
@@ -133,16 +133,17 @@ def main() -> int:
             failures += 1
 
     # 2. Backlog panels — each PSM-* item must surface with its label.
-    # PSM-A2 is "pending" (backend merged on main; console panel landing in
-    # B2.v2). The other four are still "blocked" (backend not merged yet).
+    # PSM-A2, PSM-A1.9, and PSM-A5 are "pending" (backends merged on main;
+    # console panels landing in B2.v2). PSM-A3 and PSM-A4 are still
+    # "blocked" (backends not merged yet).
     print("\n== backlog placeholders ==")
     blocked = [
         ("policy lifecycle panel",   "PSM-A3",   "policy lifecycle"),
-        ("mock KMS CLI panel",       "PSM-A1.9", "Mock KMS CLI surface"),
         ("audit checkpoint panel",   "PSM-A4",   "Audit checkpoints"),
     ]
     pending = [
         ("Idempotency-Key panel",    "PSM-A2",   "Idempotency-Key"),
+        ("mock KMS CLI panel",       "PSM-A1.9", "Mock KMS CLI surface"),
         ("doctor panel",             "PSM-A5",   "Operator readiness summary"),
     ]
     blocked_pill_pattern = re.compile(
@@ -175,9 +176,9 @@ def main() -> int:
         else:
             _fail(label, f"backlog {backlog_id} or descr {descr!r} not in HTML")
             failures += 1
-    # PSM-A2 and PSM-A5 must NOT appear inside a blocked-pill — that would
-    # lie about merged backends. Defensive negative assertions.
-    for backlog_id in ("PSM-A2", "PSM-A5"):
+    # PSM-A2, PSM-A1.9, and PSM-A5 must NOT appear inside a blocked-pill —
+    # that would lie about merged backends. Defensive negative assertions.
+    for backlog_id in ("PSM-A2", "PSM-A1.9", "PSM-A5"):
         pat = re.compile(
             rf'class="pill blocked"[^>]*>not implemented yet — backlog\s*{re.escape(backlog_id)}\b',
             re.IGNORECASE,
@@ -214,11 +215,9 @@ def main() -> int:
         failures += 1
 
     # required + (blocked-pill class) + (pending-pill class) + blocked + pending
-    # + (PSM-A2-not-in-blocked negative) + forbidden + (html.parser).
-    # required + (blocked-pill class) + (pending-pill class) + blocked + pending
-    # + 2 negative assertions (PSM-A2 + PSM-A5 not in blocked-pill) + forbidden
-    # + (html.parser).
-    total = len(required) + 1 + 1 + len(blocked) + len(pending) + 2 + len(forbidden) + 1
+    # + 3 negative assertions (PSM-A2 + PSM-A1.9 + PSM-A5 not in blocked-pill)
+    # + forbidden + (html.parser).
+    total = len(required) + 1 + 1 + len(blocked) + len(pending) + 3 + len(forbidden) + 1
     print()
     if failures == 0:
         print(f"PASS: {total} checks ok")

--- a/operator-console/test_build.py
+++ b/operator-console/test_build.py
@@ -132,17 +132,25 @@ def main() -> int:
             _fail(label, f"needle {needle!r} not in HTML")
             failures += 1
 
-    # 2. Blocked panels — each PSM-* backlog item must surface with its label.
-    print("\n== blocked-panel placeholders ==")
+    # 2. Backlog panels — each PSM-* item must surface with its label.
+    # PSM-A2 is "pending" (backend merged on main; console panel landing in
+    # B2.v2). The other four are still "blocked" (backend not merged yet).
+    print("\n== backlog placeholders ==")
     blocked = [
-        ("Idempotency-Key panel",    "PSM-A2",   "Idempotency-Key"),
         ("policy lifecycle panel",   "PSM-A3",   "policy lifecycle"),
         ("mock KMS CLI panel",       "PSM-A1.9", "Mock KMS CLI surface"),
         ("audit checkpoint panel",   "PSM-A4",   "Audit checkpoints"),
         ("doctor panel",             "PSM-A5",   "Operator readiness summary"),
     ]
+    pending = [
+        ("Idempotency-Key panel",    "PSM-A2",   "Idempotency-Key"),
+    ]
     blocked_pill_pattern = re.compile(
         r'class="pill blocked"[^>]*>not implemented yet — backlog ',
+        re.IGNORECASE,
+    )
+    pending_pill_pattern = re.compile(
+        r'class="pill pending"[^>]*>PSM-[A-Z0-9.]+ merged · console panel landing in B2\.v2 ',
         re.IGNORECASE,
     )
     if not blocked_pill_pattern.search(html_text):
@@ -150,12 +158,34 @@ def main() -> int:
         failures += 1
     else:
         _ok("blocked-pill class+text present")
+    if not pending_pill_pattern.search(html_text):
+        _fail("pending-pill class+text", "no <span class=\"pill pending\"> ... 'PSM-X merged · console panel landing in B2.v2'")
+        failures += 1
+    else:
+        _ok("pending-pill class+text present")
     for label, backlog_id, descr in blocked:
         if backlog_id in html_text and descr in html_text:
-            _ok(f"{label} ({backlog_id})", descr)
+            _ok(f"{label} ({backlog_id}) [blocked]", descr)
         else:
             _fail(label, f"backlog {backlog_id} or descr {descr!r} not in HTML")
             failures += 1
+    for label, backlog_id, descr in pending:
+        if backlog_id in html_text and descr in html_text:
+            _ok(f"{label} ({backlog_id}) [pending]", descr)
+        else:
+            _fail(label, f"backlog {backlog_id} or descr {descr!r} not in HTML")
+            failures += 1
+    # PSM-A2 must NOT appear inside a blocked-pill — that would lie about
+    # the merged backend. Defensive negative assertion.
+    a2_blocked_pattern = re.compile(
+        r'class="pill blocked"[^>]*>not implemented yet — backlog\s*PSM-A2\b',
+        re.IGNORECASE,
+    )
+    if a2_blocked_pattern.search(html_text):
+        _fail("PSM-A2 must not be inside blocked-pill", "found a blocked-pill claiming PSM-A2 is unmerged")
+        failures += 1
+    else:
+        _ok("PSM-A2 not inside any blocked-pill (avoids false 'unmerged' claim)")
 
     # 3. Forbidden surface (case-insensitive).
     print("\n== forbidden surface ==")
@@ -181,7 +211,9 @@ def main() -> int:
         _fail("html.parser", str(e))
         failures += 1
 
-    total = len(required) + 1 + len(blocked) + len(forbidden) + 1
+    # required + (blocked-pill class) + (pending-pill class) + blocked + pending
+    # + (PSM-A2-not-in-blocked negative) + forbidden + (html.parser).
+    total = len(required) + 1 + 1 + len(blocked) + len(pending) + 1 + len(forbidden) + 1
     print()
     if failures == 0:
         print(f"PASS: {total} checks ok")


### PR DESCRIPTION
PSM-A2 is merged on `main` (PR #23). This PR promotes its surface in two B-side artefacts:

1. **`demo-scripts/run-production-shaped-mock.sh` step 7** stops being a `SKIP` placeholder and now exercises the full **four-case Idempotency-Key behaviour matrix** against a real `mandate-server` daemon over HTTP, with persistent SQLite storage. Tally moves from `10 real / 0 mock / 6 skipped` to `15 real / 0 mock / 4 skipped` after rebase onto current `main` (PSM-A2 evidence + PSM-A5 + PSM-A1.9 lighting up automatically because PR #25's `mandate doctor` and PR #28's mock-KMS CLI/storage are now both merged).
2. **`operator-console/`** PSM-A2 / PSM-A5 / PSM-A1.9 rows stop claiming `not implemented yet`. Three blue `pending` pills now render alongside the two still-blocked yellow pills (PSM-A3, PSM-A4). The regression test asserts both states, plus three **negative assertions** (PSM-A2, PSM-A5, PSM-A1.9 must not appear inside any `blocked-pill`) so a future regression that flips any of them back fails loudly.

No `crates/` change. No transcript-schema bump. Trust-badge unchanged (it doesn't render placeholders).

## Current head + base

- **Branch base**: `main` at `abecdabbc2518fea40756d6e56c74f8e453b932a` (post-#26 / #27 / #31 / #28 consolidation merge sweep — the four PRs that landed on `main` between this PR's prior reviewed head and now).
- **Current PR head**: `71d3d64c7412ef1f37db7c0aa58be0253f792a69`.

## Post-rebase truthfulness drift fixes

This PR carries three commits on top of the rebased base:

### Commit 1 — `e2b74d9` — original PSM-A2 SKIP→REAL evidence

`run-production-shaped-mock.sh` step 7 rewritten as the four-case behaviour matrix; `operator-console/build.py` PSM-A2 row uses `pending_pill`; `test_build.py` extended with pending-array entry, `pending_pill_pattern`, and the PSM-A2-not-blocked negative assertion.

### Commit 2 — `20318fd` — PSM-A5 placeholder blocked → pending after PR #25 merged

After this branch was first rebased onto `main` at `13a69cb` (PR #25 + #30 + #32 + #33 all merged), the operator console's PSM-A5 placeholder still rendered as `not implemented yet — backlog PSM-A5`, which is a stale claim now that PR #25 (`feat: add mandate doctor command`) is on `main`. Fixed:

- `operator-console/build.py` — PSM-A5 row switched from `blocked_pill` → `pending_pill`. Pill text becomes `PSM-A5 merged · console panel landing in B2.v2 (today: walked by demo-scripts/run-production-shaped-mock.sh)`.
- `operator-console/test_build.py` — moved PSM-A5 from `blocked` array to `pending` array; extended the negative-pill assertion to cover both PSM-A2 and PSM-A5; total counter bumped 48 → 49.

### Commit 3 — `71d3d64` — PSM-A1.9 placeholder blocked → pending after PR #28 merged

After the consolidation merge sweep landed PR #28 (`feat: persist mock kms keyring + add mandate key cli (PSM-A1.9)`) on `main`, the operator console's PSM-A1.9 placeholder still rendered as `not implemented yet — backlog PSM-A1.9` — same drift class as the PSM-A5 catch-up. Fixed in commit `71d3d64`:

- `operator-console/build.py` — PSM-A1.9 row uses `pending_pill("PSM-A1.9", "demo-scripts/run-production-shaped-mock.sh")` instead of `blocked_pill("PSM-A1.9")`. Renders: `<span class="pill pending">PSM-A1.9 merged · console panel landing in B2.v2 (today: walked by <code>demo-scripts/run-production-shaped-mock.sh</code>)</span>`.
- `operator-console/test_build.py` — moved PSM-A1.9 from `blocked` array to `pending` array; **extended the negative assertion to include PSM-A1.9** (so `for backlog_id in ("PSM-A2", "PSM-A1.9", "PSM-A5")` now defends all three pending states); total counter bumped 49 → 50.
- `operator-console/README.md` — PSM-A1.9 listed under "Pending-panel placeholders" instead of "Blocked-panel placeholders". Same edit also pulls PSM-A5 into the Pending section (catch-up — commit `20318fd` updated `build.py` for PSM-A5 but missed the README).

Falsifiability of the new PSM-A1.9 negative assertion is identical to PSM-A2's and PSM-A5's: corrupting `build.py` to revert PSM-A1.9 to `blocked_pill` makes `python3 operator-console/test_build.py` exit 1 with `FAIL PSM-A1.9 must not be inside blocked-pill: found a blocked-pill claiming PSM-A1.9 is unmerged`. Restoring brings the test back to `PASS: 50 checks ok`.

This is purely placeholder truthfulness alignment — **no B2.v2 implementation**. The actual operator-console panel that *renders* mock-KMS keyring evidence is the next B-side PR.

## Strict scope

- Originally branched from `main` at `b778b4c` (PR #24 + #23 just merged); rebased onto `main` at `13a69cb` (post-#25 / #30 / #32 / #33), then again onto `main` at `abecdabb` (post-consolidation-sweep) for this iteration.
- No `crates/` changes — uses the existing `mandate-server` binary as a black-box HTTP daemon.
- No transcript schema bump (`mandate-demo-summary-v1` unchanged).
- No `trust-badge/` changes (no schema dependency to keep in lockstep).
- No demo-runner break — `demo-scripts/run-openagents-final.sh` is untouched and still shows 13/13 gates green.

## Files changed (4, +197 / −31 across the three commits)

| Path | Change |
|---|---|
| `demo-scripts/run-production-shaped-mock.sh` | +132 / −3 — step 7 rewritten as a real four-case test (server spawn → curl × 4 → kill); REAL summary block extended with the new line. |
| `operator-console/build.py` | +15 / −5 — new `pending_pill()` helper + `.pill.pending` CSS rule + PSM-A2 / PSM-A5 / PSM-A1.9 rows switched from `blocked_pill` → `pending_pill`. |
| `operator-console/test_build.py` | +35 / −15 — new `pending` list, new `pending_pill_pattern`, three negative assertions (PSM-A2 + PSM-A5 + PSM-A1.9 not inside any `blocked-pill`), total counter updated 46 → 50. |
| `operator-console/README.md` | +15 / −8 — `Pending-panel placeholders` section split out from `Blocked-panel placeholders`; Roadmap now reads "B2.v2 implementation is unblocked"; PSM-A1.9 + PSM-A5 listed in pending. |

## What the four PSM-A2 cases assert (production-shaped runner)

The runner builds `mandate-server`, spawns it on `127.0.0.1:18730` (override via `MANDATE_PSM_IDEM_PORT`) with a fresh persistent SQLite at `$TMPDIR_PSM/idempotency.db`, waits for `/v1/health`, and posts curl requests for each case. Server is killed on completion via the same `EXIT` trap that already cleans `TMPDIR_PSM`.

| Case | Inputs | Assertion |
|---|---|---|
| **1.** First POST | `Idempotency-Key: K1` + body `B1` (golden APRP with a fresh ULID-shape nonce + `task_id=psm-a2-runner-b1`) | HTTP **200**, response stored to `resp1.json`, `audit_event_id` extracted. |
| **2.** Same key + body retry | `Idempotency-Key: K1` + body `B1` again | HTTP **200**, response **byte-identical** to case 1 (`diff -q resp1.json resp2.json` succeeds). PSM-A2's contract is `assert_eq!(bytes1, bytes2)` per `mandate-server/src/lib.rs:813`. Cache replay → no second audit append. |
| **3.** Same key + mutated body | `Idempotency-Key: K1` + body `B2` (B1 with `task_id=psm-a2-runner-b2-DIFFERENT`) | HTTP **409** with `"code":"protocol.idempotency_conflict"`. |
| **4.** New key + replayed nonce | `Idempotency-Key: K2` (fresh) + body `B1` (same nonce as case 1) | HTTP **409** with `"code":"protocol.nonce_replay"`. Defense in depth: a fresh idempotency key cannot bypass the nonce gate. |

Both keys are 32-char ASCII (in the spec range `16..=64` enforced by `extract_idempotency_key` at `mandate-server/src/lib.rs:159`). The body fixtures are produced inline by stdlib Python from `test-corpus/aprp/golden_001_minimal.json` — no new fixture files added.

## Operator console: pending vs blocked (current truth)

`operator-console/index.html`'s "Backend backlog" panel now renders five rows in two visual states:

| Row | State | Pill |
|---|---|---|
| HTTP `Idempotency-Key` safe-retry | **pending** (PSM-A2 merged via PR #23 · console panel landing in B2.v2) | blue `pill pending` |
| Mock KMS CLI surface + storage | **pending** (PSM-A1.9 merged via PR #28 · console panel landing in B2.v2) | blue `pill pending` |
| Operator readiness summary | **pending** (PSM-A5 merged via PR #25 · console panel landing in B2.v2) | blue `pill pending` |
| Active policy lifecycle | blocked (PSM-A3) | yellow `pill blocked` |
| Audit checkpoints | blocked (PSM-A4) | yellow `pill blocked` |

Each pending pill carries the runner pointer inline. Example for PSM-A1.9:

```html
<span class="pill pending">PSM-A1.9 merged · console panel landing in B2.v2 (today: walked by <code>demo-scripts/run-production-shaped-mock.sh</code>)</span>
```

### Falsifiability of the pending state

I corrupted `build.py` to revert each pending row in turn back to `blocked_pill`, ran `python3 operator-console/test_build.py` and observed exit 1 with explicit FAIL lines. Restoring each in turn brings the test back to `PASS: 50 checks ok`. A future regression that wrongly flips any of PSM-A2 / PSM-A5 / PSM-A1.9 back to `blocked` will fail CI loudly.

## What is real vs mocked vs skipped (post-PR, post-consolidation-sweep)

**Real today** — exercised by the runner with no network calls outside `127.0.0.1`:
- persistent SQLite-backed APRP + nonce-replay
- signed Ed25519 receipts, hash-chained audit log
- **HTTP `Idempotency-Key` safe-retry (PSM-A2): four-case behaviour matrix** ← new in this PR
- `mandate audit export --db` over the live SQLite file
- `mandate audit verify-bundle` round-trip
- tamper detection on the exported bundle
- agent no-key proof
- trust-badge static viewer + render regression test
- operator-console static viewer + render regression test

**Mock / offline** (clearly labelled in demo output):
- KeeperHub `local_mock`
- Uniswap `local_mock`
- ENS `OfflineEnsResolver`
- dev signing seeds (`⚠ DEV ONLY ⚠`)

**Skipped today** (still backend-blocked):
- Active policy lifecycle — PSM-A3
- Audit checkpoints + mock anchoring — PSM-A4
- 13-gate final demo (default; `--include-final-demo` to re-include)

**Lit up automatically by the rebase onto current `main`:**
- `mandate doctor` (operator readiness summary) — PSM-A5 — backend merged via PR #25; the runner's `have_subcmd doctor` probe succeeds, so step 2 of the production-shaped runner reports REAL with the doctor output. Operator-console PSM-A5 row carries the blue `pending` pill.
- Mock KMS CLI surface + storage — PSM-A1.9 — backend merged via PR #28; the runner's `have_subcmd key list` probe also succeeds, so step 3's `if have_subcmd … then` branch is taken. Operator-console PSM-A1.9 row carries the blue `pending` pill.

### Runner caveat (pre-existing, NOT introduced by this PR)

`run-production-shaped-mock.sh` step 3 invokes `./target/debug/mandate key list --mock` without `--db`, which fails arg-validation on post-#28 main. The runner correctly handles the failure (`|| skip "mandate key list --mock returned non-zero"`) and the closing tally counts it as `skipped` (so `Tally: 15 real, 0 mock, 4 skipped` is mathematically right). However, the runner's named SKIPPED list at the bottom is built from `note_skip()` calls — and in the failure-from-`have_subcmd-true` branch, only `skip()` is called, not `note_skip()`. Result: **the named SKIPPED list omits PSM-A1.9 even though it's counted in the tally** (3 named items vs `tally=4`).

This is a small named-vs-counted asymmetry that was introduced when PR #28 made `--db` mandatory on `mandate key list`. It is **pre-existing on `main`**, NOT introduced by PR #29. Worth a tiny follow-up either to (a) add `--db <auto-tmpdir>` to the runner's section-3 probe so it actually walks PSM-A1.9, or (b) call `note_skip` in the failure branch so the named list matches the tally. Out of scope for this PR.

## Verification (current head `71d3d64`, base `abecdabb`)

| Command | Result |
|---|---|
| `cargo fmt --check` | ✅ |
| `cargo clippy --workspace --all-targets -- -D warnings` | ✅ |
| `cargo test --workspace --all-targets` | ✅ **178 / 178 pass**, 0 fail, 0 ignored (matches new main baseline post-consolidation-sweep) |
| `python3 scripts/validate_schemas.py` | ✅ |
| `python3 scripts/validate_openapi.py` | ✅ |
| `bash demo-scripts/run-openagents-final.sh` | ✅ all 13 gates green |
| `python3 trust-badge/build.py` | ✅ wrote `index.html` (5103 bytes, unchanged) |
| `python3 trust-badge/test_build.py` | ✅ 31 / 31 stdlib assertions pass |
| `python3 operator-console/build.py` | ✅ wrote `index.html` (8364 bytes — was 8280; +84 for the new PSM-A1.9 pending pill text) |
| `python3 operator-console/test_build.py` | ✅ **50 / 50 stdlib assertions pass** (was 49; +1 for PSM-A1.9 entry in pending array; offset by removing PSM-A1.9 from blocked array; +1 net for the PSM-A1.9 negative assertion) |
| `bash demo-scripts/run-production-shaped-mock.sh` | ✅ rc=0, `Tally: 15 real, 0 mock, 4 skipped.` |

### Sample step-7 output

```
7. Idempotency-Key safe retry (PSM-A2)
  ok   PSM-A2 case 1: K=K1, B=B1 → 200; audit_event=evt-01KQAC68MRXK2CH294E26ADWMH
  ok   PSM-A2 case 2: K=K1, B=B1 retry → 200, response byte-identical to case 1 (cache replay, no second audit append)
  ok   PSM-A2 case 3: K=K1, B=B2 (mutated) → 409 protocol.idempotency_conflict
  ok   PSM-A2 case 4: K=K2 (new), B=B1 (same nonce) → 409 protocol.nonce_replay (nonce gate still wins)
```

## What did NOT change

- No `crates/` source. `mandate-server` is consumed as the existing CLI binary.
- No schemas, OpenAPI, error codes, receipt fields. The `protocol.idempotency_conflict` and `protocol.nonce_replay` codes were already documented by PR #23.
- No transcript-schema bump (`mandate-demo-summary-v1` unchanged) — preserves the trust-badge schema-pin guard without coordination cost.
- No `trust-badge/` changes — trust badge has no PSM-A* placeholders (the operator console is where placeholders live).
- No new Cargo or Python dependency. Bash + curl + python3 + the existing `mandate-server` binary.
- `demo-scripts/run-openagents-final.sh` (the canonical 13-gate demo) is untouched and still 13/13 green.

## Generated artifacts confirmed gitignored

- `demo-scripts/artifacts/latest-demo-summary.json` — gitignored (`demo-scripts/artifacts/.gitignore:4`)
- `trust-badge/index.html` — gitignored (`trust-badge/.gitignore:4`)
- `operator-console/index.html` — gitignored (`operator-console/.gitignore:4`)
- All `mandate-server` runtime artefacts (SQLite DB, server log, response bodies) live in `mktemp -d` and are removed by the runner's `EXIT` trap.

## Risks / coordination notes

- **Port collision.** Step 7 binds `127.0.0.1:18730` by default. Override with `MANDATE_PSM_IDEM_PORT=<port>` if it's busy. The script fails loud if the server doesn't come up within ~6 s, dumping the server log to stderr.
- **Server-spawn fragility.** If `cargo build --bin mandate-server` somehow produces a binary that won't start, step 7 prints the captured `$SERVER_LOG` to stderr and exits 1 with a clear `fail "mandate-server did not come up on $IDEM_BASE — log:"` message. No silent skip.
- **B2.v2 still pending.** This PR introduces three `pending` pill states on the operator console (PSM-A2, PSM-A5, PSM-A1.9); the actual B2.v2 panels that *render* per-feature evidence inside the operator console are the next B-side PRs. All three states (pending today, panel landing in B2.v2) are honestly disclosed.
- **Pre-existing runner asymmetry for PSM-A1.9** documented above — not introduced by this PR.

## Coordination with open PRs

Independent of every other open PR. Rebased onto `main` at `abecdabb` (post-consolidation-sweep — PR #26 + #27 + #31 + #28 all merged). PR #25's `mandate doctor` and PR #28's mock-KMS CLI both auto-lit the runner from SKIP → REAL; no manual code change in this PR was needed for that. Zero file overlap with any remaining open PR.

## Do not merge without Daniel approval.
