### PR TITLE
demo-fixtures: add production-shaped mock fixtures (B3)

### DIFF
--- a/demo-fixtures/README.md
+++ b/demo-fixtures/README.md
@@ -1,0 +1,88 @@
+# Demo fixtures
+
+Two kinds of fixture live here:
+
+1. **Pre-existing demo fixtures** — consumed directly by the demo runner
+   (`demo-scripts/run-openagents-final.sh`) and the per-sponsor scripts.
+2. **Production-shaped mock fixtures** — added in B3 to demonstrate the
+   *shape* of integrations that Mandate would consume against real
+   backends, with deterministic local data, no secrets, no live URLs,
+   and no production claim. These fixtures are not yet wired into any
+   runner; they are reference material for adapter authors and reviewers.
+
+## Pre-existing demo fixtures
+
+| Path | Purpose |
+|---|---|
+| `ens-records.json` | Single-agent ENS text-record fixture consumed by `mandate_identity::OfflineEnsResolver` in the 13-gate demo (gate 7). |
+| `uniswap/swap-policy.json` | Swap-policy parameters (token allowlist, max notional, max slippage, treasury recipient) consumed by `mandate_execution::uniswap::evaluate_swap`. |
+| `uniswap/mandate-policy.json` | Swap-aware Mandate policy used by gate 9 of the demo. |
+| `uniswap/quote-USDC-ETH.json` | Bounded happy-path Uniswap quote fixture. |
+| `uniswap/quote-USDC-RUG.json` | Adversarial rug-token quote fixture (used to exercise the swap-policy + Mandate deny path). |
+
+## Production-shaped mock fixtures (B3)
+
+Four JSON files demonstrating live-shape integrations against deterministic
+local data. Each carries an envelope that the validation test enforces:
+
+```json
+{
+  "schema":            "mandate-mock-<surface>-v1",
+  "mock":              true,
+  "explanation":       "<≥40 chars: what this fixture demonstrates>",
+  "live_replacement":  "<≥40 chars: what the live integration would replace this with>",
+  ...
+}
+```
+
+| Fixture | Surface | What live integration would replace it |
+|---|---|---|
+| [`mock-ens-registry.json`](mock-ens-registry.json) | ENS text-record registry across multiple agent identities (catalogue view) | Live ENS resolver against mainnet/Sepolia text records via the public Registry + Public Resolver contracts. The `mandate_identity::EnsResolver` trait already abstracts this; switching is a constructor swap. |
+| [`mock-keeperhub-sandbox.json`](mock-keeperhub-sandbox.json) | KeeperHub workflow webhook submit/result envelopes (success / idempotency-conflict / not-approved-local / lookup-status) | Real KeeperHub workflow webhook responses once a public submission/result schema and credentials are available. See [`docs/keeperhub-live-spike.md`](../docs/keeperhub-live-spike.md) and FEEDBACK.md §KeeperHub. |
+| [`mock-uniswap-quotes.json`](mock-uniswap-quotes.json) | Uniswap quote catalogue (happy path, slippage violation, recipient-allowlist violation) shaped for the swap-policy guard | Live Uniswap Trading API quote endpoint. `UniswapExecutor::live()` is intentionally stubbed (`BackendOffline`) until that wiring lands. |
+| [`mock-kms-keys.json`](mock-kms-keys.json) | Public verification-key metadata (Ed25519) for Mandate's two demo signers — same deterministic dev seeds the production-shaped runner uses | Real KMS / HSM key-listing API output (AWS KMS `ListKeys`+`GetPublicKey`, GCP KMS, Azure Key Vault, or HSM). Production deployments inject signers via `AppState::with_signers`. |
+
+### Truthfulness invariants enforced by the test
+
+`python3 demo-fixtures/test_fixtures.py` (stdlib-only, mirrors
+`trust-badge/test_build.py` and `operator-console/test_build.py`)
+asserts the following for every `mock-*.json` in this directory:
+
+- parses as JSON
+- declares the four envelope fields above
+- `schema` matches `^mandate-mock-[a-z0-9-]+-v\d+$`
+- `mock` is exactly `true`
+- `explanation` and `live_replacement` are non-empty (≥ 40 chars each)
+- contains no http/https URL outside the safe set: RFC 2606 reserved
+  hostnames (`example.*`, `*.invalid`, `localhost`), `127.0.0.1`, and
+  the existing `schemas.mandate.dev` $id pattern
+- contains no secret-looking strings: PEM private-key blocks,
+  `private_key`/`signing_key`/`seed_hex`/`seed_bytes` fields with hex
+  values, `kh_*` or `wfb_*` workflow tokens
+- if the fixture sets `no_private_material: true`, no
+  `signing_key_hex`/`private_key_hex`/`seed_hex`/`seed_bytes_hex` fields
+  carrying ≥ 32-hex-char values appear anywhere in the document
+
+Falsifiable: a future PR that drops a `mock: true`, leaks a `kh_*`
+token, or smuggles in a real URL fails the test loudly.
+
+### Run
+
+```bash
+python3 demo-fixtures/test_fixtures.py
+```
+
+### Honest scope
+
+- **No runner wiring in B3.** These fixtures are reference material for
+  adapter authors and reviewers; the production-shaped runner does not
+  yet consume them. Wiring them in is a candidate for a follow-up B-side
+  PR (B3.v2 if useful, or it may stay reference-only).
+- **No transcript schema bump.** The trust badge and operator console
+  continue to consume `mandate-demo-summary-v1` unchanged.
+- **No secrets.** Every fixture is committed in the open repo and is
+  meant to be inspected line by line. The two `verifying_key_hex`
+  values in `mock-kms-keys.json` are public Ed25519 verification keys
+  derived from public seeds already in `crates/mandate-server/src/lib.rs`.
+- **No production claim.** Every fixture says `mock: true` and points at
+  what would replace it in a real deployment.

