### PR TITLE
Passport P7.1: GitHub Pages public proof site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,119 @@
+name: Pages
+
+# Deploys the Mandate public proof surface to GitHub Pages.
+#
+# What gets deployed (per docs/product/MANDATE_PASSPORT_BACKLOG.md §P7.1):
+#   - site/index.html              — committed landing page.
+#   - site/README.md               — committed deploy-source README.
+#   - site/trust-badge/index.html  — built by trust-badge/build.py from
+#                                    the committed trust-badge fixture.
+#   - site/operator-console/index.html
+#                                  — built by operator-console/build.py
+#                                    from the committed operator-console
+#                                    fixtures + golden Passport capsule.
+#   - site/capsule.json            — copy of the on-main golden Passport
+#                                    capsule fixture (test-corpus/passport/).
+#
+# Why fixtures, not runtime artefacts: see site/README.md. Stable URL,
+# deterministic content, no Rust build required, no external fetches.
+#
+# Risk: if GitHub Pages is not enabled in repo settings (Settings → Pages
+# → Source: GitHub Actions), the deploy job will fail with a clear error.
+# Build job stays green either way — the site/ artefact is still uploaded.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Single in-flight deploy per ref. Do not cancel the in-progress run —
+# Pages deploys are short and queueing is the right behaviour.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build static site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Render trust-badge from committed fixture
+        run: |
+          mkdir -p _site/trust-badge
+          python3 trust-badge/build.py \
+            --input trust-badge/fixtures/demo-summary.json \
+            --capsule test-corpus/passport/golden_001_allow_keeperhub_mock.json \
+            --output _site/trust-badge/index.html
+
+      - name: Render operator-console from committed fixtures
+        run: |
+          mkdir -p _site/operator-console
+          python3 operator-console/build.py \
+            --input operator-console/fixtures/operator-summary.json \
+            --evidence operator-console/fixtures/operator-evidence.json \
+            --capsule-allow test-corpus/passport/golden_001_allow_keeperhub_mock.json \
+            --output _site/operator-console/index.html
+
+      - name: Copy committed landing page + golden capsule into _site/
+        run: |
+          # site/README.md is intentionally NOT copied — it is source-side
+          # documentation describing this workflow + the directory layout
+          # for someone reading `git log site/`, not visitor-facing copy.
+          # See site/README.md for the rationale.
+          cp site/index.html _site/index.html
+          cp test-corpus/passport/golden_001_allow_keeperhub_mock.json _site/capsule.json
+
+      - name: Byte-grep for unsafe surface (defence in depth)
+        run: |
+          python3 - <<'PY'
+          import re, sys, pathlib
+          # Same allowlist as demo-fixtures/test_fixtures.py:
+          # RFC 2606 / 6761 reserved + 127.0.0.1 + schemas.mandate.dev.
+          pat = re.compile(
+              r'<script|fetch\(|https?://(?!localhost|127\.0\.0\.1'
+              r'|.*\.invalid|.*\.example|.*\.test|schemas\.mandate\.dev)',
+              re.IGNORECASE,
+          )
+          fail = 0
+          for path in pathlib.Path('_site').rglob('*'):
+              if not path.is_file() or path.suffix not in {'.html', '.md'}:
+                  continue
+              text = path.read_text(encoding='utf-8', errors='replace')
+              hits = pat.findall(text)
+              if hits:
+                  print(f'FAIL {path}: {hits[:5]}', file=sys.stderr)
+                  fail += 1
+          if fail:
+              print(f'\nbyte-grep fail: {fail} file(s) carry unsafe surface', file=sys.stderr)
+              sys.exit(1)
+          print('byte-grep clean — no <script>, no fetch(, no unsafe URL in deployed _site/')
+          PY
+
+      - name: Upload Pages artefact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ __pycache__/
 
 # Logs
 *.log
