### PR TITLE
feat: KeeperHub mandate_* envelope helper (Passport P5.1, IP-1)

### DIFF
--- a/crates/mandate-core/src/execution.rs
+++ b/crates/mandate-core/src/execution.rs
@@ -12,6 +12,7 @@
 
 use crate::aprp::PaymentRequest;
 use crate::receipt::{Decision, PolicyReceipt};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -48,4 +49,237 @@ pub trait GuardedExecutor {
         request: &PaymentRequest,
         receipt: &PolicyReceipt,
     ) -> Result<ExecutionReceipt, ExecutionError>;
+}
+
+/// IP-1 upstream-proof envelope (KeeperHub Integration Path catalogue
+/// §IP-1, see `docs/keeperhub-integration-paths.md`). Carried alongside
+/// the APRP body + signed `PolicyReceipt` on every workflow-webhook
+/// submission so a downstream auditor can re-verify the policy decision
+/// **without trusting either side**:
+///
+/// - `mandate_request_hash` — JCS-canonical SHA-256 of the APRP body.
+///   Same value any other Mandate consumer can re-derive.
+/// - `mandate_policy_hash` — canonical hash of the active policy.
+///   Drift means the same agent produced this request under a different
+///   rulebook.
+/// - `mandate_receipt_signature` — Ed25519 signature on the
+///   `PolicyReceipt`, verifiable against the receipt-signer pubkey
+///   published in the agent's ENS / Passport.
+/// - `mandate_audit_event_id` — position of the decision in Mandate's
+///   hash-chained audit log; lets the auditor pull the chain prefix and
+///   re-derive the per-event hash.
+/// - `mandate_passport_capsule_hash` — *target*, optional today. Once a
+///   Passport capsule lives at a published URI, its content hash goes
+///   here so the auditor can pin the snapshot they verified against.
+///
+/// Field order is fixed by the JSON Schema sketch in
+/// `docs/keeperhub-integration-paths.md` §IP-3 — the
+/// `envelope_serialises_with_documented_field_order` test pins it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MandateEnvelope {
+    pub mandate_request_hash: String,
+    pub mandate_policy_hash: String,
+    pub mandate_receipt_signature: String,
+    pub mandate_audit_event_id: String,
+    /// Optional. Omitted from the wire form when `None` so that
+    /// pre-Passport KeeperHub deployments don't need to special-case
+    /// it. Set via [`MandateEnvelope::with_passport_capsule`] once the
+    /// Passport surface ships (P5.1 → P7.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mandate_passport_capsule_hash: Option<String>,
+}
+
+impl MandateEnvelope {
+    /// Build an envelope from a freshly-signed `PolicyReceipt` plus the
+    /// audit chain's just-appended event id (the value
+    /// [`PaymentRequestResponse::audit_event_id`](
+    /// https://docs.rs/mandate-server) carries back over HTTP).
+    ///
+    /// Notably, this does **not** copy `receipt.audit_event_id`
+    /// blindly: callers pass the `audit_event_id` they actually saw on
+    /// the response so a future receipt-shape change can't silently
+    /// desync the envelope from the wire. The two values must agree;
+    /// any verifier that re-derives the receipt's signature will catch
+    /// a mismatch immediately.
+    pub fn from_receipt(receipt: &PolicyReceipt, audit_event_id: &str) -> Self {
+        Self {
+            mandate_request_hash: receipt.request_hash.clone(),
+            mandate_policy_hash: receipt.policy_hash.clone(),
+            mandate_receipt_signature: receipt.signature.signature_hex.clone(),
+            mandate_audit_event_id: audit_event_id.to_string(),
+            mandate_passport_capsule_hash: None,
+        }
+    }
+
+    /// Attach a Passport capsule content hash. The capsule is the
+    /// portable proof artefact (`mandate.passport_capsule.v1`) that
+    /// `mandate passport run` writes; once a Passport URI exists the
+    /// envelope can pin its hash so an auditor can detect tampering of
+    /// the published file. Today the field stays `None` for
+    /// pre-Passport deployments.
+    pub fn with_passport_capsule(mut self, capsule_hash: String) -> Self {
+        self.mandate_passport_capsule_hash = Some(capsule_hash);
+        self
+    }
+
+    /// Render to a `serde_json::Value` for embedding in a workflow
+    /// submission body. The five field order is deliberate: it matches
+    /// the JSON Schema sketch in
+    /// `docs/keeperhub-integration-paths.md` §IP-3 (request_hash →
+    /// policy_hash → receipt_signature → audit_event_id →
+    /// passport_capsule_hash) so KeeperHub-side auditors can byte-diff
+    /// envelopes from different Mandate instances and not see spurious
+    /// reorderings.
+    pub fn to_json_payload(&self) -> serde_json::Value {
+        serde_json::to_value(self)
+            .expect("MandateEnvelope's #[derive(Serialize)] is infallible for owned fields")
+    }
+}
+
+#[cfg(test)]
+mod envelope_tests {
+    use super::*;
+    use crate::receipt::{EmbeddedSignature, ReceiptType, SignatureAlgorithm};
+
+    /// Reuse the same fixture-shape `mandate-execution/src/keeperhub.rs`
+    /// uses — same agent_id, same hash widths, same audit_event_id
+    /// shape — so the envelope tests pin the exact wire shape the live
+    /// adapter will produce when it stops returning `BackendOffline`.
+    fn fixture_receipt() -> PolicyReceipt {
+        PolicyReceipt {
+            receipt_type: ReceiptType::PolicyReceiptV1,
+            version: 1,
+            agent_id: "research-agent-01".to_string(),
+            decision: Decision::Allow,
+            deny_code: None,
+            request_hash: "a".repeat(64),
+            policy_hash: "b".repeat(64),
+            policy_version: Some(1),
+            audit_event_id: "evt-01HTAWX5K3R8YV9NQB7C6P2DGS".to_string(),
+            execution_ref: None,
+            issued_at: chrono::Utc::now(),
+            expires_at: None,
+            signature: EmbeddedSignature {
+                algorithm: SignatureAlgorithm::Ed25519,
+                key_id: "decision-signer-v1".to_string(),
+                signature_hex: "f".repeat(128),
+            },
+        }
+    }
+
+    #[test]
+    fn envelope_constructed_from_real_receipt() {
+        let r = fixture_receipt();
+        let env = MandateEnvelope::from_receipt(&r, &r.audit_event_id);
+        assert_eq!(env.mandate_request_hash, r.request_hash);
+        assert_eq!(env.mandate_policy_hash, r.policy_hash);
+        assert_eq!(env.mandate_receipt_signature, r.signature.signature_hex);
+        assert_eq!(env.mandate_audit_event_id, r.audit_event_id);
+        assert_eq!(env.mandate_passport_capsule_hash, None);
+    }
+
+    #[test]
+    fn envelope_serialises_with_documented_field_order() {
+        // Field order pinned: request_hash → policy_hash → receipt_signature
+        // → audit_event_id → passport_capsule_hash. `serde_json::to_string`
+        // honours struct-declaration order for the `Serialize` derive,
+        // so a mismatched key ordering is a real regression that this
+        // test catches.
+        let r = fixture_receipt();
+        let env = MandateEnvelope::from_receipt(&r, &r.audit_event_id)
+            .with_passport_capsule("c".repeat(64));
+        let s = serde_json::to_string(&env).expect("serialise");
+        let r_idx = s.find("mandate_request_hash").expect("request_hash key");
+        let p_idx = s.find("mandate_policy_hash").expect("policy_hash key");
+        let sig_idx = s.find("mandate_receipt_signature").expect("signature key");
+        let ev_idx = s
+            .find("mandate_audit_event_id")
+            .expect("audit_event_id key");
+        let cap_idx = s
+            .find("mandate_passport_capsule_hash")
+            .expect("capsule_hash key");
+        assert!(
+            r_idx < p_idx && p_idx < sig_idx && sig_idx < ev_idx && ev_idx < cap_idx,
+            "field order violated; got serialised body: {s}"
+        );
+    }
+
+    #[test]
+    fn envelope_audit_event_id_matches_crockford_pattern() {
+        // The IP-3 sister-tool docs pin `^evt-[0-7][0-9A-HJKMNP-TV-Z]{25}$`
+        // — Crockford base32 ULID, no I/L/O/U. Our fixture uses a real
+        // ULID so this check is meaningful: a future refactor that
+        // accidentally lowercases the id (or strips the `evt-` prefix)
+        // breaks here.
+        let r = fixture_receipt();
+        let env = MandateEnvelope::from_receipt(&r, &r.audit_event_id);
+        let id = &env.mandate_audit_event_id;
+        assert!(id.starts_with("evt-"), "got: {id}");
+        let body = &id["evt-".len()..];
+        assert_eq!(body.len(), 26, "ULID body must be 26 chars; got: {body}");
+        let mut cs = body.chars();
+        let first = cs.next().expect("non-empty");
+        assert!(
+            ('0'..='7').contains(&first),
+            "first char must be 0-7 (ULID timestamp upper bits); got: {first}"
+        );
+        const CROCKFORD_TAIL: &str = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+        for c in cs {
+            assert!(
+                CROCKFORD_TAIL.contains(c),
+                "tail char {c:?} not in Crockford alphabet (no I/L/O/U)"
+            );
+        }
+    }
+
+    #[test]
+    fn envelope_capsule_hash_omitted_when_none_via_skip_serializing() {
+        let r = fixture_receipt();
+        let env = MandateEnvelope::from_receipt(&r, &r.audit_event_id);
+        let v = env.to_json_payload();
+        let obj = v.as_object().expect("object");
+        assert!(
+            !obj.contains_key("mandate_passport_capsule_hash"),
+            "skip_serializing_if didn't omit the absent capsule hash; obj: {obj:?}"
+        );
+        // Only the four mandatory fields appear on the wire when the
+        // capsule isn't yet known.
+        assert_eq!(obj.len(), 4, "expected 4 fields, got: {obj:?}");
+    }
+
+    #[test]
+    fn envelope_capsule_hash_present_when_with_passport_capsule_called() {
+        let r = fixture_receipt();
+        let capsule_hash = "d".repeat(64);
+        let env = MandateEnvelope::from_receipt(&r, &r.audit_event_id)
+            .with_passport_capsule(capsule_hash.clone());
+        assert_eq!(
+            env.mandate_passport_capsule_hash,
+            Some(capsule_hash.clone())
+        );
+        // Round-trip via to_json_payload to be sure the field is on
+        // the wire when populated.
+        let v = env.to_json_payload();
+        assert_eq!(
+            v.get("mandate_passport_capsule_hash")
+                .and_then(|v| v.as_str()),
+            Some(capsule_hash.as_str())
+        );
+    }
+
+    #[test]
+    fn envelope_to_json_payload_round_trips_via_serde() {
+        // `to_json_payload` is documented as the canonical wire-form
+        // helper. A consumer should be able to deserialise it back
+        // into a MandateEnvelope without losing fields — including the
+        // optional capsule hash. This guards against a silent
+        // drift between `Serialize` and `Deserialize`.
+        let r = fixture_receipt();
+        let original = MandateEnvelope::from_receipt(&r, &r.audit_event_id)
+            .with_passport_capsule("9".repeat(64));
+        let v = original.to_json_payload();
+        let round_tripped: MandateEnvelope =
+            serde_json::from_value(v).expect("round-trip deserialise");
+        assert_eq!(round_tripped, original);
+    }
 }

