### PR TITLE
docs: Mandate × {KeeperHub, ENS, Uniswap} partner one-pagers + Passport-aligned FEEDBACK expansion (B1)

### DIFF
--- a/FEEDBACK.md
+++ b/FEEDBACK.md
@@ -2,6 +2,8 @@
 
 Notes for partner sponsors during the ETHGlobal Open Agents 2026 build of **Mandate**. This file is required for some partner prizes (e.g. Uniswap API integration) and is offered to all selected partners.
 
+> **Mandate Passport context.** The asks below are organised around what the *Mandate Passport* product target needs from each partner surface in order to compose into a single proof-carrying execution flow. Mandate Passport is *target product framing* — the capsule schema and verifier are tracked as A-side work in [`docs/product/MANDATE_PASSPORT_BACKLOG.md`](docs/product/MANDATE_PASSPORT_BACKLOG.md) and are not yet on `main`. Partner-specific one-pagers separate "what is implemented today" from "what is target": [`docs/partner-onepagers/keeperhub.md`](docs/partner-onepagers/keeperhub.md), [`docs/partner-onepagers/ens.md`](docs/partner-onepagers/ens.md), [`docs/partner-onepagers/uniswap.md`](docs/partner-onepagers/uniswap.md). Source of truth: [`docs/product/MANDATE_PASSPORT_SOURCE_OF_TRUTH.md`](docs/product/MANDATE_PASSPORT_SOURCE_OF_TRUTH.md).
+
 ## KeeperHub
 
 How Mandate uses KeeperHub: *Mandate decides, KeeperHub executes.* After Mandate signs an `allow` policy receipt, the receipt and the underlying APRP are handed to `KeeperHubExecutor::execute()`. Denied receipts are refused before any sponsor call. The same signed receipt can be packaged into a verifiable audit bundle (`mandate audit export` / `mandate audit verify-bundle`) so downstream audits can re-derive what KeeperHub was asked to execute, what was approved, and which audit-chain position the decision occupies.
@@ -25,6 +27,9 @@ The "execution layer for AI agents onchain" framing maps directly onto our `Guar
   - `mandate_policy_hash` — canonical hash of the policy that authorised the action.
   - `mandate_receipt_signature` — Ed25519 signature of the policy receipt (hex).
   - `mandate_audit_event_id` — ULID of the audit-chain event the decision occupies.
+  - `mandate_passport_capsule_hash` — content hash of the Mandate Passport capsule (target field; populated once the Passport capsule schema lands on `main` — A-side work tracked at [`docs/product/MANDATE_PASSPORT_BACKLOG.md` §P1.1](docs/product/MANDATE_PASSPORT_BACKLOG.md)).
+- **Idempotency semantics on workflow webhooks.** Mandate already enforces HTTP `Idempotency-Key` safe-retry on its own ingest (PR #23 + #29). Documenting which header / field KeeperHub honours for caller-supplied retry keys, and what KeeperHub does on duplicate delivery (cached response vs new execution), would let policy engines safely retry a webhook submit without double-spending an authorisation.
+- **Webhook signing / callback authenticity.** When a workflow webhook fires back to a Mandate-style consumer, a documented signature scheme (e.g. `X-KeeperHub-Signature: sha256=<hex>` over the raw body, with a documented secret-rotation path) lets the consumer trust the inbound result without a side-channel.
 - **MCP tool: `keeperhub.lookup_execution(execution_id)`** — returns status + run-log pointer + the `mandate_*` fields above (echoed back). Lets a Mandate operator (or any auditor) connect a KeeperHub execution row directly to the upstream Mandate authorization proof without out-of-band correlation.
 - **Optional webhook headers from KeeperHub → caller.** When a workflow webhook fires back to a Mandate-style consumer, attach two optional headers so the consumer can verify the upstream proof in one network round trip:
   - `X-Mandate-Receipt-Signature: <hex>`
@@ -52,8 +57,10 @@ How Mandate uses ENS: ENS is the agent's public identity. `research-agent.team.e
 - **What worked:** text records are perfect for arbitrary structured metadata — no custom contract needed. The "policy hash matches what is published" pattern is a one-line check that gives judges immediate confidence.
 - **What was unclear:** there is no canonical reverse pointer from a Mandate-style identity back to its ENS name. The text-record namespace is a soft convention; we picked the `mandate:*` prefix and would happily move under a blessed `agent:*` namespace if the ecosystem standardises one.
 - **Suggested improvements:**