--- a/demo-fixtures/mock-ens-registry.json
+++ b/demo-fixtures/mock-ens-registry.json
@@ -1,0 +1,29 @@
+{
+  "schema": "mandate-mock-ens-registry-v1",
+  "mock": true,
+  "explanation": "A multi-agent mock of an ENS text-record registry shaped like what Mandate's `mandate_identity::EnsResolver` consumes. Demonstrates the `mandate:*` text-record convention across three deterministic agent identities, so adapter authors can see the catalogue shape (not just the single-agent shape in `demo-fixtures/ens-records.json`). Every record set is local fixture data — there are no real ENS registrations involved.",
+  "live_replacement": "Replace with a live ENS resolver (mainnet or Sepolia testnet) reading text records via the public `ENS Registry` + `Public Resolver` contracts. The `mandate_identity::EnsResolver` trait already abstracts this; switching is a constructor swap once the resolver implementation lands. See `crates/mandate-identity/` and FEEDBACK.md §ENS.",
+  "registry": {
+    "research-agent.team.eth": {
+      "mandate:agent_id": "research-agent-01",
+      "mandate:endpoint": "http://127.0.0.1:8730/v1",
+      "mandate:policy_hash": "e044f13c5acb792dd3109f1be3a98536168b0990e25595b3cedc131d02e666cf",
+      "mandate:audit_root": "0000000000000000000000000000000000000000000000000000000000000000",
+      "mandate:receipt_schema": "https://schemas.mandate.dev/policy-receipt/v1.json"
+    },
+    "trading-agent.team.eth": {
+      "mandate:agent_id": "trading-agent-01",
+      "mandate:endpoint": "http://127.0.0.1:8731/v1",
+      "mandate:policy_hash": "1111111111111111111111111111111111111111111111111111111111111111",
+      "mandate:audit_root": "0000000000000000000000000000000000000000000000000000000000000000",
+      "mandate:receipt_schema": "https://schemas.mandate.dev/policy-receipt/v1.json"
+    },
+    "support-agent.team.eth": {
+      "mandate:agent_id": "support-agent-01",
+      "mandate:endpoint": "http://127.0.0.1:8732/v1",
+      "mandate:policy_hash": "2222222222222222222222222222222222222222222222222222222222222222",
+      "mandate:audit_root": "0000000000000000000000000000000000000000000000000000000000000000",
+      "mandate:receipt_schema": "https://schemas.mandate.dev/policy-receipt/v1.json"
+    }
+  }
+}