--- a/crates/mandate-core/src/execution.rs
+++ b/crates/mandate-core/src/execution.rs
@@ -122,16 +122,19 @@ impl MandateEnvelope {
         self
     }
 
-    /// Render to a `serde_json::Value` for embedding in a workflow
-    /// submission body. The five field order is deliberate: it matches
-    /// the JSON Schema sketch in
+    /// Returns the canonical wire-format String. Field order is honoured
+    /// via `derive(Serialize)` on the struct; this method bypasses
+    /// `serde_json::Value`, which would otherwise alphabetically reorder
+    /// keys under the workspace's no-`preserve_order` `serde_json` setup.
+    ///
+    /// The five-field declaration order matches the JSON Schema sketch in
     /// `docs/keeperhub-integration-paths.md` §IP-3 (request_hash →
     /// policy_hash → receipt_signature → audit_event_id →
     /// passport_capsule_hash) so KeeperHub-side auditors can byte-diff
     /// envelopes from different Mandate instances and not see spurious
     /// reorderings.
-    pub fn to_json_payload(&self) -> serde_json::Value {
-        serde_json::to_value(self)
+    pub fn to_json_payload(&self) -> String {
+        serde_json::to_string(self)
             .expect("MandateEnvelope's #[derive(Serialize)] is infallible for owned fields")
     }
 }
