### PR TITLE
docs: add Mandate Passport product plan

### DIFF
--- a/docs/product/MANDATE_PASSPORT_BACKLOG.md
+++ b/docs/product/MANDATE_PASSPORT_BACKLOG.md
@@ -1,0 +1,738 @@
+# Mandate Passport Two-Developer Backlog
+
+**Goal:** turn the existing Mandate implementation into a coherent
+prize-ready product without destabilizing the working submission.
+
+**Team model:** two developers running continuously.
+
+- **Developer A:** Rust core, CLI, MCP, schemas, storage, daemon, sponsor
+  adapters, demo scripts that exercise binaries.
+- **Developer B:** operator-console, trust-badge, static proof pages,
+  docs, submission copy, reward one-pagers, GitHub Pages, PR polish.
+
+**Baseline:** `main` after B5 final submission wiring (`8e48ec1`). All
+A-side backend backlog items are merged, B2.v2 operator-console
+real-evidence panels are merged, and the submission baseline is aligned.
+The next unblocked implementation task is P1.1.
+
+## Product Outcome
+
+At the end of this backlog, Mandate should demonstrate:
+
+> An ENS-named AI agent calls Mandate through MCP, receives a signed
+> allow/deny decision, optionally hands allowed execution to KeeperHub or
+> Uniswap, and emits a portable passport capsule that verifies offline.
+
+The output should feel like one product, not a set of disconnected
+hackathon scripts.
+
+## Work Rules
+
+1. Keep the existing 13-gate demo green.
+2. Keep the production-shaped mock runner deterministic by default.
+3. Never hide mock/offline modes.
+4. Do not let live modes silently fall back to mock modes.
+5. Keep Developer A and B write scopes mostly disjoint.
+6. Land small PRs; each PR must have a crisp verification matrix.
+7. B-side UI/docs may depend on A-side transcript fields, but must not
+   invent values.
+8. Every schema bump must update generators, fixtures, tests, and docs in
+   the same PR.
+9. When an upstream PR is in flight, the other developer may prepare
+   docs/fixtures but must not merge a claim that depends on unmerged code.
+
+## Verification Matrix
+
+Run the full matrix at major merge points and before submission:
+
+| Command | Required when |
+|---|---|
+| `cargo fmt --check` | Any Rust change. |
+| `cargo clippy --workspace --all-targets -- -D warnings` | Any Rust change. |
+| `cargo test --workspace --all-targets` | Any Rust/schema/CLI/storage change. |
+| `python3 scripts/validate_schemas.py` | Any schema or corpus change. |
+| `python3 scripts/validate_openapi.py` | Any HTTP API/OpenAPI change. |
+| `bash demo-scripts/run-openagents-final.sh` | Any product-flow, demo, core, sponsor, or submission change. |
+| `bash demo-scripts/run-production-shaped-mock.sh` | Any operator, PSM, proof, or sponsor-surface change. |
+| `python3 trust-badge/build.py && python3 trust-badge/test_build.py` | Any transcript, trust badge, capsule, or proof-view change. |
+| `python3 operator-console/build.py && python3 operator-console/test_build.py` | Any transcript, operator-console, capsule, or proof-view change. |
+| `python3 demo-fixtures/test_fixtures.py` | Any fixture or fixture-doc change. |
+
+Doc-only PRs may run a reduced matrix, but any doc that updates counts,
+tallies, or product claims must cite the command output it reflects.
+
+## PR Sequence Overview
+
+| Phase | PR | Owner | Title | Dependency | Merge condition |
+|---|---|---|---|---|---|
+| 0 | P0.1 | B | Finish B2.v2 operator-console real evidence | Complete on main via PR #37 | Done. |
+| 0 | P0.2 | B | B5 final submission wiring baseline | Complete on main via PR #39 | Done. |
+| 1 | P1.1 | A | Passport capsule schema + verifier skeleton | P0.1 + P0.2 complete | Schema validates, fixture verifies. |
+| 1 | P1.2 | B | Passport source docs + proof copy alignment | P1.1 | No false live claims. |
+| 2 | P2.1 | A | `mandate passport` CLI MVP | P1.1 | Capsule created from existing offline flow. |
+| 2 | P2.2 | B | Trust-badge/operator-console capsule panels | P2.1 | Static UI renders capsule truthfully. |
+| 3 | P3.1 | A | Functional `mandate-mcp` stdio server | P2.1 | MCP smoke test passes offline. |
+| 3 | P3.2 | B | MCP demo docs + agent integration guide | P3.1 | Judge can run one MCP demo command. |
+| 4 | P4.1 | A | ENS passport resolver records | P2.1 | Offline fixture first; live optional gated. |
+| 4 | P4.2 | B | ENS reward one-pager + proof UI | P4.1 | ENS records visible and non-cosmetic. |
+| 5 | P5.1 | A | KeeperHub proof handoff envelope | P3.1 | Mock server test proves envelope fields. |
+| 5 | P5.2 | B | KeeperHub feedback/issues/one-pager | P5.1 | Actionable feedback linked from repo. |
+| 6 | P6.1 | A | Uniswap guarded quote capsule evidence | P2.1 | Quote evidence appears in capsule. |
+| 6 | P6.2 | B | Uniswap FEEDBACK + one-pager | P6.1 | FEEDBACK meets prize requirement. |
+| 7 | P7.1 | B | GitHub Pages public proof site | P2.2 | Public static proof URL. |
+| 7 | P7.2 | A+B | Final smoke, video, submission freeze | All must-have PRs | Fresh clone green, video URL inserted. |
+
+Phases 5 and 6 can run in parallel after P3.1 if Developer A can keep
+write sets separate. Phase 7 must not start final copy until the last
+feature PR it references is merged.
+
+## Phase 0: Stabilize Existing Proof Surface
+
+**Current status:** complete on `main`. P0.1 landed via PR #37 and P0.2
+landed via PR #39. This section remains as historical acceptance context
+and as a regression checklist; it is not the next task to start.
+
+### P0.1 - Finish B2.v2 Operator-Console Real Evidence
+
+**Owner:** Developer B.
+
+**Why:** all A-side backend work is merged. The operator console should
+render real evidence panels rather than pending pills before Passport
+adds a new proof layer.
+
+**Primary files:**
+
+- `operator-console/build.py`
+- `operator-console/test_build.py`
+- `operator-console/fixtures/operator-summary.json`
+- `operator-console/README.md`
+- `demo-scripts/run-production-shaped-mock.sh`
+- `trust-badge/build.py` only if schema pin changes
+
+**Acceptance criteria:**
+
+- PSM-A2 idempotency panel renders the four cases:
+  - first request returns 200;
+  - same key/body returns byte-identical cached 200;
+  - same key/different body returns 409 idempotency conflict;
+  - different key/same nonce returns 409 nonce replay.
+- PSM-A5 doctor panel renders grouped ok/skip/warn/fail rows.
+- PSM-A1.9 mock-KMS panel renders key id/version/public-key prefix and
+  keeps `mock: true`.
+- PSM-A3 active policy panel renders current policy hash/version/source.
+- PSM-A4 audit checkpoint panel renders create/verify evidence with
+  `mock anchoring, not onchain`.
+- No A-side backend item appears in a blocked pill.
+- Tests assert malformed evidence renders failure, not a placeholder.
+
+**Verification:**
+
+- `bash demo-scripts/run-production-shaped-mock.sh`
+- `python3 operator-console/build.py`
+- `python3 operator-console/test_build.py`
+- `python3 trust-badge/test_build.py` if transcript schema changes
+
+### P0.2 - B5 Final Submission Wiring Baseline
+
+**Owner:** Developer B.
+
+**Why:** before Passport changes the story, current submission docs must
+be clean and not stale.
+
+**Primary files:**
+
+- `README.md`
+- `SUBMISSION_FORM_DRAFT.md`
+- `SUBMISSION_NOTES.md`
+- `IMPLEMENTATION_STATUS.md`
+- `demo-scripts/demo-video-script.md`
+- `FEEDBACK.md`
+
+**Acceptance criteria:**
+
+- Counts/tallies match current verified command output.
+- B2.v2 state is reflected correctly.
+- No stale "A3/A4 backlog" copy remains.
+- Submission form clearly says which integrations are mock/offline/live.
+- Demo video placeholders are easy to fill once recorded.
+
+**Verification:**
+
+- Grep for stale phrases:
+  - `A3.*backlog`
+  - `A4.*backlog`
+  - `three pending`
+  - old runner tallies
+- Run proof-surface build/test commands.
+
+## Phase 1: Passport Capsule Foundation
+
+### P1.1 - Passport Capsule Schema + Verifier Skeleton
+
+**Owner:** Developer A.
+
+**Why:** the capsule is the product's core artifact. Build the schema
+before UI copy so every future panel has one source of truth.
+
+**Primary files:**
+
+- `schemas/mandate.passport_capsule.v1.json`
+- `test-corpus/passport/*.json`
+- `crates/mandate-cli/src/passport.rs`
+- `crates/mandate-cli/src/main.rs`
+- `crates/mandate-core` or a new small passport module if local pattern
+  suggests it
+- `scripts/validate_schemas.py`
+
+**Acceptance criteria:**
+
+- New schema id: `mandate.passport_capsule.v1`.
+- Golden valid capsule fixture validates.
+- Tampered fixtures fail:
+  - deny capsule with execution ref;
+  - mock anchor marked live/onchain;
+  - live mode without live evidence;
+  - request hash mismatch;
+  - policy hash mismatch;
+  - malformed checkpoint;
+  - unknown field if schema discipline requires deny-unknown.
+- `mandate passport verify --path <capsule>` exists and performs
+  structural verification.
+- Verifier returns explicit exit codes.
+- No execution logic is added in this PR.
+
+**Verification:**
+
+- `cargo fmt --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test --workspace --all-targets`
+- `python3 scripts/validate_schemas.py`
+
+**Risk:** schema can become too ambitious. Keep MVP fields only:
+agent, request, policy, decision, execution, audit, verification.
+
+### P1.2 - Passport Product Docs + Copy Alignment
+
+**Owner:** Developer B.
+
+**Why:** B can build judge-facing clarity while A lands the schema.
+
+**Primary files:**
+
+- `docs/product/*`
+- `README.md`
+- `SUBMISSION_NOTES.md`
+- `SUBMISSION_FORM_DRAFT.md`
+- `FEEDBACK.md`
+
+**Acceptance criteria:**
+
+- README links the product docs without claiming Passport MVP is shipped
+  until A's CLI can emit a capsule.
+- Submission text says "Passport target" vs "implemented today"
+  cleanly.
+- Partner feedback names the capsule fields each sponsor would benefit
+  from.
+
+**Verification:**
+
+- Manual doc review.
+- Grep for false claims:
+  - `live KeeperHub` without `mock`/`target`;
+  - `onchain anchor` without `mock`/`future`;
+  - `production-ready` in contexts where it overclaims.
+
+## Phase 2: Passport CLI MVP
+
+### P2.1 - `mandate passport` CLI MVP
+
+**Owner:** Developer A.
+
+**Why:** make the product tangible. Judges and devs must be able to run a
+single command that produces a proof capsule.
+
+**Primary files:**
+
+- `crates/mandate-cli/src/passport.rs`
+- `crates/mandate-cli/tests/passport_cli.rs`
+- `demo-scripts/run-production-shaped-mock.sh`
+- `docs/cli/passport.md`
+
+**CLI target:**
+
+```bash
+mandate passport run test-corpus/aprp/legit-x402.json \
+  --db "$POLICY_DB" \
+  --agent research-agent.team.eth \
+  --resolver offline-fixture \
+  --ens-fixture demo-fixtures/mock-ens-registry.json \
+  --executor keeperhub \
+  --mode mock \
+  --out "$TMPDIR/passport-capsule.json"
+```
+
+**Acceptance criteria:**
+
+- The command emits a valid `mandate.passport_capsule.v1`.
+- Allow path has execution ref.
+- Deny path writes a capsule with `execution.status = not_called`.
+- Capsule embeds or references:
+  - request hash;
+  - policy hash/version;
+  - receipt signature;
+  - audit event id;
+  - checkpoint artifact;
+  - mock/live labels.
+- `passport verify` succeeds on generated capsule.
+- `passport explain` produces a concise human explanation.
+- Production-shaped runner writes capsules into its artifact directory.
+
+**Verification:**
+
+- Full Rust matrix.
+- `bash demo-scripts/run-production-shaped-mock.sh`
+- `python3 scripts/validate_schemas.py`
+
+**Risk:** duplicating audit-bundle logic. Prefer wrapping existing export
+and verify components, not reimplementing cryptography.
+
+### P2.2 - Capsule Panels In Static Proof Surfaces
+
+**Owner:** Developer B.
+
+**Why:** a capsule that only exists as JSON is too technical. It needs to
+be visible in the surfaces judges already understand.
+
+**Primary files:**
+
+- `trust-badge/build.py`
+- `trust-badge/test_build.py`
+- `operator-console/build.py`
+- `operator-console/test_build.py`
+- `operator-console/fixtures/operator-summary.json`
+- `trust-badge/README.md`
+- `operator-console/README.md`
+
+**Acceptance criteria:**
+
+- Trust badge can display one capsule summary.
+- Operator console has a Passport panel:
+  - ENS name/records;
+  - active policy hash;
+  - decision result;
+  - execution ref and mock/live status;
+  - audit checkpoint;
+  - offline verification result.
+- Static surfaces remain no-JS/no-fetch/no-external-assets.
+- Failure states are explicit.
+- Tests assert the capsule schema and no-network posture.
+
+**Verification:**
+
+- `python3 trust-badge/build.py`
+- `python3 trust-badge/test_build.py`
+- `python3 operator-console/build.py`
+- `python3 operator-console/test_build.py`
+
+## Phase 3: MCP Product Interface
+
+### P3.1 - Functional `mandate-mcp` Stdio Server
+
+**Owner:** Developer A.
+
+**Why:** KeeperHub explicitly values MCP/CLI/API, and MCP turns Mandate
+from a daemon into infrastructure other agents can call.
+
+**Primary files:**
+
+- `crates/mandate-mcp/Cargo.toml`
+- `crates/mandate-mcp/src/main.rs`
+- `crates/mandate-mcp/src/lib.rs`
+- `crates/mandate-mcp/tests/*`
+- `docs/cli/mcp.md`
+- `demo-scripts/sponsors/mcp-passport.sh`
+
+**MVP tools:**
+
+- `mandate.validate_aprp`
+- `mandate.decide`
+- `mandate.run_guarded_execution`
+- `mandate.verify_capsule`
+- `mandate.explain_denial`
+
+**Acceptance criteria:**
+
+- Server runs over stdio.
+- Tools use existing Mandate libraries/CLI logic.
+- Tests drive the server with JSON-RPC messages.
+- Demo script performs one allow and one deny through MCP.
+- MCP output includes the same capsule/verifier truth as CLI.
+
+**Verification:**
+
+- Rust matrix.
+- New MCP demo script.
+- Final demo remains 13/13 unless deliberately extended with a new
+  clearly named optional gate.
+
+**Risk:** MCP SDK churn. If Rust SDK is too unstable, implement minimal
+stdio JSON-RPC for the required tool calls and document the protocol.
+
+### P3.2 - MCP Integration Guide And Demo Copy
+
+**Owner:** Developer B.
+
+**Primary files:**
+
+- `docs/cli/mcp.md`
+- `README.md`
+- `SUBMISSION_NOTES.md`
+- `docs/product/REWARD_STRATEGY.md`
+- `demo-scripts/demo-video-script.md`
+
+**Acceptance criteria:**
+
+- A judge can understand how to call Mandate from an agent tool.
+- KeeperHub narrative says "MCP-callable policy gateway" truthfully.
+- Demo video script includes a 20-second MCP moment.
+- No claim that KeeperHub's MCP server is being called unless it is.
+
+## Phase 4: ENS Passport Discovery
+
+### P4.1 - ENS Passport Resolver Records
+
+**Owner:** Developer A.
+
+**Why:** ENS must do real work. It should discover Mandate proof
+metadata, not just decorate a page.
+
+**Primary files:**
+
+- `crates/mandate-identity/src/*`
+- `crates/mandate-cli/src/passport.rs`
+- `crates/mandate-cli/tests/passport_cli.rs`
+- `demo-fixtures/mock-ens-registry.json`
+- `demo-fixtures/mock-ens-registry.md`
+- `docs/cli/passport.md`
+
+**Target records:**
+
+- `mandate:mcp_endpoint`
+- `mandate:policy_hash`
+- `mandate:audit_root`
+- `mandate:passport_schema`
+- `mandate:proof_uri`
+- `mandate:keeperhub_workflow`
+
+**Acceptance criteria:**
+
+- Offline resolver returns all records.
+- Resolver detects missing/mismatched policy hash.
+- Capsule records source as `offline-fixture`.
+- Optional live resolver remains gated and is not required for CI.
+- Tests prove no hard-coded ENS values in the product path beyond named
+  fixtures.
+
+**Verification:**
+
+- Rust matrix.
+- `python3 demo-fixtures/test_fixtures.py`
+- Passport CLI tests.
+
+### P4.2 - ENS One-Pager And UI Proof
+
+**Owner:** Developer B.
+
+**Primary files:**
+
+- `docs/product/REWARD_STRATEGY.md`
+- `docs/partner-onepagers/ens.md`
+- `operator-console/build.py`
+- `trust-badge/build.py`
+- `SUBMISSION_NOTES.md`
+
+**Acceptance criteria:**
+
+- One-pager explains why ENS improves discovery and identity.
+- UI shows ENS records as functional proof.
+- Copy explicitly says offline fixture unless live resolver lands.
+- Submission answer can point to ENS record names and values.
+
+## Phase 5: KeeperHub Proof Handoff
+
+### P5.1 - KeeperHub Proof Handoff Envelope
+
+**Owner:** Developer A.
+
+**Why:** this is the strongest KeeperHub move short of real credentials.
+Mandate should prove exactly what a live KeeperHub integration needs.
+
+**Primary files:**
+
+- `crates/mandate-execution/src/keeperhub.rs`
+- `crates/mandate-execution/tests/*`
+- `docs/keeperhub-live-spike.md`
+- `FEEDBACK.md`
+- `docs/cli/passport.md`
+
+**Target envelope fields:**
+
+- `mandate_request_hash`
+- `mandate_policy_hash`
+- `mandate_receipt_signature`
+- `mandate_audit_event_id`
+- `mandate_passport_capsule_hash`
+
+**Acceptance criteria:**
+
+- Mock/live target envelope builder exists.
+- In-process mock HTTP server test asserts every field.
+- Denied receipt still refuses before any I/O.
+- Live config reads env but is not used by default.
+- Missing env fails closed.
+- No secrets in repo.
+
+**Verification:**
+
+- Rust matrix.
+- `git grep` for known secret prefixes.
+- Production-shaped runner still defaults to mock.
+
+**Optional stretch:** if real KeeperHub credentials/workflow exist,
+add a separately gated smoke script:
+
+```bash
+MANDATE_KEEPERHUB_LIVE=1 bash demo-scripts/sponsors/keeperhub-live-smoke.sh
+```
+
+CI must never require it.
+
+### P5.2 - KeeperHub Feedback, Issue, And One-Pager
+
+**Owner:** Developer B.
+
+**Primary files:**
+
+- `FEEDBACK.md`
+- `docs/partner-onepagers/keeperhub.md`
+- `SUBMISSION_NOTES.md`
+- `SUBMISSION_FORM_DRAFT.md`
+
+**Acceptance criteria:**
+
+- Feedback has specific, actionable requests:
+  - submission/result schema;
+  - execution id lookup;
+  - upstream policy fields;
+  - idempotency semantics;
+  - webhook signing;
+  - MCP status tool.
+- One-pager tells the story:
+  "KeeperHub executes; Mandate proves the authorization."
+- If GitHub issues are filed externally, links are added.
+- If Discord engagement happens, summary is added without claiming
+  private info.
+
+## Phase 6: Uniswap Guarded Finance
+
+### P6.1 - Uniswap Quote Evidence In Passport Capsule
+
+**Owner:** Developer A.
+
+**Why:** Uniswap reward cares about agentic finance. Mandate should show
+that an agent can request a swap but cannot exceed policy.
+
+**Primary files:**
+
+- `crates/mandate-execution/src/uniswap.rs`
+- `crates/mandate-cli/src/passport.rs`
+- `crates/mandate-cli/tests/passport_cli.rs`
+- `demo-fixtures/mock-uniswap-quotes.json`
+- `demo-fixtures/mock-uniswap-quotes.md`
+- `demo-scripts/sponsors/uniswap-guarded-swap.sh`
+
+**Acceptance criteria:**
+
+- Capsule includes quote evidence:
+  - quote id/source;
+  - input/output token;
+  - route token list if available;
+  - notional;
+  - slippage cap;
+  - quote timestamp/freshness result;
+  - recipient check;
+  - deny reasons when denied.
+- At least one allow and one multi-violation deny fixture.
+- Live Trading API path remains optional and gated unless credentials
+  and stable endpoint are available.
+- FEEDBACK.md can cite real friction from the implementation.
+
+**Verification:**
+
+- Rust matrix.
+- Fixture validator.
+- Uniswap sponsor script.
+- Passport verifier.
+
+### P6.2 - Uniswap Feedback And One-Pager
+
+**Owner:** Developer B.
+
+**Primary files:**
+
+- `FEEDBACK.md`
+- `docs/partner-onepagers/uniswap.md`
+- `SUBMISSION_FORM_DRAFT.md`
+
+**Acceptance criteria:**
+
+- FEEDBACK.md remains present at repo root.
+- Uniswap section names concrete API wishes:
+  - signed quote id;
+  - expires_at;
+  - route token enumeration;
+  - slippage cap semantics;
+  - canonical quote hash.
+- One-pager frames Mandate as a safety layer for agentic swaps.
+- Submission copy does not imply a real Uniswap swap unless P6.1 ships a
+  live path.
+
+## Phase 7: Public Proof And Submission Freeze
+
+### P7.1 - GitHub Pages Public Proof Site
+
+**Owner:** Developer B.
+
+**Why:** judges need a click target.
+
+**Primary files:**
+
+- `.github/workflows/pages.yml`
+- `README.md`
+- `SUBMISSION_FORM_DRAFT.md`
+- `trust-badge/*`
+- `operator-console/*`
+- `docs/product/*`
+
+**Acceptance criteria:**
+
+- Static proof site deploys from main.
+- Site includes trust badge, operator console, one selected capsule JSON,
+  and a short README.
+- No secrets, no runtime server, no external JS.
+- README has a "Verify the demo" link.
+- Submission form has public URL.
+
+**Verification:**
+
+- GitHub Pages workflow green.
+- Open URL manually.
+- Check static HTML for no external fetches/scripts.
+
+### P7.2 - Final Smoke, Video, Submission Freeze
+
+**Owner:** Developer A + Developer B.
+
+**Acceptance criteria:**
+
+- Fresh clone smoke:
+  - full verification matrix green;
+  - no untracked required artifacts;
+  - public proof URL works.
+- Demo video recorded and under required length.
+- Submission form has:
+  - video URL;
+  - live/static proof URL;
+  - GitHub repo URL;
+  - prize-specific wording.
+- No open blocker PRs.
+- Open PRs are either merged or explicitly out of submission scope.
+
+**Freeze rule:** after video recording, only fix blockers or copy errors
+that would mislead judges. Do not add features after the recording unless
+you are willing to re-record.
+
+## Optional Stretch: 0G And Gensyn Without Core Risk
+
+These are only allowed if Phases 0-7 are stable.
+
+### O1 - 0G Proof Capsule Storage
+
+**Owner:** Developer A, B supports docs.
+
+**Scope:** upload capsule JSON or audit bundle to 0G Storage and record
+the returned reference in the public proof page.
+
+**Hard guard:** no changes to core verifier semantics. The capsule must
+verify offline even if 0G is unavailable.
+
+### O2 - Gensyn AXL Capsule Verification Demo
+
+**Owner:** Developer A, B supports narrative.
+
+**Scope:** two local agents communicate through AXL; one asks the other
+to verify a Mandate capsule.
+
+**Hard guard:** no centrality claim. This is a communication transport
+demo, not a replacement for Mandate proof.
+
+## Developer A Daily Loop
+
+1. Pull latest main.
+2. Check open PRs and unresolved review threads.
+3. Pick next A-owned PR whose dependencies are merged.
+4. Keep write scope to Rust/CLI/schema/demo script for that PR.
+5. Run required matrix.
+6. Push one focused PR.
+7. Stop after reporting CI/head SHA/review state.
+
+## Developer B Daily Loop
+
+1. Pull latest main.
+2. Check whether A-owned dependency PRs have merged.
+3. If dependency is not merged, work only on docs/fixtures that are
+   explicitly labelled target/future, not implementation claims.
+4. If dependency is merged, update proof surfaces and submission copy.
+5. Run static UI/docs verification.
+6. Push one focused PR.
+7. Stop after reporting CI/head SHA/review state.
+
+## Night Automation Prompt For Developer B
+
+Use this when Developer B should wait for an upstream PR before starting
+final/submission work:
+
+```text
+You are Developer B on Mandate. Do not start final submission wiring
+until the currently active upstream PR has merged into main and post-merge
+CI is green.
+
+Loop:
+1. Poll main and open PR state.
+2. If the upstream PR is still open, do not edit files. Report only if CI
+   fails, mergeability changes to conflict/dirty, or a new unresolved
+   review thread appears.
+3. Once the upstream PR is merged, fetch main, confirm post-merge CI
+   success, confirm open PRs are empty or only assigned to you, and then
+   branch from main.
+4. Run the pre-flight matrix relevant to B-side work.
+5. Start the next B-side task from docs/product/MANDATE_PASSPORT_BACKLOG.md.
+6. Never claim a backend is merged unless the commit is on main.
+7. Never flip mock/offline/live labels without evidence.
+8. Open a focused PR and stop for review.
+```
+
+## Definition Of Complete
+
+The backlog is complete when:
+
+- A judge can click a public proof page.
+- A developer can run an MCP tool and receive a Mandate decision.
+- A CLI user can produce and verify a passport capsule.
+- ENS records are visible as functional discovery metadata.
+- KeeperHub integration is either live or has a tested proof handoff
+  envelope with honest feedback.
+- Uniswap guard evidence appears in a capsule.
+- Submission docs map each feature to the right reward without
+  overclaiming.
+- Full verification matrix is green from a fresh clone.