--- a/demo-fixtures/mock-keeperhub-sandbox.json
+++ b/demo-fixtures/mock-keeperhub-sandbox.json
@@ -1,0 +1,96 @@
+{
+  "schema": "mandate-mock-keeperhub-sandbox-v1",
+  "mock": true,
+  "explanation": "Catalogue of the response envelopes Mandate's `KeeperHubExecutor::live()` would consume in production, modelled here against a deterministic local sandbox (NOT a real KeeperHub workflow). Each scenario shows what the live integration must parse: the success envelope (`executionId` parsing), the idempotency-conflict envelope, the not-approved envelope, and a status-lookup payload. Adapter authors can write the live parser against these shapes without ever calling KeeperHub. See `docs/keeperhub-live-spike.md` for the wire-format design notes that produced these shapes.",
+  "live_replacement": "Replace with real KeeperHub workflow webhook responses once a public submission/result schema and credentials are available. The four `mandate_*` envelope fields and the optional `X-Mandate-*` response headers are feedback asks — see FEEDBACK.md §KeeperHub. Switching is a `KeeperHubMode::Live(KeeperHubLiveConfig)` constructor in `crates/mandate-execution/src/keeperhub.rs`; this fixture documents the response shape Mandate would unwrap.",
+  "sponsor": "keeperhub",
+  "host": "sandbox.keeperhub.invalid",
+  "_host_note": "`*.invalid` is RFC 6761 §6.4 — guaranteed to never resolve, never make a real network call. Used here as a sentinel host so the fixture cannot be mistaken for a live URL.",
+  "scenarios": {
+    "submit_success": {
+      "request": {
+        "method": "POST",
+        "path": "/v1/workflows/run",
+        "headers": {
+          "Content-Type": "application/json",
+          "Authorization": "Bearer <wfb_*-mock-token-redacted>"
+        },
+        "body": {
+          "aprp": "<canonical APRP body>",
+          "policy_receipt": "<signed PolicyReceipt JSON>",
+          "mandate_request_hash":      "c0bd2fab4a7d4686d686edcc9c8356315cd66b820a2072493bf758a1eeb500db",
+          "mandate_policy_hash":       "e044f13c5acb792dd3109f1be3a98536168b0990e25595b3cedc131d02e666cf",
+          "mandate_receipt_signature": "<ed25519 hex>",
+          "mandate_audit_event_id":    "evt-MOCKKHSUCCESS00000000000A"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json",
+          "X-Mandate-Receipt-Signature": "<echoed; per FEEDBACK.md §KeeperHub ask>",
+          "X-Mandate-Policy-Hash":       "e044f13c5acb792dd3109f1be3a98536168b0990e25595b3cedc131d02e666cf"
+        },
+        "body": {
+          "executionId":  "kh-MOCKKHSUCCESS00000000001B",
+          "status":       "submitted",
+          "submittedAt":  "2026-04-28T00:00:00Z"
+        }
+      }
+    },
+    "submit_idempotency_conflict": {
+      "request": {
+        "method": "POST",
+        "path": "/v1/workflows/run",
+        "headers": {
+          "Content-Type": "application/json",
+          "Idempotency-Key": "operator-side-key-aaaaaaaaaaaaaaaa",
+          "Authorization": "Bearer <wfb_*-mock-token-redacted>"
+        },
+        "body": {
+          "aprp": "<APRP body that differs from the first submission under the same key>",
+          "policy_receipt": "<receipt>",
+          "mandate_request_hash":      "9e6deead0f72284ce5002decb5dd6dacfd4eba15487b9a17050ce2bbf1f6fc3a",
+          "mandate_policy_hash":       "e044f13c5acb792dd3109f1be3a98536168b0990e25595b3cedc131d02e666cf",
+          "mandate_receipt_signature": "<ed25519 hex>",
+          "mandate_audit_event_id":    "evt-MOCKKHCONFLICT0000000000C"
+        }
+      },
+      "response": {
+        "status": 409,
+        "headers": { "Content-Type": "application/json" },
+        "body": {
+          "code": "keeperhub.idempotency_conflict",
+          "message": "Idempotency-Key reused with different request body."
+        }
+      }
+    },
+    "submit_not_approved_local": {
+      "_note": "Mandate's KeeperHubExecutor::execute() refuses denied receipts BEFORE any network call. This scenario shows the local-side refusal envelope so live-path authors don't accidentally emit a network request for denied receipts.",
+      "input_decision": "Deny",
+      "input_deny_code": "policy.deny_unknown_provider",
+      "behaviour": "ExecutionError::NotApproved is returned synchronously; no HTTP call is made; the workflow webhook URL is never contacted.",
+      "operator_console_pill": "keeperhub.refused: true"
+    },
+    "lookup_status": {
+      "_note": "Shape of the proposed `keeperhub.lookup_execution(execution_id)` MCP tool / GET endpoint; see FEEDBACK.md §KeeperHub → 'Suggested improvements'.",
+      "request": {
+        "method": "GET",
+        "path": "/v1/executions/kh-MOCKKHSUCCESS00000000001B"
+      },
+      "response": {
+        "status": 200,
+        "body": {
+          "executionId":  "kh-MOCKKHSUCCESS00000000001B",
+          "status":       "completed",
+          "completedAt":  "2026-04-28T00:00:05Z",
+          "runLogPointer": "fixture://run-log/kh-MOCKKHSUCCESS00000000001B",
+          "mandate_request_hash":      "c0bd2fab4a7d4686d686edcc9c8356315cd66b820a2072493bf758a1eeb500db",
+          "mandate_policy_hash":       "e044f13c5acb792dd3109f1be3a98536168b0990e25595b3cedc131d02e666cf",
+          "mandate_receipt_signature": "<ed25519 hex echoed back>",
+          "mandate_audit_event_id":    "evt-MOCKKHSUCCESS00000000000A"
+        }
+      }
+    }
+  }
+}