@@ -236,7 +239,13 @@ mod envelope_tests {
     fn envelope_capsule_hash_omitted_when_none_via_skip_serializing() {
         let r = fixture_receipt();
         let env = MandateEnvelope::from_receipt(&r, &r.audit_event_id);
-        let v = env.to_json_payload();
+        let payload = env.to_json_payload();
+        // Parse the canonical wire-form String into a Value purely for
+        // structural inspection. The Map sorts keys alphabetically here,
+        // but that's fine — this test asserts on the *field set*, not
+        // the order (`to_json_payload_preserves_documented_field_order`
+        // covers ordering).
+        let v: serde_json::Value = serde_json::from_str(&payload).expect("parse payload");
         let obj = v.as_object().expect("object");
         assert!(
             !obj.contains_key("mandate_passport_capsule_hash"),
@@ -259,7 +268,8 @@ mod envelope_tests {
         );
         // Round-trip via to_json_payload to be sure the field is on
         // the wire when populated.
-        let v = env.to_json_payload();
+        let payload = env.to_json_payload();
+        let v: serde_json::Value = serde_json::from_str(&payload).expect("parse payload");
         assert_eq!(
             v.get("mandate_passport_capsule_hash")
                 .and_then(|v| v.as_str()),
@@ -277,9 +287,45 @@ mod envelope_tests {
         let r = fixture_receipt();
         let original = MandateEnvelope::from_receipt(&r, &r.audit_event_id)
             .with_passport_capsule("9".repeat(64));
-        let v = original.to_json_payload();
+        let payload = original.to_json_payload();
         let round_tripped: MandateEnvelope =
-            serde_json::from_value(v).expect("round-trip deserialise");
+            serde_json::from_str(&payload).expect("round-trip deserialise");
         assert_eq!(round_tripped, original);
+    }
+
+    /// Codex P1 on PR #51 — pins the `to_json_payload` byte order
+    /// directly. The previous `envelope_serialises_with_documented_field_order`
+    /// test serialises the *struct* via `to_string(&env)` (which honours
+    /// declaration order via `derive(Serialize)`) and so missed a
+    /// regression in `to_json_payload` itself. Asserting against the
+    /// payload String now catches a future implementation that round-
+    /// trips through `serde_json::Value` (which would alphabetically
+    /// reorder keys under the workspace's no-`preserve_order` setup).
+    #[test]
+    fn to_json_payload_preserves_documented_field_order() {
+        let r = fixture_receipt();
+        let env = MandateEnvelope::from_receipt(&r, &r.audit_event_id)
+            .with_passport_capsule("c".repeat(64));
+        let payload = env.to_json_payload();
+        // Verify byte order of the field keys.
+        let order = [
+            "mandate_request_hash",
+            "mandate_policy_hash",
+            "mandate_receipt_signature",
+            "mandate_audit_event_id",
+            "mandate_passport_capsule_hash",
+        ];
+        let mut cursor = 0usize;
+        for key in order {
+            let needle = format!(r#""{key}":"#);
+            let pos = payload
+                .find(&needle)
+                .unwrap_or_else(|| panic!("missing key {key} in payload: {payload}"));
+            assert!(
+                pos >= cursor,
+                "field {key} appears out of documented order in payload: {payload}"
+            );
+            cursor = pos;
+        }
     }
 }

--- a/crates/mandate-execution/src/keeperhub.rs
+++ b/crates/mandate-execution/src/keeperhub.rs
@@ -66,21 +66,24 @@ impl GuardedExecutor for KeeperHubExecutor {
                 ),
             }),
             KeeperHubMode::Live => {
-                // Build the IP-1 envelope alongside the still-stubbed
-                // network call. Constructing the payload here (rather
+                // Build the IP-1 envelope AND serialise it to its
+                // canonical wire-format String alongside the
+                // still-stubbed network call. Doing both here (rather
                 // than waiting for the live HTTP path to land) means
                 // the wire-format invariant — `mandate_*` fields agree
-                // with the receipt that triggered the call — is
-                // covered by tests *before* live submission turns on.
+                // with the receipt that triggered the call, in the
+                // documented field order — is covered by tests
+                // *before* live submission turns on.
                 //
                 // The payload is intentionally **dropped** below:
                 // P5.1's contract is "envelope is built and serialised
                 // in tests; HTTP send is not." Live submission lands
                 // in a follow-up PR with concrete credentials +
-                // `live_evidence`. The `let _ = …` is the explicit
-                // disclosure: we proved we *could* send this, we just
-                // don't.
+                // `live_evidence`. The `let _ = …` lines are the
+                // explicit disclosure: we proved we *could* send this,
+                // we just don't.
                 let _envelope = build_envelope(receipt);
+                let _payload_str = _envelope.to_json_payload();
                 Err(ExecutionError::BackendOffline(
                     "live KeeperHub backend not configured for this hackathon build; \
                      switch to KeeperHubMode::LocalMock or wire credentials"

--- a/crates/mandate-execution/src/keeperhub.rs
+++ b/crates/mandate-execution/src/keeperhub.rs
@@ -13,7 +13,7 @@
 //!   ULID `execution_ref` and `mock: true`. The demo discloses this clearly.
 
 use mandate_core::aprp::PaymentRequest;
-use mandate_core::execution::{ExecutionError, ExecutionReceipt, GuardedExecutor};
+use mandate_core::execution::{ExecutionError, ExecutionReceipt, GuardedExecutor, MandateEnvelope};
 use mandate_core::receipt::{Decision, PolicyReceipt};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -65,13 +65,46 @@ impl GuardedExecutor for KeeperHubExecutor {
                     intent = serde_json::to_string(&request.intent).unwrap_or_default(),
                 ),
             }),
-            KeeperHubMode::Live => Err(ExecutionError::BackendOffline(
-                "live KeeperHub backend not configured for this hackathon build; \
-                 switch to KeeperHubMode::LocalMock or wire credentials"
-                    .to_string(),
-            )),
+            KeeperHubMode::Live => {
+                // Build the IP-1 envelope alongside the still-stubbed
+                // network call. Constructing the payload here (rather
+                // than waiting for the live HTTP path to land) means
+                // the wire-format invariant — `mandate_*` fields agree
+                // with the receipt that triggered the call — is
+                // covered by tests *before* live submission turns on.
+                //
+                // The payload is intentionally **dropped** below:
+                // P5.1's contract is "envelope is built and serialised
+                // in tests; HTTP send is not." Live submission lands
+                // in a follow-up PR with concrete credentials +
+                // `live_evidence`. The `let _ = …` is the explicit
+                // disclosure: we proved we *could* send this, we just
+                // don't.
+                let _envelope = build_envelope(receipt);
+                Err(ExecutionError::BackendOffline(
+                    "live KeeperHub backend not configured for this hackathon build; \
+                     switch to KeeperHubMode::LocalMock or wire credentials"
+                        .to_string(),
+                ))
+            }
         }
     }
+}
+
+/// Build the IP-1 envelope that a future live KeeperHub submission
+/// will carry alongside the APRP body + signed `PolicyReceipt`. Today
+/// the envelope is constructed but never sent (live mode returns
+/// `BackendOffline`); exposing it on this module surface lets tests
+/// pin the wire shape without poking through the error path.
+///
+/// Callers in P5.1+ are expected to use the receipt's `audit_event_id`
+/// directly because the live path runs *after* the receipt has been
+/// signed and the audit event has been appended — both values are
+/// already pinned in the receipt the executor receives. A future split
+/// (e.g. submit before audit-append) would change the contract and
+/// would land its own helper.
+pub(crate) fn build_envelope(receipt: &PolicyReceipt) -> MandateEnvelope {
+    MandateEnvelope::from_receipt(receipt, &receipt.audit_event_id)
 }
 
 #[cfg(test)]