--- a/docs/product/MANDATE_PASSPORT_SOURCE_OF_TRUTH.md
+++ b/docs/product/MANDATE_PASSPORT_SOURCE_OF_TRUTH.md
@@ -1,0 +1,541 @@
+# Mandate Passport Source of Truth
+
+**Status:** product target and implementation guide, not a claim that all
+future-state features exist today.
+
+**Baseline:** `main` after B5 final submission wiring (`8e48ec1`), with
+all A-side backend backlog items merged, B2.v2 operator-console
+real-evidence panels merged, and the submission baseline aligned.
+
+**Working title:** Mandate Passport.
+
+**Product line:** proof-carrying execution for AI agents.
+
+## One Sentence
+
+Mandate Passport gives every autonomous agent a portable, verifiable
+execution passport: ENS-discoverable identity, MCP-callable policy
+checks, KeeperHub execution handoff, Uniswap guarded finance, and an
+offline proof capsule showing exactly why each action was allowed or
+denied.
+
+## North Star
+
+Do not give an agent a wallet.
+
+Give it:
+
+- a public identity;
+- an active policy;
+- a budget boundary;
+- a replay/idempotency boundary;
+- a signed receipt for every decision;
+- an audit chain;
+- a checkpoint;
+- an execution handoff;
+- a portable proof capsule.
+
+That is the Mandate Passport.
+
+## What Exists Today
+
+Mandate already has the difficult substrate. The next product phase
+should compose these primitives instead of replacing them.
+
+| Primitive | Current state | Product role in Passport |
+|---|---|---|
+| APRP v1 | Strict wire format, canonical request hashing, schemas | The action request language every agent submits. |
+| Policy engine | Canonical policy hash, budget checks, allow/deny receipts | The authorization layer of the passport. |
+| Signed receipts | Ed25519 policy receipts and decision tokens | Portable proof that Mandate decided. |
+| Persistent nonce replay | SQLite-backed nonce claim | Prevents agent replay under normal retries. |
+| HTTP idempotency | Persistent safe-retry matrix | Prevents duplicate side effects under client retry. |
+| Audit chain | Hash-chained SQLite audit log | Tamper-evident execution history. |
+| Audit bundle | Offline export and verifier | Portable proof of one decision. |
+| Active policy lifecycle | `mandate policy validate/current/activate/diff` | Operator can rotate and prove active policy state. |
+| Audit checkpoints | `mandate audit checkpoint create/verify` with mock anchor | Checkpoint artifact for chain prefix proof. |
+| Mock KMS | Persistent mock keyring CLI | Production-shaped signer lifecycle without overclaiming HSM. |
+| Doctor | `mandate doctor` readiness summary | Operator health check before proof generation. |
+| Trust badge | Static, offline proof viewer | Judge-facing proof page. |
+| Operator console | Static, offline operations surface | Operator-facing proof and readiness dashboard. |
+| ENS adapter | Offline fixture resolver | Agent identity/discovery model. |
+| KeeperHub adapter | `local_mock()` plus live-spike doc | Execution layer handoff model. |
+| Uniswap guard | Mock quote and guard checks | Agentic finance safety model. |
+| MCP crate | Placeholder | Natural product interface for agents and tools. |
+
+The Passport is a product wrapper over these pieces. It is not a rewrite.
+
+## Why This Wins
+
+The prize field rewards visible integrations, but most integrations are
+thin demos: an agent calls a sponsor API, gets a result, and puts it in a
+dashboard. Mandate should show something deeper:
+
+> Every sponsor call can carry a cryptographic explanation of why it was
+> allowed.
+
+That matters to all reward owners:
+
+- KeeperHub wants reliable execution infrastructure for agents. Mandate
+  provides the upstream authorization proof for every execution.
+- ENS wants identities that do real work. Mandate uses ENS records as
+  discovery for policy hash, audit root, MCP endpoint, and proof URI.
+- Uniswap wants agentic finance with transparency and real execution.
+  Mandate turns a swap into a guarded, receipt-backed financial action.
+- Builder Feedback wants specific, actionable product insight. Mandate's
+  proof-carrying handoff exposes exactly which KeeperHub, ENS, and
+  Uniswap fields are missing for first-class agent accountability.
+- Optional 0G/Gensyn tracks care about frameworks and agent
+  infrastructure. Mandate can frame Passport capsules as portable agent
+  memory/proof objects without destabilizing the core.
+
+Official source links checked for this plan:
+
+- ETHGlobal Open Agents prizes: <https://ethglobal.com/events/openagents/prizes>
+- KeeperHub MCP docs: <https://docs.keeperhub.com/ai-tools/mcp-server>
+- Uniswap Trading API integration guide: <https://developers.uniswap.org/docs/trading/swapping-api/integration-guide>
+- ENS resolution and text-record docs: <https://docs.ens.domains/web/resolution/> and <https://docs.ens.domains/web/records/>
+
+## Product Positioning
+
+### The Short Pitch
+
+Mandate Passport is the proof layer for autonomous execution. Agents ask
+for actions; Mandate decides; KeeperHub executes; ENS publishes identity;
+Uniswap settles value; the operator gets a portable proof capsule.
+
+### The Judge Pitch
+
+Most hackathon demos show that an agent can act. Mandate shows whether an
+agent was authorized to act, under which policy, against which budget,
+with which nonce/idempotency boundary, and with an audit trail that still
+verifies offline after the demo ends.
+
+### The Sponsor Pitch
+
+Sponsor infrastructure becomes more valuable when execution logs can be
+linked to upstream authorization receipts. Mandate gives KeeperHub,
+Uniswap, and ENS a common proof envelope for agent actions.
+
+### The Operator Pitch
+
+You can let agents operate without giving them wallets or blind API
+power. Every allowed action has a signed receipt; every denied action has
+a reason; every execution can be checkpointed and exported.
+
+## Product Vocabulary
+
+| Term | Meaning |
+|---|---|
+| Agent passport | ENS-visible identity plus Mandate policy and proof metadata for an agent. |
+| Passport capsule | JSON artifact containing one decision, execution handoff, audit proof, checkpoint, and resolver metadata. |
+| Proof-carrying execution | An execution request that includes a signed upstream authorization proof, not just an opaque API call. |
+| Mandate endpoint | The MCP/API surface an agent calls to request a decision. |
+| Active policy | The policy currently activated in Mandate storage via PSM-A3. |
+| Audit root | Current audit-chain/checkpoint commitment exposed to operators and optionally ENS. |
+| Execution ref | Sponsor-native reference such as KeeperHub `executionId` or Uniswap quote/swap id. |
+| Mock anchor | Local deterministic checkpoint id, explicitly not onchain. |
+
+## The Product Contract
+
+Mandate Passport promises four things and no more:
+
+1. **Identity:** the agent can be found and inspected by a stable name.
+2. **Authorization:** every action is checked against an active policy.
+3. **Execution handoff:** allowed actions can be handed to an executor.
+4. **Proof:** a third party can verify the decision and audit evidence.
+
+Any feature that does not strengthen one of these four promises is lower
+priority for this hackathon.
+
+## Production User Journeys
+
+### Journey 1: Agent Developer Integrates Mandate
+
+1. Developer installs/runs `mandate-mcp`.
+2. Developer configures the agent to call `mandate.run_guarded_execution`
+   before any value-moving action.
+3. Agent sends APRP JSON, desired executor, idempotency key, and optional
+   ENS name.
+4. Mandate returns either:
+   - deny receipt with no sponsor call; or
+   - allow receipt plus execution handoff result.
+5. Developer stores the returned passport capsule with the agent's run.
+
+Success condition: the agent can operate through Mandate without holding
+signing keys.
+
+### Journey 2: Operator Publishes Agent Passport
+
+1. Operator activates a policy with `mandate policy activate`.
+2. Operator runs `mandate doctor --json`.
+3. Operator creates an audit checkpoint.
+4. Operator publishes ENS text records:
+   - `mandate:mcp_endpoint`
+   - `mandate:policy_hash`
+   - `mandate:audit_root`
+   - `mandate:passport_schema`
+   - `mandate:proof_uri`
+   - `mandate:keeperhub_workflow`
+5. Operator renders trust badge and operator console.
+
+Success condition: a judge can resolve the name, compare the policy hash,
+open the proof, and see consistent values.
+
+### Journey 3: KeeperHub Executes With Upstream Proof
+
+1. Agent asks Mandate to execute a KeeperHub action.
+2. Mandate validates APRP, idempotency key, nonce, policy, and budget.
+3. If deny: Mandate writes audit event and refuses to call KeeperHub.
+4. If allow: Mandate sends KeeperHub a workflow request with:
+   - APRP body;
+   - policy receipt;
+   - request hash;
+   - policy hash;
+   - receipt signature;
+   - audit event id.
+5. KeeperHub returns `executionId`.
+6. Mandate records the execution ref and builds a passport capsule.
+
+Success condition: a KeeperHub run is cryptographically linkable to the
+Mandate decision that allowed it.
+
+### Journey 4: Uniswap Guarded Swap
+
+1. Agent asks to swap using Uniswap.
+2. Mandate resolves or receives a quote.
+3. Swap guard enforces:
+   - token allowlist;
+   - recipient allowlist;
+   - max notional;
+   - max slippage;
+   - quote freshness;
+   - active policy hash.
+4. If deny: no swap handoff.
+5. If allow: execution ref and quote metadata enter the passport capsule.
+
+Success condition: the judge sees not just that a quote happened, but why
+the agent was allowed to use it.
+
+### Journey 5: Auditor Verifies Offline
+
+1. Auditor downloads `mandate.passport_capsule.v1`.
+2. Auditor runs `mandate passport verify capsule.json`.
+3. Verifier checks:
+   - schema;
+   - receipt signature;
+   - request hash;
+   - policy hash;
+   - audit event id;
+   - audit-chain prefix;
+   - checkpoint;
+   - execution ref consistency.
+4. Auditor can inspect the same evidence in static HTML without network.
+
+Success condition: the proof survives outside the running demo.
+
+## Future Data Model
+
+### `mandate.passport_capsule.v1`
+
+The passport capsule is additive. It should be built from existing
+receipt/audit/bundle/checkpoint artifacts, not by inventing parallel
+truth.
+
+```json
+{
+  "schema": "mandate.passport_capsule.v1",
+  "generated_at": "2026-04-29T00:00:00Z",
+  "agent": {
+    "agent_id": "research-agent",
+    "ens_name": "research-agent.team.eth",
+    "resolver": "offline-fixture|live-ens",
+    "records": {
+      "mandate:mcp_endpoint": "https://...",
+      "mandate:policy_hash": "e044f13c...",
+      "mandate:audit_root": "local-mock-anchor-...",
+      "mandate:passport_schema": "mandate.passport_capsule.v1",
+      "mandate:proof_uri": "https://...",
+      "mandate:keeperhub_workflow": "..."
+    }
+  },
+  "request": {
+    "aprp": {},
+    "request_hash": "c0bd2fab...",
+    "idempotency_key": "demo-key-1",
+    "nonce": "..."
+  },
+  "policy": {
+    "policy_hash": "e044f13c...",
+    "policy_version": 1,
+    "activated_at": "2026-04-29T00:00:00Z",
+    "source": "reference_low_risk.json"
+  },
+  "decision": {
+    "result": "allow",
+    "matched_rule": "allow-low-risk-x402",
+    "deny_code": null,
+    "receipt": {},
+    "receipt_signature": "..."
+  },
+  "execution": {
+    "executor": "keeperhub|uniswap|none",
+    "mode": "mock|live",
+    "execution_ref": "kh-...",
+    "status": "submitted|succeeded|denied|not_called",
+    "sponsor_payload_hash": "..."
+  },
+  "audit": {
+    "audit_event_id": "evt-...",
+    "prev_event_hash": "...",
+    "event_hash": "...",
+    "bundle_ref": "mandate.audit_bundle.v1",
+    "checkpoint": {
+      "schema": "mandate.audit_checkpoint.v1",
+      "sequence": 2,
+      "chain_digest": "...",
+      "mock_anchor": true,
+      "mock_anchor_ref": "local-mock-anchor-..."
+    }
+  },
+  "verification": {
+    "doctor_status": "ok|warn|skip|fail",
+    "offline_verifiable": true,
+    "live_claims": []
+  }
+}
+```
+
+Required invariants:
+
+- `decision.result == "deny"` implies `execution.status == "not_called"`.
+- `execution.mode == "live"` is forbidden unless the capsule contains a
+  real network response reference.
+- `audit.checkpoint.mock_anchor == true` must be rendered as mock, not
+  onchain.
+- ENS records must be source-labelled as `offline-fixture` or `live-ens`.
+- Any unsupported field must fail schema validation once the capsule
+  schema lands.
+
+## Future CLI Surface
+
+The CLI should feel like a product, not a pile of scripts.
+
+```bash
+# Resolve an agent passport from ENS/offline fixture.
+mandate passport resolve research-agent.team.eth \
+  --resolver offline-fixture \
+  --fixture demo-fixtures/mock-ens-registry.json
+
+# Run an APRP action through Mandate and emit one proof capsule.
+mandate passport run test-corpus/aprp/legit-x402.json \
+  --agent research-agent.team.eth \
+  --executor keeperhub \
+  --mode mock \
+  --db /tmp/mandate.db \
+  --out artifacts/capsule.json
+
+# Verify a capsule offline.
+mandate passport verify artifacts/capsule.json
+
+# Produce human-readable explanation for judges/operators.
+mandate passport explain artifacts/capsule.json
+```
+
+### CLI Exit Codes
+
+| Command | Exit | Meaning |
+|---|---:|---|
+| `passport resolve` | 0 | Agent identity resolved and required records present. |
+| `passport resolve` | 2 | Required record missing or mismatched. |
+| `passport run` | 0 | Decision completed and capsule written. |
+| `passport run` | 3 | Denied by policy; capsule still written if `--write-deny-capsule` is set. |
+| `passport run` | 4 | Idempotency conflict or nonce replay. |
+| `passport verify` | 0 | Capsule verifies. |
+| `passport verify` | 2 | Capsule is malformed, tampered, or internally inconsistent. |
+
+## Future MCP Surface
+
+The MCP implementation is the highest-leverage product surface because it
+lets other agents and IDEs call Mandate directly.
+
+Target tools:
+
+| Tool | Input | Output | Product value |
+|---|---|---|---|
+| `mandate.resolve_passport` | ENS name or fixture id | Agent records + policy hash + proof URI | ENS does real discovery work. |
+| `mandate.validate_aprp` | APRP JSON | schema/hash result | Agent can preflight before asking to execute. |
+| `mandate.decide` | APRP JSON + policy db | allow/deny receipt | Pure authorization with no side effects. |
+| `mandate.run_guarded_execution` | APRP + executor + idempotency key | passport capsule | Full proof-carrying execution. |
+| `mandate.verify_capsule` | capsule JSON | verification result | Any client can audit a prior run. |
+| `mandate.explain_denial` | deny receipt/capsule | concise human explanation | Helps agent recover safely. |
+
+MCP must call existing Mandate code and CLI surfaces where practical. It
+must not reimplement policy logic in an MCP-only path.
+
+## Future API Surface
+
+The HTTP daemon should remain lean. The product should add endpoints only
+when they are proof-bearing:
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /v1/health` | Existing public health. |
+| `POST /v1/payment-requests` | Existing APRP decision pipeline. |
+| `POST /v1/passport/run` | Optional wrapper that returns a capsule. |
+| `GET /v1/passport/:id` | Public read-only capsule lookup in deployed demo. |
+| `GET /v1/audit/checkpoints/latest` | Public read-only latest checkpoint. |
+
+Do not turn the daemon into a marketing website. The proof viewers should
+remain static.
+
+## UI/Proof Surfaces
+
+### Trust Badge
+
+Audience: judge, sponsor, first-click reviewer.
+
+It should answer in 10 seconds:
+
+- Which agent?
+- Which policy?
+- Which decision?
+- Which sponsor execution?
+- Was denied action prevented?
+- Is this mock/live?
+- Can I verify it offline?
+
+### Operator Console
+
+Audience: operator, auditor, deeper technical judge.
+
+It should show:
+
+- active policy lifecycle;
+- idempotency matrix;
+- doctor state;
+- mock KMS keyring state;
+- audit checkpoint create/verify;
+- KeeperHub execution ref;
+- Uniswap quote/swap guard evidence;
+- ENS passport records;
+- capsule verification result.
+
+### Public Demo Page
+
+Audience: everyone.
+
+This can be GitHub Pages hosting of static artifacts only:
+
+- `trust-badge/index.html`
+- `operator-console/index.html`
+- selected capsule JSON
+- README links
+
+No live database needs to be exposed for the first shipping version.
+
+## Reward Mapping
+
+| Reward owner | What they care about | Passport feature that makes them feel seen |
+|---|---|---|
+| KeeperHub | Reliable agent execution, MCP/CLI/API, audit trails, utility | KeeperHub receives Mandate receipt fields; MCP tool wraps execution; capsule links `executionId` to authorization. |
+| ENS | Agent identity, discovery, metadata, functional demo | ENS text records discover Mandate endpoint, policy hash, audit root, proof URI. |
+| Uniswap | Agentic finance with transparency and API integration | Guarded quote/swap proof, slippage/notional/recipient checks, FEEDBACK grounded in API needs. |
+| 0G | Framework/tooling/core extensions deployed on 0G | Optional capsule storage backend or proof registry, not core dependency. |
+| Gensyn | Agent-to-agent communication over AXL | Optional AXL transport for one agent asking another to verify a capsule. |
+| Builder Feedback | Specific friction and actionable asks | FEEDBACK updates based on real integration attempts, not generic praise. |
+
+## Truthfulness Rules
+
+These are product laws, not suggestions:
+
+1. A mock is always labelled as mock in CLI, JSON, HTML, README, and
+   submission text.
+2. A denied action never calls a sponsor executor.
+3. Live mode never falls back to mock mode.
+4. ENS fixture mode never claims to be live ENS.
+5. Mock audit anchoring never claims onchain finality.
+6. Static proof viewers never fetch network resources.
+7. If a proof value is malformed, the UI renders failure, not omission.
+8. If a schema bumps, all guards/tests/docs move in the same PR.
+9. Sponsor-specific features must be useful even if that sponsor is not
+   awarding us: the product must remain coherent.
+
+## Non-Goals For This Hackathon Phase
+
+- Rewriting APRP.
+- Rewriting the audit chain.
+- Replacing the trust badge with a marketing landing page.
+- Shipping fake live integrations.
+- Giving agents signing keys.
+- Building a full hosted SaaS.
+- Building ZK proofs.
+- Building a real onchain anchoring protocol.
+- Building a complex Uniswap v4 hook.
+- Chasing every prize at the cost of the core story.
+
+## Architecture Target
+
+```text
+Agent / MCP client
+        |
+        v
+Mandate MCP / CLI / HTTP
+        |
+        +-- APRP schema + canonical hash
+        +-- idempotency + nonce replay
+        +-- active policy lookup
+        +-- budget / recipient / sponsor guard
+        +-- signed policy receipt
+        +-- audit event + checkpoint
+        |
+        +--> KeeperHub executor      (mock by default, live optional)
+        +--> Uniswap quote/executor  (mock by default, live optional)
+        |
+        v
+mandate.passport_capsule.v1
+        |
+        +-- trust badge
+        +-- operator console
+        +-- audit bundle verifier
+        +-- ENS proof records
+```
+
+## Production Deployment Target
+
+The production-shaped version should support three deployment modes:
+
+| Mode | Purpose | Required properties |
+|---|---|---|
+| Offline local | Judging, demos, CI | deterministic, no secrets, no network, all mocks labelled. |
+| Public proof | GitHub Pages / static hosting | static HTML + capsule JSON, no server trust required. |
+| Live operator | Real partner integration | env-only secrets, live modes explicit, no mock fallback, rate limits. |
+
+Production-ready later means:
+
+- real KMS/HSM signer backend;
+- managed SQLite/Postgres storage;
+- authenticated operator console;
+- real ENS resolver;
+- KeeperHub live workflow handoff;
+- Uniswap live quote/swap path;
+- optional onchain or 0G proof publication;
+- alerting and retention.
+
+For the hackathon, the strongest move is not pretending all of that
+exists. The strongest move is showing the production path with honest
+proof boundaries.
+
+## Definition Of Done For Passport MVP
+
+The Passport MVP is complete when a judge can do this:
+
+1. Open a public proof URL.
+2. See an ENS-named agent.
+3. See the active policy hash.
+4. See one allowed KeeperHub-style execution and one denied action.
+5. See a Uniswap guarded swap or quote decision.
+6. Download a capsule JSON.
+7. Run `mandate passport verify capsule.json`.
+8. See that all mock/live labels are honest.
+9. Understand in under one minute why Mandate is infrastructure, not just
+   another agent demo.

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -1,0 +1,58 @@
+# Mandate Passport Product Plan
+
+This folder is the product-planning layer for the next Mandate phase.
+It does not replace the implemented submission surface. It explains how
+the already-built Mandate primitives should compose into one coherent
+hackathon-winning product:
+
+> Mandate Passport: proof-carrying execution for AI agents.
+
+The current implementation already has the hard substrate: APRP,
+policy decisions, signed receipts, persistent replay protection,
+active policy lifecycle, mock KMS, doctor, audit checkpoints, audit
+bundles, trust badge, operator console, and sponsor-facing adapters.
+The next phase is packaging those pieces into a product that prize
+judges can understand, use, and map directly to their own goals.
+
+## Documents
+
+| Document | Purpose |
+|---|---|
+| [`MANDATE_PASSPORT_SOURCE_OF_TRUTH.md`](MANDATE_PASSPORT_SOURCE_OF_TRUTH.md) | Single source of truth for the product vision, future production state, data model, user journeys, and non-goals. |
+| [`MANDATE_PASSPORT_BACKLOG.md`](MANDATE_PASSPORT_BACKLOG.md) | Detailed two-developer execution backlog. PR sequence, owners, acceptance criteria, verification, and merge gates. |
+| [`REWARD_STRATEGY.md`](REWARD_STRATEGY.md) | Prize-by-prize strategy for KeeperHub, ENS, Uniswap, Builder Feedback, and optional 0G/Gensyn reach. |
+| [`TWO_DEVELOPER_EXECUTION_PROTOCOL.md`](TWO_DEVELOPER_EXECUTION_PROTOCOL.md) | Operating protocol for Developer A + Developer B working continuously without breaking the existing product. |
+
+## Product Thesis
+
+Most teams are building agents. Mandate should be the infrastructure an
+agent must pass through before it can move value:
+
+1. ENS tells the world which agent this is and which policy/audit roots
+   define its public mandate.
+2. MCP lets any agent, IDE, or orchestration framework ask Mandate for a
+   decision.
+3. Mandate produces a signed policy receipt and a tamper-evident audit
+   trail.
+4. KeeperHub executes only after Mandate has allowed the action.
+5. Uniswap swaps are quote-checked, budget-checked, and recipient-checked
+   before execution.
+6. The whole thing is exported as a portable proof capsule a judge can
+   inspect offline.
+
+Short version:
+
+> KeeperHub executes. ENS discovers. Uniswap settles. Mandate proves the
+> action was authorized.
+
+## Discipline
+
+This plan is additive. It must not weaken the current submission-grade
+surface:
+
+- The existing 13-gate demo remains green.
+- The production-shaped mock runner remains deterministic by default.
+- Offline static trust badge and operator console remain file-safe.
+- Mocks stay labelled as mocks until a real network call exists.
+- The APRP wire format, audit bundle, and receipt semantics stay stable
+  unless a schema bump is explicit and tested in lockstep.

--- a/docs/product/REWARD_STRATEGY.md
+++ b/docs/product/REWARD_STRATEGY.md
@@ -1,0 +1,370 @@
+# Mandate Passport Reward Strategy
+
+**Purpose:** align the Mandate Passport product story with multiple
+ETHGlobal Open Agents reward surfaces without diluting the core product.
+
+**Principle:** build one product that naturally touches multiple rewards,
+not five disconnected prize hacks.
+
+## Core Reward Story
+
+Every sponsor in the Open Agents landscape is trying to answer a version
+of the same question:
+
+> What happens when agents can act with real authority?
+
+Mandate's answer:
+
+> Agents should not get raw authority. They should get proof-carrying
+> execution.
+
+Mandate Passport turns sponsor integrations into a single accountable
+execution flow:
+
+```text
+ENS names the agent
+MCP lets the agent ask for authority
+Mandate decides and signs the receipt
+KeeperHub executes allowed actions
+Uniswap handles guarded finance
+Audit bundle/checkpoint proves what happened
+Trust badge/operator console makes it visible
+```
+
+This is the story that should appear everywhere:
+
+> KeeperHub executes. ENS discovers. Uniswap settles. Mandate proves the
+> action was authorized.
+
+## Prize-by-Prize Mapping
+
+| Reward surface | What the reward owner wants | Mandate Passport answer | Proof artifact |
+|---|---|---|---|
+| KeeperHub | Real utility for agent execution, MCP/CLI/API usage, workflow value | Mandate is the policy gateway before KeeperHub execution; every KeeperHub run can carry Mandate receipt fields. | KeeperHub handoff envelope + `executionId` in passport capsule + MCP tool. |
+| ENS | Identity, discovery, coordination, gating, metadata that matters | ENS records publish policy hash, audit root, MCP endpoint, proof URI, and workflow id. | ENS passport panel + resolver verification. |
+| Uniswap | Agentic finance, API integration, transparent quote/swap decisions | Mandate guards swaps by token, recipient, notional, slippage, freshness, and policy. | Quote/swap evidence in passport capsule + FEEDBACK.md. |
+| Builder Feedback | Specific product feedback from real integration work | Mandate names missing schema/headers/status lookup/quote semantics as concrete asks. | FEEDBACK.md + linked issues/Discord follow-up. |
+| 0G optional | Framework/tool/core-extension usage with agent relevance | Store capsule/bundle as optional proof object, never required for verification. | Optional storage ref in capsule. |
+| Gensyn optional | Agent-to-agent coordination and framework use | One agent asks another to verify a capsule through AXL. | Optional AXL demo transcript. |
+
+## KeeperHub Strategy
+
+### Desired Judge Reaction
+
+"This is not just another agent using KeeperHub. This is the missing
+authorization layer that makes KeeperHub executions auditable."
+
+### Product Angle
+
+KeeperHub should be framed as the execution layer. Mandate should be the
+proof layer in front of it.
+
+Key line:
+
+> Mandate decides; KeeperHub executes; the passport capsule proves both
+> sides line up.
+
+### Features That Matter
+
+1. **MCP-callable Mandate gateway.**
+   - Agents can call `mandate.run_guarded_execution` from an MCP client.
+   - This maps directly to KeeperHub's MCP/agent tooling narrative.
+
+2. **Proof handoff envelope.**
+   - Every KeeperHub call can carry:
+     - `mandate_request_hash`
+     - `mandate_policy_hash`
+     - `mandate_receipt_signature`
+     - `mandate_audit_event_id`
+     - `mandate_passport_capsule_hash`
+
+3. **Denied actions never reach KeeperHub.**
+   - This is a high-signal demo moment.
+   - Show allow path and deny path side by side.
+
+4. **ExecutionId reconciliation.**
+   - Store KeeperHub `executionId`/execution ref in the capsule.
+   - Render it next to the receipt signature and audit event.
+
+5. **Builder Feedback that feels earned.**
+   - Ask KeeperHub for public submission/result schema.
+   - Ask for execution status lookup by `executionId`.
+   - Ask for upstream proof fields in workflow logs.
+   - Ask for webhook signing/idempotency semantics.
+
+### What Not To Claim
+
+- Do not claim live KeeperHub execution unless a real network call
+  happened against a KeeperHub endpoint.
+- Do not call a mock `execution_ref` a real `executionId`.
+- Do not imply KeeperHub verifies Mandate receipts unless that code or
+  workflow exists.
+
+### Best Demo Segment
+
+1. Agent requests allowed action.
+2. Mandate signs allow receipt.
+3. KeeperHub executor receives proof envelope.
+4. Capsule shows execution ref.
+5. Prompt-injection action is denied and never calls executor.
+
+The reason this lands: it validates KeeperHub's execution thesis while
+showing a missing upstream trust boundary.
+
+## ENS Strategy
+
+### Desired Judge Reaction
+
+"ENS is not cosmetic here. It is how I find and verify an agent's
+mandate."
+
+### Product Angle
+
+ENS becomes the agent passport registry. It tells clients where to find
+the agent's Mandate endpoint, which policy is active, where the latest
+proof lives, and which audit root is expected.
+
+### Proposed Text Records
+
+| Record | Example | Why it matters |
+|---|---|---|
+| `mandate:mcp_endpoint` | `https://mandate-demo.../mcp` | Agents/tools know where to ask for decisions. |
+| `mandate:policy_hash` | `e044f13c...` | Prevents policy drift and hidden policy swaps. |
+| `mandate:audit_root` | `local-mock-anchor-...` or future real ref | Binds public identity to audit state. |
+| `mandate:passport_schema` | `mandate.passport_capsule.v1` | Clients know which verifier to use. |
+| `mandate:proof_uri` | `https://.../capsule.json` | Judge can click/download proof. |
+| `mandate:keeperhub_workflow` | `workflow-id-or-url` | Connects identity to execution workflow. |
+
+### Features That Matter
+
+1. **Resolver verification.**
+   - Mandate resolves ENS records and compares `mandate:policy_hash` to
+     active policy hash.
+
+2. **Drift detection.**
+   - If ENS says policy hash A but active Mandate policy is hash B, the
+     proof viewer must show failure.
+
+3. **Functional UI panel.**
+   - Trust badge/operator console should display the records and source
+     label (`offline-fixture` or `live-ens`).
+
+4. **No hard-coded proof.**
+   - Demo fixtures are acceptable if labelled. The product path should
+     still model real resolution.
+
+### What Not To Claim
+
+- Do not call the offline fixture live ENS.
+- Do not claim an ENS record exists on mainnet/testnet unless it does.
+- Do not imply ENS enforces policy. ENS publishes/discovers commitments;
+  Mandate enforces.
+
+### Best Demo Segment
+
+Resolve `research-agent.team.eth`, show `mandate:policy_hash`, then show
+the same hash in the active Mandate policy and receipt.
+
+The reason this lands: it turns ENS into a verification surface.
+
+## Uniswap Strategy
+
+### Desired Judge Reaction
+
+"This is a credible safety layer for agentic swaps, not just a quote API
+call."
+
+### Product Angle
+
+Autonomous agents should not be able to swap any token to any recipient
+at any slippage. Mandate turns Uniswap interaction into policy-controlled
+finance.
+
+### Features That Matter
+
+1. **Guarded quote/swap evidence.**
+   - Capsule includes token pair, route metadata, slippage cap, notional
+     cap, recipient check, and freshness result.
+
+2. **Allow and deny paths.**
+   - The allow path shows a safe quote.
+   - The deny path shows multiple violations such as disallowed token,
+     stale quote, or wrong recipient.
+
+3. **Quote hash.**
+   - Even with mock quotes, hash the quote evidence and bind it to the
+     receipt.
+
+4. **FEEDBACK.md specificity.**
+   - Ask for signed quote ids.
+   - Ask for `expires_at`.
+   - Ask for route token enumeration.
+   - Ask for canonical quote hash.
+   - Ask for clearer slippage cap semantics.
+
+### What Not To Claim
+
+- Do not claim a live swap unless a live transaction path exists.
+- Do not claim a live Trading API quote unless the API was called.
+- Do not chase Uniswap v4 hook depth unless there is enough time; Mandate
+  is a policy layer, not a DEX hook project.
+
+### Best Demo Segment
+
+Show a safe quote allowed, then a "rug route" denied before execution,
+with both results in the same passport capsule/proof UI.
+
+The reason this lands: it demonstrates agentic finance risk control.
+
+## Builder Feedback Strategy
+
+### Desired Judge Reaction
+
+"This team integrated deeply enough to find concrete product gaps."
+
+### Product Angle
+
+Mandate should write feedback as a product team building a real
+authorization gateway, not as a generic sponsor thank-you note.
+
+### Required Feedback Topics
+
+KeeperHub:
+
+- Which token goes where (`kh_*` vs `wfb_*`) with worked examples.
+- Public submission/result envelope schema.
+- `executionId` status lookup.
+- Optional Mandate proof fields in workflow logs.
+- Idempotency semantics on workflow webhooks.
+- Webhook signing/callback authenticity.
+- MCP tool for execution lookup.
+
+ENS:
+
+- Blessed agent metadata namespace.
+- Standard policy commitment key.
+- Standard proof URI key.
+- Guidance for agent endpoint records.
+
+Uniswap:
+
+- Signed quote id.
+- `expires_at`.
+- Route token enumeration.
+- Canonical quote hash.
+- Slippage cap semantics.
+
+### External Engagement
+
+If time allows:
+
+- File one KeeperHub docs/feature issue.
+- Join KeeperHub Discord and post a concise technical intro.
+- Link any public issue from `FEEDBACK.md`.
+
+Do not depend on private Discord conversations for submission claims.
+
+## 0G Optional Strategy
+
+### Desired Judge Reaction
+
+"This proof capsule is a natural object to store in decentralized data
+infrastructure."
+
+### Product Angle
+
+0G should be an optional proof-publication backend, not a core dependency.
+
+### Safe Scope
+
+- Upload capsule or audit bundle to 0G Storage.
+- Store returned reference in `passport_capsule.verification.storage_refs`.
+- Public proof page links the 0G ref.
+- Offline verifier still works without 0G.
+
+### Skip If
+
+- Phases 0-7 are not stable.
+- API/account setup burns more than one focused block.
+- It requires changing core proof semantics.
+
+## Gensyn Optional Strategy
+
+### Desired Judge Reaction
+
+"Mandate can sit between cooperating agents and prove authorization."
+
+### Safe Scope
+
+- Two-agent demo:
+  - Agent A requests action.
+  - Agent B verifies Mandate capsule.
+  - Communication uses AXL or Gensyn-supported framework if available.
+
+### Skip If
+
+- It becomes a new agent framework project.
+- It distracts from MCP/Passport.
+
+## Public Demo Strategy
+
+The public proof URL should show three things immediately:
+
+1. **Proof badge:** one allow, one deny, one capsule, one verification.
+2. **Operator console:** deeper evidence panels.
+3. **Partner one-pagers:** KeeperHub, ENS, Uniswap.
+
+Do not build a generic landing page first. The first viewport should show
+the proof object, not marketing copy.
+
+## Video Strategy
+
+The video should be structured around proof, not features:
+
+1. Problem: agents can act but cannot prove authority.
+2. Mandate Passport: identity + policy + receipt + execution + audit.
+3. Run allow path.
+4. Run deny path.
+5. Show KeeperHub/ENS/Uniswap mapping.
+6. Open trust badge/operator console.
+7. Verify capsule offline.
+8. End with the line:
+   "Mandate is not another agent. It is the proof layer before agents act."
+
+## Final Submission Wording
+
+Use this as the submission spine:
+
+> Mandate Passport is proof-carrying execution for AI agents. An
+> ENS-named agent asks Mandate for permission through MCP. Mandate checks
+> the active policy, budget, nonce, and idempotency boundary, signs an
+> allow or deny receipt, writes a tamper-evident audit event, and only
+> then hands allowed actions to KeeperHub or a guarded Uniswap executor.
+> The whole run becomes a portable passport capsule that verifies offline
+> and renders as a static trust badge.
+
+Add only the integrations that actually landed:
+
+- If MCP lands: "MCP-callable."
+- If ENS stays fixture: "ENS-shaped offline fixture."
+- If ENS live lands: "live ENS resolver."
+- If KeeperHub stays mock: "KeeperHub proof handoff envelope, mock
+  execution in default demo."
+- If KeeperHub live lands: "live KeeperHub workflow call, env-gated."
+- If Uniswap stays mock: "Uniswap quote guard against fixtures."
+- If Uniswap live lands: "live Trading API quote, env-gated."
+
+## Priority Stack
+
+If time becomes tight, keep this order:
+
+1. Public proof URL and final submission packaging.
+2. Passport capsule CLI/verifier.
+3. MCP server.
+4. ENS passport records.
+5. KeeperHub proof handoff envelope or live call.
+6. Uniswap capsule evidence.
+7. Optional 0G/Gensyn.
+
+The reason: a coherent proof product beats scattered partial sponsor
+integrations.