--- a/demo-fixtures/mock-kms-keys.json
+++ b/demo-fixtures/mock-kms-keys.json
@@ -1,0 +1,38 @@
+{
+  "schema": "mandate-mock-kms-keys-v1",
+  "mock": true,
+  "explanation": "Public verification-key metadata for Mandate's two demo signers — the same deterministic dev seeds that ship in `crates/mandate-server/src/lib.rs:54-55` and that the production-shaped runner's step 9 uses to verify audit bundles. NO private/signing material is included; only Ed25519 verification (public) keys, derived from the public seed bytes already committed in the open repo. This fixture demonstrates the *catalogue shape* a future `mandate key list --mock` CLI (PSM-A1.9) would emit, so adapter authors and operators can target a stable JSON shape now.",
+  "live_replacement": "Replace with the real-time output of a production KMS / HSM key-listing API (AWS KMS `ListKeys` + `GetPublicKey`, GCP KMS, Azure Key Vault, or an HSM-backed signer). Production deployments inject signers via `AppState::with_signers` (TEE/HSM-backed) — the dev signers in `mandate-server::lib.rs` are clearly labelled `⚠ DEV ONLY ⚠` and never ship as production keys.",
+  "no_private_material": true,
+  "_no_private_material_note": "Every entry below carries `verifying_key_hex` only. There are no `signing_key_hex`, `private_key_hex`, `seed_hex`, or PEM fields anywhere in this fixture. The `seed_source` field documents the *public* derivation path (already in the open repo) — it is not a secret.",
+  "keys": [
+    {
+      "key_id":             "audit-signer-v1",
+      "key_version":        1,
+      "algorithm":          "Ed25519",
+      "purpose":            "audit_event_signing",
+      "verifying_key_hex":  "66be7e332c7a453332bd9d0a7f7db055f5c5ef1a06ada66d98b39fb6810c473a",
+      "seed_source":        "DevSigner::from_seed(\"audit-signer-v1\", [11u8; 32])",
+      "seed_source_path":   "crates/mandate-server/src/lib.rs:54",
+      "created_at_iso":     "2026-04-01T00:00:00Z",
+      "rotated_at_iso":     null,
+      "active":             true,
+      "mock":               true,
+      "production_warning": "DEV ONLY — public seed, deterministic derivation. Production signers are injected via AppState::with_signers and live in TEE/HSM."
+    },
+    {
+      "key_id":             "decision-signer-v1",
+      "key_version":        1,
+      "algorithm":          "Ed25519",
+      "purpose":            "policy_receipt_signing",
+      "verifying_key_hex":  "ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c",
+      "seed_source":        "DevSigner::from_seed(\"decision-signer-v1\", [7u8; 32])",
+      "seed_source_path":   "crates/mandate-server/src/lib.rs:55",
+      "created_at_iso":     "2026-04-01T00:00:00Z",
+      "rotated_at_iso":     null,
+      "active":             true,
+      "mock":               true,
+      "production_warning": "DEV ONLY — public seed, deterministic derivation. Production signers are injected via AppState::with_signers and live in TEE/HSM."
+    }
+  ]
+}