-  - A blessed text-record namespace for autonomous agents to prevent fragmentation.
-  - A canonical record for "policy commitment" so multiple security tools can share a slot rather than each picking their own key.
+  - A blessed text-record namespace for autonomous agents to prevent fragmentation. Today the `mandate:*` prefix is a soft convention; a standardised `agent:*` (or similar) namespace would let tooling agree without ad-hoc keys.
+  - A canonical record for **policy commitment** so multiple security tools can share a slot rather than each picking their own key. Mandate would publish its active policy hash there.
+  - A canonical record for **proof URI** — a standardised slot for "where the public proof / capsule for this agent lives", so any client can find the proof without out-of-band convention. (For Mandate this corresponds to the future `mandate.passport_capsule.v1` artefact published at the `mandate:proof_uri` value, target — see [`docs/partner-onepagers/ens.md`](docs/partner-onepagers/ens.md).)
+  - **Endpoint-record guidance for agents.** Where the MCP/API endpoint a third-party tool should call to talk to the agent's policy gateway should live (alongside `url`, in a sub-namespace, etc.) is not standardised; today we self-publish under `mandate:mcp_endpoint`.
 
 ## Uniswap (stretch)
 
@@ -68,9 +75,12 @@ How Mandate uses Uniswap: Mandate sits in front of any agent that wants to swap.
   - Quote freshness is implicit. We approximate freshness from local timestamps; the demo's static fixture has to relax this and we surface a `(relaxed)` flag explicitly so judges see it. Server-issued `quote_id` + `expires_at` would let policy engines anchor cryptographically into the receipt.
   - Multi-hop routes occasionally touch tokens that are not on our allowlist. We treat that as deny by default; explicit per-path token enumeration in the API response would let policy engines opt in or out at the path level.
 - **Suggested improvements:**
-  - **Signed quotes** — server-signed `quote_id + expires_at + canonical hash`. We would embed the hash into the Mandate decision token so the on-chain executor can require the same quote.
-  - **Route token enumeration** — list every intermediate token, not just input/output.
-  - **First-class slippage caps in the request** — letting the API reject a quote whose realised slippage already exceeds the caller's cap removes a class of agent footguns.
+  - **Signed quotes** — server-signed `quote_id + expires_at + canonical hash`. We would embed the canonical hash into the Mandate decision token (and, target, into the `mandate.passport_capsule.v1` Uniswap evidence section — see [`docs/partner-onepagers/uniswap.md`](docs/partner-onepagers/uniswap.md)) so the on-chain executor can require the same quote that authorised the action.
+  - **`expires_at` on the quote response.** Today freshness is approximated from local timestamps; the demo's static fixture has to relax this and we surface a `(relaxed)` flag explicitly so judges see it. A server-side `expires_at` removes the approximation entirely.
+  - **Route token enumeration** — list every intermediate token, not just input/output, so per-path swap-policy guards can opt in or out of multi-hop routes at the path level instead of denying by default.
+  - **First-class slippage caps in the request** — letting the API reject a quote whose realised slippage already exceeds the caller's cap removes a class of agent footguns at the network boundary, before Mandate's `evaluate_swap` ever sees the quote.
+  - **Slippage-cap semantics, documented.** Whether `slippageBps` in the request is "max acceptable realised slippage" vs "request the route to target this slippage" is not obvious from the integration guide — third-party policy engines need that distinction explicit, with a worked example.
+  - **Canonical quote hash.** A documented JCS-shape (or equivalent) over the quote response so third-party policy engines can hash deterministically without inventing a canonicalisation. Mandate already canonicalises APRP via JCS for `request_hash`; a server-side canonical quote hash slots into the same pattern.
 
 ### Known limitations of the hackathon implementation
 

--- a/FEEDBACK.md
+++ b/FEEDBACK.md
@@ -60,7 +60,7 @@ How Mandate uses ENS: ENS is the agent's public identity. `research-agent.team.e
   - A blessed text-record namespace for autonomous agents to prevent fragmentation. Today the `mandate:*` prefix is a soft convention; a standardised `agent:*` (or similar) namespace would let tooling agree without ad-hoc keys.
   - A canonical record for **policy commitment** so multiple security tools can share a slot rather than each picking their own key. Mandate would publish its active policy hash there.
   - A canonical record for **proof URI** — a standardised slot for "where the public proof / capsule for this agent lives", so any client can find the proof without out-of-band convention. (For Mandate this corresponds to the future `mandate.passport_capsule.v1` artefact published at the `mandate:proof_uri` value, target — see [`docs/partner-onepagers/ens.md`](docs/partner-onepagers/ens.md).)
-  - **Endpoint-record guidance for agents.** Where the MCP/API endpoint a third-party tool should call to talk to the agent's policy gateway should live (alongside `url`, in a sub-namespace, etc.) is not standardised; today we self-publish under `mandate:mcp_endpoint`.
+  - **Endpoint-record guidance for agents.** Where the MCP/API endpoint a third-party tool should call to talk to the agent's policy gateway should live (alongside `url`, in a sub-namespace, etc.) is not standardised. The shipped offline ENS fixture currently uses `mandate:endpoint`; the Passport target introduces a more specific `mandate:mcp_endpoint` (or future blessed equivalent) once the MCP surface lands.
 
 ## Uniswap (stretch)
 

