### PR TITLE
feat: functional mandate-mcp stdio server (Passport P3.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,10 +1105,26 @@ dependencies = [
 name = "mandate-mcp"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "axum",
+ "chrono",
+ "hex",
+ "http-body-util",
  "mandate-core",
+ "mandate-execution",
+ "mandate-identity",
+ "mandate-policy",
+ "mandate-server",
+ "mandate-storage",
+ "rusqlite",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
+ "tokio",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/mandate-mcp/Cargo.toml
+++ b/crates/mandate-mcp/Cargo.toml
@@ -5,10 +5,45 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "Mandate MCP adapter (placeholder)."
+description = "Mandate MCP — stdio JSON-RPC server wrapping Mandate primitives (Passport P3.1)."
+
+[[bin]]
+name = "mandate-mcp"
+path = "src/main.rs"
 
 [dependencies]
+# Core Mandate primitives — every MCP tool wraps one of these.
+# No new logic: validate_aprp / verify_capsule / build / verify in mandate-core,
+# AppState + router in mandate-server, executor mocks in mandate-execution.
 mandate-core = { workspace = true }
+mandate-policy = { workspace = true }
+mandate-storage = { workspace = true }
+mandate-identity = { workspace = true }
+mandate-execution = { workspace = true }
+mandate-server = { path = "../mandate-server" }
+
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+anyhow = { workspace = true }
+chrono = { workspace = true }
+hex = { workspace = true }
+
+# Stdio JSON-RPC dispatch loop runs inside a tokio runtime so each
+# tool call can drive the existing axum/tower payment-requests pipeline
+# in-process via the same `oneshot` pattern `mandate passport run` uses
+# (see crates/mandate-cli/src/passport.rs::oneshot_payment_request).
+tokio = { workspace = true }
+axum = { workspace = true }
+tower = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"
+
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+# Tests drive the binary over stdio — `assert_cmd` would add a transitive,
+# so we use Command::spawn directly with stdin/stdout pipes (same pattern
+# as crates/mandate-cli/tests/passport_cli.rs).
+tempfile = { workspace = true }
+rusqlite = { workspace = true }

--- a/crates/mandate-mcp/src/jsonrpc.rs
+++ b/crates/mandate-mcp/src/jsonrpc.rs
@@ -1,0 +1,167 @@
+//! Minimal JSON-RPC 2.0 envelope types for the stdio transport.
+//!
+//! We deliberately do not depend on `jsonrpc-core` or any other RPC
+//! crate — every dependency is one more thing to track for security
+//! advisories on a hackathon submission. The shape we use is exactly
+//! what `https://www.jsonrpc.org/specification` defines, and tests
+//! pin the wire format.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+/// JSON-RPC 2.0 request / notification envelope. Notifications (no
+/// `id`) are not currently emitted by any tool, but the field is
+/// optional to accept them on input — we just ignore them.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Request {
+    pub jsonrpc: String,
+    pub method: String,
+    #[serde(default)]
+    pub params: Value,
+    #[serde(default)]
+    pub id: Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Response {
+    pub jsonrpc: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ErrorObject>,
+    pub id: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ErrorObject {
+    pub code: i64,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+impl Response {
+    pub fn ok(id: Value, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            result: Some(result),
+            error: None,
+            id,
+        }
+    }
+
+    pub fn err(id: Value, error: ErrorObject) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            result: None,
+            error: Some(error),
+            id,
+        }
+    }
+
+    /// Manufacture a parse-error response — used when stdin contains
+    /// non-JSON or a JSON value that doesn't match the request shape.
+    /// Per JSON-RPC 2.0 §5: `id` MUST be null when the request itself
+    /// could not be parsed, since the server cannot recover the
+    /// original id.
+    pub fn parse_error(message: impl Into<String>) -> Self {
+        Self::err(
+            Value::Null,
+            ErrorObject {
+                code: -32700,
+                message: message.into(),
+                data: None,
+            },
+        )
+    }
+
+    /// Manufacture an invalid-request response — used when the JSON
+    /// parsed but lacks the JSON-RPC 2.0 envelope (no `method`, wrong
+    /// `jsonrpc` version, etc).
+    pub fn invalid_request(id: Value, message: impl Into<String>) -> Self {
+        Self::err(
+            id,
+            ErrorObject {
+                code: -32600,
+                message: message.into(),
+                data: None,
+            },
+        )
+    }
+}
+
+/// Parse one line of stdin into a `Request`. Returns `Err` containing a
+/// pre-built `Response` (parse error / invalid request) on failure, so
+/// the caller can write that directly back to stdout without further
+/// branching.
+//
+// `Response` is ~144 bytes and clippy's `result_large_err` lint flags
+// returning it as `Err` directly. Boxing isn't worth the indirection
+// here — the `Err` path is the one-per-bad-input case on the slow stdio
+// boundary, and the size is dominated by `serde_json::Value`.
+#[allow(clippy::result_large_err)]
+pub fn parse_request(line: &str) -> Result<Request, Response> {
+    let trimmed = line.trim();
+    let value: Value = serde_json::from_str(trimmed)
+        .map_err(|e| Response::parse_error(format!("parse error: {e}")))?;
+    if value.get("jsonrpc").and_then(|v| v.as_str()) != Some("2.0") {
+        return Err(Response::invalid_request(
+            value.get("id").cloned().unwrap_or(Value::Null),
+            "jsonrpc field must be \"2.0\"",
+        ));
+    }
+    if value.get("method").and_then(|v| v.as_str()).is_none() {
+        return Err(Response::invalid_request(
+            value.get("id").cloned().unwrap_or(Value::Null),
+            "method field is required",
+        ));
+    }
+    serde_json::from_value(value)
+        .map_err(|e| Response::invalid_request(Value::Null, format!("envelope deserialise: {e}")))
+}
+
+/// Convenience builder for tests. Produces a request value as
+/// `serde_json::Value` so callers can pretty-print it before writing.
+pub fn make_request(id: Value, method: &str, params: Value) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": method,
+        "params": params,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_request_accepts_valid_envelope() {
+        let raw = r#"{"jsonrpc":"2.0","id":1,"method":"foo","params":{"x":1}}"#;
+        let req = parse_request(raw).unwrap();
+        assert_eq!(req.method, "foo");
+        assert_eq!(req.params["x"], 1);
+    }
+
+    #[test]
+    fn parse_request_rejects_wrong_version() {
+        let raw = r#"{"jsonrpc":"1.0","id":1,"method":"foo"}"#;
+        let resp = parse_request(raw).unwrap_err();
+        assert_eq!(resp.error.unwrap().code, -32600);
+    }
+
+    #[test]
+    fn parse_request_rejects_missing_method() {
+        let raw = r#"{"jsonrpc":"2.0","id":1}"#;
+        let resp = parse_request(raw).unwrap_err();
+        assert_eq!(resp.error.unwrap().code, -32600);
+    }
+
+    #[test]
+    fn parse_error_id_is_null() {
+        let raw = "not json";
+        let resp = parse_request(raw).unwrap_err();
+        assert_eq!(resp.id, Value::Null);
+        assert_eq!(resp.error.unwrap().code, -32700);
+    }
+}