--- a/demo-fixtures/mock-uniswap-quotes.json
+++ b/demo-fixtures/mock-uniswap-quotes.json
@@ -1,0 +1,73 @@
+{
+  "schema": "mandate-mock-uniswap-quotes-v1",
+  "mock": true,
+  "explanation": "Catalogue of mock Uniswap quote envelopes shaped like what the Mandate Uniswap swap-policy guard (`mandate_execution::uniswap::evaluate_swap`) consumes. Three deterministic quotes — bounded happy path, slippage-cap violation, treasury-recipient-allowlist violation — give swap-policy authors a single file to dry-run their policy against. Distinct from the existing `demo-fixtures/uniswap/quote-USDC-{ETH,RUG}.json` per-quote files: this is the catalogue view for sponsor reviewers.",
+  "live_replacement": "Replace with live responses from the Uniswap Trading API quote endpoint. The `UniswapExecutor::live()` constructor in `crates/mandate-execution/src/uniswap.rs` is intentionally stubbed (`BackendOffline`) until that wiring lands — see FEEDBACK.md §Uniswap → 'Suggested improvements' for the signed-quote and route-token-enumeration asks.",
+  "host": "sandbox.uniswap.invalid",
+  "_host_note": "`*.invalid` is RFC 6761 §6.4 — guaranteed to never resolve. Sentinel host so the fixture cannot be mistaken for a live URL.",
+  "treasury_recipient_allowlist": [
+    "0x1111111111111111111111111111111111111111"
+  ],
+  "token_allowlist": ["USDC", "USDT", "DAI", "ETH", "WETH"],
+  "max_slippage_bps": 50,
+  "max_notional_usd": "20.00",
+  "fetched_at_unix": 1745798400,
+  "fetched_at_iso":  "2026-04-28T00:00:00Z",
+  "quotes": [
+    {
+      "id": "happy_path_within_caps",
+      "expected_swap_policy": "allow",
+      "expected_mandate_decision": "Allow",
+      "quote": {
+        "quote_id": "qt-MOCKUNIHAPPYPATH00000000",
+        "input":  { "token_symbol": "USDC", "amount": "5.00", "decimals": 6 },
+        "output": { "token_symbol": "ETH",  "amount": "0.0014", "decimals": 18 },
+        "route": [
+          { "token_symbol": "USDC" },
+          { "token_symbol": "ETH" }
+        ],
+        "expected_slippage_bps": 35,
+        "treasury_recipient": "0x1111111111111111111111111111111111111111",
+        "chain": "base"
+      }
+    },
+    {
+      "id": "slippage_violation",
+      "expected_swap_policy": "deny",
+      "expected_swap_policy_reason": "max_slippage_bps",
+      "expected_mandate_decision": "Deny",
+      "expected_mandate_deny_code": "policy.deny_recipient_not_allowlisted",
+      "quote": {
+        "quote_id": "qt-MOCKUNISLIPPAGEVIOLATION",
+        "input":  { "token_symbol": "USDC", "amount": "5.00", "decimals": 6 },
+        "output": { "token_symbol": "RUG",  "amount": "1000000", "decimals": 0 },
+        "route": [
+          { "token_symbol": "USDC" },
+          { "token_symbol": "RUG" }
+        ],
+        "expected_slippage_bps": 1500,
+        "treasury_recipient": "0x9999999999999999999999999999999999999999",
+        "chain": "base"
+      }
+    },
+    {
+      "id": "recipient_allowlist_violation",
+      "expected_swap_policy": "deny",
+      "expected_swap_policy_reason": "treasury_recipient_allowlisted",
+      "expected_mandate_decision": "Deny",
+      "expected_mandate_deny_code": "policy.deny_recipient_not_allowlisted",
+      "quote": {
+        "quote_id": "qt-MOCKUNIRECIPIENTVIOLATIO",
+        "input":  { "token_symbol": "USDC", "amount": "10.00", "decimals": 6 },
+        "output": { "token_symbol": "ETH",  "amount": "0.0028", "decimals": 18 },
+        "route": [
+          { "token_symbol": "USDC" },
+          { "token_symbol": "ETH" }
+        ],
+        "expected_slippage_bps": 30,
+        "treasury_recipient": "0x9999999999999999999999999999999999999999",
+        "chain": "base"
+      }
+    }
+  ]
+}

