### PR TITLE
chore: CI security hygiene (audit follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: ["**"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   rust:
     name: Rust ${{ matrix.profile }}

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -12,11 +12,35 @@ on:
 
 jobs:
   codex:
+    # Author-association gate (defence in depth):
+    # `issue_comment` / `pull_request_review_comment` / `pull_request_review` /
+    # `issues` all fire on activity from anyone with read access (or no access
+    # at all, for public repo issues). The original `@codex` substring filter
+    # was the only gate, so a drive-by stranger could trigger a job that holds
+    # `secrets.CLAUDE_CODE_OAUTH_TOKEN` and `contents: write`. The association
+    # check restricts execution to repo OWNER / MEMBER / COLLABORATOR — i.e.
+    # the people who already have direct push access. Bot comments (Codex
+    # bot, Dependabot, etc.) post under their own logins so this filter is
+    # author-driven, not phrase-driven.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@codex')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@codex')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@codex')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@codex') || contains(github.event.issue.title, '@codex')))
+      (
+        github.event.sender.type == 'User' && (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR' ||
+          github.event.review.author_association == 'OWNER' ||
+          github.event.review.author_association == 'MEMBER' ||
+          github.event.review.author_association == 'COLLABORATOR' ||
+          github.event.issue.author_association == 'OWNER' ||
+          github.event.issue.author_association == 'MEMBER' ||
+          github.event.issue.author_association == 'COLLABORATOR'
+        )
+      ) && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@codex')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@codex')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@codex')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@codex') || contains(github.event.issue.title, '@codex')))
+      )
 
     runs-on: ubuntu-latest
 

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ __pycache__/
 # Logs
 *.log
 _site/
+.claude/


### PR DESCRIPTION
## Summary

Two small defensive fixes flagged by the parallel CI/build audit agent. Each closes a real attack surface.

## Changes

1. **`.github/workflows/ci.yml`** — add top-level `permissions: contents: read`. Without this block, the workflow inherits whatever default `GITHUB_TOKEN` permissions the repo-level setting grants — typically permissive. Explicit minimal scope means even a hypothetically-compromised CI step cannot push to the repo via the implicit token.

2. **`.github/workflows/codex-review.yml`** — add author-association gate. The job runs on `issue_comment`, `pull_request_review_comment`, `pull_request_review`, and `issues` triggers, all of which fire on activity from any drive-by stranger on this public repo. The original `if:` block only filtered for the substring `@codex` in the body. Combined with the job's `permissions: contents: write` and `secrets.CLAUDE_CODE_OAUTH_TOKEN`, that meant a stranger commenting `@codex` could trigger a write-scoped, OAuth-token-bearing job.

   The new gate restricts execution to authors with `OWNER` / `MEMBER` / `COLLABORATOR` association — the same set that already has direct push access. The `@codex` substring filter is preserved as a second layer.

3. **`.gitignore`** — add `.claude/` to keep Claude Code session settings out of commits (caught by the first amended push of this PR).

## Out of scope (deferred)

- **`rust-toolchain.toml` + `dtolnay/rust-toolchain@1.80` pin** — the audit agent flagged the floating `@stable` toolchain as a reproducibility risk. Pinning to `1.80` was attempted in an earlier revision of this PR but turned CI red because `time v0.3.47` (transitive via several deps) requires `edition2024` which is only stabilised in Rust 1.85+. Real MSRV is therefore higher than the `Cargo.toml` claim of `rust-version = "1.80"`. Resolving cleanly requires either bumping MSRV documentation OR a more involved dep audit; deferred so this PR can land its security wins now.
- **SHA-pinning of all GitHub Actions** (`actions/checkout@v4` → `actions/checkout@<sha> # v4.x.y`). Tag pins are the supply-chain hygiene gap the audit flagged but the maintenance burden of SHA-pinning ~10 actions and renewing them on each release is not worth the 3-day window before submission.
- **Branch protection on `main`** (require CI checks, require 1 review, disallow force-push). Tracked separately — being applied via `gh api` rather than YAML.

## Test plan

- [x] Edits are workflow + .gitignore only — no code, no schemas, no tests
- [x] `cargo test --workspace` will run unchanged on next CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)