--- a/docs/product/TWO_DEVELOPER_EXECUTION_PROTOCOL.md
+++ b/docs/product/TWO_DEVELOPER_EXECUTION_PROTOCOL.md
@@ -1,0 +1,370 @@
+# Two-Developer Execution Protocol
+
+**Purpose:** keep Developer A and Developer B moving continuously without
+breaking the already-working Mandate submission.
+
+This protocol is intentionally operational. It tells the developers when
+to branch, what they own, what they must verify, and when they must stop.
+
+## Roles
+
+### Developer A
+
+Owns implementation-heavy changes:
+
+- Rust crates;
+- CLI commands;
+- schema files;
+- storage migrations;
+- MCP server;
+- sponsor adapters;
+- daemon/API changes;
+- demo scripts that exercise binaries;
+- integration tests.
+
+Developer A should avoid editing submission copy except when needed to
+document a newly landed CLI/API behavior.
+
+### Developer B
+
+Owns product/proof/surface changes:
+
+- `trust-badge/`;
+- `operator-console/`;
+- docs;
+- submission copy;
+- reward one-pagers;
+- public proof site;
+- FEEDBACK.md;
+- video script;
+- static fixtures when they are UI/demo inputs.
+
+Developer B should not invent backend truth. If a panel depends on a
+value that does not exist yet, it must render an honest pending/future
+state.
+
+## Shared Laws
+
+1. Main must stay green.
+2. Small PRs beat giant PRs.
+3. One PR should have one sentence explaining why it exists.
+4. No stale docs after a merge if they are in the changed surface.
+5. Every mock/offline path must say mock/offline.
+6. Every live claim must have evidence.
+7. Review findings are fixed before merge unless explicitly accepted as
+   low-risk follow-up.
+8. No developer rewrites the other developer's unrelated work.
+9. If a branch is stale, rebase before adding more features.
+10. If the proof story becomes confusing, stop and update the product
+    docs before adding more code.
+
+## Branch Discipline
+
+Always start from current main:
+
+```bash
+git fetch --all --prune
+git checkout main
+git pull --ff-only origin main
+git checkout -b <focused-branch-name>
+```
+
+Branch naming:
+
+- A-side: `feat/passport-cli-p1`, `feat/mandate-mcp-p3`, etc.
+- B-side: `docs/passport-reward-strategy`, `feat/passport-proof-ui`, etc.
+- Fix-only: `fix/<surface>-<short-risk>`.
+
+No branch should contain unrelated cleanup.
+
+## PR Template
+
+Every PR report should include:
+
+```text
+Title:
+Scope:
+Base main SHA:
+Head SHA:
+Files changed:
+What changed:
+What is intentionally not changed:
+Truthfulness notes:
+Verification:
+Open risks:
+Next dependency:
+```
+
+Truthfulness notes are mandatory for:
+
+- KeeperHub;
+- ENS;
+- Uniswap;
+- audit anchoring;
+- signer/KMS;
+- public deployment;
+- anything that says live, production, onchain, or verified.
+
+## Merge Readiness Rules
+
+A PR is merge-ready only when:
+
+- merge state is clean;
+- CI is green;
+- required local verification was run or explicitly skipped with reason;
+- unresolved review threads are zero or intentionally accepted;
+- docs and tests match the behavior changed by the PR;
+- no false mock/live/onchain claims were introduced.
+
+If there is any P1 or blocker finding, do not merge.
+
+If there are only low doc findings, Daniel can choose:
+
+- hold for author fix; or
+- merge and queue a consolidation PR.
+
+## Watcher Protocol
+
+When a developer is waiting for another PR:
+
+1. Do not edit files based on assumptions.
+2. Poll open PRs and main HEAD.
+3. Report only state changes:
+   - CI failure;
+   - merge conflict;
+   - new unresolved review thread;
+   - merge complete;
+   - post-merge CI success/failure.
+4. Once merged, fetch main and re-run pre-flight before starting.
+
+This is especially important for B-side final/submission work. Final copy
+must describe what is on main, not what is expected to land.
+
+## Overnight Autopilot Prompt
+
+Use this prompt for a developer who should continue only after a blocking
+PR lands:
+
+```text
+You are working on Mandate. Your immediate task is gated on the upstream
+PR named below. Do not start implementation until that PR has merged into
+main and post-merge CI has completed successfully.
+
+Upstream PR:
+<insert PR number/title>
+
+After it merges:
+1. Fetch and checkout main.
+2. Confirm main HEAD contains the upstream merge commit.
+3. Confirm post-merge CI succeeded.
+4. Confirm open PRs are empty or only contain PRs assigned to you.
+5. Create a fresh branch from main.
+6. Read docs/product/MANDATE_PASSPORT_BACKLOG.md and pick the next task
+   assigned to your role.
+7. Keep your write scope to your role.
+8. Run the task-specific verification matrix.
+9. Push one focused PR and stop for review.
+
+Do not:
+- claim unmerged work as shipped;
+- flip mock/offline/live labels without evidence;
+- touch unrelated files;
+- start final submission copy before all referenced PRs are on main;
+- merge without explicit authorization.
+```
+
+## Parallelization Map
+
+Safe parallel pairs:
+
+| Developer A work | Developer B parallel work |
+|---|---|
+| Passport schema | Product docs labelled future/target. |
+| Passport CLI | Static UI fixture planning and copy placeholders. |
+| MCP server | MCP docs and demo script skeleton. |
+| ENS resolver | ENS one-pager and reward copy. |
+| KeeperHub envelope tests | KeeperHub FEEDBACK draft and one-pager. |
+| Uniswap quote evidence | Uniswap FEEDBACK draft and one-pager. |
+| Live optional adapter | Submission text that keeps live claim gated. |
+
+Unsafe parallel pairs:
+
+| Conflict | Why |
+|---|---|
+| Both editing same generated proof fixture | High merge-conflict risk and truth drift. |
+| B writing final copy before A merges | Copy can overclaim. |
+| A changing transcript schema while B changes build guards | Schema-pin drift. |
+| Both editing `IMPLEMENTATION_STATUS.md` | Stale line risk. |
+| Live adapter plus submission "live" wording before real smoke | False claim risk. |
+
+## Pre-Flight Checklist
+
+Before starting any task:
+
+```bash
+git status -sb
+git fetch --all --prune
+git branch --show-current
+git log --oneline -5
+```
+
+Check:
+
+- current branch is correct;
+- no unrelated dirty files;
+- upstream main is current;
+- open PR state does not block you;
+- your task dependency is on main.
+
+If `.claude/` or other local untracked tool state exists, ignore it
+unless the task explicitly concerns it.
+
+## Developer A Task Checklist
+
+For every A-side PR:
+
+1. Read the relevant existing crate/module before editing.
+2. Add tests before or with implementation.
+3. Prefer existing crate patterns over new abstractions.
+4. Keep default path offline/deterministic.
+5. Add env-gated live paths only when live credentials are optional.
+6. Update CLI docs for new commands.
+7. Update schema validators when adding schema.
+8. Run Rust + schema + relevant demo checks.
+
+Stop and ask for direction if:
+
+- implementing the task requires changing APRP semantics;
+- a live integration requires secrets or non-deterministic CI;
+- a schema bump would ripple through more than expected;
+- a sponsor API is undocumented enough that code would be guesswork.
+
+## Developer B Task Checklist
+
+For every B-side PR:
+
+1. Identify whether the backend value is on main.
+2. If yes, render real evidence.
+3. If no, render target/future copy only in product docs, not current
+   implementation docs.
+4. Keep static proof surfaces no-JS/no-fetch.
+5. Add tests for every rendered proof field.
+6. Update README/submission only with current truth.
+7. Grep for stale counts and old backlog phrases.
+8. Run static UI tests and relevant demo runner.
+
+Stop and ask for direction if:
+
+- docs would need to claim work that is not merged;
+- a proof panel needs values the transcript does not contain;
+- a prize narrative conflicts with truthfulness labels;
+- public proof deployment requires repo settings Daniel must change.
+
+## Review Protocol
+
+Review should start with findings, not summaries.
+
+Severity:
+
+- **Blocker:** breaks build, verification, security boundary, or core
+  truthfulness.
+- **High:** likely incorrect behavior or significant proof drift.
+- **Medium:** misrepresents a merged/unmerged capability, missing
+  regression test, confusing API behavior.
+- **Low:** stale prose, typo, minor copy drift, non-blocking doc issue.
+
+A PR with Medium or above findings should not merge without a fix or an
+explicit Daniel decision.
+
+## Continuous QA State Report
+
+When reporting state, use this compact format:
+
+```text
+PR:
+Head:
+Base:
+Merge state:
+CI:
+Review threads:
+Verification run:
+Findings:
+Recommendation:
+Next action:
+```
+
+Avoid long prose unless a finding requires evidence.
+
+## Schema Change Protocol
+
+Any schema bump must land atomically:
+
+- schema file;
+- Rust structs/parsers;
+- CLI command output;
+- fixture;
+- schema validator;
+- trust-badge guard if consumed;
+- operator-console guard if consumed;
+- tests;
+- docs.
+
+Never allow a generator to silently accept both old and new schemas unless
+there is a documented migration reason.
+
+## Live Integration Protocol
+
+Live integrations are allowed only if:
+
+- env vars are documented;
+- missing env fails closed;
+- CI does not require live network;
+- mock remains the default;
+- live output includes a real reference from the remote system;
+- docs say how to reproduce the live smoke;
+- no secret appears in git.
+
+Live mode must not silently fall back to mock.
+
+## Public Proof Protocol
+
+Public proof pages must:
+
+- be static;
+- contain no secrets;
+- contain no external JS;
+- contain no fetch calls;
+- work from `file://` locally;
+- include downloadable proof JSON;
+- label mock/offline/live values;
+- show verification status;
+- link to exact commands needed to reproduce.
+
+## Freeze Protocol
+
+When the demo video is recorded:
+
+1. Freeze feature work.
+2. Only accept:
+   - blocker fixes;
+   - CI fixes;
+   - typo/copy fixes;
+   - proof URL updates;
+   - submission form updates.
+3. Do not change demo flow without re-recording.
+4. Run fresh-clone smoke once after final merge.
+
+## Done State
+
+The team is done when all are true:
+
+- main is green;
+- no open blocker PRs;
+- public proof URL works;
+- video URL is in submission draft;
+- final README is current;
+- FEEDBACK.md is sponsor-specific;
+- reward strategy is reflected in submission text;
+- no stale "backlog" lines claim shipped work is missing;
+- no "live" claim lacks evidence;
+- fresh clone can run the documented commands.