@@ -130,5 +163,23 @@ mod tests {
             .execute(&aprp(), &receipt(Decision::Allow))
             .unwrap_err();
         assert!(matches!(err, ExecutionError::BackendOffline(_)));
+    }
+
+    #[test]
+    fn keeperhub_live_constructs_envelope_via_from_receipt() {
+        // P5.1 contract: even though the live path returns BackendOffline,
+        // the envelope IS constructed and serialised. The wire-format
+        // invariant — `mandate_*` fields agree with the receipt that
+        // triggered the call — must hold *before* live submission turns
+        // on. Driving `build_envelope` here proves the same code path
+        // the live executor invokes maps the receipt 1:1 into the
+        // envelope.
+        let r = receipt(Decision::Allow);
+        let env = build_envelope(&r);
+        assert_eq!(env.mandate_request_hash, r.request_hash);
+        assert_eq!(env.mandate_policy_hash, r.policy_hash);
+        assert_eq!(env.mandate_receipt_signature, r.signature.signature_hex);
+        assert_eq!(env.mandate_audit_event_id, r.audit_event_id);
+        assert!(env.mandate_passport_capsule_hash.is_none());
     }
 }

--- a/docs/keeperhub-live-spike.md
+++ b/docs/keeperhub-live-spike.md
@@ -114,6 +114,18 @@ KeeperHub's actual schema will override; the four `mandate_*` fields are
 the only ones we need first-class on KeeperHub's side (per `FEEDBACK.md`
 §KeeperHub → "Suggested improvements").
 