+_site/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This repository was implemented during **ETHGlobal Open Agents 2026**. Planning 
 
 **Implemented and reproducible from a fresh clone.** `cargo test --workspace --all-targets` runs **292/292 green**. `bash demo-scripts/run-openagents-final.sh` runs all **13 demo gates** end-to-end clean in ~5 seconds. `bash demo-scripts/run-production-shaped-mock.sh` exercises the production-shaped surface (HTTP `Idempotency-Key` four-case matrix + `mandate doctor` + mock-KMS CLI lifecycle + active-policy lifecycle + **audit checkpoint create/verify with mock anchoring** + audit-bundle round-trip + the operator-evidence transcript consumed by the operator console + the Passport capsule emit/verify pair) end-to-end with **Tally: 26 real, 0 mock, 1 skipped** (only the optional `--include-final-demo` flag remains on the SKIPPED list — every A-side backlog item has merged). See [`IMPLEMENTATION_STATUS.md`](IMPLEMENTATION_STATUS.md) for the current snapshot.
 
+## Verify the demo
+
+Public proof URL (deployed from `main` by [`.github/workflows/pages.yml`](.github/workflows/pages.yml)): **<https://b2jk-industry.github.io/mandate-ethglobal-openagents-2026/>** — landing page links to the trust-badge proof viewer, the operator-console evidence panels, and a downloadable Passport capsule (`mandate.passport_capsule.v1`) you can verify offline with `mandate passport verify --path capsule.json`. The site is plain static HTML, no JavaScript, no client-side network calls; the `_site/` build is rendered from the same deterministic regression fixtures `python3 trust-badge/test_build.py` + `python3 operator-console/test_build.py` validate on every CI run, so the URL shows the same shape on every visit.
+
 ## Three commands a judge needs
 
 ```bash

--- a/SUBMISSION_FORM_DRAFT.md
+++ b/SUBMISSION_FORM_DRAFT.md
@@ -178,7 +178,11 @@ In this hackathon build the demo always constructs `UniswapExecutor::local_mock(
 ## Demo link
 
 ```
-<TODO: paste recorded demo URL (YouTube unlisted or Loom) before submission>
+Public proof URL (static, no JS, offline-verifiable):
+    https://b2jk-industry.github.io/mandate-ethglobal-openagents-2026/
+
+Recorded video:
+    <TODO: paste recorded demo URL (YouTube unlisted or Loom) before submission>
 
 Backup live-demo command for any judge who can build from source:
     git clone https://github.com/B2JK-Industry/mandate-ethglobal-openagents-2026.git
@@ -187,6 +191,8 @@ Backup live-demo command for any judge who can build from source:
     python3 trust-badge/build.py
     # then open trust-badge/index.html
 ```
+
+The public proof URL is deployed from `main` by `.github/workflows/pages.yml` (Passport P7.1) and links to: the trust-badge proof viewer, the operator-console evidence panels, and a downloadable `mandate.passport_capsule.v1` Passport capsule a judge can verify offline with `mandate passport verify --path capsule.json`. The deployed surface is plain static HTML — no JavaScript, no client-side network calls, no external CDN/font/script — and is rendered from the same deterministic regression fixtures the trust-badge / operator-console test suites validate on every CI run, so the URL shows the same shape on every visit.
 
 ## GitHub repo link
 

--- a/docs/product/MANDATE_PASSPORT_BACKLOG.md
+++ b/docs/product/MANDATE_PASSPORT_BACKLOG.md
@@ -79,7 +79,7 @@ tallies, or product claims must cite the command output it reflects.
 | 5 | P5.2 | B | KeeperHub feedback/issues/one-pager | P5.1 | Actionable feedback linked from repo. |
 | 6 | P6.1 | A | Uniswap guarded quote capsule evidence | P2.1 | Quote evidence appears in capsule. |
 | 6 | P6.2 | B | Uniswap FEEDBACK + one-pager | P6.1 | FEEDBACK meets prize requirement. |
-| 7 | P7.1 | B | GitHub Pages public proof site | P2.2 | Public static proof URL. |
+| 7 | P7.1 | B | GitHub Pages public proof site | P2.2 | Public static proof URL. **Open as PR off `main = 92e94e0`** — `.github/workflows/pages.yml` renders trust-badge + operator-console + golden capsule into a static `_site/` artefact and deploys via `actions/deploy-pages`; landing page at `site/index.html` is offline-only (no JS, no network), byte-grep clean. |
 | 7 | P7.2 | A+B | Final smoke, video, submission freeze | All must-have PRs | Fresh clone green, video URL inserted. |
 
 Phases 5 and 6 can run in parallel after P3.1 if Developer A can keep
@@ -602,6 +602,7 @@ that an agent can request a swap but cannot exceed policy.
 ### P7.1 - GitHub Pages Public Proof Site
 
 **Owner:** Developer B.
+**Status:** PR open off `main = 92e94e0`; deploy job runs on merge (or via `workflow_dispatch`) at `https://b2jk-industry.github.io/mandate-ethglobal-openagents-2026/`.
 
 **Why:** judges need a click target.
 

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,30 @@
+# `site/` — public proof surface (GitHub Pages)
+
+> **Source-side documentation only — this file is not deployed.** The Pages workflow intentionally skips `cp site/README.md _site/README.md` because this README describes the offline-surface byte-grep pattern in text, which would itself trip the grep on the deployed site. Visitors land on `site/index.html`; reviewers reading `git log site/` land here.
+
+The committed contents of this directory are the **source** for the GitHub Pages public proof surface deployed by [`.github/workflows/pages.yml`](../.github/workflows/pages.yml).
+
+| Path | Source / generated | What it is |
+|---|---|---|
+| `site/index.html` | source (committed) | Landing page. Plain HTML, no JS, no client-side network calls, no external asset. Same offline / no-network discipline as `trust-badge/index.html` and `operator-console/index.html`. |
+| `site/README.md` | source (committed) | This file. Describes what the deployed site shows. |
+| `site/trust-badge/index.html` | **generated at deploy time** | `python3 trust-badge/build.py` output, built from `trust-badge/fixtures/demo-summary.json` + `test-corpus/passport/golden_001_allow_keeperhub_mock.json`. Not committed (gitignored). |
+| `site/operator-console/index.html` | **generated at deploy time** | `python3 operator-console/build.py` output, built from `operator-console/fixtures/operator-summary.json` + `operator-console/fixtures/operator-evidence.json` + the same golden capsule. Not committed. |
+| `site/capsule.json` | **generated at deploy time** | Copy of `test-corpus/passport/golden_001_allow_keeperhub_mock.json` — the canonical, deterministic Passport capsule fixture committed alongside the schema + verifier. Not committed under `site/`. |
+
+The workflow runs offline: it does not fetch external resources at build time, and the deployed HTML does not fetch external resources at view time. The byte-grep `'<script|fetch\(|https?://(?!safe-allowlist)'` returns 0 matches against every deployed file.
+
+## Why fixtures, not runtime artefacts
+
+The Pages site is a **stable public URL** — judges should see the same shape on every visit. Committed fixtures are:
+
+- deterministic (no fresh ULIDs / hashes per deploy);
+- verified by `trust-badge/test_build.py` and `operator-console/test_build.py` on every CI run;
+- explicitly disclosed as fixture data in the rendered HTML (`agent_id: fixture-agent-01`, etc.);
+- stable across pushes, so a `git diff site/` between deploys is meaningful.
+
+The runtime artefacts under `demo-scripts/artifacts/` change on every demo run; they are right for local development and the operator-evidence transcript, but wrong for a stable judge-facing URL.
+
+## Why this exists separately from `trust-badge/` and `operator-console/`
+
+`trust-badge/` and `operator-console/` are the source surfaces — they own their own `build.py`, regression tests, and fixture data, and the rendered HTML is the test artefact (gitignored under each). `site/` is the **deployment wrapper**: it composes those rendered artefacts into a single landing page and one canonical capsule download, behind one stable URL. The committed contents are intentionally minimal so that a reviewer reading `git log site/` sees deployment-pipeline changes, not data drift.

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Mandate · Public Proof</title>
+<style>
+*{box-sizing:border-box}
+html,body{margin:0;padding:0;background:#0e1116;color:#e6edf3;
+  font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
+  font-size:13px;line-height:1.5}
+.wrap{max-width:900px;margin:0 auto;padding:24px}
+header{border:1px solid #30363d;padding:16px 18px;margin-bottom:18px;background:#161b22}
+header h1{margin:0 0 4px 0;font-size:18px;font-weight:600;letter-spacing:.2px}
+header .tag{color:#8b949e;font-size:13px}
+header .meta{color:#8b949e;font-size:11px;margin-top:8px}
+header .meta b{color:#e6edf3;font-weight:500}
+section.panel{border:1px solid #30363d;background:#161b22;margin-bottom:14px}
+section.panel h2{margin:0;padding:10px 16px;border-bottom:1px solid #30363d;
+  font-size:11px;font-weight:600;letter-spacing:.6px;text-transform:uppercase;color:#8b949e}
+section.panel .body{padding:14px 16px}
+section.panel p{margin:0 0 8px 0}
+section.panel p:last-child{margin-bottom:0}
+.proof-list{list-style:none;padding:0;margin:0}
+.proof-list li{padding:10px 0;border-bottom:1px solid #21262d}
+.proof-list li:last-child{border-bottom:0}
+.proof-list a{color:#58a6ff;text-decoration:none;font-weight:600}
+.proof-list a:hover{text-decoration:underline}
+.proof-list .desc{color:#8b949e;font-size:12px;margin-top:4px}
+code{background:#21262d;padding:1px 5px;border-radius:2px;font-size:12px}
+.pill{display:inline-block;padding:1px 7px;border-radius:2px;font-size:11px;
+  font-weight:600;letter-spacing:.3px;font-family:inherit}
+.pill.neutral{background:#21262d;color:#8b949e;border:1px solid #30363d}
+.pill.ok{background:#0f2b15;color:#3fb950;border:1px solid #2ea043}
+footer{margin-top:8px;color:#8b949e;font-size:11px;border-top:1px solid #30363d;padding-top:12px}
+footer a{color:#58a6ff;text-decoration:none}
+footer a:hover{text-decoration:underline}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header>
+<h1>Mandate · Public Proof</h1>
+<div class="tag">"Don't give your agent a wallet. Give it a mandate."</div>
+<div class="meta"><span><b>tagline</b> proof-carrying execution for AI agents</span></div>
+</header>
+
+<section class="panel">
+<h2>What this site is</h2>
+<div class="body">
+<p>Mandate is a local policy / budget / receipt / audit firewall for AI agents — the agent never holds a private key; Mandate decides, signs, and audits. This page is the <b>public, static proof surface</b> for the ETHGlobal Open Agents 2026 submission.</p>
+<p>Everything below is generated from the deterministic regression fixtures committed alongside the source. No JavaScript, no client-side network calls, no external asset; the same HTML works from <code>file://</code> after a fresh clone. <span class="pill neutral">no JS</span> <span class="pill neutral">no network</span> <span class="pill ok">offline-verifiable</span></p>
+</div>
+</section>
+
+<section class="panel">
+<h2>What you can verify</h2>
+<div class="body">
+<ul class="proof-list">
+
+<li>
+<a href="trust-badge/index.html">Trust badge — judge-readable proof viewer</a>
+<div class="desc">One-screen, side-by-side allow + deny scenarios from the deterministic demo fixture. Request hash, policy hash, signed receipt, audit-event id, no-key proof, audit-chain tamper detection — all rendered server-side at build time. Same HTML as <code>python3 trust-badge/build.py</code> emits locally.</div>
+</li>
+
+<li>
+<a href="operator-console/index.html">Operator console — multi-panel evidence</a>
+<div class="desc">The longer operational view. Allow / deny timeline, no-key proof, audit-chain tamper detection, mock sponsor disclosure (KeeperHub <code>local_mock</code> / Uniswap <code>local_mock</code> / ENS <code>offline-fixture</code> / mock KMS), and the five PSM-A* real-evidence panels — all rendered from the operator-evidence fixture. Bundle and Passport-capsule tiles fall through to the explicit "evidence not gathered" placeholder when their inputs aren't on the deploy environment.</div>
+</li>
+
+<li>
+<a href="capsule.json">Mandate Passport capsule — <code>mandate.passport_capsule.v1</code></a>
+<div class="desc">A self-contained, offline-verifiable proof artefact for one Allow decision. Schema + structural verifier shipped in PR #42; the passport CLI MVP shipped in PR #44. Download this file and run <code>mandate passport verify --path capsule.json</code> from a fresh clone — every signature, hash, and link should re-derive without any daemon.</div>
+</li>
+
+</ul>
+</div>
+</section>
+
+<section class="panel">
+<h2>What this site is NOT</h2>
+<div class="body">
+<p>Not a daemon. Not a hosted API. Not a live KeeperHub / live Uniswap / live ENS integration — every sponsor adapter in this build is a clearly-disclosed local mock or offline fixture. The "live" path is documented in <code>docs/keeperhub-live-spike.md</code> with the eight open questions for the KeeperHub team and the file-by-file shopping list for the live PR; it is not exercised here. Mocks remain explicitly labelled — this site never silently upgrades a mock to a live claim.</p>
+</div>
+</section>
+
+<footer>
+Source: <code>B2JK-Industry/mandate-ethglobal-openagents-2026</code> on GitHub · ETHGlobal Open Agents 2026 submission. <span class="pill neutral">no external links on this page (offline-verifiable surface)</span>
+</footer>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

P7.1 of the Mandate Passport packaging push (per [`docs/product/MANDATE_PASSPORT_BACKLOG.md`](https://github.com/B2JK-Industry/mandate-ethglobal-openagents-2026/blob/main/docs/product/MANDATE_PASSPORT_BACKLOG.md) Phase 7 / P7.1). Wires the public proof surface to GitHub Pages so a judge has **one click target**.

**Public URL:** `https://b2jk-industry.github.io/mandate-ethglobal-openagents-2026/` (served once Pages is enabled in repo settings — see Risk checkpoint below).

## What gets deployed

| Path on the deployed site | Source | Notes |
|---|---|---|
| `/index.html` | `site/index.html` (committed) | Landing page. Plain HTML, no JS, no client-side network calls, no external asset. |
| `/trust-badge/index.html` | built at deploy time | `python3 trust-badge/build.py` against the committed `trust-badge/fixtures/demo-summary.json` + the golden Passport capsule (`test-corpus/passport/golden_001_allow_keeperhub_mock.json`). |
| `/operator-console/index.html` | built at deploy time | `python3 operator-console/build.py` against the committed `operator-console/fixtures/{operator-summary,operator-evidence}.json` + same golden capsule. |
| `/capsule.json` | copy of the golden capsule | Verifiable offline with `mandate passport verify --path capsule.json` from a fresh clone. |

`site/README.md` is **intentionally not deployed** — it describes the byte-grep pattern in text, which would itself trip the grep on the deployed site. It exists as source-side documentation for `git log site/` readers.

## Why fixtures, not runtime artefacts

The Pages site is a **stable public URL** — judges should see the same shape on every visit. Committed fixtures are deterministic, validated by `trust-badge/test_build.py` (49/49) and `operator-console/test_build.py` (118/118) on every CI run, and explicitly disclosed as fixture data in the rendered HTML. Runtime artefacts under `demo-scripts/artifacts/` change on every demo run (fresh ULIDs / hashes), which is right for local development but wrong for a stable judge URL. Rationale in `site/README.md`.

## ⚠️ Risk checkpoint — GitHub Pages must be enabled in repo settings

If GitHub Pages is **not** enabled in repo settings (Settings → Pages → Source: GitHub Actions), the `deploy` job will fail with a clear error on first run. The `build` job stays green either way and uploads the `_site/` artefact, so you can re-run the workflow after enabling Pages without rebasing.

**Daniel: please enable Pages (Settings → Pages → Source: GitHub Actions) before merging this PR (or at least before triggering the workflow).**

## Out of scope (per backlog §P7.1)

- No new features. P7.1 is purely deployment infrastructure.
- No JS / fetch / external CDN / external font / external script.
- No secrets in the workflow beyond `GITHUB_TOKEN` (auto-injected by Actions).
- No code changes in `crates/` / `schemas/` / `migrations/`.
- No video. P7.2 covers the video.

## Files (7 changed, +257 / -2)

```
.github/workflows/pages.yml                 NEW (~90 lines, 2 jobs)
site/index.html                             NEW (landing page, byte-grep clean)
site/README.md                              NEW (source-side, not deployed)
README.md                                   MOD ('Verify the demo' section + URL)
SUBMISSION_FORM_DRAFT.md                    MOD (Pages URL filled into demo-link field)
docs/product/MANDATE_PASSPORT_BACKLOG.md    MOD (P7.1 status + table)
.gitignore                                  MOD (adds _site/ for local workflow sim)
```

## Truthfulness

- The deployed `_site/` is **byte-grep clean** for `<script`, `fetch(`, and any HTTP(S) URL outside the safe allowlist (RFC 2606/6761 reserved + `127.0.0.1` + `schemas.mandate.dev`). Verified locally by simulating the workflow steps; the workflow has the same byte-grep as a defence-in-depth step before upload.
- The site shows **fixture-disclosed data** — the rendered HTML labels every value as fixture data (e.g. `agent_id: fixture-agent-01`), so a judge can't mistake it for a live run. Trust-badge / operator-console regression tests already validate the same fixtures.
- The `_site/` build is fully **offline** at deploy time. No `cargo build`, no demo-runner execution, no network fetch. Just two Python invocations + three `cp`s.
- `site/index.html` contains **no `<a href>` to external domains** — every link is relative (`trust-badge/index.html`, `operator-console/index.html`, `capsule.json`).

## Verification (all unchanged from pre-PR baseline)

| Check | Result |
|---|---|
| `python3 trust-badge/build.py` + `test_build.py` | ✅ PASS **49/49** |
| `python3 operator-console/build.py` + `test_build.py` | ✅ PASS **118/118** |
| `bash demo-scripts/run-openagents-final.sh` | ✅ Demo complete (13/13 gates) |
| `bash demo-scripts/run-production-shaped-mock.sh` | ✅ `Tally: 26 real, 0 mock, 1 skipped` |
| Local workflow simulation (every command from `pages.yml` `build` job) | ✅ All EXIT 0 |
| byte-grep `<script\|fetch(\|unsafe-URL` over `_site/` | ✅ **CLEAN** (0 matches) |
| `html.parser` over `_site/index.html` + `trust-badge/index.html` + `operator-console/index.html` | ✅ all OK |
| `yaml.safe_load(.github/workflows/pages.yml)` | ✅ parses identically to existing `ci.yml` (same `on:` YAML 1.1 quirk; GitHub Actions handles natively) |

## Stop conditions

- ✅ PR created. **Stopping per protocol — NOT merging.**
- After push, will check `gh api repos/.../pulls/<NUM>/comments` for any Codex P-findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)