### PR TITLE
refactor: extract GuardedExecutor + execution types to mandate-core (P5.1 prereq)

### DIFF
--- a/crates/mandate-core/src/execution.rs
+++ b/crates/mandate-core/src/execution.rs
@@ -1,0 +1,51 @@
+//! Sponsor-execution trait + types.
+//!
+//! Hosting these in `mandate-core` (rather than `mandate-execution`) is the
+//! IP-4 prerequisite from `docs/keeperhub-integration-paths.md`: a future
+//! `mandate-keeperhub-adapter` crate can `cargo add mandate-core` and
+//! implement [`GuardedExecutor`] without pulling the whole Mandate
+//! workspace.
+//!
+//! `mandate-execution` re-exports these symbols so existing call sites
+//! (`mandate-server`, `mandate-cli`, `mandate-mcp`, `demo-agents/research-agent`)
+//! continue to compile unchanged.
+
+use crate::aprp::PaymentRequest;
+use crate::receipt::{Decision, PolicyReceipt};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ExecutionError {
+    #[error("policy receipt rejected: decision={0:?}")]
+    NotApproved(Decision),
+    #[error("sponsor backend offline: {0}")]
+    BackendOffline(String),
+    #[error("integration: {0}")]
+    Integration(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct ExecutionReceipt {
+    pub sponsor: &'static str,
+    pub execution_ref: String,
+    pub mock: bool,
+    pub note: String,
+}
+
+/// Contract every sponsor adapter implements. An executor takes a
+/// Mandate-approved [`PolicyReceipt`] plus the original [`PaymentRequest`]
+/// and returns an [`ExecutionReceipt`] callers can attach to the audit
+/// log.
+///
+/// * **Mandate decides.** The receipt is the proof of authorisation.
+/// * **Sponsor executes.** Each adapter is a thin wrapper over the
+///   partner's real interface (or a clearly-disclosed local mock when
+///   credentials are not available).
+pub trait GuardedExecutor {
+    fn sponsor_id(&self) -> &'static str;
+    fn execute(
+        &self,
+        request: &PaymentRequest,
+        receipt: &PolicyReceipt,
+    ) -> Result<ExecutionReceipt, ExecutionError>;
+}

--- a/crates/mandate-core/src/lib.rs
+++ b/crates/mandate-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod audit;
 pub mod audit_bundle;
 pub mod decision_token;
 pub mod error;
+pub mod execution;
 pub mod hashing;
 pub mod mock_kms;
 pub mod passport;

--- a/crates/mandate-execution/src/keeperhub.rs
+++ b/crates/mandate-execution/src/keeperhub.rs
@@ -13,9 +13,8 @@
 //!   ULID `execution_ref` and `mock: true`. The demo discloses this clearly.
 
 use mandate_core::aprp::PaymentRequest;
+use mandate_core::execution::{ExecutionError, ExecutionReceipt, GuardedExecutor};
 use mandate_core::receipt::{Decision, PolicyReceipt};
-
-use crate::{ExecutionError, ExecutionReceipt, GuardedExecutor};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeeperHubMode {

--- a/crates/mandate-execution/src/lib.rs
+++ b/crates/mandate-execution/src/lib.rs
@@ -1,51 +1,31 @@
 //! Mandate execution: sponsor execution adapters.
 //!
-//! This crate exposes the `GuardedExecutor` trait that every sponsor adapter
-//! must implement. The contract is: an executor takes a Mandate-approved
-//! `PolicyReceipt` plus the original `PaymentRequest` and returns an
-//! `ExecutionReceipt` that callers can attach to the Mandate audit log.
+//! This crate exposes the [`GuardedExecutor`] trait that every sponsor
+//! adapter must implement. The contract is: an executor takes a
+//! Mandate-approved [`PolicyReceipt`](mandate_core::receipt::PolicyReceipt)
+//! plus the original [`PaymentRequest`](mandate_core::aprp::PaymentRequest)
+//! and returns an [`ExecutionReceipt`] that callers can attach to the
+//! Mandate audit log.
 //!
 //! * **Mandate decides.** The receipt is the proof of authorisation.
 //! * **Sponsor executes.** Each adapter is a thin wrapper over the partner's
 //!   real interface (or a clearly-disclosed local mock when credentials are
 //!   not available during the hackathon build).
+//!
+//! The trait + receipt + error types live in
+//! [`mandate_core::execution`] (extracted in PR #48 / P5.1 prereq) so the
+//! IP-4 standalone-adapter crate can depend on `mandate-core` alone. They
+//! are re-exported here so existing call sites
+//! (`mandate-server`, `mandate-cli`, `mandate-mcp`,
+//! `demo-agents/research-agent`) keep working without import-path
+//! changes.
 
 pub mod keeperhub;
 pub mod uniswap;
 
 pub use keeperhub::{KeeperHubExecutor, KeeperHubMode};
+pub use mandate_core::execution::{ExecutionError, ExecutionReceipt, GuardedExecutor};
 pub use uniswap::{
     evaluate_swap, SwapCheck, SwapPolicy, SwapPolicyOutcome, SwapQuote, SwapToken, UniswapExecutor,
     UniswapMode,
 };
-
-use mandate_core::aprp::PaymentRequest;
-use mandate_core::receipt::PolicyReceipt;
-use thiserror::Error;
-
-#[derive(Debug, Error)]
-pub enum ExecutionError {
-    #[error("policy receipt rejected: decision={0:?}")]
-    NotApproved(mandate_core::receipt::Decision),
-    #[error("sponsor backend offline: {0}")]
-    BackendOffline(String),
-    #[error("integration: {0}")]
-    Integration(String),
-}
-
-#[derive(Debug, Clone)]
-pub struct ExecutionReceipt {
-    pub sponsor: &'static str,
-    pub execution_ref: String,
-    pub mock: bool,
-    pub note: String,
-}
-
-pub trait GuardedExecutor {
-    fn sponsor_id(&self) -> &'static str;
-    fn execute(
-        &self,
-        request: &PaymentRequest,
-        receipt: &PolicyReceipt,
-    ) -> Result<ExecutionReceipt, ExecutionError>;
-}

--- a/crates/mandate-execution/src/uniswap.rs
+++ b/crates/mandate-execution/src/uniswap.rs
@@ -20,11 +20,10 @@
 use std::str::FromStr;
 
 use mandate_core::aprp::PaymentRequest;
+use mandate_core::execution::{ExecutionError, ExecutionReceipt, GuardedExecutor};
 use mandate_core::receipt::{Decision, PolicyReceipt};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
-
-use crate::{ExecutionError, ExecutionReceipt, GuardedExecutor};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]


### PR DESCRIPTION
## Summary

- Pure refactor — **zero behaviour change**. Moves `GuardedExecutor` + `ExecutionReceipt` + `ExecutionError` from `crates/mandate-execution/src/lib.rs` into a new `crates/mandate-core/src/execution.rs` module.
- IP-4 prerequisite from [`docs/keeperhub-integration-paths.md`](../blob/main/docs/keeperhub-integration-paths.md#ip-4--standalone-mandate-adapter-crate): a future `mandate-keeperhub-adapter` crate now needs only `mandate-core` as a dependency, not the whole workspace.
- Sets up the natural home for the IP-1 envelope helper that lands in PR β (P5.1 proper).

## What moved

| Symbol | From | To |
| --- | --- | --- |
| `GuardedExecutor` (trait) | `mandate_execution` | `mandate_core::execution` |
| `ExecutionReceipt` (struct) | `mandate_execution` | `mandate_core::execution` |
| `ExecutionError` (enum) | `mandate_execution` | `mandate_core::execution` |

Re-exported from `mandate_execution::lib.rs`, so every existing call site keeps working unchanged:
- `mandate-server`, `mandate-cli`, `mandate-mcp`, `demo-agents/research-agent` — no import-path changes.
- Internal `mandate-execution::keeperhub` and `::uniswap` switched from `use crate::{...}` to `use mandate_core::execution::{...}` so the adapter modules consume the extracted trait directly (proving the trait really is portable).

## Risk-checkpoint outcome

The brief flagged "GuardedExecutor extraction may reveal hidden coupling to `mandate-storage` / `mandate-server` / `mandate-policy`." Confirmed Dev B's audit finding: **zero such leaks**. The trait body imports come exclusively from `mandate_core::aprp` and `mandate_core::receipt`, both already in `mandate-core`. No `Cargo.toml` dependency additions needed in `mandate-core`.

## Verification

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo test --workspace --all-targets` — **292/292**, exactly the pre-refactor count.
- [x] `bash demo-scripts/run-openagents-final.sh` — 13/13 gates green.
- [x] `bash demo-scripts/run-production-shaped-mock.sh` — tally still **26/0/1**.

## Test plan

- [x] Workspace tests stay at 292.
- [x] No new tests, no test moves (the existing `keeperhub.rs` / `uniswap.rs` test modules continue to assert against `ExecutionError` / `ExecutionReceipt` through the same names, now resolved via `mandate_core::execution`).
- [x] Both demo runners reproduce identical output to pre-refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)