### PR TITLE
fix(fixture): correct mock-uniswap-quotes rug entry — first violation is output_token_allowlisted

### DIFF
--- a/demo-fixtures/mock-uniswap-quotes.json
+++ b/demo-fixtures/mock-uniswap-quotes.json
@@ -1,7 +1,7 @@
 {
   "schema": "mandate-mock-uniswap-quotes-v1",
   "mock": true,
-  "explanation": "Catalogue of mock Uniswap quote envelopes shaped like what the Mandate Uniswap swap-policy guard (`mandate_execution::uniswap::evaluate_swap`) consumes. Three deterministic quotes — bounded happy path, slippage-cap violation, treasury-recipient-allowlist violation — give swap-policy authors a single file to dry-run their policy against. Distinct from the existing `demo-fixtures/uniswap/quote-USDC-{ETH,RUG}.json` per-quote files: this is the catalogue view for sponsor reviewers.",
+  "explanation": "Catalogue of mock Uniswap quote envelopes shaped like what the Mandate Uniswap swap-policy guard (`mandate_execution::uniswap::evaluate_swap`) consumes. Three deterministic quotes — bounded happy path, multi-violation rug quote, single-violation recipient-allowlist case — give swap-policy authors a single file to dry-run their policy against. The rug quote intentionally trips THREE checks (output token, slippage, recipient); `evaluate_swap` traverses checks in field order so the FIRST reported violation is `output_token_allowlisted`, not slippage. Distinct from the existing `demo-fixtures/uniswap/quote-USDC-{ETH,RUG}.json` per-quote files: this is the catalogue view for sponsor reviewers.",
   "live_replacement": "Replace with live responses from the Uniswap Trading API quote endpoint. The `UniswapExecutor::live()` constructor in `crates/mandate-execution/src/uniswap.rs` is intentionally stubbed (`BackendOffline`) until that wiring lands — see FEEDBACK.md §Uniswap → 'Suggested improvements' for the signed-quote and route-token-enumeration asks.",
   "host": "sandbox.uniswap.invalid",
   "_host_note": "`*.invalid` is RFC 6761 §6.4 — guaranteed to never resolve. Sentinel host so the fixture cannot be mistaken for a live URL.",
@@ -32,13 +32,15 @@
       }
     },
     {
-      "id": "slippage_violation",
+      "id": "multiple_violations_rug_quote",
       "expected_swap_policy": "deny",
-      "expected_swap_policy_reason": "max_slippage_bps",
+      "_swap_policy_reason_note": "`evaluate_swap` (`crates/mandate-execution/src/uniswap.rs`) traverses checks in field order: input_token → output_token → max_notional_usd → max_slippage_bps → quote_freshness → treasury_recipient. The first violation a consumer sees is therefore output_token, not slippage. All three violations below ARE reported in the returned `SwapPolicyOutcome.checks` vector.",
+      "expected_swap_policy_reason": "output_token_allowlisted",
+      "expected_additional_violations": ["max_slippage_bps", "treasury_recipient_allowlisted"],
       "expected_mandate_decision": "Deny",
       "expected_mandate_deny_code": "policy.deny_recipient_not_allowlisted",
       "quote": {
-        "quote_id": "qt-MOCKUNISLIPPAGEVIOLATION",
+        "quote_id": "qt-MOCKUNIRUGQUOTE0000000000",
         "input":  { "token_symbol": "USDC", "amount": "5.00", "decimals": 6 },
         "output": { "token_symbol": "RUG",  "amount": "1000000", "decimals": 0 },
         "route": [


### PR DESCRIPTION
**B-side hotfix.** The B3 fixture `demo-fixtures/mock-uniswap-quotes.json` mislabels its rug-token entry: it claims `expected_swap_policy_reason: "max_slippage_bps"`, but `evaluate_swap` (`crates/mandate-execution/src/uniswap.rs`) traverses checks in **field order** (input_token → output_token → max_notional_usd → max_slippage_bps → quote_freshness → treasury_recipient). The first violation that consumer code sees is therefore `output_token_allowlisted`, not slippage. The fixture overstated; the hotfix corrects it without touching A-side code.

## Strict scope

- Branched off `main` at `20a34b6`.
- Touches **only** `demo-fixtures/mock-uniswap-quotes.json` — one file, +6 / −4 lines.
- **No A-side files.** `crates/mandate-execution/src/uniswap.rs`'s actual semantics are correct and unchanged; this PR only fixes the docs/fixture overstatement.
- No transcript schema bump, no `crates/`, no `demo-scripts/`, no `operator-console/`, no `trust-badge/`, no schemas, no OpenAPI.

## What changed in the rug entry (`quotes[1]`)

| Field | Before | After |
|---|---|---|
| `id` | `slippage_violation` | `multiple_violations_rug_quote` |
| `expected_swap_policy_reason` | `max_slippage_bps` (the SECOND violation in field order — overstatement) | `output_token_allowlisted` (the actual FIRST violation) |
| `expected_additional_violations` | *(absent)* | `["max_slippage_bps", "treasury_recipient_allowlisted"]` (the other two violations the same quote trips) |
| `_swap_policy_reason_note` | *(absent)* | inline note documenting the field-order traversal in `evaluate_swap` and pointing at the source path so future maintainers can verify |
| `quote.quote_id` | `qt-MOCKUNISLIPPAGEVIOLATION` | `qt-MOCKUNIRUGQUOTE0000000000` (matches the renamed entry id) |

The top-level `explanation` field is also tightened: drops "slippage-cap violation" framing, adds explicit "the rug quote intentionally trips THREE checks (output token, slippage, recipient); `evaluate_swap` traverses checks in field order so the FIRST reported violation is `output_token_allowlisted`, not slippage."

## What did NOT change

- **Entry #1 `happy_path_within_caps`** — untouched. Already honest (no failures, no `expected_swap_policy_reason` field).
- **Entry #3 `recipient_allowlist_violation`** — untouched. Genuinely a single-violation case (input/output/notional/slippage all pass; only the recipient allowlist trips). `expected_swap_policy_reason: "treasury_recipient_allowlisted"` was and remains accurate.
- **`crates/mandate-execution/src/uniswap.rs`** — untouched. The evaluator's field-order traversal is the contract, and the fixture is what was wrong.
- **`demo-fixtures/test_fixtures.py`** — untouched. The validator only enforces envelope shape (`mock: true`, schema id, no secrets, no live URLs) — it does not assert on per-quote `expected_*` fields, so no test change is required.

## Truthfulness verification

```text
$ python3 -c "
import json
d = json.load(open('demo-fixtures/mock-uniswap-quotes.json'))
rug = next(q for q in d['quotes'] if q['id'] == 'multiple_violations_rug_quote')
print('first reason:', rug['expected_swap_policy_reason'])
print('additional:  ', rug['expected_additional_violations'])
"
first reason: output_token_allowlisted
additional:   ['max_slippage_bps', 'treasury_recipient_allowlisted']
```

`evaluate_swap` source-of-truth (lines from `crates/mandate-execution/src/uniswap.rs`):

```text
118-131  check 1: input_token_allowlisted
133-146  check 2: output_token_allowlisted   ← first to fail for the rug quote (RUG ∉ allowlist)
148-164  check 3: max_notional_usd
166-176  check 4: max_slippage_bps           ← second to fail (1500 > 50)
178-190  check 5: quote_freshness
192-205  check 6: treasury_recipient_allowlisted  ← third to fail (0x9999 ∉ allowlist)
207      blocked = checks.iter().any(|c| !c.ok)   — all 6 always evaluated
```

## Verification

| Command | Result |
|---|---|
| `cargo fmt --check` | ✅ |
| `cargo clippy --workspace --all-targets -- -D warnings` | ✅ |
| `cargo test --workspace --all-targets` | ✅ **158 / 158 pass** |
| `python3 scripts/validate_schemas.py` | ✅ |
| `python3 scripts/validate_openapi.py` | ✅ |
| `bash demo-scripts/run-openagents-final.sh` | ✅ all 13 gate headers |
| `python3 trust-badge/test_build.py` | ✅ 31 / 31 |
| `python3 operator-console/test_build.py` | ✅ 46 / 46 |
| `python3 demo-fixtures/test_fixtures.py` | ✅ PASS: all 4 mock fixture(s) clean |

## Coordination

- **Independent of every open PR.** Branched directly off `main`.
- **PR #31 (B4 docs) heads-up:** the `demo-fixtures/mock-uniswap-quotes.md` doc on PR #31's branch currently describes this fixture entry under its old name (`slippage_violation`) and old reason (`max_slippage_bps`). Once *this* hotfix lands on `main`, PR #31 will need a tiny follow-up commit aligning the .md doc — same kind of mechanical wording fix as the Codex P2 fix-up that's already in PR #31. I'll send that follow-up commit on PR #31's branch as soon as either (a) this hotfix merges, or (b) you tell me to rebase #31 on top of this regardless. **No conflict either way** — the .md doc and the .json fixture are disjoint files; the only coupling is consistency of names and reasons.
- **No B5 impact.** B5 is on hold; the submission package's `transcripts/` capture the current 13-gate state which doesn't depend on the rug fixture's labels.

## Limitations

- **The `quote_id` change** (`qt-MOCKUNISLIPPAGEVIOLATION` → `qt-MOCKUNIRUGQUOTE0000000000`) is a fixture-internal rename. No runner consumes this fixture, so no other file references the old `quote_id`. If a future B-side PR wires this fixture into a runner, that PR will reference the new id; no migration needed.

## Do not merge without Daniel approval.