### PR TITLE
fix: address Codex P1 reviews from #25 + #30 (read-only doctor + anchored host regex)

### DIFF
--- a/crates/mandate-cli/src/doctor.rs
+++ b/crates/mandate-cli/src/doctor.rs
@@ -271,22 +271,43 @@ pub fn run(db: Option<&Path>, json: bool) -> ExitCode {
     // filesystem and produces a misleading "ok" report for a DB that
     // never existed. Pre-check existence and refuse to open a missing
     // path. Codex P1 review on PR #25.
+    //
+    // Codex P2 follow-up on PR #32 asked us to use `try_exists()` instead
+    // of `exists()`: `exists()` swallows fs/permission errors as `false`,
+    // which would mis-report a permission-denied path as "does not exist"
+    // and exit 2. With `try_exists()`:
+    //   - Ok(false) → file genuinely missing → exit 2 with "does not exist"
+    //   - Ok(true)  → file present → fall through to `Storage::open`
+    //   - Err(e)    → fs/permission metadata error → fall through to
+    //                 `Storage::open`, which surfaces the real cause as
+    //                 a `storage_open` fail (the existing error path).
     if let Some(p) = db {
-        if !p.exists() {
-            let path = p.display().to_string();
-            let msg = format!("doctor target DB does not exist: {path}");
-            if json {
-                let report = DoctorReport {
-                    report_type: "mandate.doctor.v1",
-                    overall: "fail",
-                    db_path: path,
-                    checks: vec![fail("storage_open", msg)],
-                };
-                println!("{}", serde_json::to_string_pretty(&report).unwrap());
-            } else {
-                eprintln!("mandate doctor: {msg}");
+        match p.try_exists() {
+            Ok(false) => {
+                let path = p.display().to_string();
+                let msg = format!("doctor target DB does not exist: {path}");
+                if json {
+                    let report = DoctorReport {
+                        report_type: "mandate.doctor.v1",
+                        overall: "fail",
+                        db_path: path,
+                        checks: vec![fail("storage_open", msg)],
+                    };
+                    println!("{}", serde_json::to_string_pretty(&report).unwrap());
+                } else {
+                    eprintln!("mandate doctor: {msg}");
+                }
+                return ExitCode::from(2);
             }
-            return ExitCode::from(2);
+            Ok(true) => {
+                // file is there; let Storage::open validate it
+            }
+            Err(_) => {
+                // metadata error (e.g. permission denied on parent
+                // directory). Don't claim "does not exist"; let the
+                // existing storage_open fail path surface the real
+                // OS-level error verbatim.
+            }
         }
     }
 

--- a/crates/mandate-cli/src/doctor.rs
+++ b/crates/mandate-cli/src/doctor.rs
@@ -265,6 +265,31 @@ fn render_human(report: &DoctorReport) -> String {
 /// `0` on `ok` / `warn`, `1` if any check failed, `2` if the database
 /// itself could not be opened.
 pub fn run(db: Option<&Path>, json: bool) -> ExitCode {
+    // doctor must be inspection-only. `Storage::open` (rusqlite default)
+    // would create a fresh SQLite file at `--db` if it didn't exist and
+    // run migrations against it — which silently mutates the operator's
+    // filesystem and produces a misleading "ok" report for a DB that
+    // never existed. Pre-check existence and refuse to open a missing
+    // path. Codex P1 review on PR #25.
+    if let Some(p) = db {
+        if !p.exists() {
+            let path = p.display().to_string();
+            let msg = format!("doctor target DB does not exist: {path}");
+            if json {
+                let report = DoctorReport {
+                    report_type: "mandate.doctor.v1",
+                    overall: "fail",
+                    db_path: path,
+                    checks: vec![fail("storage_open", msg)],
+                };
+                println!("{}", serde_json::to_string_pretty(&report).unwrap());
+            } else {
+                eprintln!("mandate doctor: {msg}");
+            }
+            return ExitCode::from(2);
+        }
+    }
+
     let storage_result = match db {
         Some(p) => Storage::open(p),
         None => Storage::open_in_memory(),

--- a/crates/mandate-cli/tests/doctor_missing_db.rs
+++ b/crates/mandate-cli/tests/doctor_missing_db.rs
@@ -93,3 +93,84 @@ fn doctor_json_mode_against_missing_db_emits_fail_envelope() {
         "expected a storage_open fail row; got {checks:?}"
     );
 }
+
+/// Codex P2 on PR #32: permission/fs metadata errors must surface as a
+/// `storage_open` fail, NOT mislabel the path as "does not exist". We
+/// construct that shape on Unix by chmod'ing a parent directory to 000
+/// so `try_exists()` of a child path returns `Err(EACCES)`. The doctor
+/// should fall through to `Storage::open`, which then hits the real
+/// OS-level error and reports it via the existing `storage_open` fail
+/// path.
+///
+/// Gated on `cfg(unix)` because chmod(000) semantics differ on Windows.
+/// We probe at runtime for "are mode bits actually being enforced for
+/// this user?" by trying to stat a child of the locked dir; if stat
+/// succeeds we're effectively root (or running on a filesystem that
+/// ignores mode bits) and skip rather than fail.
+#[cfg(unix)]
+#[test]
+fn doctor_permission_denied_falls_through_to_storage_open_fail() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let locked = tmp.path().join("locked");
+    std::fs::create_dir(&locked).unwrap();
+    let target = locked.join("would-be-db.sqlite");
+
+    // Lock the parent directory: 000 means no read, no write, no
+    // execute → child stat fails with EACCES, which is the exact shape
+    // try_exists() converts to Err.
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    // Confirm the lock is actually being enforced. If the caller is
+    // root (or the FS ignores mode bits), `try_exists` returns Ok and
+    // this test cannot exercise the Err branch — skip cleanly.
+    let lock_is_effective = std::path::Path::new(&target).try_exists().is_err();
+    if !lock_is_effective {
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+        eprintln!(
+            "skipping: chmod(000) not enforced for this caller \
+             (likely running as root or a permissive FS)"
+        );
+        return;
+    }
+
+    let out = Command::new(cli_bin())
+        .arg("doctor")
+        .arg("--json")
+        .arg("--db")
+        .arg(&target)
+        .output()
+        .expect("failed to spawn mandate doctor");
+
+    // Restore permissions BEFORE asserting so tempdir cleanup works
+    // even if the assertions fail.
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "doctor must still exit non-zero on metadata errors; stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .expect("doctor --json must emit valid JSON on permission-denied");
+    assert_eq!(v["overall"], "fail");
+    let checks = v["checks"].as_array().expect("checks array");
+    let storage_open = checks
+        .iter()
+        .find(|c| c["name"] == "storage_open")
+        .expect("storage_open row required when fs metadata cannot be read");
+    let err_msg = storage_open["error"].as_str().unwrap_or("");
+    assert!(
+        !err_msg.contains("does not exist"),
+        "permission-denied must NOT be mislabelled as 'does not exist'; got error={err_msg:?}"
+    );
+    assert!(
+        !target.exists(),
+        "doctor must still leave the target untouched on the permission path"
+    );
+}

--- a/crates/mandate-cli/tests/doctor_missing_db.rs
+++ b/crates/mandate-cli/tests/doctor_missing_db.rs
@@ -1,0 +1,95 @@
+//! Regression test: `mandate doctor --db <missing>` must NOT create the
+//! file. Codex P1 review on PR #25 flagged that `Storage::open` is the
+//! rusqlite default which silently creates a fresh SQLite file and runs
+//! migrations against it — a doctor that mutates an operator's
+//! filesystem and reports "ok" against a DB that never existed is the
+//! opposite of inspection-only. This test pins the corrected behaviour:
+//! exit code 2, stderr explains what happened, and no file is created
+//! at the requested path.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn cli_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_mandate"))
+}
+
+#[test]
+fn doctor_does_not_create_missing_db_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let missing = tmp.path().join("does-not-exist.sqlite");
+    assert!(
+        !missing.exists(),
+        "precondition: target path must not exist before doctor runs"
+    );
+
+    let out = Command::new(cli_bin())
+        .arg("doctor")
+        .arg("--db")
+        .arg(&missing)
+        .output()
+        .expect("failed to spawn mandate doctor");
+
+    assert!(
+        !out.status.success(),
+        "doctor must not succeed against a missing DB; stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "expected exit code 2 (cannot open db); got {:?}",
+        out.status.code(),
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("does not exist"),
+        "stderr must explain the missing DB path; got: {stderr}"
+    );
+
+    assert!(
+        !missing.exists(),
+        "doctor must NOT create the SQLite file at the requested path; \
+         this is the inspection-only invariant Codex P1 flagged"
+    );
+    let entries = std::fs::read_dir(tmp.path())
+        .unwrap()
+        .filter_map(Result::ok)
+        .collect::<Vec<_>>();
+    assert!(
+        entries.is_empty(),
+        "doctor must leave the parent directory untouched; found: {entries:?}"
+    );
+}
+
+#[test]
+fn doctor_json_mode_against_missing_db_emits_fail_envelope() {
+    let tmp = tempfile::tempdir().unwrap();
+    let missing = tmp.path().join("nope.sqlite");
+
+    let out = Command::new(cli_bin())
+        .arg("doctor")
+        .arg("--json")
+        .arg("--db")
+        .arg(&missing)
+        .output()
+        .expect("failed to spawn mandate doctor");
+
+    assert_eq!(out.status.code(), Some(2));
+    assert!(!missing.exists(), "json mode must also be inspection-only");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value =
+        serde_json::from_str(&stdout).expect("doctor --json must emit valid JSON even on failure");
+    assert_eq!(v["report_type"], "mandate.doctor.v1");
+    assert_eq!(v["overall"], "fail");
+    let checks = v["checks"].as_array().expect("checks array");
+    assert!(
+        checks
+            .iter()
+            .any(|c| c["name"] == "storage_open" && c["status"] == "fail"),
+        "expected a storage_open fail row; got {checks:?}"
+    );
+}

--- a/demo-fixtures/test_fixtures.py
+++ b/demo-fixtures/test_fixtures.py
@@ -23,20 +23,40 @@ import json
 import re
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 HERE = Path(__file__).resolve().parent
 
-# Hostnames that are explicitly safe to reference in fixtures:
-#   - example.* (RFC 2606 §3) reserved for documentation
-#   - test/example/invalid/localhost TLDs (RFC 6761 / 2606)
-#   - schemas.mandate.dev / 127.0.0.1 — already in pre-existing fixtures
-SAFE_HOST_PATTERNS = [
-    re.compile(r"^https?://(?:[a-z0-9-]+\.)*example\.(?:com|net|org|test)\b", re.IGNORECASE),
-    re.compile(r"^https?://(?:[a-z0-9-]+\.)*invalid\b", re.IGNORECASE),
-    re.compile(r"^https?://(?:[a-z0-9-]+\.)*localhost\b", re.IGNORECASE),
-    re.compile(r"^https?://127\.0\.0\.1\b"),
-    re.compile(r"^https?://schemas\.mandate\.dev/", re.IGNORECASE),
-]
+# Hostnames that are explicitly safe to reference in fixtures.
+#
+# Codex P1 review on PR #30 caught that the previous regex-based
+# allowlist anchored only at the start of the URL and used `\b` (word
+# boundary) at the end of the host, which lets attacker-controlled
+# infixes slip through:
+#   "https://schemas.mandate.dev.attacker.io/x"
+# matches `^https?://schemas\.mandate\.dev/` only if anchored, but a
+# regex like `^https?://(?:[a-z0-9-]+\.)*example\.(?:com|net|org|test)\b`
+# does match `https://example.com.evil.org/x` because `\b` sits between
+# `m` and `.` (word↔non-word). Switching to `urllib.parse.urlparse` +
+# exact-host or safe-suffix membership makes the bypass structurally
+# impossible.
+#
+#   - exact hosts: 127.0.0.1, localhost, schemas.mandate.dev
+#   - safe suffixes (RFC 2606 / 6761 reserved):
+#       .invalid, .example, .test, .localhost
+#     The leading dot is required so "evilexample" does NOT end with
+#     ".example".
+SAFE_HOSTS_EXACT = frozenset({
+    "127.0.0.1",
+    "localhost",
+    "schemas.mandate.dev",
+})
+SAFE_HOST_SUFFIXES = (
+    ".invalid",
+    ".example",
+    ".test",
+    ".localhost",
+)
 
 URL_PATTERN = re.compile(r"https?://[^\s\"'<>]+", re.IGNORECASE)
 SECRET_PATTERNS = [
@@ -58,7 +78,27 @@ def _fail(label: str, hint: str = "") -> None:
 
 
 def url_is_safe(url: str) -> bool:
-    return any(p.match(url) for p in SAFE_HOST_PATTERNS)
+    """True iff `url` is http(s) and its hostname is in the allowlist.
+
+    The hostname comes from `urllib.parse.urlparse(...).hostname`, which
+    extracts only the `host` component (port stripped, lowercased) — so
+    `https://schemas.mandate.dev.attacker.io/x` resolves to host
+    `schemas.mandate.dev.attacker.io`, which is neither in the exact set
+    nor ends with a safe suffix → reject.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    if parsed.scheme not in ("http", "https"):
+        return False
+    host = parsed.hostname
+    if not host:
+        return False
+    host = host.lower()
+    if host in SAFE_HOSTS_EXACT:
+        return True
+    return any(host.endswith(suffix) for suffix in SAFE_HOST_SUFFIXES)
 
 
 def find_urls(raw: str) -> list[str]:
@@ -146,21 +186,106 @@ def validate_one(path: Path) -> int:
     return failures
 
 
+def _self_test_url_safety() -> int:
+    """Pin the URL allowlist against past-bypass shapes.
+
+    Every case is a regression for the Codex P1 finding on PR #30: the
+    old regex anchored only at the start of the URL, which let
+    attacker-infixed hostnames pass. After switching to
+    `urlparse().hostname` + exact/safe-suffix membership, these all
+    resolve correctly.
+    """
+    cases: list[tuple[str, bool, str]] = [
+        # (url, expected_safe, why)
+        # --- bypass attempts MUST be rejected ---
+        (
+            "https://example.com.evil.org/x",
+            False,
+            "infix bypass: 'example.com' inside an attacker-controlled host",
+        ),
+        (
+            "https://schemas.mandate.dev.attacker.io/x",
+            False,
+            "infix bypass: 'schemas.mandate.dev' as a left-prefix of attacker host",
+        ),
+        (
+            "https://evilexample/x",
+            False,
+            "no-leading-dot bypass: 'evilexample' does not end with '.example'",
+        ),
+        (
+            "ftp://schemas.mandate.dev/x",
+            False,
+            "non-http(s) scheme: only http/https are allowed",
+        ),
+        # --- legitimate references MUST be accepted ---
+        (
+            "https://schemas.mandate.dev/x",
+            True,
+            "exact-host allowlist member",
+        ),
+        (
+            "https://research-agent.team.eth.invalid/x",
+            True,
+            "RFC 2606 reserved suffix '.invalid'",
+        ),
+        (
+            "http://127.0.0.1:8730/v1",
+            True,
+            "exact-host loopback IP with port",
+        ),
+        (
+            "http://localhost/x",
+            True,
+            "exact-host 'localhost'",
+        ),
+    ]
+
+    print("-- url_is_safe self-test --")
+    failures = 0
+    for url, expected, why in cases:
+        actual = url_is_safe(url)
+        verdict = "ok" if actual == expected else "FAIL"
+        marker = "accept" if expected else "reject"
+        if actual == expected:
+            _ok(f"url_is_safe({marker:>6}) {url}", why)
+        else:
+            failures += 1
+            _fail(
+                f"url_is_safe({marker:>6}) {url}",
+                f"expected {expected}, got {actual} — {why}",
+            )
+        # Surface the verdict variable so static-analysis tooling that
+        # walks the loop sees both branches; no behavioural change.
+        del verdict
+    return failures
+
+
 def main() -> int:
+    print("== url_is_safe self-test ==")
+    self_test_failures = _self_test_url_safety()
+    if self_test_failures:
+        print(
+            f"FAIL: url_is_safe self-test had {self_test_failures} failure(s)",
+            file=sys.stderr,
+        )
+        # Don't short-circuit — still validate fixtures so the operator
+        # sees the full picture, but the exit code reflects the failure.
+
     fixtures = sorted(HERE.glob("mock-*.json"))
     if not fixtures:
         _fail("no mock-*.json fixtures found", str(HERE))
         return 1
 
-    print(f"== validating {len(fixtures)} mock fixture(s) ==")
-    total_failures = 0
+    print(f"\n== validating {len(fixtures)} mock fixture(s) ==")
+    total_failures = self_test_failures
     for f in fixtures:
         print(f"\n-- {f.name} --")
         total_failures += validate_one(f)
 
     print()
     if total_failures == 0:
-        print(f"PASS: all {len(fixtures)} mock fixture(s) clean")
+        print(f"PASS: all {len(fixtures)} mock fixture(s) clean + url self-test")
         return 0
     print(f"FAIL: {total_failures} failure(s) across {len(fixtures)} fixture(s)", file=sys.stderr)
     return 1

--- a/demo-fixtures/test_fixtures.py
+++ b/demo-fixtures/test_fixtures.py
@@ -41,21 +41,40 @@ HERE = Path(__file__).resolve().parent
 # exact-host or safe-suffix membership makes the bypass structurally
 # impossible.
 #
-#   - exact hosts: 127.0.0.1, localhost, schemas.mandate.dev
-#   - safe suffixes (RFC 2606 / 6761 reserved):
-#       .invalid, .example, .test, .localhost
+# Codex P2 follow-up on PR #32 asked us to keep RFC 2606 §3 reserved
+# documentation domains (example.com / example.net / example.org)
+# usable in fixtures — they're the canonical "use this URL in docs"
+# hosts. Adding them as exact-match entries keeps `https://example.com`
+# safe, and adding the dotted forms (`.example.com`, …) as suffixes
+# keeps `https://docs.example.org/x` safe, while
+# `https://evilexample.com` (no leading dot) and
+# `https://example.com.evil.org` (different host entirely) both still
+# reject.
+#
+#   - exact hosts:
+#       127.0.0.1, localhost, schemas.mandate.dev,
+#       example.com, example.net, example.org
+#   - safe suffixes (RFC 2606 / 6761 reserved + RFC 2606 §3 docs):
+#       .invalid, .example, .test, .localhost,
+#       .example.com, .example.net, .example.org
 #     The leading dot is required so "evilexample" does NOT end with
-#     ".example".
+#     ".example" and "evilexample.com" does NOT end with ".example.com".
 SAFE_HOSTS_EXACT = frozenset({
     "127.0.0.1",
     "localhost",
     "schemas.mandate.dev",
+    "example.com",
+    "example.net",
+    "example.org",
 })
 SAFE_HOST_SUFFIXES = (
     ".invalid",
     ".example",
     ".test",
     ".localhost",
+    ".example.com",
+    ".example.net",
+    ".example.org",
 )
 
 URL_PATTERN = re.compile(r"https?://[^\s\"'<>]+", re.IGNORECASE)
@@ -214,6 +233,16 @@ def _self_test_url_safety() -> int:
             "no-leading-dot bypass: 'evilexample' does not end with '.example'",
         ),
         (
+            "https://evilexample.com/x",
+            False,
+            "no-leading-dot bypass on docs domain: 'evilexample.com' does not end with '.example.com'",
+        ),
+        (
+            "https://example.org.attacker.io/x",
+            False,
+            "infix bypass on RFC 2606 §3 docs domain: host is 'example.org.attacker.io', not 'example.org'",
+        ),
+        (
             "ftp://schemas.mandate.dev/x",
             False,
             "non-http(s) scheme: only http/https are allowed",
@@ -238,6 +267,26 @@ def _self_test_url_safety() -> int:
             "http://localhost/x",
             True,
             "exact-host 'localhost'",
+        ),
+        (
+            "https://example.com/x",
+            True,
+            "RFC 2606 §3 reserved docs domain (exact host)",
+        ),
+        (
+            "https://example.org/x",
+            True,
+            "RFC 2606 §3 reserved docs domain (exact host)",
+        ),
+        (
+            "https://docs.example.net/x",
+            True,
+            "subdomain of RFC 2606 §3 docs domain (suffix '.example.net')",
+        ),
+        (
+            "https://deeply.nested.example.com/x",
+            True,
+            "deep subdomain of docs domain (suffix '.example.com')",
         ),
     ]
 


### PR DESCRIPTION
## Summary

Codex P1 fixes from the reviews on **PR #25** (mandate doctor) and **PR #30** (demo-fixtures URL allowlist), plus the two Codex P2 follow-ups raised on this PR. One PR, three files (2 modified + 1 new test file). V006 / PSM-A3 work intentionally untouched on this branch.

### P1 #1 — `mandate doctor` is now inspection-only

`mandate doctor --db <path>` previously called `Storage::open(p)`, which is the rusqlite default that **silently creates a fresh SQLite file** at the given path and applies migrations against it. The doctor would then report `overall: ok` for a database that never existed and write a brand-new file to the operator's filesystem — the opposite of an inspection-only diagnostic.

**Fix:** pre-check the path before `Storage::open`. The original commit used `Path::exists()`; the **P2 follow-up** swapped it for `Path::try_exists()` so permission/fs metadata errors are not silently swallowed:

| `try_exists()` result | Doctor behaviour                                                                                |
| --------------------- | ----------------------------------------------------------------------------------------------- |
| `Ok(false)`           | exit 2, stderr `mandate doctor: doctor target DB does not exist: <path>` (or fail JSON envelope) |
| `Ok(true)`            | fall through to `Storage::open` (normal happy path)                                              |
| `Err(_)`              | fall through to `Storage::open`, which surfaces the real OS error as a `storage_open` fail row   |

In every case the requested file is **not created**.

### P1 #2 — URL allowlist resists infix bypasses (P2: with docs hosts restored)

`demo-fixtures/test_fixtures.py` used regex-based host allowlisting anchored only at the start of the URL, with `\b` at the end of the host. `\b` matches the word↔non-word boundary between `m` and `.`, so `https://example.com.evil.org/x` and `https://schemas.mandate.dev.attacker.io/x` both slipped through.

**Fix:** rewrite `url_is_safe()` to use `urllib.parse.urlparse(...).hostname` + structural membership checks. The **P2 follow-up** restored RFC 2606 §3 reserved documentation hosts (`example.com` / `example.net` / `example.org` and subdomains) without re-introducing the infix bypass:

| Allowlist     | Members                                                                              |
| ------------- | ------------------------------------------------------------------------------------ |
| Exact host    | `127.0.0.1`, `localhost`, `schemas.mandate.dev`, `example.com`, `example.net`, `example.org` |
| Safe suffix   | `.invalid`, `.example`, `.test`, `.localhost`, `.example.com`, `.example.net`, `.example.org` |

The leading dot on every suffix is what blocks the bypass: `evilexample.com` does not end with `.example.com`, and `example.com.evil.org` is not exact-match nor ends with any safe suffix.

## Files changed (exactly 3)

- `crates/mandate-cli/src/doctor.rs` (modified) — `Path::try_exists()` pre-check before `Storage::open`
- `demo-fixtures/test_fixtures.py` (modified) — `urlparse`-based allowlist + `_self_test_url_safety()` wired into `main()`
- `crates/mandate-cli/tests/doctor_missing_db.rs` (new) — 3 integration tests pinning inspection-only behaviour for human mode, JSON mode, and the permission-denied fall-through

## Test plan

- [x] `cargo build -p mandate-cli` — clean
- [x] `cargo test -p mandate-cli` — 11 doctor unit + 8 audit_bundle + **3 doctor_missing_db** = **22/22** pass
- [x] `cargo clippy -p mandate-cli --all-targets -- -D warnings` — clean
- [x] `python3 demo-fixtures/test_fixtures.py` — **14/14** url self-test cases + 4/4 mock fixtures clean
- [x] Manual smoke (missing path): `mandate doctor --db /tmp/no-such-db.sqlite` → exit 2, stderr says "does not exist", file does not exist after the run
- [x] Manual smoke (in-memory): `mandate doctor` → unchanged, `overall: ok`, all 7 expected rows present

### URL self-test cases (14 / 14 pass)

| URL                                              | Expected | Reason                                                        |
| ------------------------------------------------ | -------- | ------------------------------------------------------------- |
| `https://example.com.evil.org/x`                 | reject   | infix bypass: `example.com` inside attacker host              |
| `https://schemas.mandate.dev.attacker.io/x`      | reject   | infix bypass: `schemas.mandate.dev` as left-prefix            |
| `https://evilexample/x`                          | reject   | no-leading-dot bypass: doesn't end with `.example`            |
| `https://evilexample.com/x`                      | reject   | no-leading-dot bypass on docs domain (P2)                     |
| `https://example.org.attacker.io/x`              | reject   | infix bypass on docs domain (P2)                              |
| `ftp://schemas.mandate.dev/x`                    | reject   | non-http(s) scheme                                            |
| `https://schemas.mandate.dev/x`                  | accept   | exact-host allowlist                                          |
| `https://research-agent.team.eth.invalid/x`      | accept   | RFC 2606 reserved suffix `.invalid`                           |
| `http://127.0.0.1:8730/v1`                       | accept   | exact-host loopback IP with port                              |
| `http://localhost/x`                             | accept   | exact-host `localhost`                                        |
| `https://example.com/x`                          | accept   | RFC 2606 §3 docs domain (exact, P2)                           |
| `https://example.org/x`                          | accept   | RFC 2606 §3 docs domain (exact, P2)                           |
| `https://docs.example.net/x`                     | accept   | suffix `.example.net` (P2)                                    |
| `https://deeply.nested.example.com/x`            | accept   | deep subdomain of docs domain (P2)                            |

🤖 Generated with [Claude Code](https://claude.com/claude-code)