--- a/docs/partner-onepagers/ens.md
+++ b/docs/partner-onepagers/ens.md
@@ -1,0 +1,115 @@
+# Mandate × ENS — partner one-pager
+
+> ENS is not cosmetic here. It is how a third party finds and verifies an
+> agent's mandate.
+
+**Status: target product framing, with the parts that already exist on
+`main` clearly separated from the parts that depend on later phases.**
+
+## The pitch in one paragraph
+
+Autonomous agents need a stable public identity that points at *what
+authority they hold*, not just *who they are*. Mandate uses ENS text
+records as the agent passport registry: the agent's ENS name resolves to
+the Mandate endpoint, the active policy hash, the audit root, the proof
+URI, and (target) the passport schema and KeeperHub workflow id. This
+turns ENS from a name service into a verifiable agent-discovery surface:
+a reviewer or sponsor can resolve `research-agent.team.eth`, see the
+published policy hash, and compare it to the policy Mandate is actually
+running.
+
+## What is implemented today (on `main`, this build)
+
+- ENS adapter `mandate_identity::OfflineEnsResolver` — offline, fixture-
+  driven resolver. The 13-gate final demo (gate 7) uses this resolver to
+  look up `research-agent.team.eth` and verifies the resolved
+  `mandate:policy_hash` matches the receipt's `policy_hash`.
+- Multi-agent ENS fixture catalogue:
+  [`demo-fixtures/mock-ens-registry.json`](../../demo-fixtures/mock-ens-registry.json)
+  with companion guide
+  [`demo-fixtures/mock-ens-registry.md`](../../demo-fixtures/mock-ens-registry.md).
+- Single-agent runtime input consumed by the demo script:
+  [`demo-fixtures/ens-records.json`](../../demo-fixtures/ens-records.json).
+- Builder feedback (current): [`FEEDBACK.md` §ENS](../../FEEDBACK.md).
+
+**Resolver source today: `offline-fixture` only.** No live ENS RPC is
+called from any code path in this build. The trust badge and operator
+console label every ENS reference accordingly.
+
+## What is target (Mandate Passport phase, not on main yet)
+
+These are explicit *targets* documented for the team and for ENS reviewers
+— none of them are claimed as shipped:
+
+- **`mandate:*` text-record namespace (target).** A blessed set of agent
+  metadata records:
+  - `mandate:mcp_endpoint` — MCP/API surface an agent can ask for
+    decisions.
+  - `mandate:policy_hash` — canonical hash of the active policy.
+  - `mandate:audit_root` — current audit-chain / mock-checkpoint
+    commitment (mock today; real onchain later).
+  - `mandate:passport_schema` — capsule schema id (`mandate.passport_capsule.v1`,
+    target).
+  - `mandate:proof_uri` — public capsule/proof URL.
+  - `mandate:keeperhub_workflow` — sponsor execution workflow id.
+- **Live ENS resolver (`LiveEnsResolver`, future, gated).** Same trait
+  surface as the offline resolver, gated behind an explicit
+  `MANDATE_ENS_LIVE=1` env-var. Never a silent fallback from offline
+  fixture. CI will never require live ENS.
+- **Drift detection in proof viewers (target).** When ENS publishes
+  policy hash A but Mandate's active policy is hash B, the trust badge
+  and operator console must render an explicit failure pill — never a
+  fake-OK.
+
+## Why ENS specifically
+
+Text records are a perfect substrate for arbitrary structured agent
+metadata — no custom contract needed. The "policy hash matches what is
+published" pattern gives reviewers immediate confidence in a single line
+of comparison. ENS publishes the commitment; Mandate enforces it.
+
+## What we are asking ENS for (concrete, scoped)
+
+These are the same asks recorded in
+[`FEEDBACK.md` §ENS](../../FEEDBACK.md), summarised here:
+
+1. **A blessed text-record namespace for autonomous agents.** Today the
+   `mandate:*` prefix is a soft convention; we'd happily move under a
+   blessed `agent:*` namespace if the ecosystem standardises one.
+   Fragmentation across projects is the bigger risk than naming.
+2. **A canonical `policy_commitment` record.** Multiple security tools
+   (Mandate plus future analogues) should be able to publish a hash of
+   their active policy under one key, instead of each tool inventing its
+   own slot.
+3. **A canonical `proof_uri` record.** A standardised slot for "where the
+   public proof / capsule for this agent lives", so any client can find
+   the proof without out-of-band convention.
+4. **Guidance for endpoint records on agents.** Where should
+   `mandate:mcp_endpoint` (or the future blessed equivalent) live —
+   alongside `url` text records, under a sub-namespace, etc. Today it is
+   self-published.
+
+## What this one-pager will NOT claim
+
+- Mandate **does not** resolve a real ENS testnet/mainnet name in this
+  build. Every ENS reference goes through `OfflineEnsResolver` against a
+  fixture file, and the source is labelled `offline-fixture`.
+- The published `mandate:*` keys are **a soft convention** — ENS does
+  not endorse them as a namespace yet.
+- ENS **does not** enforce policy. It publishes / discovers a commitment;
+  Mandate enforces.
+- Mandate Passport capsule + `mandate:passport_schema` are **target
+  product framing**, not shipped artefacts in this build. The capsule
+  schema (A-side) lands in a later phase; this one-pager will be updated
+  to reference the actual schema id once that PR is on `main`.
+
+## Pointers in this repo
+
+- Adapter source: [`crates/mandate-identity/src/`](../../crates/mandate-identity/src/)
+- Single-agent runtime input: [`demo-fixtures/ens-records.json`](../../demo-fixtures/ens-records.json)
+- Multi-agent catalogue + guide: [`demo-fixtures/mock-ens-registry.json`](../../demo-fixtures/mock-ens-registry.json) / [`demo-fixtures/mock-ens-registry.md`](../../demo-fixtures/mock-ens-registry.md)
+- Sponsor demo (offline today): [`demo-scripts/sponsors/ens-agent-identity.sh`](../../demo-scripts/sponsors/ens-agent-identity.sh)
+- Production transition checklist (env vars for live resolver): [`docs/production-transition-checklist.md` §ENS](../production-transition-checklist.md#ens-resolver)
+- Builder feedback: [`FEEDBACK.md` §ENS](../../FEEDBACK.md)
+- Product source of truth: [`docs/product/MANDATE_PASSPORT_SOURCE_OF_TRUTH.md`](../product/MANDATE_PASSPORT_SOURCE_OF_TRUTH.md)
+- Reward strategy: [`docs/product/REWARD_STRATEGY.md`](../product/REWARD_STRATEGY.md)

--- a/docs/partner-onepagers/ens.md
+++ b/docs/partner-onepagers/ens.md
@@ -43,8 +43,9 @@ These are explicit *targets* documented for the team and for ENS reviewers
 
 - **`mandate:*` text-record namespace (target).** A blessed set of agent
   metadata records:
-  - `mandate:mcp_endpoint` — MCP/API surface an agent can ask for
-    decisions.
+  - `mandate:mcp_endpoint` — target MCP/API surface an agent can ask for
+    decisions. The shipped offline fixture currently uses the generic
+    `mandate:endpoint` key.
   - `mandate:policy_hash` — canonical hash of the active policy.
   - `mandate:audit_root` — current audit-chain / mock-checkpoint
     commitment (mock today; real onchain later).
@@ -84,10 +85,11 @@ These are the same asks recorded in
 3. **A canonical `proof_uri` record.** A standardised slot for "where the
    public proof / capsule for this agent lives", so any client can find
    the proof without out-of-band convention.
-4. **Guidance for endpoint records on agents.** Where should
-   `mandate:mcp_endpoint` (or the future blessed equivalent) live —
-   alongside `url` text records, under a sub-namespace, etc. Today it is
-   self-published.
+4. **Guidance for endpoint records on agents.** Where should a policy
+   gateway endpoint live — alongside `url` text records, under a
+   sub-namespace, etc.? Today the shipped fixture uses
+   `mandate:endpoint`; the Passport target would prefer
+   `mandate:mcp_endpoint` or a future blessed equivalent.
 
 ## What this one-pager will NOT claim
 

--- a/docs/partner-onepagers/keeperhub.md
+++ b/docs/partner-onepagers/keeperhub.md
@@ -1,0 +1,125 @@
+# Mandate × KeeperHub — partner one-pager
+
+> KeeperHub executes. Mandate proves the execution was authorized.
+
+**Status: target product framing, with the parts that already exist on
+`main` clearly separated from the parts that depend on later phases.**
+
+## The pitch in one paragraph
+
+Autonomous agents can be wrong. KeeperHub gives them a reliable execution
+substrate; Mandate is the upstream policy boundary that decides whether the
+execution should happen and signs a receipt that ties the KeeperHub run
+back to a specific request, policy, budget, and audit-chain position.
+Together they make agent execution accountable: every KeeperHub
+`executionId` can carry a cryptographic explanation of *why* it was
+allowed.
+
+## What is implemented today (on `main`, this build)
+
+- Adapter trait `GuardedExecutor` and concrete `KeeperHubExecutor`
+  (`crates/mandate-execution/src/keeperhub.rs`) with two constructors:
+  - `KeeperHubExecutor::local_mock()` — used in every demo path today.
+    Returns a deterministic `kh-<ULID>` execution_ref and prints
+    `mock: true` in demo output.
+  - `KeeperHubExecutor::live()` — present as a constructor; intentionally
+    `BackendOffline` until a stable submission/result schema and
+    credentials are available. **No live network call is made in this
+    build.**
+- Production-shaped runner step 6 walks the allow → KeeperHub mock path
+  end-to-end. Step 6 also walks the prompt-injection deny path and proves
+  the denied receipt never reaches the sponsor (`keeperhub_refused: true`,
+  visible in transcript and operator console).
+- KeeperHub live-integration design notes: [`docs/keeperhub-live-spike.md`](../keeperhub-live-spike.md).
+- Builder feedback (current): [`FEEDBACK.md` §KeeperHub](../../FEEDBACK.md).
+
+## What is target (Mandate Passport phase, not on main yet)
+
+These are explicit *targets* documented for the team and for KeeperHub's
+review — none of them are claimed as shipped:
+
+- **Mandate Passport capsule (target)** — a single JSON artefact
+  (`mandate.passport_capsule.v1`, schema/verifier owned by the A-side
+  Passport CLI work) that records, in one file, the request, decision,
+  KeeperHub `execution_ref`, audit event, and checkpoint. Until the
+  capsule schema lands on `main`, no UI or doc claims a capsule was
+  produced.
+- **Proof handoff envelope (target)** — a documented set of fields
+  Mandate would attach when calling a real KeeperHub workflow webhook:
+  - `mandate_request_hash` — JCS-canonical SHA-256 of the APRP.
+  - `mandate_policy_hash` — canonical hash of the active policy.
+  - `mandate_receipt_signature` — Ed25519 signature of the policy receipt.
+  - `mandate_audit_event_id` — ULID of the audit-chain event.
+  - `mandate_passport_capsule_hash` — content hash of the capsule, once
+    capsule schema lands.
+
+  This is the smallest set we believe lets a KeeperHub auditor reading an
+  execution row reconnect to the upstream Mandate decision without
+  out-of-band correlation. It is not implemented in this build because
+  the live KeeperHub path is intentionally stubbed.
+- **Live KeeperHub call (future, gated)** — would be wired through
+  `KeeperHubExecutor::live()` and exposed via an explicit
+  `MANDATE_KEEPERHUB_LIVE=1` env-var gate, never as a silent fallback
+  from mock. CI will never require it. **No live KeeperHub call is made
+  in this build.**
+
+## Why KeeperHub specifically
+
+KeeperHub's framing — execution layer for AI agents — maps cleanly onto
+Mandate's `GuardedExecutor` trait. The integration is a thin adapter, not
+a rewrite. KeeperHub's audit trail and Mandate's hash-chained audit log
+are complementary: KeeperHub records *what was executed*, Mandate records
+*why it was authorised*. The proof handoff envelope above is the bridge.
+
+## What we are asking KeeperHub for (concrete, scoped)
+
+These are the same asks recorded in
+[`FEEDBACK.md` §KeeperHub](../../FEEDBACK.md), summarised here for review
+context:
+
+1. **Public submission/result envelope schema.** Third-party policy
+   engines could validate locally before submission; mismatches surface
+   at the policy boundary, not over the wire.
+2. **Documented `executionId` → status / run-log lookup.** Either a GET
+   path or an MCP tool. Mandate would call this from the operator console
+   to render execution status next to the audit-bundle verification panel.
+3. **First-class upstream proof fields on submission.** Native,
+   schema-blessed slots for the five `mandate_*` fields above so
+   KeeperHub's audit trail can re-emit them on the result side and in
+   workflow logs.
+4. **Optional webhook headers from KeeperHub → caller.** When a workflow
+   webhook fires back to a Mandate-style consumer:
+   - `X-Mandate-Receipt-Signature: <hex>`
+   - `X-Mandate-Policy-Hash: <hex>`
+
+   so the consumer can verify the upstream proof in one network round trip.
+5. **Token-prefix naming clarity.** The `kh_*` vs `wfb_*` prefix split
+   (KeeperHub-native API tokens vs workflow-webhook tokens) is not obvious
+   from outside the docs. A short "which token does which thing" page
+   with worked examples would shave significant integration time.
+6. **Webhook signing / callback authenticity** semantics so a Mandate
+   operator can trust an inbound execution result without a side-channel.
+
+## What this one-pager will NOT claim
+
+- Mandate **does not** call a real KeeperHub endpoint in this build.
+- The mock `kh-<ULID>` execution_ref **is not** a real KeeperHub
+  `executionId`.
+- KeeperHub **does not** verify Mandate receipts today; the proof
+  envelope above is a target for live integration, not a current
+  KeeperHub-side feature.
+- Mandate Passport capsule is **target product framing**, not a shipped
+  artefact in this build. The Passport CLI + verifier (A-side) lands in a
+  later phase; this one-pager will be updated to reference the actual
+  schema/verifier once that PR is on `main`.
+
+## Pointers in this repo
+
+- Adapter source: [`crates/mandate-execution/src/keeperhub.rs`](../../crates/mandate-execution/src/keeperhub.rs)
+- Sponsor demo (mock today): [`demo-scripts/sponsors/keeperhub-guarded-execution.sh`](../../demo-scripts/sponsors/keeperhub-guarded-execution.sh)
+- Production-shaped runner step 6 walks both allow and deny paths: [`demo-scripts/run-production-shaped-mock.sh`](../../demo-scripts/run-production-shaped-mock.sh)
+- Live-spike design notes: [`docs/keeperhub-live-spike.md`](../keeperhub-live-spike.md)
+- Production transition checklist (env vars / endpoints / credentials): [`docs/production-transition-checklist.md` §KeeperHub](../production-transition-checklist.md#keeperhub-guarded-execution)
+- Builder feedback: [`FEEDBACK.md` §KeeperHub](../../FEEDBACK.md)
+- Product source of truth: [`docs/product/MANDATE_PASSPORT_SOURCE_OF_TRUTH.md`](../product/MANDATE_PASSPORT_SOURCE_OF_TRUTH.md)
+- Reward strategy: [`docs/product/REWARD_STRATEGY.md`](../product/REWARD_STRATEGY.md)

--- a/docs/partner-onepagers/uniswap.md
+++ b/docs/partner-onepagers/uniswap.md
@@ -14,8 +14,9 @@ interaction into policy-controlled finance: the agent emits a swap intent
 through APRP, a swap-policy guard enforces token allowlists, max
 notional, max slippage, quote freshness, and treasury recipient, and
 Mandate's policy boundary independently denies if any of those checks
-fail. Approved quotes are routed to the executor; denied quotes die at
-the policy boundary and never produce a signed receipt.
+fail. Approved quotes are routed to the executor; denied quotes still
+produce signed deny receipts for auditability, but they die at the policy
+boundary and never reach the executor.
 
 ## What is implemented today (on `main`, this build)
 

--- a/docs/partner-onepagers/uniswap.md
+++ b/docs/partner-onepagers/uniswap.md
@@ -1,0 +1,145 @@
+# Mandate × Uniswap — partner one-pager
+
+> A credible safety layer for agentic swaps, not just another quote API
+> call.
+
+**Status: target product framing, with the parts that already exist on
+`main` clearly separated from the parts that depend on later phases.**
+
+## The pitch in one paragraph
+
+Autonomous agents should not be able to swap any token to any recipient
+at any slippage. Mandate sits in front of the agent and turns Uniswap
+interaction into policy-controlled finance: the agent emits a swap intent
+through APRP, a swap-policy guard enforces token allowlists, max
+notional, max slippage, quote freshness, and treasury recipient, and
+Mandate's policy boundary independently denies if any of those checks
+fail. Approved quotes are routed to the executor; denied quotes die at
+the policy boundary and never produce a signed receipt.
+
+## What is implemented today (on `main`, this build)
+
+- Adapter trait and `UniswapExecutor`
+  (`crates/mandate-execution/src/uniswap.rs`) with two constructors:
+  - `UniswapExecutor::local_mock()` — used in every demo path today.
+    Returns a deterministic `uni-<ULID>` execution_ref against a stored
+    quote fixture.
+  - `UniswapExecutor::live()` — present as a constructor; intentionally
+    `BackendOffline` until a stable Trading API endpoint and credentials
+    are wired. **No live network call is made in this build.**
+- Swap-policy guard `evaluate_swap` (`crates/mandate-execution/src/uniswap.rs`)
+  enforces, in field order:
+  1. `input_token_allowlisted`
+  2. `output_token_allowlisted`
+  3. `max_notional_usd`
+  4. `max_slippage_bps`
+  5. `quote_freshness`
+  6. `treasury_recipient_allowlisted`
+- Three-quote production-shaped catalogue:
+  [`demo-fixtures/mock-uniswap-quotes.json`](../../demo-fixtures/mock-uniswap-quotes.json)
+  with companion guide
+  [`demo-fixtures/mock-uniswap-quotes.md`](../../demo-fixtures/mock-uniswap-quotes.md):
+  1. `happy_path_within_caps` — bounded USDC → ETH; allowed.
+  2. `multiple_violations_rug_quote` — USDC → RUG with 1500 bps
+     slippage and an off-allowlist recipient. Trips three checks at
+     once. Documented `expected_swap_policy_reason` is the **first**
+     violation under field-order traversal (`output_token_allowlisted`),
+     with `expected_additional_violations` listing the other two.
+  3. `recipient_allowlist_violation` — bounded slippage, off-allowlist
+     recipient is the **only** failing check.
+- Per-quote runtime mocks (gate 9 of the 13-gate demo):
+  [`demo-fixtures/uniswap/quote-USDC-ETH.json`](../../demo-fixtures/uniswap/quote-USDC-ETH.json)
+  and
+  [`demo-fixtures/uniswap/quote-USDC-RUG.json`](../../demo-fixtures/uniswap/quote-USDC-RUG.json).
+- Builder feedback (current): [`FEEDBACK.md` §Uniswap](../../FEEDBACK.md).
+
+## What is target (Mandate Passport phase, not on main yet)
+
+These are explicit *targets* documented for the team and for Uniswap
+reviewers — none of them are claimed as shipped:
+
+- **Mandate Passport capsule (target)** — a single JSON artefact
+  (`mandate.passport_capsule.v1`, schema/verifier owned by the A-side
+  Passport CLI work) that records, in one file, the request, the
+  decision, the swap-policy result vector, and the executor's
+  `execution_ref`. Until the capsule schema lands on `main`, no UI
+  claims a Uniswap-evidence capsule was produced.
+- **Capsule quote-evidence section (target)** — when capsule schema
+  lands, the Uniswap path will populate:
+  - quote id / source;
+  - input / output token symbols;
+  - route token list (when surfaced by the API);
+  - notional + caps;
+  - slippage + caps;
+  - quote timestamp + freshness result;
+  - recipient check;
+  - per-violation deny reasons when denied.
+- **Live Trading API call (future, gated)** — wired through
+  `UniswapExecutor::live()` and exposed via an explicit
+  `MANDATE_UNISWAP_LIVE=1` env-var gate, never as a silent fallback from
+  mock. CI will never require it. **No live Uniswap API call is made in
+  this build.**
+- **Signed-quote anchoring (target ask, not implemented)** — when the
+  Trading API publishes server-issued `quote_id` + `expires_at` +
+  canonical quote hash, Mandate would anchor that hash into the decision
+  token so a downstream executor can require the same quote. See
+  feedback below.
+
+## Why Uniswap specifically
+
+Quote shapes (input / output amount, route, slippage) map cleanly onto
+Mandate's `smart_account_session` APRP variant. The split between
+swap-policy guard (numeric / policy checks against the canonical quote)
+and Mandate's recipient / provider / budget boundary is natural — they
+catch overlapping problems at different layers. Defense in depth: the
+rug-quote fixture is denied independently by both the swap-policy guard
+(`output_token_allowlisted` first, `max_slippage_bps` and
+`treasury_recipient_allowlisted` as additional violations) and Mandate's
+policy boundary (`policy.deny_recipient_not_allowlisted`).
+
+## What we are asking Uniswap for (concrete, scoped)
+
+These are the same asks recorded in
+[`FEEDBACK.md` §Uniswap](../../FEEDBACK.md), summarised here:
+
+1. **Signed quotes.** Server-issued `quote_id`, `expires_at`, and a
+   canonical quote hash, so a policy engine can anchor the hash into a
+   decision token and a downstream executor can require the same quote.
+2. **`expires_at` on the quote response.** Today freshness is
+   approximated from local timestamps; the demo's static fixture has to
+   relax this and we surface a `(relaxed)` flag so judges see it. A
+   server-side `expires_at` removes the approximation.
+3. **Route token enumeration.** Today multi-hop routes occasionally
+   touch tokens not on a caller's allowlist. Returning every intermediate
+   token (not just input / output) lets policy engines opt in or out at
+   the path level instead of denying by default.
+4. **First-class slippage caps in the request.** Letting the API reject a
+   quote whose realised slippage already exceeds the caller's cap removes
+   a class of agent footguns at the network boundary.
+5. **Canonical quote hash.** A documented JCS-shape over the quote so
+   third-party policy engines can hash deterministically without inventing
+   a canonicalisation.
+
+## What this one-pager will NOT claim
+
+- Mandate **does not** call the Uniswap Trading API in this build.
+  `UniswapExecutor::live()` is a `BackendOffline` stub today; every demo
+  path uses `UniswapExecutor::local_mock()` against the fixture catalogue.
+- The mock `uni-<ULID>` execution_ref **is not** a real Uniswap
+  transaction id.
+- This is **not** a Uniswap v4 hook project. Mandate is a policy /
+  authorisation layer that sits in front of Uniswap, not a DEX hook.
+- Mandate Passport capsule + Uniswap quote-evidence section are **target
+  product framing**, not shipped artefacts in this build. The capsule
+  schema (A-side) lands in a later phase; this one-pager will be updated
+  to reference the actual schema once that PR is on `main`.
+
+## Pointers in this repo
+
+- Adapter + swap-policy guard source: [`crates/mandate-execution/src/uniswap.rs`](../../crates/mandate-execution/src/uniswap.rs)
+- Sponsor demo (mock today): [`demo-scripts/sponsors/uniswap-guarded-swap.sh`](../../demo-scripts/sponsors/uniswap-guarded-swap.sh)
+- Production-shaped catalogue + transition guide: [`demo-fixtures/mock-uniswap-quotes.json`](../../demo-fixtures/mock-uniswap-quotes.json) / [`demo-fixtures/mock-uniswap-quotes.md`](../../demo-fixtures/mock-uniswap-quotes.md)
+- Production transition checklist (env vars / endpoints / credentials): [`docs/production-transition-checklist.md` §Uniswap](../production-transition-checklist.md#uniswap-guarded-swap)
+- Builder feedback: [`FEEDBACK.md` §Uniswap](../../FEEDBACK.md)
+- Product source of truth: [`docs/product/MANDATE_PASSPORT_SOURCE_OF_TRUTH.md`](../product/MANDATE_PASSPORT_SOURCE_OF_TRUTH.md)
+- Reward strategy: [`docs/product/REWARD_STRATEGY.md`](../product/REWARD_STRATEGY.md)


### PR DESCRIPTION
## Summary

B1 of the Mandate Passport packaging push (per [`docs/product/MANDATE_PASSPORT_BACKLOG.md`](https://github.com/B2JK-Industry/mandate-ethglobal-openagents-2026/blob/main/docs/product/MANDATE_PASSPORT_BACKLOG.md), owner Developer B). Adds three judge/sponsor-facing one-pagers under `docs/partner-onepagers/` and expands `FEEDBACK.md` with the additional asks each one-pager references.

**All copy strictly separates "implemented today on main" from "target product framing".** Mandate Passport (capsule schema + verifier, A-side P1.1) is not yet on main and is consistently labelled as **target**, never as shipped.

## New files

- `docs/partner-onepagers/keeperhub.md` — proof handoff envelope target (`mandate_request_hash` / `mandate_policy_hash` / `mandate_receipt_signature` / `mandate_audit_event_id` / `mandate_passport_capsule_hash`), MCP tool ask, `executionId` lookup ask, webhook signing / idempotency asks, explicit "no live KeeperHub call is made in this build".
- `docs/partner-onepagers/ens.md` — `mandate:*` text-record namespace as target, `OfflineEnsResolver` as today's source, drift detection as target. Explicit "no live ENS RPC is called in this build".
- `docs/partner-onepagers/uniswap.md` — swap-policy guard field-order documented, three-quote production-shaped catalogue today, capsule quote-evidence as target, signed quotes / `expires_at` / route token enumeration / canonical quote hash / slippage cap semantics asks. Explicit "no live Uniswap API call is made in this build".

## FEEDBACK.md changes

- Top-of-file Mandate Passport context note pointing at backlog, source-of-truth, and the three one-pagers.
- **KeeperHub**: added `mandate_passport_capsule_hash` (target field), workflow-webhook idempotency semantics ask, webhook signing / callback authenticity ask.
- **ENS**: namespace ask sharpened, added `proof_uri` canonical record ask, added endpoint-record guidance ask.
- **Uniswap**: added explicit `expires_at` ask, slippage cap semantics ask, canonical quote hash ask; signed-quotes ask now references capsule target.

## Claim changes

| Claim shape | Before | After |
|---|---|---|
| Mandate Passport capsule | not mentioned | **target product framing**, schema/verifier owned by A-side P1.1, not on main |
| Live KeeperHub / ENS / Uniswap | implicit "future" | **explicit "no live … call is made in this build"** in every relevant section |
| Partner asks | flat list | grouped per-partner, each tied back to the capsule/envelope target |
| Onepager surface | absent | three self-contained one-pagers under `docs/partner-onepagers/` |

## Truthfulness notes

- No claim that the Mandate Passport capsule schema or verifier is shipped (A-side P1.1 still pending).
- No claim of live KeeperHub / live ENS / live Uniswap. All such phrases appear only as **explicit denials** or **future-gated targets**.
- No `production-ready` overclaim. No `onchain anchor` claim for the mock audit checkpoint.
- No edits to README / IMPLEMENTATION_STATUS / SUBMISSION_NOTES / SUBMISSION_FORM_DRAFT (those are P0.2 baseline already on main; B1 is partner-facing material only).

## Verification

| Check | Result |
|---|---|
| Stale-phrase grep on changed files (`live KeeperHub`, `live ENS`, `onchain anchor`, `production-ready`, `Passport verifier shipped`, `capsule emitted`) | ✅ clean — every `live X` match is an explicit denial; the others have zero matches |
| Proof-surface builds (`trust-badge`, `operator-console`) | not run — no proof-surface code touched |
| Submission tally / test count | not edited — matches main |

## Blocker / dependency

None. This PR is independent of A-side P1.1 (passport capsule schema + verifier skeleton) — it explicitly frames Passport as target, so it does not depend on P1.1 landing first. P1.2 (Passport copy alignment) will be a separate stacked PR after P1.1 lands and will update these one-pagers + FEEDBACK to reference the actual schema id once it exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)