--- a/crates/mandate-mcp/src/lib.rs
+++ b/crates/mandate-mcp/src/lib.rs
@@ -1,1 +1,844 @@
-//! Mandate MCP adapter (placeholder).
+//! Mandate MCP — stdio JSON-RPC server (Passport P3.1).
+//!
+//! This crate exposes Mandate's policy + capsule + audit primitives as
+//! JSON-RPC 2.0 tools over stdio. Six tools today; every one of them
+//! **wraps** an existing primitive and adds *no* new business logic:
+//!
+//! | Tool | Wraps |
+//! | --- | --- |
+//! | `mandate.validate_aprp` | `mandate_core::schema::validate_aprp` |
+//! | `mandate.decide` | `mandate_server::router` (oneshot pattern) |
+//! | `mandate.run_guarded_execution` | `mandate_server` + `KeeperHubExecutor::local_mock` / `UniswapExecutor::local_mock` |
+//! | `mandate.verify_capsule` | `mandate_core::passport::verify_capsule` |
+//! | `mandate.explain_denial` | `mandate_core::passport::verify_capsule` + structured projection |
+//! | `mandate.audit_lookup` | `Storage::audit_chain_prefix_through` + `mandate_core::audit_bundle::build` (IP-3) |
+//!
+//! Plus one meta method `tools/list` that returns the catalogue with
+//! input/output schemas.
+//!
+//! Wire format. Requests and responses are line-delimited JSON
+//! (one JSON-RPC 2.0 envelope per line). MCP's normal Content-Length
+//! framing is not required for the local-stdio use cases this surface
+//! targets (test harnesses, demo scripts, MCP-aware clients that accept
+//! NDJSON). The Rust MCP SDK is too churn-heavy for a hackathon
+//! deliverable; per the P3.1 backlog risk note we implement a minimal
+//! protocol and document it (see `docs/cli/mcp.md`).
+//!
+//! No daemon. Each tool call opens a fresh `Storage` handle against the
+//! supplied `db` path, drives the request, and drops the handle. SQLite
+//! WAL mode tolerates the sequential opens; the server itself is
+//! stateless.
+//!
+//! Live mode is rejected. The IP-3 catalogue alignment intentionally
+//! does not include a "submit to a real KeeperHub backend" path — that
+//! lives in P5.1 / P6.1 with concrete credentials + `live_evidence`.
+//! `mandate.run_guarded_execution` accepts only `mode: "mock"`.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use mandate_core::audit_bundle::{self, BundleError};
+use mandate_core::error::SchemaError;
+use mandate_core::passport::{verify_capsule, CapsuleVerifyError};
+use mandate_core::receipt::PolicyReceipt;
+use mandate_core::schema::{validate_aprp, validate_passport_capsule};
+use mandate_execution::keeperhub::KeeperHubExecutor;
+use mandate_execution::uniswap::UniswapExecutor;
+use mandate_execution::GuardedExecutor;
+use mandate_policy::Policy;
+use mandate_server::{AppState, PaymentRequestResponse, PaymentStatus};
+use mandate_storage::Storage;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+
+pub mod jsonrpc;
+
+pub use jsonrpc::{ErrorObject, Request, Response};
+
+/// JSON-RPC error code namespace for tool-level failures (per JSON-RPC
+/// 2.0 §5.1: `-32000..-32099` is reserved for server-defined errors).
+/// We use a single base code and a stable string `data.code` to
+/// distinguish kinds — that lets new failure modes land without
+/// burning JSON-RPC code points.
+pub const TOOL_ERROR_CODE: i64 = -32000;
+
+/// Stable, machine-readable error codes attached to the JSON-RPC
+/// `error.data.code` field. Tests assert on these — they are part of
+/// the wire contract.
+pub mod error_codes {
+    pub const PARAMS_INVALID: &str = "params_invalid";
+    pub const SCHEMA_VIOLATION: &str = "schema_violation";
+    pub const APRP_INVALID: &str = "aprp_invalid";
+    pub const POLICY_LOAD_FAILED: &str = "policy_load_failed";
+    pub const POLICY_NOT_ACTIVE: &str = "policy_not_active";
+    pub const PIPELINE_FAILED: &str = "pipeline_failed";
+    pub const EXECUTOR_FAILED: &str = "executor_failed";
+    pub const REQUIRES_HUMAN: &str = "requires_human_unsupported";
+    pub const LIVE_MODE_REJECTED: &str = "live_mode_rejected";
+    pub const CAPSULE_IO_FAILED: &str = "capsule_io_failed";
+    pub const CAPSULE_INVALID: &str = "capsule_invalid";
+    pub const CAPSULE_NOT_DENY: &str = "capsule_not_deny";
+    pub const AUDIT_EVENT_NOT_FOUND: &str = "audit_event_not_found";
+    pub const AUDIT_EVENT_ID_MISMATCH: &str = "audit_event_id_mismatch";
+    pub const BUNDLE_BUILD_FAILED: &str = "bundle_build_failed";
+    pub const STORAGE_FAILED: &str = "storage_failed";
+}
+
+/// Tool dispatch context. Held by the binary and passed into each
+/// `dispatch` call. Today this is essentially an empty handle; future
+/// phases may add a shared metrics surface or capability-token gate.
+#[derive(Default, Clone)]
+pub struct ServerContext {
+    pub _marker: (),
+}
+
+impl ServerContext {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// One tool call's structured failure.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolError {
+    pub code: String,
+    pub message: String,
+}
+
+impl ToolError {
+    pub fn new(code: &str, message: impl Into<String>) -> Self {
+        Self {
+            code: code.to_string(),
+            message: message.into(),
+        }
+    }
+
+    pub fn into_jsonrpc(self) -> ErrorObject {
+        ErrorObject {
+            code: TOOL_ERROR_CODE,
+            message: self.message.clone(),
+            data: Some(json!({ "code": self.code })),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tool catalogue
+// ---------------------------------------------------------------------------
+
+/// Static description of one MCP tool. Returned by the `tools/list`
+/// meta-method.
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolDescriptor {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub input_schema: Value,
+    pub output_schema: Value,
+}
+
+pub fn tools_catalogue() -> Vec<ToolDescriptor> {
+    vec![
+        ToolDescriptor {
+            name: "mandate.validate_aprp",
+            description: "Validate an APRP body against schemas/aprp_v1.json. Returns ok=true on \
+                 success; on failure returns a tool error with code=aprp_invalid.",
+            input_schema: json!({
+                "type": "object",
+                "required": ["aprp"],
+                "properties": {
+                    "aprp": { "type": "object" }
+                },
+                "additionalProperties": false
+            }),
+            output_schema: json!({
+                "type": "object",
+                "properties": {
+                    "ok":           { "const": true },
+                    "request_hash": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+                },
+                "required": ["ok", "request_hash"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "mandate.decide",
+            description:
+                "Drive the offline payment-requests pipeline (APRP → policy → budget → audit \
+                 → signed receipt) in-process. Returns the same PaymentRequestResponse the \
+                 HTTP API would. Requires an active policy in the DB.",
+            input_schema: json!({
+                "type": "object",
+                "required": ["aprp", "db"],
+                "properties": {
+                    "aprp": { "type": "object" },
+                    "db":   { "type": "string", "description": "filesystem path to a Mandate SQLite DB" }
+                },
+                "additionalProperties": false
+            }),
+            output_schema: json!({
+                "type": "object",
+                "description": "mandate-server PaymentRequestResponse",
+                "additionalProperties": true
+            }),
+        },
+        ToolDescriptor {
+            name: "mandate.run_guarded_execution",
+            description:
+                "Run mandate.decide + (allow path) the chosen mock executor (KeeperHub or \
+                 Uniswap). Returns the receipt + execution block. mode=live is rejected with \
+                 code=live_mode_rejected.",
+            input_schema: json!({
+                "type": "object",
+                "required": ["aprp", "db", "executor"],
+                "properties": {
+                    "aprp":     { "type": "object" },
+                    "db":       { "type": "string" },
+                    "executor": { "enum": ["keeperhub", "uniswap"] },
+                    "mode":     { "enum": ["mock"], "default": "mock" }
+                },
+                "additionalProperties": false
+            }),
+            output_schema: json!({
+                "type": "object",
+                "properties": {
+                    "decision":         { "type": "object" },
+                    "execution":        { "type": "object" },
+                    "audit_event_id":   { "type": "string" }
+                },
+                "required": ["decision", "execution", "audit_event_id"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "mandate.verify_capsule",
+            description: "Run the P1.1 verifier on a capsule (schema + 8 cross-field invariants). \
+                 Accepts either an inline `capsule` object or a `path` to read from disk.",
+            input_schema: json!({
+                "type": "object",
+                "oneOf": [
+                    { "required": ["capsule"] },
+                    { "required": ["path"] }
+                ],
+                "properties": {
+                    "capsule": { "type": "object" },
+                    "path":    { "type": "string" }
+                },
+                "additionalProperties": false
+            }),
+            output_schema: json!({
+                "type": "object",
+                "properties": {
+                    "ok":     { "const": true },
+                    "schema": { "const": "mandate.passport_capsule.v1" }
+                },
+                "required": ["ok", "schema"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "mandate.explain_denial",
+            description: "Read + verify a capsule and return a deny-only structured explanation \
+                 (matched_rule, deny_code, audit_event_id). Returns code=capsule_not_deny if \
+                 the capsule is an allow.",
+            input_schema: json!({
+                "type": "object",
+                "oneOf": [
+                    { "required": ["capsule"] },
+                    { "required": ["path"] }
+                ],
+                "properties": {
+                    "capsule": { "type": "object" },
+                    "path":    { "type": "string" }
+                },
+                "additionalProperties": false
+            }),
+            output_schema: json!({
+                "type": "object",
+                "properties": {
+                    "schema":         { "const": "mandate.passport_capsule.v1" },
+                    "decision":       { "type": "object" },
+                    "audit":          { "type": "object" },
+                    "policy":         { "type": "object" }
+                },
+                "required": ["schema", "decision", "audit", "policy"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "mandate.audit_lookup",
+            description:
+                "IP-3 sister tool. Given a Mandate audit_event_id + a signed PolicyReceipt + \
+                 the DB path + signer pubkeys, returns the corresponding mandate.audit_bundle.v1. \
+                 Calls `Storage::audit_chain_prefix_through` and `audit_bundle::build` — no \
+                 storage changes vs. main. See docs/keeperhub-integration-paths.md §IP-3.",
+            input_schema: json!({
+                "type": "object",
+                "required": ["audit_event_id", "db", "receipt", "receipt_pubkey", "audit_pubkey"],
+                "properties": {
+                    "audit_event_id": { "type": "string", "pattern": "^evt-[0-9A-Z]{26}$" },
+                    "db":             { "type": "string" },
+                    "receipt":        { "type": "object" },
+                    "receipt_pubkey": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+                    "audit_pubkey":   { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+                },
+                "additionalProperties": false
+            }),
+            output_schema: json!({
+                "type": "object",
+                "properties": {
+                    "ok":     { "const": true },
+                    "bundle": { "type": "object", "description": "mandate.audit_bundle.v1" }
+                },
+                "required": ["ok", "bundle"],
+                "additionalProperties": false
+            }),
+        },
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+/// Synchronous dispatch entrypoint. Returns the JSON-RPC `result` value
+/// on success, or a structured `ToolError` on failure. The binary
+/// translates `ToolError` into a JSON-RPC error envelope.
+///
+/// Internally, methods that need to drive the axum router (which is
+/// async) build a single-thread tokio runtime and `block_on` it. This
+/// matches the in-process pattern `mandate passport run` already uses
+/// (`crates/mandate-cli/src/passport.rs::cmd_run` step 6).
+pub fn dispatch(method: &str, params: &Value, _ctx: &ServerContext) -> Result<Value, ToolError> {
+    match method {
+        "tools/list" => Ok(serde_json::to_value(tools_catalogue()).map_err(|e| {
+            ToolError::new(
+                error_codes::PARAMS_INVALID,
+                format!("serialise catalogue: {e}"),
+            )
+        })?),
+        "mandate.validate_aprp" => tool_validate_aprp(params),
+        "mandate.decide" => tool_decide(params),
+        "mandate.run_guarded_execution" => tool_run_guarded(params),
+        "mandate.verify_capsule" => tool_verify_capsule(params),
+        "mandate.explain_denial" => tool_explain_denial(params),
+        "mandate.audit_lookup" => tool_audit_lookup(params),
+        _ => Err(ToolError::new(
+            error_codes::PARAMS_INVALID,
+            format!("unknown method: {method}"),
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-tool implementations
+// ---------------------------------------------------------------------------
+
+fn tool_validate_aprp(params: &Value) -> Result<Value, ToolError> {
+    let aprp = params
+        .get("aprp")
+        .ok_or_else(|| ToolError::new(error_codes::PARAMS_INVALID, "missing field `aprp`"))?;
+    if let Err(e) = validate_aprp(aprp) {
+        return Err(ToolError::new(
+            error_codes::APRP_INVALID,
+            schema_error_message(e),
+        ));
+    }
+    let bytes = mandate_core::hashing::canonical_json(aprp).map_err(|e| {
+        ToolError::new(
+            error_codes::APRP_INVALID,
+            format!("APRP is schema-valid but could not be canonicalised: {e}"),
+        )
+    })?;
+    let request_hash = mandate_core::hashing::sha256_hex(&bytes);
+    Ok(json!({ "ok": true, "request_hash": request_hash }))
+}
+
+fn tool_decide(params: &Value) -> Result<Value, ToolError> {
+    let aprp = params
+        .get("aprp")
+        .ok_or_else(|| ToolError::new(error_codes::PARAMS_INVALID, "missing field `aprp`"))?
+        .clone();
+    let db_path = params
+        .get("db")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| ToolError::new(error_codes::PARAMS_INVALID, "missing field `db`"))?;
+
+    let policy = load_active_policy(Path::new(db_path))?;
+    let response = run_pipeline(Path::new(db_path), policy, &aprp)?;
+    serde_json::to_value(&response).map_err(|e| {
+        ToolError::new(
+            error_codes::PIPELINE_FAILED,
+            format!("serialise response: {e}"),
+        )
+    })
+}
+
+fn tool_run_guarded(params: &Value) -> Result<Value, ToolError> {
+    let aprp = params
+        .get("aprp")
+        .ok_or_else(|| ToolError::new(error_codes::PARAMS_INVALID, "missing field `aprp`"))?
+        .clone();
+    let db_path = params
+        .get("db")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| ToolError::new(error_codes::PARAMS_INVALID, "missing field `db`"))?;
+    let executor = params
+        .get("executor")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| ToolError::new(error_codes::PARAMS_INVALID, "missing field `executor`"))?;
+    let mode = params
+        .get("mode")
+        .and_then(|v| v.as_str())
+        .unwrap_or("mock");
+
+    if mode != "mock" {
+        return Err(ToolError::new(
+            error_codes::LIVE_MODE_REJECTED,
+            "mandate.run_guarded_execution only supports mode=mock in P3.1; live integration \
+             lands with P5.1/P6.1.",
+        ));
+    }
+    let exec_choice = match executor {
+        "keeperhub" => ExecutorChoice::Keeperhub,
+        "uniswap" => ExecutorChoice::Uniswap,
+        other => {
+            return Err(ToolError::new(
+                error_codes::PARAMS_INVALID,
+                format!("unknown executor: {other} (expected keeperhub|uniswap)"),
+            ));
+        }
+    };
+
+    let policy = load_active_policy(Path::new(db_path))?;
+    let response = run_pipeline(Path::new(db_path), policy, &aprp)?;
+
+    // Truthfulness rule from passport run: deny path never calls executor.
+    if matches!(
+        response.receipt.decision,
+        mandate_core::receipt::Decision::RequiresHuman
+    ) {
+        return Err(ToolError::new(
+            error_codes::REQUIRES_HUMAN,
+            "policy returned requires_human; mandate.run_guarded_execution does not encode that \
+             outcome (mandate.passport_capsule.v1 only allows allow/deny). Use the regular API \
+             surface for human-review workflows.",
+        ));
+    }
+    let allow_path = matches!(response.status, PaymentStatus::AutoApproved);
+    let exec_block = if allow_path {
+        match call_mock_executor(exec_choice, &aprp, &response) {
+            Ok(block) => block,
+            Err(msg) => {
+                return Err(ToolError::new(error_codes::EXECUTOR_FAILED, msg));
+            }
+        }
+    } else {
+        deny_execution_block(exec_choice)
+    };
+
+    let receipt_value = serde_json::to_value(&response.receipt).map_err(|e| {
+        ToolError::new(
+            error_codes::PIPELINE_FAILED,
+            format!("serialise receipt: {e}"),
+        )
+    })?;
+    let decision_block = json!({
+        "result": match response.receipt.decision {
+            mandate_core::receipt::Decision::Allow => "allow",
+            mandate_core::receipt::Decision::Deny => "deny",
+            mandate_core::receipt::Decision::RequiresHuman => unreachable!("rejected above"),
+        },
+        "matched_rule": response.matched_rule_id,
+        "deny_code":    response.deny_code,
+        "request_hash": response.request_hash,
+        "policy_hash":  response.policy_hash,
+        "receipt":      receipt_value,
+    });
+    Ok(json!({
+        "decision": decision_block,
+        "execution": Value::Object(exec_block),
+        "audit_event_id": response.audit_event_id,
+    }))
+}
+
+fn tool_verify_capsule(params: &Value) -> Result<Value, ToolError> {
+    let capsule = load_capsule_param(params)?;
+    if let Err(e) = validate_passport_capsule(&capsule) {
+        return Err(ToolError::new(
+            error_codes::SCHEMA_VIOLATION,
+            schema_error_message(e),
+        ));
+    }
+    if let Err(e) = verify_capsule(&capsule) {
+        return Err(ToolError::new(
+            capsule_error_code(&e),
+            format!("{e} ({})", e.code()),
+        ));
+    }
+    Ok(json!({ "ok": true, "schema": "mandate.passport_capsule.v1" }))
+}
+
+fn tool_explain_denial(params: &Value) -> Result<Value, ToolError> {
+    let capsule = load_capsule_param(params)?;
+    if let Err(e) = verify_capsule(&capsule) {
+        return Err(ToolError::new(
+            capsule_error_code(&e),
+            format!("{e} ({})", e.code()),
+        ));
+    }
+    let result = capsule
+        .pointer("/decision/result")
+        .and_then(|v| v.as_str())
+        .unwrap_or("?");
+    if result != "deny" {
+        return Err(ToolError::new(
+            error_codes::CAPSULE_NOT_DENY,
+            format!(
+                "mandate.explain_denial only operates on deny capsules; this capsule is `{result}`"
+            ),
+        ));
+    }
+    let projection = json!({
+        "schema": "mandate.passport_capsule.v1",
+        "decision": {
+            "result": "deny",
+            "matched_rule": capsule.pointer("/decision/matched_rule").cloned().unwrap_or(Value::Null),
+            "deny_code":    capsule.pointer("/decision/deny_code").cloned().unwrap_or(Value::Null),
+        },
+        "audit": {
+            "audit_event_id": capsule.pointer("/audit/audit_event_id").cloned().unwrap_or(Value::Null),
+        },
+        "policy": {
+            "policy_hash":    capsule.pointer("/policy/policy_hash").cloned().unwrap_or(Value::Null),
+            "policy_version": capsule.pointer("/policy/policy_version").cloned().unwrap_or(Value::Null),
+        },
+    });
+    Ok(projection)
+}
+
+fn tool_audit_lookup(params: &Value) -> Result<Value, ToolError> {
+    let event_id = params
+        .get("audit_event_id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            ToolError::new(
+                error_codes::PARAMS_INVALID,
+                "missing field `audit_event_id`",
+            )
+        })?;
+    let db_path = params
+        .get("db")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| ToolError::new(error_codes::PARAMS_INVALID, "missing field `db`"))?;
+    let receipt_value = params
+        .get("receipt")
+        .ok_or_else(|| ToolError::new(error_codes::PARAMS_INVALID, "missing field `receipt`"))?;
+    let receipt_pubkey = params
+        .get("receipt_pubkey")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            ToolError::new(
+                error_codes::PARAMS_INVALID,
+                "missing field `receipt_pubkey`",
+            )
+        })?
+        .to_string();
+    let audit_pubkey = params
+        .get("audit_pubkey")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| ToolError::new(error_codes::PARAMS_INVALID, "missing field `audit_pubkey`"))?
+        .to_string();
+
+    let receipt: PolicyReceipt = serde_json::from_value(receipt_value.clone()).map_err(|e| {
+        ToolError::new(
+            error_codes::PARAMS_INVALID,
+            format!("receipt does not deserialise as PolicyReceipt: {e}"),
+        )
+    })?;
+    if receipt.audit_event_id != event_id {
+        return Err(ToolError::new(
+            error_codes::AUDIT_EVENT_ID_MISMATCH,
+            format!(
+                "receipt.audit_event_id={} but request asked for audit_event_id={event_id}",
+                receipt.audit_event_id
+            ),
+        ));
+    }
+    let storage = Storage::open(Path::new(db_path)).map_err(|e| {
+        ToolError::new(
+            error_codes::STORAGE_FAILED,
+            format!("open db {db_path}: {e}"),
+        )
+    })?;
+    let chain = match storage.audit_chain_prefix_through(event_id) {
+        Ok(c) => c,
+        Err(mandate_storage::error::StorageError::AuditEventNotFound { id }) => {
+            return Err(ToolError::new(
+                error_codes::AUDIT_EVENT_NOT_FOUND,
+                format!("audit_event_id {id} not present in {db_path}"),
+            ));
+        }
+        Err(e) => {
+            return Err(ToolError::new(
+                error_codes::STORAGE_FAILED,
+                format!("audit_chain_prefix_through: {e}"),
+            ));
+        }
+    };
+    let bundle = audit_bundle::build(
+        receipt,
+        chain,
+        receipt_pubkey,
+        audit_pubkey,
+        chrono::Utc::now(),
+    )
+    .map_err(|e| ToolError::new(error_codes::BUNDLE_BUILD_FAILED, bundle_error_message(e)))?;
+    let serialised = serde_json::to_value(&bundle).map_err(|e| {
+        ToolError::new(
+            error_codes::BUNDLE_BUILD_FAILED,
+            format!("serialise bundle: {e}"),
+        )
+    })?;
+    Ok(json!({ "ok": true, "bundle": serialised }))
+}
+
+// ---------------------------------------------------------------------------
+// Internals shared between tools
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy)]
+enum ExecutorChoice {
+    Keeperhub,
+    Uniswap,
+}
+
+impl ExecutorChoice {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Keeperhub => "keeperhub",
+            Self::Uniswap => "uniswap",
+        }
+    }
+}
+
+fn load_active_policy(db_path: &Path) -> Result<Policy, ToolError> {
+    let storage = Storage::open(db_path).map_err(|e| {
+        ToolError::new(
+            error_codes::STORAGE_FAILED,
+            format!("open db {}: {e}", db_path.display()),
+        )
+    })?;
+    let active = storage
+        .policy_current()
+        .map_err(|e| ToolError::new(error_codes::STORAGE_FAILED, format!("policy_current: {e}")))?
+        .ok_or_else(|| {
+            ToolError::new(
+                error_codes::POLICY_NOT_ACTIVE,
+                format!(
+                    "no active policy in {}; run `mandate policy activate` first",
+                    db_path.display()
+                ),
+            )
+        })?;
+    Policy::parse_json(&active.policy_json).map_err(|e| {
+        ToolError::new(
+            error_codes::POLICY_LOAD_FAILED,
+            format!("active policy v{} no longer validates: {e}", active.version),
+        )
+    })
+}
+
+fn run_pipeline(
+    db_path: &Path,
+    policy: Policy,
+    aprp: &Value,
+) -> Result<PaymentRequestResponse, ToolError> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| {
+            ToolError::new(
+                error_codes::PIPELINE_FAILED,
+                format!("tokio runtime init: {e}"),
+            )
+        })?;
+    let aprp_owned = aprp.clone();
+    let db_owned = db_path.to_path_buf();
+    runtime.block_on(async move {
+        let storage = Storage::open(&db_owned).map_err(|e| {
+            ToolError::new(
+                error_codes::STORAGE_FAILED,
+                format!("open db {}: {e}", db_owned.display()),
+            )
+        })?;
+        let state = AppState::new(policy, storage);
+        let app = mandate_server::router(state);
+        oneshot_payment_request(app, &aprp_owned).await
+    })
+}
+
+async fn oneshot_payment_request(
+    app: axum::Router,
+    aprp: &Value,
+) -> Result<PaymentRequestResponse, ToolError> {
+    use axum::body::Body;
+    use axum::http::Request;
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    let body = serde_json::to_vec(aprp).map_err(|e| {
+        ToolError::new(error_codes::PIPELINE_FAILED, format!("serialise aprp: {e}"))
+    })?;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/payment-requests")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .map_err(|e| ToolError::new(error_codes::PIPELINE_FAILED, format!("build request: {e}")))?;
+    let resp = app
+        .oneshot(req)
+        .await
+        .map_err(|e| ToolError::new(error_codes::PIPELINE_FAILED, format!("oneshot: {e}")))?;
+    let status = resp.status();
+    let body_bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .map_err(|e| {
+            ToolError::new(
+                error_codes::PIPELINE_FAILED,
+                format!("read response body: {e}"),
+            )
+        })?
+        .to_bytes();
+    if !status.is_success() {
+        let body: Value = serde_json::from_slice(&body_bytes).unwrap_or(Value::Null);
+        // Map the schema/protocol/policy/budget Problem codes back to a
+        // useful tool error. The Problem body's `code` field is the
+        // canonical machine-readable error string; surface it verbatim
+        // through `data.code` so MCP clients branch on the same key as
+        // the HTTP API.
+        let code = body
+            .get("code")
+            .and_then(|v| v.as_str())
+            .unwrap_or(error_codes::PIPELINE_FAILED)
+            .to_string();
+        return Err(ToolError::new(&code, format!("HTTP {status}: {body}")));
+    }
+    serde_json::from_slice(&body_bytes)
+        .map_err(|e| ToolError::new(error_codes::PIPELINE_FAILED, format!("parse response: {e}")))
+}
+
+fn call_mock_executor(
+    choice: ExecutorChoice,
+    aprp: &Value,
+    response: &PaymentRequestResponse,
+) -> Result<Map<String, Value>, String> {
+    let request: mandate_core::aprp::PaymentRequest =
+        serde_json::from_value(aprp.clone()).map_err(|e| format!("aprp typed parse: {e}"))?;
+    let executor: Box<dyn GuardedExecutor> = match choice {
+        ExecutorChoice::Keeperhub => Box::new(KeeperHubExecutor::local_mock()),
+        ExecutorChoice::Uniswap => Box::new(UniswapExecutor::local_mock()),
+    };
+    let exec_receipt = executor
+        .execute(&request, &response.receipt)
+        .map_err(|e| format!("executor: {e}"))?;
+    let mut block = Map::new();
+    block.insert("executor".into(), Value::String(choice.label().to_string()));
+    block.insert("mode".into(), Value::String("mock".to_string()));
+    block.insert(
+        "execution_ref".into(),
+        Value::String(exec_receipt.execution_ref),
+    );
+    block.insert("status".into(), Value::String("submitted".to_string()));
+    block.insert("sponsor_payload_hash".into(), Value::Null);
+    block.insert("live_evidence".into(), Value::Null);
+    Ok(block)
+}
+
+fn deny_execution_block(choice: ExecutorChoice) -> Map<String, Value> {
+    let mut block = Map::new();
+    block.insert("executor".into(), Value::String(choice.label().to_string()));
+    block.insert("mode".into(), Value::String("mock".to_string()));
+    block.insert("execution_ref".into(), Value::Null);
+    block.insert("status".into(), Value::String("not_called".to_string()));
+    block.insert("sponsor_payload_hash".into(), Value::Null);
+    block.insert("live_evidence".into(), Value::Null);
+    block
+}
+
+fn load_capsule_param(params: &Value) -> Result<Value, ToolError> {
+    if let Some(v) = params.get("capsule") {
+        return Ok(v.clone());
+    }
+    if let Some(p) = params.get("path").and_then(|v| v.as_str()) {
+        let raw = std::fs::read_to_string(p).map_err(|e| {
+            ToolError::new(error_codes::CAPSULE_IO_FAILED, format!("read {p}: {e}"))
+        })?;
+        return serde_json::from_str::<Value>(&raw)
+            .map_err(|e| ToolError::new(error_codes::CAPSULE_INVALID, format!("parse {p}: {e}")));
+    }
+    Err(ToolError::new(
+        error_codes::PARAMS_INVALID,
+        "expected one of fields `capsule` (object) or `path` (string)",
+    ))
+}
+
+fn schema_error_message(err: SchemaError) -> String {
+    err.to_string()
+}
+
+fn bundle_error_message(err: BundleError) -> String {
+    err.to_string()
+}
+
+fn capsule_error_code(_err: &CapsuleVerifyError) -> &'static str {
+    // All P1.1 verifier failures collapse into one tool-level code today;
+    // the verifier's own `(capsule.<code>)` discriminator is preserved
+    // verbatim in the error message so MCP clients can branch on it
+    // exactly the way `mandate passport verify` callers do.
+    error_codes::CAPSULE_INVALID
+}
+
+// ---------------------------------------------------------------------------
+// Public re-exports for tests and the binary
+// ---------------------------------------------------------------------------
+
+/// Convenience: dispatch into a JSON-RPC `Response`. Used by the binary
+/// and by integration tests that drive the dispatcher without spawning
+/// a child process.
+pub fn dispatch_to_response(req: &Request, ctx: &Arc<ServerContext>) -> Response {
+    match dispatch(&req.method, &req.params, ctx) {
+        Ok(result) => Response::ok(req.id.clone(), result),
+        Err(e) => Response::err(req.id.clone(), e.into_jsonrpc()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tools_catalogue_lists_six_tools_plus_meta() {
+        let catalogue = tools_catalogue();
+        assert_eq!(catalogue.len(), 6, "P3.1 ships six tools");
+        let names: Vec<&str> = catalogue.iter().map(|t| t.name).collect();
+        for name in [
+            "mandate.validate_aprp",
+            "mandate.decide",
+            "mandate.run_guarded_execution",
+            "mandate.verify_capsule",
+            "mandate.explain_denial",
+            "mandate.audit_lookup",
+        ] {
+            assert!(names.contains(&name), "missing tool `{name}` in catalogue");
+        }
+    }
+
+    #[test]
+    fn unknown_method_returns_params_invalid() {
+        let ctx = ServerContext::new();
+        let err = dispatch("does.not.exist", &json!({}), &ctx).unwrap_err();
+        assert_eq!(err.code, error_codes::PARAMS_INVALID);
+    }
+}

--- a/crates/mandate-mcp/src/main.rs
+++ b/crates/mandate-mcp/src/main.rs
@@ -1,0 +1,70 @@
+//! `mandate-mcp` — Mandate MCP stdio JSON-RPC server (Passport P3.1).
+//!
+//! Reads newline-delimited JSON-RPC 2.0 requests from stdin, dispatches
+//! them through the in-process tool catalogue (`mandate_mcp::dispatch`),
+//! and writes one newline-delimited JSON-RPC 2.0 response per request
+//! to stdout. Logs go to stderr so MCP clients consuming stdout aren't
+//! confused by interleaved tracing output.
+//!
+//! The protocol is documented in `docs/cli/mcp.md`. Tests drive the
+//! binary by spawning a child process and writing/reading through the
+//! pipes; see `crates/mandate-mcp/tests/stdio_jsonrpc.rs`.
+
+use std::io::{BufRead, Write};
+use std::sync::Arc;
+
+use mandate_mcp::{dispatch_to_response, jsonrpc, ServerContext};
+
+fn main() {
+    // tracing → stderr only; stdout is the JSON-RPC channel.
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    tracing::info!(
+        "mandate-mcp: stdio JSON-RPC server ready (protocol: NDJSON, tools: 6, see docs/cli/mcp.md)"
+    );
+
+    let ctx = Arc::new(ServerContext::new());
+    let stdin = std::io::stdin();
+    let mut stdout = std::io::stdout().lock();
+    let reader = stdin.lock();
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::error!("read stdin: {e}");
+                break;
+            }
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let response = match jsonrpc::parse_request(&line) {
+            Ok(req) => dispatch_to_response(&req, &ctx),
+            Err(resp) => resp,
+        };
+        let serialised = match serde_json::to_string(&response) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!("serialise response: {e}");
+                continue;
+            }
+        };
+        if let Err(e) = writeln!(stdout, "{serialised}") {
+            tracing::error!("write stdout: {e}");
+            break;
+        }
+        if let Err(e) = stdout.flush() {
+            tracing::error!("flush stdout: {e}");
+            break;
+        }
+    }
+
+    tracing::info!("mandate-mcp: stdin closed, exiting");
+}

--- a/crates/mandate-mcp/tests/jsonrpc_integration.rs
+++ b/crates/mandate-mcp/tests/jsonrpc_integration.rs
@@ -1,0 +1,589 @@
+//! Integration tests for the `mandate-mcp` stdio JSON-RPC server (Passport P3.1).
+//!
+//! Two layers:
+//! 1. **In-process dispatch** — calls `mandate_mcp::dispatch` directly. Exercises
+//!    every tool through `ServerContext` without spawning a subprocess; this is
+//!    where most of the coverage lives because it's fast and lets us pin the
+//!    JSON-RPC error envelope shape exactly.
+//! 2. **Stdio child-process** — spawns the `mandate-mcp` binary, writes
+//!    newline-delimited JSON-RPC requests, reads responses. Exists to prove
+//!    the wire transport works end-to-end (the dispatcher logic is the same).
+//!
+//! Test DB / policy setup:
+//! - Each test gets a fresh `tempfile::TempDir` SQLite DB (so the nonce
+//!   replay-protection store is empty).
+//! - Tests activate `test-corpus/policy/reference_low_risk.json` directly via
+//!   `Storage::policy_activate` rather than spawning `mandate policy activate`,
+//!   which would force a cross-crate binary dependency.
+//! - APRP fixtures come from `test-corpus/aprp/` — `golden_001_minimal.json`
+//!   for allow paths, `deny_prompt_injection_request.json` for deny paths.
+//!   Both have `expiry: "2026-05-01T..."`, comfortably in the future for
+//!   2026-Q2 CI.
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+use mandate_mcp::{dispatch, error_codes, ServerContext, TOOL_ERROR_CODE};
+use serde_json::{json, Value};
+
+const REF_POLICY: &str = "../../test-corpus/policy/reference_low_risk.json";
+const APRP_ALLOW: &str = "../../test-corpus/aprp/golden_001_minimal.json";
+const APRP_DENY: &str = "../../test-corpus/aprp/deny_prompt_injection_request.json";
+
+const CAPSULE_GOLDEN: &str = "../../test-corpus/passport/golden_001_allow_keeperhub_mock.json";
+const CAPSULE_TAMPERED_HASH: &str =
+    "../../test-corpus/passport/tampered_004_request_hash_mismatch.json";
+
+// Public dev signers from `mandate_server::AppState::new`. These match the
+// seeds in the production-shaped runner; auditors can derive the same
+// pubkeys themselves (or read them off any signed receipt's `key_id`).
+//
+// The `dev_pubkeys_match_canonical_constants` test below pins the exact
+// hex bytes — the sponsor demo (`demo-scripts/sponsors/mcp-passport.sh`)
+// hardcodes the same values. If a seed ever changes, both this test and
+// the demo break together — that's the contract.
+const DEV_AUDIT_PUBKEY_HEX: &str =
+    "66be7e332c7a453332bd9d0a7f7db055f5c5ef1a06ada66d98b39fb6810c473a";
+const DEV_RECEIPT_PUBKEY_HEX: &str =
+    "ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c";
+
+fn audit_signer_pubkey_hex() -> String {
+    use mandate_core::signer::DevSigner;
+    DevSigner::from_seed("audit-signer-v1", [11u8; 32]).verifying_key_hex()
+}
+
+fn receipt_signer_pubkey_hex() -> String {
+    use mandate_core::signer::DevSigner;
+    DevSigner::from_seed("decision-signer-v1", [7u8; 32]).verifying_key_hex()
+}
+
+#[test]
+fn dev_pubkeys_match_canonical_constants() {
+    // Anchor for the sponsor demo's hardcoded hex. If anyone changes the
+    // seeds in `crates/mandate-server/src/lib.rs::AppState::new`, this
+    // test catches it before the demo silently breaks.
+    assert_eq!(audit_signer_pubkey_hex(), DEV_AUDIT_PUBKEY_HEX);
+    assert_eq!(receipt_signer_pubkey_hex(), DEV_RECEIPT_PUBKEY_HEX);
+}
+
+fn read_json(path: &str) -> Value {
+    let raw = std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read fixture {path}: {e}"));
+    serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse fixture {path}: {e}"))
+}
+
+fn fresh_db() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("mandate.sqlite");
+    activate_reference_policy(&path);
+    (dir, path)
+}
+
+fn activate_reference_policy(db_path: &Path) {
+    use mandate_core::hashing::{canonical_json, sha256_hex};
+    use mandate_storage::Storage;
+
+    let policy_value = read_json(REF_POLICY);
+    let policy_hash = sha256_hex(&canonical_json(&policy_value).expect("canonicalise policy"));
+    let policy_json = serde_json::to_string(&policy_value).expect("re-serialise policy");
+    let mut storage = Storage::open(db_path).expect("open storage");
+    storage
+        .policy_activate(
+            &policy_json,
+            &policy_hash,
+            "operator-cli",
+            chrono::Utc::now(),
+        )
+        .expect("policy_activate");
+}
+
+fn aprp_with_unique_nonce(path: &str, nonce_suffix: &str) -> Value {
+    let mut v = read_json(path);
+    let nonce = format!("01HTAWX5K3R8YV9NQB7C6P{nonce_suffix:>04}");
+    v["nonce"] = Value::String(nonce);
+    v
+}
+
+// ---------------------------------------------------------------------------
+// Tool 1 — mandate.validate_aprp
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validate_aprp_accepts_golden_fixture() {
+    let ctx = ServerContext::new();
+    let aprp = read_json(APRP_ALLOW);
+    let result = dispatch("mandate.validate_aprp", &json!({ "aprp": aprp }), &ctx).unwrap();
+    assert_eq!(result["ok"], true);
+    let hash = result["request_hash"].as_str().expect("request_hash str");
+    assert_eq!(hash.len(), 64, "request_hash must be 64 hex chars");
+    assert!(
+        hash.chars().all(|c| c.is_ascii_hexdigit()),
+        "request_hash must be lowercase hex; got {hash}"
+    );
+}
+
+#[test]
+fn validate_aprp_rejects_unknown_field_with_stable_code() {
+    let ctx = ServerContext::new();
+    let mut aprp = read_json(APRP_ALLOW);
+    aprp["totally_unknown_root_field"] = json!("nope");
+    let err = dispatch("mandate.validate_aprp", &json!({ "aprp": aprp }), &ctx).unwrap_err();
+    assert_eq!(err.code, error_codes::APRP_INVALID);
+}
+
+#[test]
+fn validate_aprp_rejects_missing_field_param() {
+    let ctx = ServerContext::new();
+    let err = dispatch("mandate.validate_aprp", &json!({}), &ctx).unwrap_err();
+    assert_eq!(err.code, error_codes::PARAMS_INVALID);
+    assert!(err.message.contains("aprp"));
+}
+
+// ---------------------------------------------------------------------------
+// Tool 2 — mandate.decide
+// ---------------------------------------------------------------------------
+
+#[test]
+fn decide_allow_path_returns_auto_approved() {
+    let (_dir, db) = fresh_db();
+    let aprp = aprp_with_unique_nonce(APRP_ALLOW, "DEC1");
+    let ctx = ServerContext::new();
+    let result = dispatch(
+        "mandate.decide",
+        &json!({ "aprp": aprp, "db": db.to_string_lossy() }),
+        &ctx,
+    )
+    .unwrap();
+    assert_eq!(result["status"], "auto_approved");
+    let event_id = result["audit_event_id"].as_str().unwrap();
+    assert!(
+        event_id.starts_with("evt-"),
+        "audit_event_id shape: {event_id}"
+    );
+    assert!(result["receipt"].is_object(), "receipt must be present");
+}
+
+#[test]
+fn decide_deny_path_returns_rejected_with_deny_code() {
+    let (_dir, db) = fresh_db();
+    let aprp = aprp_with_unique_nonce(APRP_DENY, "DEC2");
+    let ctx = ServerContext::new();
+    let result = dispatch(
+        "mandate.decide",
+        &json!({ "aprp": aprp, "db": db.to_string_lossy() }),
+        &ctx,
+    )
+    .unwrap();
+    assert_eq!(result["status"], "rejected");
+    let deny = result["deny_code"].as_str().expect("deny_code present");
+    assert!(!deny.is_empty(), "deny_code must be non-empty on a deny");
+}
+
+#[test]
+fn decide_without_active_policy_returns_policy_not_active() {
+    // Empty DB → no active policy.
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("empty.sqlite");
+    let _ = mandate_storage::Storage::open(&db).expect("init empty db");
+    let aprp = read_json(APRP_ALLOW);
+    let ctx = ServerContext::new();
+    let err = dispatch(
+        "mandate.decide",
+        &json!({ "aprp": aprp, "db": db.to_string_lossy() }),
+        &ctx,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, error_codes::POLICY_NOT_ACTIVE);
+}
+
+// ---------------------------------------------------------------------------
+// Tool 3 — mandate.run_guarded_execution
+// ---------------------------------------------------------------------------
+
+#[test]
+fn run_guarded_allow_calls_keeperhub_mock_executor() {
+    let (_dir, db) = fresh_db();
+    let aprp = aprp_with_unique_nonce(APRP_ALLOW, "EXC1");
+    let ctx = ServerContext::new();
+    let result = dispatch(
+        "mandate.run_guarded_execution",
+        &json!({ "aprp": aprp, "db": db.to_string_lossy(), "executor": "keeperhub" }),
+        &ctx,
+    )
+    .unwrap();
+    assert_eq!(result["execution"]["executor"], "keeperhub");
+    assert_eq!(result["execution"]["mode"], "mock");
+    assert_eq!(result["execution"]["status"], "submitted");
+    let exec_ref = result["execution"]["execution_ref"]
+        .as_str()
+        .expect("execution_ref string on allow path");
+    assert!(
+        exec_ref.starts_with("kh-"),
+        "KeeperHub mock prefix: {exec_ref}"
+    );
+}
+
+#[test]
+fn run_guarded_deny_does_not_call_executor() {
+    let (_dir, db) = fresh_db();
+    let aprp = aprp_with_unique_nonce(APRP_DENY, "EXC2");
+    let ctx = ServerContext::new();
+    let result = dispatch(
+        "mandate.run_guarded_execution",
+        &json!({ "aprp": aprp, "db": db.to_string_lossy(), "executor": "keeperhub" }),
+        &ctx,
+    )
+    .unwrap();
+    // Hard truthfulness invariant from P1.1 (tampered_001): deny ⇒ executor is never called.
+    assert_eq!(result["execution"]["status"], "not_called");
+    assert_eq!(result["execution"]["execution_ref"], Value::Null);
+    assert_eq!(result["decision"]["result"], "deny");
+}
+
+#[test]
+fn run_guarded_rejects_live_mode() {
+    let (_dir, db) = fresh_db();
+    let aprp = aprp_with_unique_nonce(APRP_ALLOW, "EXC3");
+    let ctx = ServerContext::new();
+    let err = dispatch(
+        "mandate.run_guarded_execution",
+        &json!({
+            "aprp": aprp,
+            "db": db.to_string_lossy(),
+            "executor": "keeperhub",
+            "mode": "live"
+        }),
+        &ctx,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, error_codes::LIVE_MODE_REJECTED);
+}
+
+// ---------------------------------------------------------------------------
+// Tool 4 — mandate.verify_capsule
+// ---------------------------------------------------------------------------
+
+#[test]
+fn verify_capsule_accepts_golden_fixture_via_path() {
+    let ctx = ServerContext::new();
+    let result = dispatch(
+        "mandate.verify_capsule",
+        &json!({ "path": CAPSULE_GOLDEN }),
+        &ctx,
+    )
+    .unwrap();
+    assert_eq!(result["ok"], true);
+    assert_eq!(result["schema"], "mandate.passport_capsule.v1");
+}
+
+#[test]
+fn verify_capsule_rejects_tampered_request_hash() {
+    let ctx = ServerContext::new();
+    let err = dispatch(
+        "mandate.verify_capsule",
+        &json!({ "path": CAPSULE_TAMPERED_HASH }),
+        &ctx,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, error_codes::CAPSULE_INVALID);
+    assert!(
+        err.message.contains("capsule.request_hash_mismatch"),
+        "verifier code must surface in message: {}",
+        err.message
+    );
+}
+
+#[test]
+fn verify_capsule_accepts_inline_object() {
+    let ctx = ServerContext::new();
+    let capsule = read_json(CAPSULE_GOLDEN);
+    let result = dispatch(
+        "mandate.verify_capsule",
+        &json!({ "capsule": capsule }),
+        &ctx,
+    )
+    .unwrap();
+    assert_eq!(result["ok"], true);
+}
+
+// ---------------------------------------------------------------------------
+// Tool 5 — mandate.explain_denial
+// ---------------------------------------------------------------------------
+
+#[test]
+fn explain_denial_rejects_allow_capsule() {
+    let ctx = ServerContext::new();
+    let err = dispatch(
+        "mandate.explain_denial",
+        &json!({ "path": CAPSULE_GOLDEN }),
+        &ctx,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, error_codes::CAPSULE_NOT_DENY);
+}
+
+// ---------------------------------------------------------------------------
+// Tool 6 — mandate.audit_lookup (IP-3)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn audit_lookup_hit_returns_bundle_for_seeded_audit_event() {
+    let (_dir, db) = fresh_db();
+    let aprp = aprp_with_unique_nonce(APRP_ALLOW, "AAA1");
+    let ctx = ServerContext::new();
+
+    // Seed: drive a real decide so the audit chain has at least one event.
+    let decide = dispatch(
+        "mandate.decide",
+        &json!({ "aprp": aprp, "db": db.to_string_lossy() }),
+        &ctx,
+    )
+    .unwrap();
+    let event_id = decide["audit_event_id"].as_str().unwrap().to_string();
+    let receipt = decide["receipt"].clone();
+
+    let result = dispatch(
+        "mandate.audit_lookup",
+        &json!({
+            "audit_event_id": event_id,
+            "db": db.to_string_lossy(),
+            "receipt": receipt,
+            "receipt_pubkey": receipt_signer_pubkey_hex(),
+            "audit_pubkey":   audit_signer_pubkey_hex(),
+        }),
+        &ctx,
+    )
+    .unwrap();
+
+    assert_eq!(result["ok"], true);
+    let bundle = &result["bundle"];
+    assert_eq!(bundle["bundle_type"], "mandate.audit_bundle.v1");
+    assert_eq!(bundle["version"], 1);
+    assert_eq!(bundle["summary"]["audit_event_id"], event_id);
+}
+
+#[test]
+fn audit_lookup_miss_returns_audit_event_not_found() {
+    let (_dir, db) = fresh_db();
+    let aprp = aprp_with_unique_nonce(APRP_ALLOW, "AAA2");
+    let ctx = ServerContext::new();
+    // Seed one event so the DB has a chain at all.
+    let decide = dispatch(
+        "mandate.decide",
+        &json!({ "aprp": aprp, "db": db.to_string_lossy() }),
+        &ctx,
+    )
+    .unwrap();
+    let receipt = decide["receipt"].clone();
+    // Now ask for an event id that exists nowhere.
+    let bogus = "evt-01HZZZZZZZZZZZZZZZZZZZZZZZ";
+    let err = dispatch(
+        "mandate.audit_lookup",
+        &json!({
+            "audit_event_id": bogus,
+            "db": db.to_string_lossy(),
+            "receipt": receipt,
+            "receipt_pubkey": receipt_signer_pubkey_hex(),
+            "audit_pubkey":   audit_signer_pubkey_hex(),
+        }),
+        &ctx,
+    )
+    .unwrap_err();
+    // Receipt's audit_event_id ≠ bogus, so the early mismatch check fires
+    // first. That's correct: it short-circuits before even touching SQLite,
+    // and the contract is "either id mismatch OR not-found is the failure
+    // mode an auditor can branch on."
+    assert_eq!(err.code, error_codes::AUDIT_EVENT_ID_MISMATCH);
+}
+
+#[test]
+fn audit_lookup_with_matching_receipt_but_unknown_event_id_returns_not_found() {
+    // Constructs the failure mode where the receipt and event_id agree on a
+    // string, but no such event lives in the DB — the second branch of the
+    // 404 contract.
+    let (_dir, db) = fresh_db();
+    let aprp = aprp_with_unique_nonce(APRP_ALLOW, "AAA3");
+    let ctx = ServerContext::new();
+    let decide = dispatch(
+        "mandate.decide",
+        &json!({ "aprp": aprp, "db": db.to_string_lossy() }),
+        &ctx,
+    )
+    .unwrap();
+    let mut receipt = decide["receipt"].clone();
+    let bogus = "evt-01HZZZZZZZZZZZZZZZZZZZZZZZ";
+    receipt["audit_event_id"] = json!(bogus);
+    let err = dispatch(
+        "mandate.audit_lookup",
+        &json!({
+            "audit_event_id": bogus,
+            "db": db.to_string_lossy(),
+            "receipt": receipt,
+            "receipt_pubkey": receipt_signer_pubkey_hex(),
+            "audit_pubkey":   audit_signer_pubkey_hex(),
+        }),
+        &ctx,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, error_codes::AUDIT_EVENT_NOT_FOUND);
+}
+
+// ---------------------------------------------------------------------------
+// JSON-RPC envelope shape — wire-format conformance
+// ---------------------------------------------------------------------------
+
+#[test]
+fn jsonrpc_error_envelope_carries_stable_code_in_data() {
+    use mandate_mcp::dispatch_to_response;
+    use mandate_mcp::jsonrpc::Request;
+    use std::sync::Arc;
+
+    let req: Request = serde_json::from_value(json!({
+        "jsonrpc": "2.0",
+        "id": 17,
+        "method": "mandate.validate_aprp",
+        "params": {}
+    }))
+    .unwrap();
+    let ctx = Arc::new(ServerContext::new());
+    let resp = dispatch_to_response(&req, &ctx);
+    let body = serde_json::to_value(&resp).unwrap();
+    assert_eq!(body["jsonrpc"], "2.0");
+    assert_eq!(body["id"], 17);
+    assert!(
+        body["result"].is_null(),
+        "error path must not emit `result`"
+    );
+    let err = &body["error"];
+    assert_eq!(err["code"].as_i64(), Some(TOOL_ERROR_CODE));
+    assert_eq!(err["data"]["code"], error_codes::PARAMS_INVALID);
+}
+
+#[test]
+fn jsonrpc_unknown_method_yields_params_invalid() {
+    use mandate_mcp::dispatch_to_response;
+    use mandate_mcp::jsonrpc::Request;
+    use std::sync::Arc;
+
+    let req: Request = serde_json::from_value(json!({
+        "jsonrpc": "2.0",
+        "id": "x",
+        "method": "mandate.does_not_exist",
+        "params": {}
+    }))
+    .unwrap();
+    let ctx = Arc::new(ServerContext::new());
+    let resp = dispatch_to_response(&req, &ctx);
+    let body = serde_json::to_value(&resp).unwrap();
+    assert_eq!(body["error"]["data"]["code"], error_codes::PARAMS_INVALID);
+}
+
+// ---------------------------------------------------------------------------
+// Stdio transport — child process, NDJSON
+// ---------------------------------------------------------------------------
+
+struct McpServer {
+    child: Child,
+}
+
+impl McpServer {
+    fn spawn() -> Self {
+        let bin = env!("CARGO_BIN_EXE_mandate-mcp");
+        let child = Command::new(bin)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn mandate-mcp");
+        Self { child }
+    }
+
+    fn call(&mut self, method: &str, params: Value) -> Value {
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": method,
+            "params": params,
+        });
+        let stdin = self.child.stdin.as_mut().expect("stdin pipe");
+        let line = serde_json::to_string(&req).unwrap();
+        writeln!(stdin, "{line}").expect("write stdin");
+        stdin.flush().expect("flush stdin");
+
+        let stdout = self.child.stdout.as_mut().expect("stdout pipe");
+        let mut reader = BufReader::new(stdout);
+        let mut response_line = String::new();
+        reader
+            .read_line(&mut response_line)
+            .expect("read response line");
+        serde_json::from_str(response_line.trim()).expect("parse response JSON")
+    }
+}
+
+impl Drop for McpServer {
+    fn drop(&mut self) {
+        // Closing stdin makes the child exit cleanly. Wait briefly so we
+        // don't leave zombie processes between test runs.
+        if let Some(stdin) = self.child.stdin.take() {
+            drop(stdin);
+        }
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn stdio_tools_list_round_trips_through_child_process() {
+    let mut server = McpServer::spawn();
+    let resp = server.call("tools/list", json!({}));
+    assert_eq!(resp["jsonrpc"], "2.0");
+    let result = resp["result"].as_array().expect("tools/list returns array");
+    assert_eq!(result.len(), 6, "P3.1 ships six tools");
+    let names: Vec<&str> = result.iter().filter_map(|t| t["name"].as_str()).collect();
+    assert!(names.contains(&"mandate.audit_lookup"));
+}
+
+#[test]
+fn stdio_validate_aprp_round_trips_through_child_process() {
+    let aprp = read_json(APRP_ALLOW);
+    let mut server = McpServer::spawn();
+    let resp = server.call("mandate.validate_aprp", json!({ "aprp": aprp }));
+    assert_eq!(resp["result"]["ok"], true);
+    let hash = resp["result"]["request_hash"].as_str().unwrap();
+    assert_eq!(hash.len(), 64);
+}
+
+#[test]
+fn stdio_decide_allow_round_trips_through_child_process() {
+    let (_dir, db) = fresh_db();
+    let aprp = aprp_with_unique_nonce(APRP_ALLOW, "STD1");
+    let mut server = McpServer::spawn();
+    let resp = server.call(
+        "mandate.decide",
+        json!({ "aprp": aprp, "db": db.to_string_lossy() }),
+    );
+    assert_eq!(resp["result"]["status"], "auto_approved");
+}
+
+#[test]
+fn stdio_garbage_input_yields_parse_error() {
+    let bin = env!("CARGO_BIN_EXE_mandate-mcp");
+    let mut child = Command::new(bin)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn");
+    {
+        let stdin = child.stdin.as_mut().expect("stdin");
+        writeln!(stdin, "not json at all").unwrap();
+        stdin.flush().unwrap();
+    }
+    let stdout = child.stdout.as_mut().expect("stdout");
+    let mut line = String::new();
+    BufReader::new(stdout).read_line(&mut line).unwrap();
+    let resp: Value = serde_json::from_str(line.trim()).unwrap();
+    assert_eq!(resp["error"]["code"].as_i64(), Some(-32700));
+    assert!(resp["id"].is_null());
+    drop(child.stdin.take());
+    let _ = child.wait();
+}

--- a/demo-scripts/sponsors/mcp-passport.sh
+++ b/demo-scripts/sponsors/mcp-passport.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Sponsor demo: Mandate MCP stdio JSON-RPC — Passport P3.1.
+#
+# Drives the freshly-built `mandate-mcp` server over a stdin/stdout pipe and
+# exercises every shipping tool in the catalogue:
+#
+#   1. tools/list                       — meta, prove the catalogue is wired
+#   2. mandate.validate_aprp            — schema check against APRP fixture
+#   3. mandate.decide  (allow path)     — full pipeline → auto_approved
+#   4. mandate.decide  (deny path)      — prompt-injection → rejected
+#   5. mandate.run_guarded_execution    — KeeperHub mock executor on allow
+#   6. mandate.verify_capsule           — re-verify the production-shaped
+#                                         passport-allow.json capsule
+#   7. mandate.audit_lookup             — IP-3 sister tool: event_id + receipt
+#                                         → mandate.audit_bundle.v1
+#
+# A transcript of all requests and responses is written to
+# `demo-scripts/artifacts/mcp-transcript.json`. Exit 0 iff every step
+# returned the expected result.
+#
+# This demo is **not** in the 13-gate `run-openagents-final.sh` and **not**
+# in the production-shaped runner — it's a separate sponsor surface that
+# proves the IP-3 alignment story end-to-end.
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+ARTIFACTS=demo-scripts/artifacts
+TRANSCRIPT="$ARTIFACTS/mcp-transcript.json"
+mkdir -p "$ARTIFACTS"
+
+bold()  { printf '\033[1m%s\033[0m\n' "$1"; }
+ok()    { printf '  \033[32mok\033[0m  %s\n' "$1"; }
+fail()  { printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+
+bold "mandate-mcp — sponsor demo (Passport P3.1)"
+echo
+
+# Pre-flight: required tooling.
+for tool in jq cargo; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "missing dependency: $tool" >&2
+    exit 1
+  }
+done
+
+# Build both binaries upfront. The MCP server doesn't need `mandate`, but
+# step 3+4 seed the DB via `mandate policy activate` to match the runtime
+# layout the operator console + production-shaped runner already use.
+cargo build --quiet --bin mandate --bin mandate-mcp
+
+# Fresh DB per run so the nonce store is empty.
+WORK=$(mktemp -d -t mcp-passport-demo.XXXXXX)
+DB="$WORK/mandate.sqlite"
+trap 'rm -rf "$WORK"' EXIT
+
+./target/debug/mandate policy activate \
+  test-corpus/policy/reference_low_risk.json \
+  --db "$DB" >/dev/null
+ok "policy activated in $DB"
+
+# Per-test unique nonces (Crockford base32 — no I/L/O/U). Each request body
+# uses a different nonce so the nonce-replay store doesn't collapse two
+# calls into one cached response.
+nonce_replace () {
+  local in="$1"; local suffix="$2"
+  jq --arg n "01HTAWX5K3R8YV9NQB7C6P${suffix}" '.nonce = $n' "$in"
+}
+
+ALLOW_APRP=$(nonce_replace test-corpus/aprp/golden_001_minimal.json "MCP1")
+DENY_APRP=$(nonce_replace  test-corpus/aprp/deny_prompt_injection_request.json "MCP2")
+GUARD_APRP=$(nonce_replace test-corpus/aprp/golden_001_minimal.json "MCP3")
+
+# Audit + receipt signer pubkeys.
+#
+# These are the deterministic dev pubkeys baked into
+# `mandate_server::AppState::new` — derived from
+# `DevSigner::from_seed("audit-signer-v1", [11u8; 32]).verifying_key_hex()`
+# and `DevSigner::from_seed("decision-signer-v1", [7u8; 32]).verifying_key_hex()`.
+# They are PUBLIC (the seeds live in `crates/mandate-server/src/lib.rs`
+# under a ⚠ DEV ONLY ⚠ banner) and therefore safe to inline here.
+#
+# The values are pinned by `dev_pubkeys_match_canonical_constants` in
+# `crates/mandate-mcp/tests/jsonrpc_integration.rs` — if the seeds ever
+# change, that test breaks and this demo updates in the same commit.
+AUDIT_PUBKEY="66be7e332c7a453332bd9d0a7f7db055f5c5ef1a06ada66d98b39fb6810c473a"
+RECEIPT_PUBKEY="ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c"
+
+# ----------------------------------------------------------------------------
+# Phase 1: requests that don't depend on each other → batch over one stdin.
+# ----------------------------------------------------------------------------
+PHASE1_REQS="$WORK/phase1.req"
+PHASE1_RESPS="$WORK/phase1.resp"
+
+{
+  echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+  jq -nc --argjson aprp "$ALLOW_APRP" \
+    '{jsonrpc:"2.0",id:2,method:"mandate.validate_aprp",params:{aprp:$aprp}}'
+  jq -nc --argjson aprp "$ALLOW_APRP" --arg db "$DB" \
+    '{jsonrpc:"2.0",id:3,method:"mandate.decide",params:{aprp:$aprp,db:$db}}'
+  jq -nc --argjson aprp "$DENY_APRP"  --arg db "$DB" \
+    '{jsonrpc:"2.0",id:4,method:"mandate.decide",params:{aprp:$aprp,db:$db}}'
+  jq -nc --argjson aprp "$GUARD_APRP" --arg db "$DB" \
+    '{jsonrpc:"2.0",id:5,method:"mandate.run_guarded_execution",params:{aprp:$aprp,db:$db,executor:"keeperhub"}}'
+} > "$PHASE1_REQS"
+
+./target/debug/mandate-mcp < "$PHASE1_REQS" > "$PHASE1_RESPS" 2>/dev/null
+
+# Sanity-check each response.
+LIST_RESP=$(jq    -c 'select(.id==1)' "$PHASE1_RESPS")
+VALIDATE_RESP=$(jq -c 'select(.id==2)' "$PHASE1_RESPS")
+ALLOW_RESP=$(jq    -c 'select(.id==3)' "$PHASE1_RESPS")
+DENY_RESP=$(jq     -c 'select(.id==4)' "$PHASE1_RESPS")
+GUARD_RESP=$(jq    -c 'select(.id==5)' "$PHASE1_RESPS")
+
+jq -e '.result | length == 6' <<<"$LIST_RESP" >/dev/null \
+  && ok "tools/list returned 6 tools" \
+  || { fail "tools/list shape wrong"; exit 1; }
+
+jq -e '.result.ok == true' <<<"$VALIDATE_RESP" >/dev/null \
+  && ok "mandate.validate_aprp ok (request_hash=$(jq -r '.result.request_hash[0:12]' <<<"$VALIDATE_RESP")…)" \
+  || { fail "validate_aprp wrong"; exit 1; }
+
+ALLOW_STATUS=$(jq -r '.result.status' <<<"$ALLOW_RESP")
+ALLOW_EVENT_ID=$(jq -r '.result.audit_event_id' <<<"$ALLOW_RESP")
+ALLOW_RECEIPT=$(jq    '.result.receipt'      <<<"$ALLOW_RESP")
+[ "$ALLOW_STATUS" = "auto_approved" ] \
+  && ok "mandate.decide allow → auto_approved (audit_event_id=$ALLOW_EVENT_ID)" \
+  || { fail "allow path returned status=$ALLOW_STATUS"; exit 1; }
+
+DENY_STATUS=$(jq -r '.result.status'    <<<"$DENY_RESP")
+DENY_CODE=$(jq   -r '.result.deny_code' <<<"$DENY_RESP")
+[ "$DENY_STATUS" = "rejected" ] \
+  && ok "mandate.decide deny → rejected (deny_code=$DENY_CODE)" \
+  || { fail "deny path returned status=$DENY_STATUS"; exit 1; }
+
+GUARD_STATUS=$(jq -r '.result.execution.status'     <<<"$GUARD_RESP")
+GUARD_REF=$(jq    -r '.result.execution.execution_ref' <<<"$GUARD_RESP")
+[ "$GUARD_STATUS" = "submitted" ] \
+  && ok "mandate.run_guarded_execution → keeperhub mock submitted (ref=$GUARD_REF)" \
+  || { fail "run_guarded_execution status=$GUARD_STATUS"; exit 1; }
+
+# ----------------------------------------------------------------------------
+# Phase 2: verify the production-shaped passport capsule (if it exists)
+# ----------------------------------------------------------------------------
+CAPSULE="$ARTIFACTS/passport-allow.json"
+if [ -f "$CAPSULE" ]; then
+  VERIFY_REQ=$(jq -nc --slurpfile c "$CAPSULE" \
+    '{jsonrpc:"2.0",id:6,method:"mandate.verify_capsule",params:{capsule:$c[0]}}')
+  VERIFY_RESP=$(printf '%s\n' "$VERIFY_REQ" | ./target/debug/mandate-mcp 2>/dev/null)
+  jq -e '.result.ok == true' <<<"$VERIFY_RESP" >/dev/null \
+    && ok "mandate.verify_capsule on $CAPSULE → ok" \
+    || { fail "verify_capsule on $CAPSULE failed"; exit 1; }
+else
+  VERIFY_RESP='null'
+  echo "  -- skipping capsule verify: $CAPSULE not present (run bash demo-scripts/run-production-shaped-mock.sh first)"
+fi
+
+# ----------------------------------------------------------------------------
+# Phase 3: audit_lookup (IP-3) — needs allow's event_id + receipt
+# ----------------------------------------------------------------------------
+LOOKUP_REQ=$(jq -nc \
+  --arg event_id "$ALLOW_EVENT_ID" \
+  --arg db "$DB" \
+  --argjson receipt "$ALLOW_RECEIPT" \
+  --arg audit_pk "$AUDIT_PUBKEY" \
+  --arg receipt_pk "$RECEIPT_PUBKEY" \
+  '{jsonrpc:"2.0",id:7,method:"mandate.audit_lookup",params:{audit_event_id:$event_id,db:$db,receipt:$receipt,receipt_pubkey:$receipt_pk,audit_pubkey:$audit_pk}}')
+LOOKUP_RESP=$(printf '%s\n' "$LOOKUP_REQ" | ./target/debug/mandate-mcp 2>/dev/null)
+
+if jq -e '.result.ok == true' <<<"$LOOKUP_RESP" >/dev/null; then
+  BUNDLE_TYPE=$(jq -r '.result.bundle.bundle_type'                 <<<"$LOOKUP_RESP")
+  BUNDLE_LEN=$( jq    '.result.bundle.audit_chain_segment | length' <<<"$LOOKUP_RESP")
+  ok "mandate.audit_lookup → $BUNDLE_TYPE (chain_length=$BUNDLE_LEN, audit_event_id=$ALLOW_EVENT_ID)"
+else
+  fail "audit_lookup failed: $(jq -c '.error' <<<"$LOOKUP_RESP")"
+  exit 1
+fi
+
+# ----------------------------------------------------------------------------
+# Transcript
+# ----------------------------------------------------------------------------
+jq -nc \
+  --argjson list      "$LIST_RESP" \
+  --argjson validate  "$VALIDATE_RESP" \
+  --argjson allow     "$ALLOW_RESP" \
+  --argjson deny      "$DENY_RESP" \
+  --argjson guard     "$GUARD_RESP" \
+  --argjson verify    "$VERIFY_RESP" \
+  --argjson lookup    "$LOOKUP_RESP" \
+  '{
+    schema: "mandate.mcp_demo_transcript.v1",
+    generated_at: now | todate,
+    requests_in_order: ["tools/list","mandate.validate_aprp","mandate.decide(allow)","mandate.decide(deny)","mandate.run_guarded_execution","mandate.verify_capsule","mandate.audit_lookup"],
+    responses: {
+      "tools/list":                      $list,
+      "mandate.validate_aprp":           $validate,
+      "mandate.decide.allow":            $allow,
+      "mandate.decide.deny":             $deny,
+      "mandate.run_guarded_execution":   $guard,
+      "mandate.verify_capsule":          $verify,
+      "mandate.audit_lookup":            $lookup
+    }
+  }' | jq '.' > "$TRANSCRIPT"
+
+echo
+ok "transcript → $TRANSCRIPT"
+echo
+bold "All MCP demo steps completed."

--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -1,0 +1,336 @@
+# `mandate-mcp` — Mandate MCP stdio JSON-RPC server (Passport P3.1)
+
+> *MCP turns Mandate from a daemon into infrastructure other agents can call.*
+
+`mandate-mcp` is a line-delimited JSON-RPC 2.0 server over stdio that
+exposes Mandate's policy, capsule, and audit primitives as MCP tools.
+Every tool **wraps** an existing primitive — no new business logic, no
+new schemas — so the wire contract any MCP client gets is exactly the
+same truth the CLI and HTTP API already publish.
+
+- Source: [`crates/mandate-mcp/`](../../crates/mandate-mcp/).
+- Demo: [`demo-scripts/sponsors/mcp-passport.sh`](../../demo-scripts/sponsors/mcp-passport.sh) — exercises every tool and writes a transcript to `demo-scripts/artifacts/mcp-transcript.json`.
+- Tests: [`crates/mandate-mcp/tests/jsonrpc_integration.rs`](../../crates/mandate-mcp/tests/jsonrpc_integration.rs) — 22 integration tests across in-process dispatch and stdio child-process transport.
+
+## Wire format
+
+JSON-RPC 2.0 requests and responses, **one JSON object per line**.
+That's the entire transport — no Content-Length header framing. Stdin
+EOF closes the server cleanly. Tracing logs go to stderr; stdout is the
+JSON-RPC channel only, so MCP-aware clients reading stdout are never
+interleaved with diagnostic output.
+
+The Rust MCP SDK is too churn-heavy for a hackathon deliverable; per
+the P3.1 backlog risk note we ship a minimal protocol and document it
+here. Clients that already speak JSON-RPC over stdio (Claude Code, Cursor,
+the demo script's `bash + jq` setup) can call any tool without an MCP
+SDK shim.
+
+### Request
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "id":      1,                    // any JSON value; echoed in the response
+  "method":  "mandate.validate_aprp",
+  "params":  { "aprp": { /* APRP body */ } }
+}
+```
+
+### Response — success
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "id":      1,
+  "result":  { "ok": true, "request_hash": "835469d807bb…" }
+}
+```
+
+### Response — error
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "id":      1,
+  "error": {
+    "code":    -32000,                 // tool-level error namespace
+    "message": "schema.value_out_of_range at /amount.value: …",
+    "data":    { "code": "aprp_invalid" }   // stable, machine-readable
+  }
+}
+```
+
+Pre-tool envelope errors use the standard JSON-RPC 2.0 codes:
+
+| Code     | Meaning |
+| -------- | ------- |
+| `-32700` | Parse error. Stdin contained a non-JSON line. `id` is null. |
+| `-32600` | Invalid Request. JSON parsed but lacks the JSON-RPC envelope. |
+| `-32000` | Tool-level error. `data.code` carries a stable string (see below). |
+
+### Stable `data.code` values
+
+Tests pin these exact strings — they are part of the wire contract.
+
+| `data.code`                   | Meaning |
+| ----------------------------- | ------- |
+| `params_invalid`              | Required parameter missing / wrong shape / unknown method. |
+| `schema_violation`            | Capsule failed JSON-Schema 2020-12 validation. |
+| `aprp_invalid`                | APRP body failed `schemas/aprp_v1.json`. |
+| `policy_not_active`           | DB has no active policy row (run `mandate policy activate` first). |
+| `policy_load_failed`          | Active policy row no longer parses (storage corruption). |
+| `pipeline_failed`             | The in-process payment-requests pipeline returned an unexpected error. |
+| `executor_failed`             | The mock executor (KeeperHub / Uniswap) returned an error. |
+| `requires_human_unsupported`  | Policy returned `requires_human`; the capsule schema only encodes allow/deny. |
+| `live_mode_rejected`          | `mandate.run_guarded_execution` was called with `mode: "live"`. P5.1+. |
+| `capsule_io_failed`           | Capsule path could not be read. |
+| `capsule_invalid`             | Capsule failed P1.1 cross-field invariants (`message` carries `(capsule.<code>)`). |
+| `capsule_not_deny`            | `mandate.explain_denial` was called on an allow capsule. |
+| `audit_event_not_found`       | `audit_lookup`: the event_id is not in the chain. |
+| `audit_event_id_mismatch`     | `audit_lookup`: receipt's `audit_event_id` ≠ requested `audit_event_id`. |
+| `bundle_build_failed`         | `audit_bundle::build` returned an error (e.g. chain segment doesn't include the receipt's event). |
+| `storage_failed`              | SQLite open / read failure. |
+
+Pipeline failures additionally surface the HTTP-level Problem code
+verbatim under `data.code` (e.g. `schema.value_out_of_range`,
+`policy.nonce_replay`) — same string an HTTP API caller branches on.
+
+## Tool catalogue
+
+Six tools today; every one of them wraps an existing primitive:
+
+| Tool                                | Wraps |
+| ----------------------------------- | ----- |
+| `mandate.validate_aprp`             | `mandate_core::schema::validate_aprp` |
+| `mandate.decide`                    | `mandate_server::router` (oneshot pattern) |
+| `mandate.run_guarded_execution`     | `mandate_server` + `KeeperHubExecutor::local_mock` / `UniswapExecutor::local_mock` |
+| `mandate.verify_capsule`            | `mandate_core::passport::verify_capsule` |
+| `mandate.explain_denial`            | `verify_capsule` + structured projection |
+| `mandate.audit_lookup`              | `Storage::audit_chain_prefix_through` + `mandate_core::audit_bundle::build` |
+
+Plus one meta method `tools/list` that returns this catalogue with
+input/output JSON schemas. Useful for MCP clients that auto-discover
+tools.
+
+### `mandate.validate_aprp`
+
+Validate an APRP body against `schemas/aprp_v1.json` and (on success)
+return its canonical JCS SHA-256 hash.
+
+```jsonc
+// request
+{ "method": "mandate.validate_aprp", "params": { "aprp": { /* body */ } } }
+// success
+{ "result": { "ok": true, "request_hash": "835469d807bb…" } }
+// failure
+{ "error": { "code": -32000, "data": { "code": "aprp_invalid" }, "message": "…" } }
+```
+
+### `mandate.decide`
+
+Drive the offline payment-requests pipeline (APRP → policy → budget →
+audit → signed receipt) in-process via the same axum oneshot pattern
+`mandate passport run` uses. Returns the same `PaymentRequestResponse`
+the HTTP `POST /v1/payment-requests` API would.
+
+```jsonc
+// request
+{ "method": "mandate.decide",
+  "params": { "aprp": { /* body */ }, "db": "/path/to/mandate.sqlite" } }
+// success — allow path
+{ "result": { "status": "auto_approved",
+              "decision": "allow",
+              "request_hash": "…",
+              "policy_hash":  "…",
+              "audit_event_id": "evt-…",
+              "receipt": { /* signed PolicyReceipt */ } } }
+// success — deny path
+{ "result": { "status": "rejected",
+              "decision": "deny",
+              "deny_code": "policy.deny_unknown_provider", … } }
+```
+
+The DB must already have an active policy (run `mandate policy activate
+<file> --db <path>` once). Empty DB → `policy_not_active`.
+
+### `mandate.run_guarded_execution`
+
+Run `mandate.decide` and, on the allow path only, call the chosen mock
+executor.
+
+- Allow path: invokes `KeeperHubExecutor::local_mock` or
+  `UniswapExecutor::local_mock`; returns `execution.status="submitted"`
+  with the executor's `execution_ref` (`kh-<ULID>` / `uni-<ULID>`).
+- Deny path: executor is **never** called.
+  `execution.status="not_called"`, `execution.execution_ref=null`. Hard
+  truthfulness invariant from P1.1's tampered_001 fixture — same rule
+  `mandate passport run` enforces.
+
+```jsonc
+// request
+{ "method": "mandate.run_guarded_execution",
+  "params": { "aprp": {...}, "db": "...", "executor": "keeperhub" } }
+```
+
+`mode: "live"` is rejected with `live_mode_rejected`; live integration
+lands in P5.1 (`KeeperHubExecutor::live`) and P6.1 (Uniswap quote
+evidence).
+
+### `mandate.verify_capsule`
+
+Run the P1.1 verifier (schema + 8 cross-field invariants) on a capsule.
+Accepts either `{ "capsule": { /* inline */ } }` or `{ "path": "…" }`
+to read from disk.
+
+```jsonc
+// request
+{ "method": "mandate.verify_capsule",
+  "params": { "path": "demo-scripts/artifacts/passport-allow.json" } }
+// success
+{ "result": { "ok": true, "schema": "mandate.passport_capsule.v1" } }
+// failure (cross-field)
+{ "error": { "code": -32000, "data": { "code": "capsule_invalid" },
+             "message": "capsule.request_hash_mismatch: … (capsule.request_hash_mismatch)" } }
+```
+
+The verifier's `(capsule.<code>)` discriminator (request_hash_mismatch,
+deny_with_execution, schema_invalid, …) is preserved verbatim in the
+error message so MCP clients can branch on the same key as
+`mandate passport verify` callers.
+
+### `mandate.explain_denial`
+
+Reads + verifies a capsule and returns a deny-only structured
+projection. Returns `capsule_not_deny` if the capsule is an allow.
+
+```jsonc
+// success
+{ "result": {
+    "schema": "mandate.passport_capsule.v1",
+    "decision": { "result": "deny", "matched_rule": "…", "deny_code": "…" },
+    "audit":    { "audit_event_id": "evt-…" },
+    "policy":   { "policy_hash": "…", "policy_version": 1 } } }
+```
+
+### `mandate.audit_lookup` (IP-3 alignment)
+
+The IP-3 sister tool. Given a Mandate `audit_event_id` plus the signed
+`PolicyReceipt` plus signer pubkeys, returns the corresponding
+`mandate.audit_bundle.v1`. See
+[**docs/keeperhub-integration-paths.md §IP-3**](../keeperhub-integration-paths.md)
+for the cross-side composition story.
+
+```jsonc
+// request
+{ "method": "mandate.audit_lookup",
+  "params": {
+    "audit_event_id": "evt-01KQCKM35K3E7DMXMBSNG250HQ",
+    "db":             "/path/to/mandate.sqlite",
+    "receipt":        { /* signed PolicyReceipt JSON */ },
+    "receipt_pubkey": "ea4a6c63…",
+    "audit_pubkey":   "66be7e33…"
+  }
+}
+// success
+{ "result": {
+    "ok": true,
+    "bundle": {
+      "bundle_type": "mandate.audit_bundle.v1",
+      "version": 1,
+      "exported_at": "2026-04-29T…Z",
+      "receipt": {…},
+      "audit_event": {…},
+      "audit_chain_segment": [{…}, {…}],
+      "verification_keys": { "receipt_signer_pubkey_hex": "…", "audit_signer_pubkey_hex": "…" },
+      "summary": { "decision": "allow", … }
+    }
+  } }
+// failure modes
+{ "error": { "data": { "code": "audit_event_not_found" }, … } }
+{ "error": { "data": { "code": "audit_event_id_mismatch" }, … } }
+```
+
+The tool wraps `Storage::audit_chain_prefix_through(event_id)` and
+`audit_bundle::build` verbatim — **no storage changes** vs. main, no
+`audit_event_id` index, no new fields. The receipt is taken as input
+because Mandate doesn't currently store receipts (they live with the
+agent that received them); auditors compose
+`keeperhub.lookup_execution(execution_id)` (KeeperHub side, IP-3) →
+`mandate.audit_lookup(audit_event_id, receipt)` (Mandate side, this
+tool) for one round-trip per side end-to-end verification.
+
+## IP-3 cross-side composition
+
+Mandate Passport's wire-level claim is "any signed Mandate decision can
+be re-verified offline by anyone who has the bundle and the public
+keys." IP-3 makes that one-tool-call from an MCP client by pairing two
+symmetric tools:
+
+```
+auditor                                                                  result
+   │
+   ├──── keeperhub.lookup_execution(execution_id) ──────────────►  KeeperHub MCP
+   │      ◄── { status, mandate_audit_event_id,                    (their side)
+   │           mandate_request_hash, mandate_receipt_signature, … }
+   │
+   ├──── mandate.audit_lookup(audit_event_id, receipt, …) ───────►  Mandate MCP
+   │      ◄── { bundle: mandate.audit_bundle.v1 }                   (this server)
+   │
+   └────  bundle.audit_event_id == mandate_audit_event_id?  ─►  ✓ end-to-end
+          bundle.summary.request_hash == mandate_request_hash?      auditability
+```
+
+KeeperHub builds the left-hand tool on their side
+(`keeperhub.lookup_execution` per
+[`docs/keeperhub-integration-paths.md` §IP-3](../keeperhub-integration-paths.md));
+Mandate ships the right-hand `mandate.audit_lookup` here. The
+catalogue's "what we are asking for" stays exactly that — KeeperHub
+reviews the contract; we already have the symmetric tool.
+
+## Running the server
+
+```bash
+cargo build --release --bin mandate-mcp
+
+# As a stdio server, e.g. behind an MCP client:
+./target/release/mandate-mcp
+
+# As a one-shot dialog, piping NDJSON:
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  | ./target/release/mandate-mcp
+```
+
+The server is **stateless** between calls — each tool that needs SQLite
+opens a fresh `Storage` handle against the supplied `db` path and drops
+it on return. SQLite WAL mode tolerates the sequential opens.
+
+## Demo
+
+```bash
+bash demo-scripts/sponsors/mcp-passport.sh
+```
+
+Builds both binaries, activates the reference policy in a tempfile DB,
+exercises every tool over a stdin/stdout pipe, and writes a complete
+transcript to `demo-scripts/artifacts/mcp-transcript.json`. Exit 0
+iff every step returned the expected result.
+
+The 13-gate hackathon demo (`demo-scripts/run-openagents-final.sh`)
+and the production-shaped runner (`demo-scripts/run-production-shaped-mock.sh`,
+26 real / 0 mock / 1 skipped) are **untouched** — the MCP demo lives
+on its own surface.
+
+## Out of scope on this server (Passport P3.1)
+
+- No live network calls. `mode: "live"` is rejected. Real KeeperHub
+  submission lands in P5.1; live ENS resolution in P4.1; Uniswap quote
+  evidence in P6.1.
+- No HTTP transport. Stdio only.
+- No new schemas. Every tool reads/writes the existing APRP / receipt /
+  capsule / audit-bundle shapes.
+- No `keeperhub.lookup_execution` — that's KeeperHub's side of IP-3.
+- No `mandate.lookup_passport_capsule` — out of scope per the IP-3
+  catalogue (the symmetric tool returns the audit bundle, not the
+  capsule). Capsule lookup, if useful, can land in a follow-up PR.


### PR DESCRIPTION
## Summary

- Turns `crates/mandate-mcp/` from a placeholder into a working JSON-RPC 2.0 stdio server that exposes six Mandate primitives as MCP tools.
- All six tools **wrap** existing primitives — no new business logic, no new schemas, no storage changes.
- IP-3 alignment: ships `mandate.audit_lookup` (the symmetric tool the [KeeperHub Integration Path catalogue](../blob/main/docs/keeperhub-integration-paths.md#ip-3--keeperhublookup_executionexecution_id-mcp-tool) describes); the keeperhub side is theirs to build.

## Tools shipped

| Tool                                | Wraps |
| ----------------------------------- | ----- |
| `mandate.validate_aprp`             | `mandate_core::schema::validate_aprp` |
| `mandate.decide`                    | `mandate_server::router` (oneshot pattern) |
| `mandate.run_guarded_execution`     | `mandate_server` + `KeeperHubExecutor::local_mock` / `UniswapExecutor::local_mock` |
| `mandate.verify_capsule`            | `mandate_core::passport::verify_capsule` |
| `mandate.explain_denial`            | `verify_capsule` + structured projection |
| `mandate.audit_lookup`              | `Storage::audit_chain_prefix_through` + `audit_bundle::build` |

Plus `tools/list` meta-method.

## Wire format

Newline-delimited JSON-RPC 2.0. No Content-Length header framing. Per the P3.1 backlog risk note, ships a minimal protocol rather than fighting an unstable Rust MCP SDK; the contract is documented in [`docs/cli/mcp.md`](../blob/feat/mandate-mcp-passport/docs/cli/mcp.md), including:
- Stable `data.code` strings for every error mode (16 codes pinned by tests).
- Standard JSON-RPC `-32700`/`-32600` envelope errors for parse / invalid-request shapes.
- IP-3 cross-side composition story showing how `keeperhub.lookup_execution` + `mandate.audit_lookup` compose end-to-end.

## Tests

23 integration tests (`crates/mandate-mcp/tests/jsonrpc_integration.rs`):
- 18 in-process `dispatch()` tests (3 per tool, plus envelope shape and unknown-method).
- 4 child-process stdio tests (transport confidence — same dispatch logic, different boundary).
- 1 anchor test (`dev_pubkeys_match_canonical_constants`) pinning the deterministic dev-signer pubkeys the demo script hardcodes.

Plus 6 lib unit tests for jsonrpc envelope parsing + tool catalogue shape. Workspace-wide: **all tests pass**, **clippy clean** with `-D warnings`, **fmt clean**.

## Demo

```bash
bash demo-scripts/sponsors/mcp-passport.sh
```

Builds both binaries, activates the reference policy in a tempfile DB, runs every tool over a stdin/stdout pipe, writes a transcript to `demo-scripts/artifacts/mcp-transcript.json`. Exit 0 iff every step returns the expected result.

## Untouched surfaces

- 13-gate `demo-scripts/run-openagents-final.sh` — unchanged.
- Production-shaped runner `demo-scripts/run-production-shaped-mock.sh` — **stays at 26/0/1**. The MCP demo is its own gate.
- Existing storage / schemas / CLI surfaces — no changes.

## Out of scope (deferred)

- No live network calls. `mode: "live"` is rejected with `live_mode_rejected`. Real KeeperHub submission lands in P5.1; live ENS in P4.1; Uniswap quote evidence in P6.1.
- No HTTP transport. Stdio only.
- No `keeperhub.lookup_execution` — KeeperHub's side of IP-3.
- No `mandate.lookup_passport_capsule` — out of IP-3 catalogue scope; can land in a follow-up PR.

## Test plan

- [x] `cargo test --workspace` — all green (23 new mandate-mcp tests + 6 lib tests).
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `python3 scripts/validate_schemas.py` — clean (no new schemas; passport runtime artifacts still validate).
- [x] `bash demo-scripts/run-production-shaped-mock.sh` — tally still 26/0/1.
- [x] `bash demo-scripts/sponsors/mcp-passport.sh` — every step ok, transcript written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)