+The `mandate_*` block is built and serialised by
+[`MandateEnvelope::to_json_payload()`](../crates/mandate-core/src/execution.rs)
+(landed in P5.1 / PR #51). `mandate_request_hash`,
+`mandate_policy_hash`, and `mandate_receipt_signature` come straight off
+the signed `PolicyReceipt`; `mandate_audit_event_id` is the receipt's
+own `audit_event_id` (already pinned to the just-appended audit chain
+event when the executor receives the receipt). The optional fifth field
+`mandate_passport_capsule_hash` is set via
+[`MandateEnvelope::with_passport_capsule()`](../crates/mandate-core/src/execution.rs)
+once a Passport capsule URI is published (P7.1); it is `serde(skip_serializing_if = "Option::is_none")`,
+so pre-Passport KeeperHub deployments don't see the field at all.
+
 ```http
 POST {webhook_url}
 Content-Type: application/json
@@ -122,12 +134,21 @@ Authorization: Bearer {token}
 {
   "aprp": { … the canonical APRP body, JCS-canonical bytes … },
   "policy_receipt": { … the signed PolicyReceipt JSON … },
-  "mandate_request_hash":      "<jcs-sha256-hex of aprp>",
-  "mandate_policy_hash":       "<canonical hash of the active policy>",
-  "mandate_receipt_signature": "<ed25519 hex>",
-  "mandate_audit_event_id":    "evt-<ULID>"
+  "mandate_request_hash":           "<jcs-sha256-hex of aprp>",
+  "mandate_policy_hash":            "<canonical hash of the active policy>",
+  "mandate_receipt_signature":      "<ed25519 hex>",
+  "mandate_audit_event_id":         "evt-<ULID>",
+  "mandate_passport_capsule_hash":  "<jcs-sha256-hex of capsule, omitted pre-Passport>"
 }
 ```
+
+The envelope IS constructed inside `KeeperHubExecutor::execute()`'s
+`Live` arm today, even though the live network call still returns
+`BackendOffline` (see PR #51's `keeperhub_live_constructs_envelope_via_from_receipt`
+test). That ordering — build the wire-format envelope *before* live
+submission turns on — is deliberate: it pins the `mandate_*` fields
+under regression tests in CI, so a future receipt-shape change can't
+silently desync the envelope from the receipt that triggered the call.
 
 Expected response (target shape — see [`FEEDBACK.md`](../FEEDBACK.md) §KeeperHub for the schema-publication ask):
 


### PR DESCRIPTION
## Summary

- Lands `MandateEnvelope` in `mandate_core::execution` — the IP-1 upstream-proof envelope (`mandate_request_hash`, `mandate_policy_hash`, `mandate_receipt_signature`, `mandate_audit_event_id`, optional `mandate_passport_capsule_hash`) that future live KeeperHub workflow-webhook submissions carry alongside the APRP body + signed `PolicyReceipt`.
- Wires construction into `KeeperHubExecutor::execute()`'s `Live` arm. The envelope IS built today; the live HTTP send is **not** — that remains gated behind `BackendOffline` until P5.1's follow-up with real credentials.

## API

```rust
MandateEnvelope::from_receipt(&receipt, audit_event_id)
                .with_passport_capsule(capsule_hash)   // optional, target field
                .to_json_payload()                     // -> serde_json::Value
```

The five-field order on the wire (`request_hash → policy_hash → receipt_signature → audit_event_id → passport_capsule_hash`) is fixed by struct declaration order in mandate-core and pinned by `envelope_serialises_with_documented_field_order` — KeeperHub-side auditors can byte-diff envelopes from different Mandate instances and not see spurious reorderings.

`mandate_passport_capsule_hash` uses `serde(skip_serializing_if = "Option::is_none")` so pre-Passport KeeperHub deployments don't see the field at all (`envelope_capsule_hash_omitted_when_none_via_skip_serializing` pins this).

## Why build the envelope when the live path doesn't send

The brief explicitly calls this out — the wire-format invariant should land *before* live submission turns on, so a future receipt-shape change can't silently desync the envelope from the receipt that triggered it. `keeperhub_live_constructs_envelope_via_from_receipt` covers it; the constructed payload is explicitly dropped via `let _envelope = …` to disclose we're proving we *could* send it without actually sending.

## Risk-checkpoint outcome

The brief flagged: \"If `MandateEnvelope::from_receipt` needs a field that `PolicyReceipt` does NOT already have, STOP.\" Confirmed: every required field is already on `PolicyReceipt` (`request_hash`, `policy_hash`, `signature.signature_hex`, `audit_event_id`). **Zero `PolicyReceipt` schema bumps.** The only new dependency on mandate-core is `serde::{Deserialize, Serialize}` (already in scope via the receipt module's existing derives).

## Tests added (+7, total 299)

| Test | Pins |
| --- | --- |
| `envelope_constructed_from_real_receipt` | `from_receipt` maps every receipt field 1:1 |
| `envelope_serialises_with_documented_field_order` | Struct declaration order = wire order (request_hash → … → capsule_hash) |
| `envelope_audit_event_id_matches_crockford_pattern` | ULID body is Crockford base32 (no I/L/O/U), matches `^evt-[0-7][0-9A-HJKMNP-TV-Z]{25}$` |
| `envelope_capsule_hash_omitted_when_none_via_skip_serializing` | Pre-Passport wire form is exactly 4 fields |
| `envelope_capsule_hash_present_when_with_passport_capsule_called` | Round-trip after `.with_passport_capsule()` |
| `envelope_to_json_payload_round_trips_via_serde` | `Serialize`/`Deserialize` derives stay in sync |
| `keeperhub_live_constructs_envelope_via_from_receipt` | Wire-up: same receipt → same envelope through the executor's `Live` arm |

## Out of scope

- No live network call. `KeeperHubMode::Live` still returns `BackendOffline`. Live submission lands with concrete credentials + `live_evidence` per the live-spike doc.
- No KeeperHub credentials, secrets, tokens, or fixtures in repo. `git grep -E 'kh_|wfb_|KEEPERHUB_TOKEN'` matches only pre-existing `FEEDBACK.md` + `demo-fixtures/` placeholders, all unchanged by this PR.
- No JSON Schema for KH `workflow_submission_v1` — IP-2 path, separate PR if useful.
- No claim that KH currently echoes `mandate_*` fields back. Doc still says \"target\" / \"would override\".

## Verification

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo test --workspace --all-targets` — **299/299** (=292 baseline + 7 new).
- [x] `bash demo-scripts/run-openagents-final.sh` — 13/13 unchanged.
- [x] `bash demo-scripts/run-production-shaped-mock.sh` — tally still **26/0/1**.
- [x] `python3 scripts/validate_schemas.py` — clean (no schema bumps).

## Test plan

- [x] Workspace tests jump from 292 → 299 (7 new).
- [x] Both demo runners reproduce identical output to pre-merge.
- [x] No KH credential surface change — repo grep stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)