### PR TITLE
docs+demo: final consolidation after PR #29

### DIFF
--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -17,12 +17,16 @@ For the historical PR-by-PR audit trail, see [`FINAL_REVIEW.md`](FINAL_REVIEW.md
 |---|---|
 | `cargo fmt --check` | ✅ |
 | `cargo clippy --workspace --all-targets -- -D warnings` | ✅ no warnings |
-| `cargo test --workspace --all-targets` | ✅ **121 / 121 pass** (0 fail, 0 ignored) |
+| `cargo test --workspace --all-targets` | ✅ **178 / 178 pass** (0 fail, 0 ignored) |
 | `python3 scripts/validate_schemas.py` | ✅ (6 schemas + 4 corpus fixtures) |
 | `python3 scripts/validate_openapi.py` | ✅ (`docs/api/openapi.json` valid) |
 | `bash demo-scripts/run-openagents-final.sh` | ✅ all **13 gates** green incl. audit-chain tamper detection and agent no-key proof (~5 seconds end-to-end) |
+| `bash demo-scripts/run-production-shaped-mock.sh` | ✅ `Tally: 16 real, 0 mock, 3 skipped` (PSM-A2 four-case matrix + PSM-A5 doctor + PSM-A1.9 mock-KMS lifecycle all walked end-to-end) |
 | `python3 trust-badge/build.py` | ✅ writes `trust-badge/index.html` (self-contained, no JS, no fetch) |
 | `python3 trust-badge/test_build.py` | ✅ 31 stdlib assertions on the rendered HTML |
+| `python3 operator-console/build.py` | ✅ writes `operator-console/index.html` (self-contained, no JS, no fetch) |
+| `python3 operator-console/test_build.py` | ✅ 50 stdlib assertions (PSM-A2 + PSM-A5 + PSM-A1.9 in pending pills; PSM-A3 + PSM-A4 still blocked) |
+| `python3 demo-fixtures/test_fixtures.py` | ✅ 4 mock fixtures clean + url-allowlist self-test |
 
 ## What is implemented
 
@@ -63,15 +67,26 @@ Full Open Agents vertical:
 - Agent no-key proof gate — asserts zero signing references, zero key-material fixtures, no signing-related cargo deps in the agent crate.
 - Deterministic transcript artifact written to `demo-scripts/artifacts/latest-demo-summary.json` (consumed by the trust-badge).
 - Static, offline trust-badge / proof viewer rendered straight from that transcript.
+- **HTTP `Idempotency-Key` safe-retry** (PSM-A2) — persistent SQLite-backed dedup; same-key/same-body → byte-identical cached response, no second audit row; same-key/different-body → 409 `protocol.idempotency_conflict`; different-key + same-nonce → 409 `protocol.nonce_replay` (defense in depth). Migration V004.
+- **`mandate doctor`** (PSM-A5) — operator readiness summary. Reports per-feature `ok`/`skip`/`warn`/`fail`; refuses to open a missing DB (no write-on-typo); falls through to real `storage_open` errors on permission/IO failures (not "does not exist"). Stable `mandate.doctor.v1` JSON envelope.
+- **Mock KMS CLI surface + persistence** (PSM-A1.9) — `mandate key {init,list,rotate} --mock`; persistent `mock_kms_keys` SQLite table (V005). Every CLI line `mock-kms:`-prefixed; `--mock` mandatory; rotate refuses on mismatched root-seed; current-version lookup propagates real DB errors. **Mock — not production-grade.**
+- **Production-shaped mock runner** (`demo-scripts/run-production-shaped-mock.sh`) — exercises the full PSM-A2 four-case matrix, PSM-A5 doctor, PSM-A1.9 init/list/rotate lifecycle end-to-end against real binaries; `Tally: 16 real, 0 mock, 3 skipped`.
+- **Static, offline operator console** (`operator-console/build.py`) — sister surface to the trust-badge: vertical timeline + multi-panel grid + backend-backlog placeholder grid. Three pending pills (PSM-A2, PSM-A5, PSM-A1.9 — backends merged, console panels landing in B2.v2); two blocked pills (PSM-A3, PSM-A4 — backends not yet merged).
+- **Production-shaped mock fixtures** (`demo-fixtures/mock-*.json`) — ENS multi-agent registry, KeeperHub workflow envelopes (success/conflict/refused/lookup), Uniswap quote catalogue (happy/multi-violation rug/recipient-allowlist), mock-KMS public keyring metadata. Plus stdlib validator (`test_fixtures.py`) with `urlparse`-based safe-host allowlist + URL-bypass self-test.
+- **Per-fixture production-transition guides** (`demo-fixtures/mock-*.md`) and a single **`docs/production-transition-checklist.md`** — every surface (ENS / KeeperHub / Uniswap / Signer-KMS-HSM) has env vars / endpoints / credentials / code-change steps / verification / truthfulness invariants spelled out.
 
 ## Pending / stretch (not blocking submission)
 
-- Live KeeperHub backend (one-constructor switch via `KeeperHubExecutor::live()`; demo uses `local_mock()`).
+- Live KeeperHub backend (one-constructor switch via `KeeperHubExecutor::live()`; demo uses `local_mock()`). Wire-format design notes in `docs/keeperhub-live-spike.md`.
 - Live ENS testnet resolver (offline fixture today; trait already abstracts the backend).
 - Live Uniswap quote backend (`UniswapExecutor::live()` is intentionally stubbed; demo uses `local_mock()`).
+- Production KMS / HSM signer (`MANDATE_SIGNER_BACKEND` selector + per-role `MANDATE_*_SIGNER_KEY_ID` env vars). The dev `DevSigner` and the persistent mock `MockKmsSigner` are both `⚠ DEV ONLY ⚠`; production injects real signers via `AppState::with_signers`.
+- B2.v2 — operator-console panels that *render* the merged backends inline (replacing the three pending pills). One panel per follow-up B-side PR.
+- PSM-A3 (active policy lifecycle: validate / current / activate / diff) and PSM-A4 (audit checkpoints) — still backlog A-side items.
 - Recorded demo video (3:30 cut). Script committed in `demo-scripts/demo-video-script.md`.
 - Pruned / Merkle-proof variants of the audit bundle, and optional embedded original APRP. Tracked in `docs/cli/audit-bundle.md`.
 - Soft-cap warning emission in receipts (`Budget.soft_cap_usd` parsed but not enforced).
+- B5 — final submission package wiring (transcripts/, recorded video URL, etc).
 
 ## Blockers
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository was implemented during **ETHGlobal Open Agents 2026**. Planning 
 
 ## Status
 
-**Implemented and reproducible from a fresh clone.** `cargo test --workspace --all-targets` runs **121/121 green**. `bash demo-scripts/run-openagents-final.sh` runs all **13 demo gates** end-to-end clean in ~5 seconds. See [`IMPLEMENTATION_STATUS.md`](IMPLEMENTATION_STATUS.md) for the current snapshot.
+**Implemented and reproducible from a fresh clone.** `cargo test --workspace --all-targets` runs **178/178 green**. `bash demo-scripts/run-openagents-final.sh` runs all **13 demo gates** end-to-end clean in ~5 seconds. `bash demo-scripts/run-production-shaped-mock.sh` exercises the production-shaped surface (HTTP `Idempotency-Key` four-case matrix + `mandate doctor` + mock-KMS CLI lifecycle + audit-bundle round-trip) end-to-end with `Tally: 16 real, 0 mock, 3 skipped`. See [`IMPLEMENTATION_STATUS.md`](IMPLEMENTATION_STATUS.md) for the current snapshot.
 
 ## Three commands a judge needs
 

--- a/SUBMISSION_FORM_DRAFT.md
+++ b/SUBMISSION_FORM_DRAFT.md
@@ -45,7 +45,7 @@ A research-agent in our demo emits a payment request (an APRP — "Agent Payment
 
 Every decision can be packaged as a verifiable audit bundle: `mandate audit export` produces a single JSON file containing the signed receipt, the audit-chain prefix, and the signer keys; `mandate audit verify-bundle` re-derives every claim from that file alone. A static, offline proof viewer (`python3 trust-badge/build.py`) renders the most recent demo run into a single self-contained HTML page — no JS, no fetch, works directly from `file://`.
 
-The whole flow is deterministic, runs offline, and reproduces from a fresh clone in ~5 seconds with `bash demo-scripts/run-openagents-final.sh`. 121/121 tests pass, schemas validate, the demo's 13 gates are green end-to-end including audit-chain tamper-detection and the agent no-key boundary proof.
+The whole flow is deterministic, runs offline, and reproduces from a fresh clone in ~5 seconds with `bash demo-scripts/run-openagents-final.sh`. 178/178 tests pass, schemas validate, the demo's 13 gates are green end-to-end including audit-chain tamper-detection and the agent no-key boundary proof. A second runner — `bash demo-scripts/run-production-shaped-mock.sh` — exercises the production-shaped surface (HTTP `Idempotency-Key` four-case matrix + `mandate doctor` + mock-KMS CLI lifecycle + audit-bundle round-trip) end-to-end with `Tally: 16 real, 0 mock, 3 skipped`.
 
 Mandate is not a wallet, not a relayer, and not a trading bot. It is the pre-execution policy and signing boundary that lets autonomous agents transact without ever being trusted with a key.
 ```

--- a/SUBMISSION_NOTES.md
+++ b/SUBMISSION_NOTES.md
@@ -26,8 +26,13 @@ All implementation code in this repository:
 - Standalone red-team gate: `demo-scripts/red-team/prompt-injection.sh`.
 - `demo-scripts/run-openagents-final.sh` — single-command demo runner with audit-chain tamper detection, agent no-key boundary proof, and a deterministic transcript artifact.
 - Static, offline trust-badge proof viewer (`trust-badge/build.py`) + stdlib regression test (`trust-badge/test_build.py`).
+- Static, offline operator console (`operator-console/build.py`) — sister surface to the trust-badge with three pending pills (PSM-A2 / PSM-A5 / PSM-A1.9 — backends merged, panels landing in B2.v2) and two blocked pills (PSM-A3 / PSM-A4).
+- HTTP `Idempotency-Key` safe-retry (PSM-A2): persistent SQLite-backed dedup with the four-case behaviour matrix exercised by `demo-scripts/run-production-shaped-mock.sh` step 7 against a real `mandate-server` daemon.
+- `mandate doctor` (PSM-A5): operator readiness summary; refuses to open a missing DB (no write-on-typo); per-feature `ok`/`skip`/`warn`/`fail`; stable JSON envelope.
+- Mock KMS CLI surface + persistence (PSM-A1.9): `mandate key {init,list,rotate} --mock` with `mock_kms_keys` SQLite table (V005). Mock — not production-grade.
+- Production-shaped mock fixtures (`demo-fixtures/mock-*.json`) + per-fixture transition guides (`demo-fixtures/mock-*.md`) + single `docs/production-transition-checklist.md`.
 - `demo-scripts/demo-video-script.md` — 3:30 video script with recording checklist.
-- CI: fmt, clippy, tests (121 passing), schema validation, OpenAPI validation, trust-badge regression test.
+- CI: fmt, clippy, tests (178 passing), schema validation, OpenAPI validation, trust-badge regression test, operator-console regression test, demo-fixtures validator.
 
 ## What was reused as planning material
 

--- a/demo-fixtures/mock-kms-keys.md
+++ b/demo-fixtures/mock-kms-keys.md
@@ -9,9 +9,10 @@ material is included.**
 
 ## What it demonstrates
 
-- The catalogue shape that a future `mandate key list --mock` CLI
-  (PSM-A1.9) would emit. Adapter authors can target a stable JSON shape
-  now without waiting for the CLI to land.
+- The catalogue shape that the `mandate key list --mock` CLI (PSM-A1.9,
+  shipped in PR #28) emits today. Adapter authors can dry-run their
+  KMS-listing parsers against this fixture without invoking the binary;
+  the CLI's actual output uses the same field set.
 - Per-key metadata fields that production callers need: `key_id`,
   `key_version`, `algorithm`, `purpose` (`audit_event_signing` /
   `policy_receipt_signing`), `verifying_key_hex`, `created_at_iso`,
@@ -38,23 +39,40 @@ clearly labelled `⚠ DEV ONLY ⚠` and never ship as production keys.
 
 ## Exact replacement step
 
-This is a two-stage replacement. **Stage 1** (PSM-A1.9) introduces a
-mock-KMS CLI surface that emits this fixture's shape from a real local
-keyring. **Stage 2** (production) swaps the mock keyring for a real
-KMS / HSM client.
+This is a two-stage replacement. **Stage 1** (PSM-A1.9) ships a mock-KMS
+CLI surface that materialises this fixture's shape from a real local
+SQLite keyring — **landed in PR #28**. **Stage 2** (production) swaps
+the mock keyring for a real KMS / HSM client.
 
-### Stage 1 — `mandate key list --mock` CLI (PSM-A1.9)
+### Stage 1 — `mandate key list --mock` CLI (PSM-A1.9 — DONE)
 
-1. Land Developer A's PSM-A1.9 PR (`feat: persist mock kms keyring + add mandate key cli`).
-2. Output of `mandate key list --mock --format json` should match this
-   fixture's shape (same fields, same envelope).
-3. Update `demo-scripts/run-production-shaped-mock.sh` step 9 to read
-   the audit/receipt verification pubkeys from
-   `mandate key list --mock --format json` instead of the current
-   hardcoded constants. Comment in the script already points at this
-   transition (`crates/mandate-server/src/lib.rs:54-55`).
-4. The fixture stays as the **shape contract** for the CLI's JSON
-   output — the validator (`test_fixtures.py`) protects against drift.
+PSM-A1.9 shipped in PR #28. The CLI exists today:
+
+```bash
+mandate key init   --mock --role audit-mock    --root-seed <hex64> --db <path>
+mandate key list   --mock                                          --db <path>
+mandate key rotate --mock --role audit-mock    --root-seed <hex64> --db <path>
+```
+
+Every operation requires `--mock` (production KMS backends are not
+implemented; calls without `--mock` exit 2 with an explicit refusal).
+Every output line is `mock-kms:`-prefixed. `rotate` refuses with exit 2
+if the supplied `--root-seed` does not derive the stored current
+version's public material — preventing accidental mixed-seed keyrings.
+The persistent `mock_kms_keys` table is migration V005; the daemon's
+`mandate doctor` reports it as `ok` once V005 is applied.
+
+The fixture stays as the **public shape reference** — useful for
+adapter authors writing KMS-listing parsers and for verification tests
+that don't want to execute the binary. The fixture's `verifying_key_hex`
+values are the same dev-signer pubkeys the runner uses today; they are
+deterministically derivable from the public dev seeds at
+`crates/mandate-server/src/lib.rs:54-55`. **Mock — not production-grade.**
+
+A future B-side follow-up can teach `demo-scripts/run-production-shaped-mock.sh`
+step 9 to read the verification pubkeys from `mandate key list --mock`
+output instead of the hardcoded constants — an internal cleanup, not a
+correctness fix.
 
 ### Stage 2 — production KMS / HSM
 

--- a/demo-scripts/run-production-shaped-mock.sh
+++ b/demo-scripts/run-production-shaped-mock.sh
@@ -110,10 +110,40 @@ else
 fi
 echo
 
-# ─── 3. Mock KMS CLI surface (Developer A backlog PSM-A1.9) ──────────────
+# ─── 3. Mock KMS CLI surface (PSM-A1.9 — REAL today) ─────────────────────
 bold "3. Mock KMS CLI surface (PSM-A1.9)"
+# PSM-A1.9 shipped in PR #28: persistent mock_kms_keys SQLite table
+# (migration V005) + `mandate key {init,list,rotate} --mock` CLI surface.
+# Every operation requires `--mock` and prefixes every output line with
+# `mock-kms:` for explicit disclosure. We exercise init → list → rotate →
+# list end-to-end against a fresh tempfile-backed SQLite, then drop it.
+# Mock — not production-grade.
 if have_subcmd key list; then
-  ./target/debug/mandate key list --mock 2>&1 | sed 's/^/    /' && ok "mandate key list --mock" || skip "mandate key list --mock returned non-zero"
+  # Section-local tempdir + EXIT trap — TMPDIR_PSM is set up in step 5,
+  # later than this section, so we use a self-contained temp space and
+  # tear it down on success. The trap is appended (not replaced) so we
+  # don't disturb any later trap installs.
+  KMS_TMP="$(mktemp -d -t mandate-mock-kms.XXXXXX)"
+  KMS_DB="$KMS_TMP/mock-kms.db"
+  # Deterministic 64-hex-char dev seed. NOT a secret — `mandate-server`'s
+  # production-shaped DevSigner uses literally this byte pattern (all 0x11),
+  # see `crates/mandate-server/src/lib.rs:54`. The corresponding public
+  # verifying key is the audit-signer pubkey shipped in
+  # `demo-fixtures/mock-kms-keys.json`.
+  KMS_ROOT_SEED="$(python3 -c 'print("11"*32)')"
+  if ./target/debug/mandate key init --mock --role audit-mock \
+       --root-seed "$KMS_ROOT_SEED" --db "$KMS_DB" 2>&1 | sed 's/^/    /' \
+     && ./target/debug/mandate key list --mock --db "$KMS_DB" 2>&1 | sed 's/^/    /' \
+     && ./target/debug/mandate key rotate --mock --role audit-mock \
+       --root-seed "$KMS_ROOT_SEED" --db "$KMS_DB" 2>&1 | sed 's/^/    /' \
+     && ./target/debug/mandate key list --mock --db "$KMS_DB" 2>&1 | sed 's/^/    /'; then
+    ok "mandate key init/list/rotate --mock — full lifecycle exercised against fresh SQLite"
+    rm -rf "$KMS_TMP"
+  else
+    fail "mandate key CLI lifecycle returned non-zero"
+    rm -rf "$KMS_TMP"
+    exit 1
+  fi
 else
   skip "signer + trait + rotation are merged in PR #22; waiting for \`mandate key list --mock\` / \`mandate key rotate --mock\` CLI + persistent mock-KMS storage table (backlog PSM-A1.9)"
   note_skip "Mock KMS CLI surface (\`mandate key list --mock\` / \`mandate key rotate --mock\`) + persistent mock-KMS storage table — PSM-A1.9"
@@ -393,6 +423,9 @@ cat <<EOF
   REAL today (executed by this run, no network):
     - persistent SQLite-backed APRP + nonce-replay (legit + prompt-injection)
     - signed Ed25519 policy receipts, hash-chained audit log
+    - mock KMS CLI surface (PSM-A1.9): \`mandate key {init,list,rotate} --mock\`
+      lifecycle exercised against a fresh SQLite (V005 \`mock_kms_keys\`)
+    - \`mandate doctor\` (PSM-A5): operator readiness summary
     - HTTP \`Idempotency-Key\` safe-retry (PSM-A2): four-case behaviour
       matrix exercised against a real mandate-server on 127.0.0.1:${IDEM_PORT}
       with persistent SQLite at \`$(basename "$IDEM_DB")\`

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -23,7 +23,7 @@ mandate doctor --db /var/lib/mandate/mandate.sqlite --json
 | `nonce_replay` | V002 table present + row count. (Implemented today.) |
 | `idempotency_keys` | V004 table present + row count. **Skip** if the migration hasn't run — reason references **PSM-A2** so an operator knows what to enable. |
 | `audit_chain` | Count + structural verify (`prev_event_hash` linkage and `event_hash` recompute). Signatures are **not** verified — the doctor doesn't have access to the daemon's signer pubkey. **Skip** if the chain is empty. |
-| `mock_kms_keys` | **Skip** today — Mock KMS keyring persistence is tracked as **PSM-A1.9**. The in-process `MockKmsSigner` (PSM-A1) still works without persistence. |
+| `mock_kms_keys` | V005 table present + row count. The persistent mock-KMS keyring shipped via **PSM-A1.9** (PR #28). **Mock — not production-grade.** **Skip** only if a daemon was upgraded without running V005. |
 | `active_policy` | **Skip** today — policy lifecycle is **PSM-A3**. The daemon currently uses the embedded reference policy. |
 | `payment_requests` | Core V001 table present + row count. |
 

--- a/docs/cli/mock-kms.md
+++ b/docs/cli/mock-kms.md
@@ -110,10 +110,16 @@ The `--root-seed` is **never** stored in the SQLite database — only the result
 - end-to-end: receipt / audit event / decision token sign + verify through `MockKmsSigner`;
 - end-to-end: a pre-rotation receipt verifies under the resolved v1 pubkey after the keyring rotates to v2; a v2 pubkey rejects the v1 receipt.
 
+## What ships today (PSM-A1 + PSM-A1.9)
+
+- In-process `MockKmsSigner` (PSM-A1) — programmatic API for signing receipts / audit events / decision tokens through the `SignerBackend` trait.
+- Persistent mock keyring storage in SQLite (PSM-A1.9, migration V005 `mock_kms_keys`) — public-key metadata only; root seeds are never persisted.
+- `mandate key {init,list,rotate} --mock --db <path>` CLI — every operation requires `--mock`; every output line is `mock-kms:`-prefixed; rotate refuses on mismatched root-seed; current-version lookup propagates real DB errors (no silent "no keyring" mask).
+- `mandate doctor` reports `mock_kms_keys` as `ok` once V005 is applied.
+
 ## Limitations carried forward (truthful disclosure)
 
-- No persistence of rotation state across processes (programmatic only).
-- No CLI surface yet — see PSM-A1.9.
-- No live KMS / HSM backend implements `SignerBackend` in this build.
-- `derive_signing_key` is a deterministic seed-stretch, **not** a production KDF; do not adopt it for any non-mock context.
-- The daemon (`mandate-server`) still constructs `DevSigner` for receipts and audit events; wiring the daemon to use `MockKmsSigner` (and persisting rotation state) is also future work.
+- **`derive_signing_key` is a deterministic seed-stretch, not a production KDF.** Do not adopt it for any non-mock context.
+- **No live KMS / HSM backend.** Production deployments inject signers via `AppState::with_signers` (TEE/HSM-backed). The `MANDATE_SIGNER_BACKEND` selector and per-role `MANDATE_*_SIGNER_KEY_ID` env vars are documented in [`docs/production-transition-checklist.md`](../production-transition-checklist.md#signer--mock-kms--hsm); none of those wirings exist in this build.
+- **Daemon still constructs `DevSigner`.** `mandate-server` does not yet load the persistent mock keyring at startup. Wiring the daemon to read v(n) public keys from the mock-KMS table for receipt/audit signing is follow-up work, not part of PSM-A1.9.
+- **`--root-seed` is a CLI input, not a secret.** It is *never* persisted to the SQLite DB (only the per-version public material is). Operators must keep the seed out of shell history / process listings the same way they would treat any other key bootstrap input.

--- a/docs/production-transition-checklist.md
+++ b/docs/production-transition-checklist.md
@@ -237,20 +237,22 @@ seeds in `crates/mandate-server/src/lib.rs:54-55` (`audit-signer-v1` +
 labelled `⚠ DEV ONLY ⚠` in the source and in `SUBMISSION_NOTES.md`.
 `AppState::with_signers(...)` is the production injection point.
 
-The catalogue shape for the future `mandate key list --mock` CLI is
+The catalogue shape for the `mandate key list --mock` CLI is
 documented in
 [`mock-kms-keys.json`](../demo-fixtures/mock-kms-keys.json) and its
 [companion guide](../demo-fixtures/mock-kms-keys.md).
 
 ### What live needs
 
-The transition is two-stage:
+Stage 1 is **shipped**. Stage 2 is the production-deployment work.
 
-- **Stage 1: Mock-KMS CLI (PSM-A1.9 — Developer A backlog).** A real
-  on-disk keyring + `mandate key list --mock` / `mandate key rotate --mock`
-  commands. Output JSON shape matches `mock-kms-keys.json`.
-- **Stage 2: production KMS / HSM.** A real `Signer` impl backed by
-  AWS KMS, GCP KMS, Azure Key Vault, or an HSM SDK.
+- **Stage 1: Mock-KMS CLI (PSM-A1.9) — DONE in PR #28.** Persistent
+  `mock_kms_keys` SQLite table (V005) + `mandate key {init,list,rotate} --mock`
+  CLI. Every operation requires `--mock` and prefixes every output line
+  with `mock-kms:`. **Mock — not production-grade.**
+- **Stage 2: production KMS / HSM — pending.** A real `Signer` impl
+  backed by AWS KMS, GCP KMS, Azure Key Vault, or an HSM SDK. This is
+  what the rest of this section documents.
 
 ### Env vars / endpoints / credentials
 
@@ -268,19 +270,16 @@ for GCP, etc.). **Never committed to the repo.**
 
 ### Code change
 
-#### Stage 1 (PSM-A1.9)
+#### Stage 1 (PSM-A1.9 — DONE in PR #28)
 
-1. Persistent SQLite-backed mock keyring in
-   `crates/mandate-storage/` (or equivalent).
-2. `mandate key list --mock --format json` outputs the
-   `mock-kms-keys.json` shape.
-3. `mandate key rotate --mock <key-id>` bumps `key_version` and stamps
-   `rotated_at_iso`. Old keys remain in the keyring with `active: false`
-   so prior receipts continue to verify.
-4. `demo-scripts/run-production-shaped-mock.sh` step 9 reads the audit
-   / receipt verification pubkeys from `mandate key list --mock --format json`
-   instead of the hardcoded constants. Comment in the script already
-   points at this transition.
+Already on `main`. No further code change needed.
+
+- Persistent SQLite-backed keyring in `crates/mandate-storage/src/mock_kms_store.rs` + migration `migrations/V005__mock_kms_keys.sql`.
+- `mandate key {init,list,rotate} --mock --db <path>` CLI in `crates/mandate-cli/src/key.rs`.
+- `--root-seed` is a CLI input only; it is **never** persisted to SQLite (only the per-version `verifying_key_hex` is). Rotate refuses with exit 2 on a mismatched seed.
+- The `mandate doctor` `mock_kms_keys` row reports `ok` once V005 is applied.
+
+Pending follow-up (B-side, optional cleanup): teach `demo-scripts/run-production-shaped-mock.sh` step 9 to read the audit / receipt verification pubkeys from `mandate key list --mock` output instead of the hardcoded constants. Internal cleanup, not a correctness fix — the runner today exercises the CLI lifecycle in step 3 and uses the existing pubkey constants in step 9.
 
 #### Stage 2 (production KMS / HSM)
 


### PR DESCRIPTION
Close-out PR after the consolidation merge sweep. Fixes truthfulness/status drift caused by the PR #25/#28/#29 wave + one real bug in the production-shaped runner. **Docs/CI/runner-only — zero production-code change.**

## main merge SHA for #29

`c6fc3afeace9535792322f4bf25b06de2ffcb622` — squash merge of PR #29 (`demo+console: promote PSM-A2 idempotency from SKIP to REAL evidence`). Branch base for this PR is `c6fc3af`.

## Files changed

```
IMPLEMENTATION_STATUS.md                   | 19 ++++++++--
README.md                                  |  2 +-
SUBMISSION_FORM_DRAFT.md                   |  2 +-
SUBMISSION_NOTES.md                        |  7 +++-
demo-fixtures/mock-kms-keys.md             | 58 +++++++++++++++++++-----------
demo-scripts/run-production-shaped-mock.sh | 37 +++++++++++++++++--
docs/cli/doctor.md                         |  2 +-
docs/cli/mock-kms.md                       | 16 ++++++---
docs/production-transition-checklist.md    | 39 ++++++++++----------
9 files changed, 129 insertions(+), 53 deletions(-)
```

## Exact stale claims fixed

| File | Before | After |
|---|---|---|
| `README.md:13` | `121/121 green` | `178/178 green`; production-shaped runner tally cited inline |
| `IMPLEMENTATION_STATUS.md:20` | `**121 / 121 pass**` | `**178 / 178 pass**`; verification table extended with production-shaped-runner + operator-console + demo-fixtures rows |
| `IMPLEMENTATION_STATUS.md` "What is implemented" | missed PSM-A2 / PSM-A5 / PSM-A1.9 / operator-console / fixtures / per-fixture guides / production-transition checklist | all six surfaces listed |
| `IMPLEMENTATION_STATUS.md` "Pending / stretch" | listed live KH/ENS/Uniswap as the only stretch | now also names PSM-A3 / PSM-A4 / B2.v2 panels / production KMS-HSM / B5 final package |
| `SUBMISSION_NOTES.md:30` | `tests (121 passing)` | `tests (178 passing)`; surfaces extended (operator console, mock-KMS CLI, transition guides) |
| `SUBMISSION_FORM_DRAFT.md:48` | `121/121 tests pass` | `178/178 tests pass`; runner tally cited |
| `docs/cli/doctor.md:26` | `mock_kms_keys → Skip today (PSM-A1.9)` | `V005 + ok`; skip only on upgraded daemon without V005 |
| `docs/cli/mock-kms.md` "Limitations" | `No CLI surface yet — see PSM-A1.9` + `daemon constructs DevSigner; future work` | replaced with "What ships today (PSM-A1 + PSM-A1.9)" block + truthful current-state limitations (production KMS/HSM still missing; daemon-side wiring follow-up; --root-seed disclosure) |
| `demo-fixtures/mock-kms-keys.md:12` | `catalogue shape that a future mandate key list --mock CLI (PSM-A1.9) would emit` | `the CLI exists today (PR #28); fixture is the public shape reference` |
| `demo-fixtures/mock-kms-keys.md` Stage 1 | `Land Developer A's PSM-A1.9 PR …` (forward-looking) | "Stage 1 — DONE in PR #28"; concrete CLI invocation example; only optional pubkey-from-CLI cleanup remains |
| `docs/production-transition-checklist.md` Stage 1 | `Mock-KMS CLI (PSM-A1.9 — Developer A backlog). A real on-disk keyring + … commands` (planning copy) | `DONE in PR #28`; concrete file paths for the implementation + truthfulness disclosures (--root-seed never persisted, rotate refuses on mismatched seed, `mandate doctor` reports `mock_kms_keys` as `ok`) |

## Runner PSM-A1.9 fix explanation

`demo-scripts/run-production-shaped-mock.sh` step 3 had a real bug post-PR-#28: it called `./target/debug/mandate key list --mock` without `--db`, which fails arg-validation (`error: --db <DB> required`). The runner's `|| skip` branch caught the failure, but only `skip()` was called (not `note_skip()`), so the closing SKIPPED list and the `Tally:` count disagreed (3 named items vs `tally=4`).

**Preferred fix applied**: section 3 now actually walks the mock-KMS CLI lifecycle:

```bash
KMS_TMP="$(mktemp -d -t mandate-mock-kms.XXXXXX)"
KMS_DB="$KMS_TMP/mock-kms.db"
KMS_ROOT_SEED="$(python3 -c 'print("11"*32)')"   # public dev pattern; see crates/mandate-server/src/lib.rs:54

mandate key init   --mock --role audit-mock --root-seed "$KMS_ROOT_SEED" --db "$KMS_DB"
mandate key list   --mock                                                --db "$KMS_DB"
mandate key rotate --mock --role audit-mock --root-seed "$KMS_ROOT_SEED" --db "$KMS_DB"
mandate key list   --mock                                                --db "$KMS_DB"

rm -rf "$KMS_TMP"
```

- Section-local `mktemp` so it doesn't collide with `TMPDIR_PSM` (set up later in step 5).
- Section-local `rm -rf` cleanup on success and on the failure path.
- Output preserves the `mock-kms:` prefix on every line (per the CLI's contract).
- Failure of any of the four commands fails the whole runner with `exit 1` and a clear `fail "mandate key CLI lifecycle returned non-zero"` message.

**Tally now: `16 real, 0 mock, 3 skipped`** — symmetric (3 named items, count = 3). The remaining 3 SKIPPED entries are: 13-gate final demo (intentional opt-in), PSM-A3 (active policy lifecycle, backlog), PSM-A4 (audit checkpoints, backlog).

The closing summary REAL block was also extended with two new lines documenting `mandate doctor` (PSM-A5) and the mock-KMS CLI lifecycle (PSM-A1.9) so the prose matches the runner's actual behaviour.

## Verification matrix

All on this branch's HEAD:

| Command | Result |
|---|---|
| `cargo fmt --check` | ✅ EXIT 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | ✅ EXIT 0, 0 warnings, 0 errors |
| `cargo test --workspace --all-targets` | ✅ **178 / 178 pass**, 0 fail, 0 ignored |
| `python3 scripts/validate_schemas.py` | ✅ 6 metaschemas + 4 corpus fixtures |
| `python3 scripts/validate_openapi.py` | ✅ `docs/api/openapi.json` valid |
| `bash demo-scripts/run-openagents-final.sh` | ✅ 13 / 13 gates green |
| `bash demo-scripts/run-production-shaped-mock.sh` | ✅ rc=0, **`Tally: 16 real, 0 mock, 3 skipped.`** (was 15/0/4 with a named-vs-counted asymmetry) |
| `python3 trust-badge/build.py` | ✅ wrote `index.html` (5103 bytes) |
| `python3 trust-badge/test_build.py` | ✅ **PASS: 31 checks ok** |
| `python3 operator-console/build.py` | ✅ wrote `index.html` (8364 bytes) |
| `python3 operator-console/test_build.py` | ✅ **PASS: 50 checks ok** |
| `python3 demo-fixtures/test_fixtures.py` | ✅ **PASS: all 4 mock fixture(s) clean + url self-test** |

## GitHub housekeeping (companion to this PR)

- **Issue #3 closed.** Each P3 checklist item resolved by an earlier merged PR (#5 / #6 / #8); closing comment carries the per-bullet resolution map.
- **8 stale review threads resolved via GraphQL** on closed PRs #25, #30, #31, #32. Every fix is on `main`; this is a UI-only cleanup. No code change.

## Truthfulness invariants preserved

- Mock KMS CLI/storage is **production-shaped, not production-ready**. Every CLI line is still `mock-kms:`-prefixed; `--mock` is still mandatory; missing `--mock` exits 2 with explicit "production KMS backends are not implemented in this build".
- No fake real / no fake live / no fake production claim anywhere.
- The operator console's three pending pills (PSM-A2 / PSM-A5 / PSM-A1.9) honestly disclose "backend merged · console panel landing in B2.v2"; the two blocked pills (PSM-A3 / PSM-A4) honestly disclose "not implemented yet".
- No B2.v2 panel work in this PR — only placeholder truthfulness alignment.
- Zero production-code touch.

## Remaining scope (NOT in this PR)

- **PSM-A3** — active policy lifecycle (`mandate policy current` / `activate` / `validate` / `diff`). Backlog A-side work.
- **PSM-A4** — audit checkpoints (`mandate audit checkpoint create` / `verify`) + mock anchoring. Backlog A-side work.
- **B2.v2** — operator-console panels that *render* the merged backends (PSM-A2 / PSM-A5 / PSM-A1.9) inline, replacing the current pending pills. One panel per follow-up B-side PR.
- **Live KeeperHub backend** — `KeeperHubExecutor::live()` wiring per the design in `docs/keeperhub-live-spike.md`.
- **Live ENS testnet resolver** — `LiveEnsResolver` impl of the existing `EnsResolver` trait.
- **Live Uniswap quote backend** — `UniswapExecutor::live()` wiring against the Uniswap Trading API.
- **Production KMS / HSM signer** — `MANDATE_SIGNER_BACKEND` selector + per-role `MANDATE_*_SIGNER_KEY_ID` env vars per the production-transition checklist. Mock KMS is the lifecycle shape; production custody is separate work.
- **B5** — final submission package wiring (recorded video URL, transcripts, etc).

## Do not merge without Daniel approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)