--- a/demo-fixtures/test_fixtures.py
+++ b/demo-fixtures/test_fixtures.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# Validation for the production-shaped mock fixtures under demo-fixtures/.
+#
+# Mirrors the stdlib-only test pattern used by trust-badge/test_build.py
+# and operator-console/test_build.py. Asserts that every `mock-*.json`
+# in this directory:
+#
+#   - parses as JSON
+#   - declares an envelope: schema, mock=true, explanation, live_replacement
+#   - has a non-empty schema id following `mandate-mock-*-v1`
+#   - contains no http/https URL outside the safe set (RFC 2606 reserved
+#     hostnames + the existing `schemas.mandate.dev` $id pattern)
+#   - contains no obvious secret-looking strings (PEM blocks, "private_key",
+#     "signing_key", `kh_*` / `wfb_*` workflow tokens)
+#   - if it claims `no_private_material`, has zero hex strings >= 64 chars
+#     in fields whose names hint at private material
+#
+# Run from repo root: `python3 demo-fixtures/test_fixtures.py`.
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+# Hostnames that are explicitly safe to reference in fixtures:
+#   - example.* (RFC 2606 §3) reserved for documentation
+#   - test/example/invalid/localhost TLDs (RFC 6761 / 2606)
+#   - schemas.mandate.dev / 127.0.0.1 — already in pre-existing fixtures
+SAFE_HOST_PATTERNS = [
+    re.compile(r"^https?://(?:[a-z0-9-]+\.)*example\.(?:com|net|org|test)\b", re.IGNORECASE),
+    re.compile(r"^https?://(?:[a-z0-9-]+\.)*invalid\b", re.IGNORECASE),
+    re.compile(r"^https?://(?:[a-z0-9-]+\.)*localhost\b", re.IGNORECASE),
+    re.compile(r"^https?://127\.0\.0\.1\b"),
+    re.compile(r"^https?://schemas\.mandate\.dev/", re.IGNORECASE),
+]
+
+URL_PATTERN = re.compile(r"https?://[^\s\"'<>]+", re.IGNORECASE)
+SECRET_PATTERNS = [
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+    re.compile(r"\b(private_key|signing_key|seed_hex|seed_bytes)\s*[:=]\s*\"[0-9a-fA-F]{32,}", re.IGNORECASE),
+    re.compile(r"\bkh_[A-Za-z0-9]{8,}"),
+    re.compile(r"\bwfb_[A-Za-z0-9]{8,}"),
+]
+
+
+def _ok(label: str, hint: str = "") -> None:
+    suffix = f": {hint}" if hint else ""
+    print(f"  ok   {label}{suffix}")
+
+
+def _fail(label: str, hint: str = "") -> None:
+    suffix = f": {hint}" if hint else ""
+    print(f"  FAIL {label}{suffix}", file=sys.stderr)
+
+
+def url_is_safe(url: str) -> bool:
+    return any(p.match(url) for p in SAFE_HOST_PATTERNS)
+
+
+def find_urls(raw: str) -> list[str]:
+    return [m.group(0) for m in URL_PATTERN.finditer(raw)]
+
+
+def find_secrets(raw: str) -> list[str]:
+    hits: list[str] = []
+    for pat in SECRET_PATTERNS:
+        m = pat.search(raw)
+        if m:
+            hits.append(m.group(0))
+    return hits
+
+
+def validate_one(path: Path) -> int:
+    """Returns the number of failures found in `path`."""
+    failures = 0
+    label = path.name
+    raw = path.read_text(encoding="utf-8")
+
+    # 1. Parses.
+    try:
+        doc = json.loads(raw)
+    except json.JSONDecodeError as e:
+        _fail(f"{label}: JSON parse", str(e))
+        return 1
+
+    # 2. Envelope: schema, mock=true, explanation, live_replacement.
+    schema = doc.get("schema")
+    if not isinstance(schema, str) or not re.match(r"^mandate-mock-[a-z0-9-]+-v\d+$", schema):
+        _fail(f"{label}: schema", f"missing or malformed schema id (got {schema!r})")
+        failures += 1
+    else:
+        _ok(f"{label}: schema id", schema)
+
+    if doc.get("mock") is not True:
+        _fail(f"{label}: mock=true", f"expected mock: true, got {doc.get('mock')!r}")
+        failures += 1
+    else:
+        _ok(f"{label}: mock=true")
+
+    expl = doc.get("explanation")
+    if not isinstance(expl, str) or len(expl.strip()) < 40:
+        _fail(f"{label}: explanation", "must be a non-empty string of at least 40 chars")
+        failures += 1
+    else:
+        _ok(f"{label}: explanation present", f"{len(expl)} chars")
+
+    live = doc.get("live_replacement")
+    if not isinstance(live, str) or len(live.strip()) < 40:
+        _fail(f"{label}: live_replacement", "must be a non-empty string of at least 40 chars")
+        failures += 1
+    else:
+        _ok(f"{label}: live_replacement present", f"{len(live)} chars")
+
+    # 3. URL safety.
+    bad_urls = [u for u in find_urls(raw) if not url_is_safe(u)]
+    if bad_urls:
+        _fail(f"{label}: external URL", f"unsafe URL(s) in fixture: {bad_urls!r}")
+        failures += 1
+    else:
+        _ok(f"{label}: no unsafe external URLs")
+
+    # 4. Secret patterns.
+    secrets = find_secrets(raw)
+    if secrets:
+        _fail(f"{label}: secret pattern", f"secret-looking string(s) in fixture: {secrets!r}")
+        failures += 1
+    else:
+        _ok(f"{label}: no secret-looking strings")
+
+    # 5. no_private_material guard (only when the fixture claims it).
+    if doc.get("no_private_material") is True:
+        suspicious = re.findall(
+            r'"(?:signing_key_hex|private_key_hex|seed_hex|seed_bytes_hex)"\s*:\s*"[0-9a-fA-F]{32,}',
+            raw,
+        )
+        if suspicious:
+            _fail(f"{label}: no_private_material guard", f"found {len(suspicious)} suspicious field(s)")
+            failures += 1
+        else:
+            _ok(f"{label}: no_private_material guard")
+
+    return failures
+
+
+def main() -> int:
+    fixtures = sorted(HERE.glob("mock-*.json"))
+    if not fixtures:
+        _fail("no mock-*.json fixtures found", str(HERE))
+        return 1
+
+    print(f"== validating {len(fixtures)} mock fixture(s) ==")
+    total_failures = 0
+    for f in fixtures:
+        print(f"\n-- {f.name} --")
+        total_failures += validate_one(f)
+
+    print()
+    if total_failures == 0:
+        print(f"PASS: all {len(fixtures)} mock fixture(s) clean")
+        return 0
+    print(f"FAIL: {total_failures} failure(s) across {len(fixtures)} fixture(s)", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**B3.** Adds four deterministic JSON fixtures shaped like the live integrations Mandate would consume against real backends — ENS, KeeperHub, Uniswap, and a future mock-KMS catalogue — plus a stdlib regression test that locks in the truthfulness invariants and a README explaining what each fixture would be replaced with at production. **No runner wiring.** No `crates/`, no `operator-console/`, no `trust-badge/`, no schema bump.

## Strict scope

- Only edits under `demo-fixtures/` (4 new fixtures + 1 test + 1 README).
- Branched off `main` at `b778b4c`.
- No runner integration — these fixtures are reference material for adapter authors and reviewers, not executed by `run-openagents-final.sh` or `run-production-shaped-mock.sh`.
- No transcript schema bump — `mandate-demo-summary-v1` unchanged.
- No `operator-console/`, no `trust-badge/`, no `crates/`.
- No new Cargo or Python dependency.

## Files added (6, +494 / 0)

| Path | What it shows |
|---|---|
| `demo-fixtures/mock-ens-registry.json` | Three-agent ENS text-record catalogue (`research-agent.team.eth`, `trading-agent.team.eth`, `support-agent.team.eth`) using the `mandate:*` text-record convention. |
| `demo-fixtures/mock-keeperhub-sandbox.json` | Four KeeperHub workflow envelopes: success (with the four `mandate_*` envelope fields and the optional `X-Mandate-*` response headers from PR #26), idempotency-conflict, not-approved-local (no network call), lookup-status (the proposed MCP tool's response shape). |
| `demo-fixtures/mock-uniswap-quotes.json` | Three Uniswap quote envelopes: bounded happy path, slippage-cap violation, treasury-recipient-allowlist violation. Includes per-quote `expected_swap_policy` / `expected_mandate_decision` / `expected_mandate_deny_code` so adapter authors can dry-run their policy. |
| `demo-fixtures/mock-kms-keys.json` | Public verification-key metadata (Ed25519) for Mandate's two demo signers — same deterministic dev seeds the production-shaped runner uses. **Public keys only** — `no_private_material: true` declares it and the test enforces it. |
| `demo-fixtures/test_fixtures.py` | Stdlib-only validator. Mirrors `trust-badge/test_build.py` and `operator-console/test_build.py`. |
| `demo-fixtures/README.md` | Explains pre-existing fixtures vs new mock fixtures, the truthfulness envelope, and what live integration would replace each one. |

## Truthfulness invariants enforced by `test_fixtures.py`

For every `mock-*.json` in `demo-fixtures/`:

- parses as JSON
- declares `schema` matching `^mandate-mock-[a-z0-9-]+-v\d+$`
- has `mock: true` (exactly)
- has `explanation` and `live_replacement` strings of ≥ 40 chars each
- contains no `http(s)://` URL outside the safe set: RFC 2606 reserved hostnames (`example.*`, `*.invalid`, `localhost`), `127.0.0.1`, and the existing `schemas.mandate.dev` $id pattern
- contains no secret-looking strings: PEM private-key blocks, `private_key` / `signing_key` / `seed_hex` / `seed_bytes` fields with hex values, `kh_*` or `wfb_*` workflow tokens
- if the fixture sets `no_private_material: true`, no `signing_key_hex` / `private_key_hex` / `seed_hex` / `seed_bytes_hex` fields with ≥ 32-hex-char values appear anywhere in the document

## Falsifiability — proven, not asserted

I injected a fake `signing_key_hex` field into `mock-kms-keys.json` and ran the validator:

```
FAIL mock-kms-keys.json: no_private_material guard: found 1 suspicious field(s)
FAIL: 1 failure(s) across 4 fixture(s)
exit code: 1
```

Restored: `PASS: all 4 mock fixture(s) clean`. A future PR that drops a `mock: true`, leaks a `kh_*` token, or smuggles in a real URL fails the test loudly.

## Honesty / truthfulness

- **No live URLs.** Every external host is either:
  - RFC 6761 §6.4 `*.invalid` (guaranteed never to resolve, never makes a network call) — used as sentinel hostnames in KeeperHub / Uniswap fixtures.
  - A loopback `http://127.0.0.1:*` — same as the existing `ens-records.json`.
  - The pre-existing `https://schemas.mandate.dev/policy-receipt/v1.json` JSON Schema `$id` — already in the open repo.
- **No secrets.** The `mock-kms-keys.json` carries Ed25519 *verification* keys (public values) deterministically derived from the public seed bytes already committed in `crates/mandate-server/src/lib.rs:54-55`. No `signing_key_hex`, no `private_key_hex`, no PEM blocks, no `kh_*` / `wfb_*` tokens anywhere in any fixture. `git grep` for those patterns under `demo-fixtures/` returns zero matches.
- **No production claim.** Every fixture says `mock: true`, has an `explanation` field, and a `live_replacement` field that names what would replace it in a real deployment.
- **No demo runner wiring.** `run-openagents-final.sh` and `run-production-shaped-mock.sh` are unchanged; the fixtures are reference material for adapter authors. Wiring them in is a candidate for a follow-up B3.v2 PR (or it may stay reference-only).

## Verification

| Command | Result |
|---|---|
| `cargo fmt --check` | ✅ |
| `cargo clippy --workspace --all-targets -- -D warnings` | ✅ |
| `cargo test --workspace --all-targets` | ✅ **147 / 147 pass** |
| `python3 scripts/validate_schemas.py` | ✅ |
| `python3 scripts/validate_openapi.py` | ✅ |
| `bash demo-scripts/run-openagents-final.sh` | ✅ all 13 gates green |
| `python3 trust-badge/test_build.py` | ✅ 31 / 31 |
| `python3 operator-console/test_build.py` | ✅ 46 / 46 (this branch is off `main` and doesn't include PR #29's pending-pill additions; on a branch off PR #29 it would be 48 / 48) |
| `python3 demo-fixtures/test_fixtures.py` | ✅ **PASS: all 4 mock fixture(s) clean** (38 individual assertions) |

## Coordination notes

- **No file overlap with any open PR.** PR #25 (mandate doctor), PR #26 (KH builder feedback), PR #27 (KH live spike), PR #28 (mock KMS keyring CLI), PR #29 (PSM-A2 evidence) — all on disjoint paths from `demo-fixtures/`.
- **Mock-KMS pubkeys match PR #29's runner.** `mock-kms-keys.json`'s `verifying_key_hex` values are exactly the constants the production-shaped runner already hardcodes in step 9 to verify the audit bundle. When PSM-A1.9 lands (the actual `mandate key list --mock` CLI), this fixture documents the JSON shape that CLI should emit, and the runner can switch to reading from the CLI without changing the values.
- **No transcript schema bump → no trust-badge/operator-console schema-pin coordination needed.** Both viewers continue consuming `mandate-demo-summary-v1` unchanged.

## Limitations

- **Reference-only today.** No runner consumes these fixtures yet. If you want them exercised in CI / the demo, that's a tiny B3.v2 follow-up that wires `mock-kms-keys.json` into the production-shaped runner's step 9 (replacing the hardcoded pubkey constants) and `mock-ens-registry.json` into a multi-agent ENS demo.
- **`no_private_material` is a fixture-level claim.** The validator enforces it inside the document, but a future maintainer could still misuse the schema by setting `no_private_material: false` and committing key material. The test catches the obvious patterns; truly motivated misuse needs human review. The README's "Honest scope" section makes the intent explicit.
- **Linting via stdlib regex.** No JSON Schema validation of the fixture envelopes themselves; the validator does shape-and-content checks. JSON Schema for `mandate-mock-*-v1` is a candidate follow-up if cross-PR coordination is wanted.

## Do not merge without Daniel approval.