### PR DESCRIPTION
## Summary

Adds the missing `docs/product/` source-of-truth package that Developer A and Developer B are blocked on:

- `MANDATE_PASSPORT_SOURCE_OF_TRUTH.md` — product vision, future production state, capsule shape, CLI/MCP/API targets, truthfulness rules.
- `MANDATE_PASSPORT_BACKLOG.md` — two-developer backlog with PR sequence, ownership, acceptance criteria, and verification gates.
- `REWARD_STRATEGY.md` — KeeperHub / ENS / Uniswap / Builder Feedback / optional 0G-Gensyn strategy.
- `TWO_DEVELOPER_EXECUTION_PROTOCOL.md` — operating protocol for A/B developers, watcher rules, merge gates, and overnight prompt.
- `README.md` — index for the product-plan folder.

## Current-state alignment

This PR is based on `main` at `8e48ec1` after B2.v2 and B5 merged. The docs explicitly mark:

- P0.1 / PR #37 as complete on main.
- P0.2 / PR #39 as complete on main.
- P1.1 (`Passport capsule schema + verifier skeleton`) as the next unblocked Developer A task.

## Truthfulness notes

- This is product planning and execution guidance, not an implementation claim.
- Live KeeperHub / ENS / Uniswap language is explicitly gated behind real evidence.
- Mock anchoring remains labelled as mock, not onchain.
- The plan is additive over existing Mandate primitives; it does not propose rewriting APRP, receipts, audit chain, trust badge, or operator console.

## Validation

- `git diff origin/main --check` — clean.
- `rg -n "[^\\x00-\\x7F]" docs/product` — no non-ASCII.
- Docs-only change; no runtime tests run.

## Why now

Developer A stopped P1.1 because these docs were referenced in the prompt but were not on main. Developer B also correctly refused to start P1.2 until the source-of-truth package exists on main. This PR unblocks both without touching runtime code.