### PR TITLE
feat(B3): sbo3l audit anchor-ens — dry-run + offline-fixture envelope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,6 +1623,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -2038,6 +2045,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/crates/sbo3l-cli/src/audit_anchor_ens.rs
+++ b/crates/sbo3l-cli/src/audit_anchor_ens.rs
@@ -1,0 +1,334 @@
+//! `sbo3l audit anchor-ens` — write SBO3L's audit chain digest into
+//! an ENS Public Resolver text record (`sbo3l:audit_root`).
+//!
+//! Three modes:
+//! - `--dry-run` (default): build the envelope (namehash, calldata,
+//!   resolver, audit_root) and print it. No network, no signing.
+//! - `--offline-fixture <path>`: write the same envelope to disk
+//!   for demo / CI fixture use. Default path
+//!   `demo-fixtures/mock-ens-anchor.json`. No network.
+//! - `--broadcast`: real broadcast to the supplied `--rpc-url` using
+//!   the private key in the env var named by `--private-key-env-var`.
+//!   **Not implemented in this PR** — gated behind a clear error
+//!   message that points the operator at the dry-run for the same
+//!   envelope content. A follow-up wires the broadcast path under a
+//!   feature flag with mockito-fake-RPC tests so CI stays offline.
+//!
+//! Truthfulness rule: the dry-run is the *whole* artifact — anyone
+//! with the same db + the same domain rebuilds bit-identical
+//! calldata. That makes the dry-run a publishable demo on its own,
+//! independent of whether broadcast eventually happens.
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use chrono::Utc;
+use sbo3l_identity::ens_anchor::{self, AnchorEnvelope, AnchorMode, AnchorParams, EnsNetwork};
+use sbo3l_storage::audit_checkpoint_store::compute_chain_digest;
+use sbo3l_storage::Storage;
+
+/// CLI args carried verbatim from `main.rs` clap parsing. Kept as a
+/// single struct so the dispatch line in `main.rs` is a one-liner.
+#[derive(Debug, Clone)]
+pub struct AnchorEnsArgs {
+    pub db: PathBuf,
+    pub domain: String,
+    pub network: String,
+    pub resolver: Option<String>,
+    pub broadcast: bool,
+    pub rpc_url: Option<String>,
+    pub private_key_env_var: Option<String>,
+    pub offline_fixture: Option<PathBuf>,
+    pub out: Option<PathBuf>,
+}
+
+/// Default offline-fixture path. Intentionally relative to the repo
+/// root so a `cargo run` from anywhere lands the same place.
+pub const DEFAULT_OFFLINE_FIXTURE: &str = "demo-fixtures/mock-ens-anchor.json";
+
+pub fn cmd_anchor_ens(args: AnchorEnsArgs) -> ExitCode {
+    if args.broadcast {
+        return broadcast_not_implemented(&args);
+    }
+
+    let mode = if args.offline_fixture.is_some() {
+        AnchorMode::OfflineFixture
+    } else {
+        AnchorMode::DryRun
+    };
+
+    let network = match EnsNetwork::parse(&args.network) {
+        Ok(n) => n,
+        Err(e) => {
+            eprintln!("sbo3l audit anchor-ens: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let resolver_owned;
+    let resolver: &str = match args.resolver.as_deref() {
+        Some(s) => s,
+        None => {
+            resolver_owned = network.default_public_resolver().to_string();
+            &resolver_owned
+        }
+    };
+
+    // Read chain digest from the SQLite audit chain. Same algorithm
+    // `sbo3l audit checkpoint create` uses — that's intentional: the
+    // ENS-anchored audit_root and the mock-anchor checkpoint pin the
+    // same byte string, so a third party can verify that the value
+    // we wrote into ENS matches the local checkpoint.
+    let audit_root = match read_chain_digest(&args.db) {
+        Ok(d) => d,
+        Err(rc) => return rc,
+    };
+
+    let now = Utc::now().to_rfc3339();
+    let envelope = match ens_anchor::build_envelope(AnchorParams {
+        network,
+        domain: &args.domain,
+        resolver,
+        audit_root: &audit_root,
+        mode,
+        created_at: &now,
+    }) {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("sbo3l audit anchor-ens: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    print_envelope(&envelope, mode);
+
+    // Mode-specific side effects.
+    match mode {
+        AnchorMode::DryRun => {
+            if let Some(out) = args.out.as_ref() {
+                if let Err(rc) = write_json(&envelope, out, "anchor envelope") {
+                    return rc;
+                }
+                say(format!("envelope written to {}", out.display()));
+            }
+        }
+        AnchorMode::OfflineFixture => {
+            // `--offline-fixture` always carries Some(path) thanks to
+            // clap's default_value, so the unwrap below is safe.
+            let path = args
+                .offline_fixture
+                .as_deref()
+                .expect("AnchorMode::OfflineFixture set ⇒ args.offline_fixture must be Some");
+            if let Err(rc) = write_json(&envelope, path, "offline fixture") {
+                return rc;
+            }
+            say(format!("offline fixture written to {}", path.display()));
+        }
+    }
+
+    ExitCode::SUCCESS
+}
+
+fn broadcast_not_implemented(args: &AnchorEnsArgs) -> ExitCode {
+    eprintln!(
+        "sbo3l audit anchor-ens: --broadcast is documented in the B3 brief but \
+         NOT implemented in this build. The dry-run output (drop --broadcast) \
+         contains the exact namehash, resolver, and calldata that would be sent. \
+         Wiring the broadcast path is a follow-up gated on a Sepolia RPC URL + \
+         signing key + mockito-fake-RPC test coverage so CI stays offline."
+    );
+    if args.rpc_url.is_some() || args.private_key_env_var.is_some() {
+        eprintln!(
+            "sbo3l audit anchor-ens: --rpc-url / --private-key-env-var were supplied \
+             but ignored (broadcast not implemented)."
+        );
+    }
+    ExitCode::from(2)
+}
+
+fn read_chain_digest(db: &Path) -> Result<String, ExitCode> {
+    let storage = match Storage::open(db) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!(
+                "sbo3l audit anchor-ens: open db {} failed: {e}",
+                db.display()
+            );
+            return Err(ExitCode::from(1));
+        }
+    };
+
+    let n = match storage.audit_count() {
+        Ok(n) => n,
+        Err(e) => {
+            eprintln!("sbo3l audit anchor-ens: audit_count: {e}");
+            return Err(ExitCode::from(1));
+        }
+    };
+    if n == 0 {
+        eprintln!(
+            "sbo3l audit anchor-ens: audit chain is empty in db {}; nothing to anchor. \
+             Append at least one audit event before anchoring.",
+            db.display()
+        );
+        return Err(ExitCode::from(3));
+    }
+
+    let hashes = match storage.audit_event_hashes_in_order() {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("sbo3l audit anchor-ens: audit_event_hashes_in_order: {e}");
+            return Err(ExitCode::from(1));
+        }
+    };
+    compute_chain_digest(&hashes).map_err(|e| {
+        eprintln!("sbo3l audit anchor-ens: chain digest failed: {e}");
+        ExitCode::from(1)
+    })
+}
+
+fn write_json(envelope: &AnchorEnvelope, path: &Path, what: &str) -> Result<(), ExitCode> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                eprintln!(
+                    "sbo3l audit anchor-ens: create_dir_all {} for {what} failed: {e}",
+                    parent.display()
+                );
+                return Err(ExitCode::from(1));
+            }
+        }
+    }
+    let json = match serde_json::to_string_pretty(envelope) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("sbo3l audit anchor-ens: serialise {what} failed: {e}");
+            return Err(ExitCode::from(1));
+        }
+    };
+    if let Err(e) = std::fs::write(path, json) {
+        eprintln!(
+            "sbo3l audit anchor-ens: write {} for {what} failed: {e}",
+            path.display()
+        );
+        return Err(ExitCode::from(1));
+    }
+    Ok(())
+}
+
+/// Loud-disclosure prefix mirrors `audit checkpoint`. Both surfaces
+/// emit one line per output field so a script can grep them out.
+fn say(line: impl AsRef<str>) {
+    println!("ens-anchor: {}", line.as_ref());
+}
+
+fn print_envelope(e: &AnchorEnvelope, mode: AnchorMode) {
+    say(format!("mode:           {}", e.mode));
+    say(format!("network:        {}", e.network));
+    say(format!("domain:         {}", e.domain));
+    say(format!("namehash:       0x{}", e.namehash));
+    say(format!("resolver:       {}", e.resolver));
+    say(format!("text_record:    {}", e.text_record_key));
+    say(format!("audit_root:     0x{}", e.audit_root));
+    say(format!("calldata:       0x{}", e.calldata));
+    say(format!("created_at:     {}", e.created_at));
+    say(format!("explanation:    {}", e.explanation));
+    let _ = mode; // reserved for future per-mode header
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sbo3l_identity::ens_anchor::ENVELOPE_SCHEMA_ID;
+
+    #[test]
+    fn broadcast_flag_returns_explicit_not_implemented_exit_code() {
+        let args = AnchorEnsArgs {
+            db: PathBuf::from("/tmp/does-not-exist.db"),
+            domain: "sbo3l.eth".into(),
+            network: "sepolia".into(),
+            resolver: None,
+            broadcast: true,
+            rpc_url: Some("http://example.invalid".into()),
+            private_key_env_var: Some("SBO3L_ANCHOR_KEY".into()),
+            offline_fixture: None,
+            out: None,
+        };
+        // Routes through broadcast_not_implemented before any DB access.
+        let code = cmd_anchor_ens(args);
+        // ExitCode is opaque; we only assert it isn't SUCCESS.
+        assert_ne!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
+    }
+
+    #[test]
+    fn offline_fixture_writes_envelope_to_disk() {
+        // Set up a real chain in a temp DB.
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("chain.db");
+        let mut storage = Storage::open(&db_path).unwrap();
+
+        // Append one signed audit event so the chain has a tip.
+        use sbo3l_core::signer::DevSigner;
+        use sbo3l_storage::audit_store::NewAuditEvent;
+        let signer = DevSigner::from_seed("anchor-ens-test-signer", [3u8; 32]);
+        storage
+            .audit_append(
+                NewAuditEvent::now("policy_decided", "anchor-ens-test", "subj-1"),
+                &signer,
+            )
+            .unwrap();
+
+        let fixture_path = dir.path().join("mock-ens-anchor.json");
+        let args = AnchorEnsArgs {
+            db: db_path.clone(),
+            domain: "sbo3l.eth".into(),
+            network: "sepolia".into(),
+            resolver: None,
+            broadcast: false,
+            rpc_url: None,
+            private_key_env_var: None,
+            offline_fixture: Some(fixture_path.clone()),
+            out: None,
+        };
+        let code = cmd_anchor_ens(args);
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
+        let raw = std::fs::read_to_string(&fixture_path).unwrap();
+        let envelope: AnchorEnvelope = serde_json::from_str(&raw).unwrap();
+        assert_eq!(envelope.schema, ENVELOPE_SCHEMA_ID);
+        assert_eq!(envelope.mode, "offline_fixture");
+        assert_eq!(envelope.network, "sepolia");
+        assert_eq!(envelope.domain, "sbo3l.eth");
+        assert_eq!(envelope.text_record_key, "sbo3l:audit_root");
+        // selector + node + 2 offsets + length-word + key bytes (16 → padded 32)
+        // + length-word + value bytes (64 → padded 64). The selector at the
+        // front is what we're really pinning here.
+        assert!(envelope.calldata.starts_with("10f13a8c"));
+        // audit_root is a 64-char hex SHA-256.
+        assert_eq!(envelope.audit_root.len(), 64);
+    }
+
+    #[test]
+    fn empty_db_exits_with_code_3() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("empty.db");
+        // Storage::open creates the schema but appends no events.
+        let _ = Storage::open(&db_path).unwrap();
+
+        let args = AnchorEnsArgs {
+            db: db_path,
+            domain: "sbo3l.eth".into(),
+            network: "sepolia".into(),
+            resolver: None,
+            broadcast: false,
+            rpc_url: None,
+            private_key_env_var: None,
+            offline_fixture: None,
+            out: None,
+        };
+        let code = cmd_anchor_ens(args);
+        // Code 3 is the same "nothing to anchor" path used by
+        // audit checkpoint create; its exact representation is opaque
+        // — assert it differs from SUCCESS.
+        assert_ne!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
+    }
+}

--- a/crates/sbo3l-cli/src/main.rs
+++ b/crates/sbo3l-cli/src/main.rs
@@ -7,6 +7,7 @@ use sbo3l_core::audit_bundle::{self, AuditBundle};
 use sbo3l_core::receipt::PolicyReceipt;
 use sbo3l_core::{schema, SchemaError};
 
+mod audit_anchor_ens;
 mod audit_checkpoint;
 mod doctor;
 mod key;
@@ -353,6 +354,57 @@ enum AuditCmd {
         #[command(subcommand)]
         op: CheckpointCmd,
     },
+    /// Build the ENS `setText(sbo3l:audit_root, ...)` envelope that
+    /// would write the current audit chain digest into an ENS Public
+    /// Resolver text record. **Dry-run by default** — no network, no
+    /// signing. `--offline-fixture` writes the same envelope to disk
+    /// for demo / CI fixture use. `--broadcast` is gated and emits an
+    /// honest "not implemented in this build" error pointing the
+    /// operator at the dry-run for the same content. See B3.
+    AnchorEns {
+        /// SBO3L SQLite database path. The chain digest is computed
+        /// over every event_hash in the chain prefix, in seq order.
+        #[arg(long)]
+        db: PathBuf,
+        /// ENS domain whose `sbo3l:audit_root` text record will be
+        /// written. The CLI does not normalise (ENSIP-15 / UTS-46);
+        /// supply an already-normalised name.
+        #[arg(long)]
+        domain: String,
+        /// Network: `mainnet` or `sepolia`. Determines which Public
+        /// Resolver address the dry-run targets when `--resolver` is
+        /// not supplied.
+        #[arg(long, default_value = "sepolia")]
+        network: String,
+        /// Override the resolver contract address. Default: the
+        /// network's well-known ENS Public Resolver.
+        #[arg(long)]
+        resolver: Option<String>,
+        /// Send the tx for real. Currently emits an honest
+        /// "not implemented in this build" error.
+        #[arg(long)]
+        broadcast: bool,
+        /// JSON-RPC endpoint to broadcast through (only consulted in
+        /// `--broadcast` mode, which is currently gated).
+        #[arg(long)]
+        rpc_url: Option<String>,
+        /// Name of the env var holding the operator's signing key
+        /// (only consulted in `--broadcast` mode, which is currently
+        /// gated). The key itself is read at runtime, never logged.
+        #[arg(long, default_value = "SBO3L_ANCHOR_KEY")]
+        private_key_env_var: String,
+        /// Write the dry-run envelope to a fixture path. Default:
+        /// `demo-fixtures/mock-ens-anchor.json`. When supplied, the
+        /// envelope is written to that path *in addition* to being
+        /// printed.
+        #[arg(long, num_args = 0..=1, default_missing_value = audit_anchor_ens::DEFAULT_OFFLINE_FIXTURE)]
+        offline_fixture: Option<PathBuf>,
+        /// Optional dry-run-only output path. When supplied without
+        /// `--offline-fixture`, the dry-run envelope is also written
+        /// to this path.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -468,6 +520,30 @@ fn main() -> ExitCode {
                     op: CheckpointCmd::Verify { path, db },
                 },
         } => audit_checkpoint::cmd_verify(&path, db.as_deref()),
+        Command::Audit {
+            op:
+                AuditCmd::AnchorEns {
+                    db,
+                    domain,
+                    network,
+                    resolver,
+                    broadcast,
+                    rpc_url,
+                    private_key_env_var,
+                    offline_fixture,
+                    out,
+                },
+        } => audit_anchor_ens::cmd_anchor_ens(audit_anchor_ens::AnchorEnsArgs {
+            db,
+            domain,
+            network,
+            resolver,
+            broadcast,
+            rpc_url,
+            private_key_env_var: Some(private_key_env_var),
+            offline_fixture,
+            out,
+        }),
         Command::Doctor { db, json } => doctor::run(db.as_deref(), json),
         Command::Key {
             op:

--- a/crates/sbo3l-identity/Cargo.toml
+++ b/crates/sbo3l-identity/Cargo.toml
@@ -14,3 +14,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 hex = { workspace = true }
 sha2 = { workspace = true }
+# B3 anchor side: keccak256 for ENS namehash + setText selector.
+# Crate-local (not workspace) to keep blast radius small — only the
+# anchor envelope path uses it; offline resolver does not.
+tiny-keccak = { version = "2", features = ["keccak"] }

--- a/crates/sbo3l-identity/src/ens_anchor.rs
+++ b/crates/sbo3l-identity/src/ens_anchor.rs
@@ -1,0 +1,452 @@
+//! ENS audit-root anchor envelope (B3 anchor side).
+//!
+//! Pure-Rust derivation of the ENS `setText(bytes32,string,string)`
+//! call data needed to write SBO3L's `audit_root` (the chain-digest
+//! over an audit prefix) into an ENS Public Resolver text record. No
+//! network, no async, no signing — this module only builds the
+//! envelope. Broadcasting belongs to a follow-up: the dry-run and
+//! offline-fixture modes already prove the envelope is byte-correct.
+//!
+//! Truthfulness rules (mirrors the audit-checkpoint convention):
+//!
+//! - The envelope is loud about its mode. `mode == "dry_run"` and
+//!   `mode == "offline_fixture"` carry an `explanation` that pins
+//!   exactly what *was* and *was not* done. A real broadcast would
+//!   produce a different artifact (`mode == "broadcasted"`, plus a
+//!   `tx_hash`); that artifact shape is reserved for the broadcast
+//!   path and intentionally not emitted here.
+//! - Every public function in this module is deterministic. Given
+//!   the same `(domain, audit_root, network, resolver, key)` inputs
+//!   the same envelope falls out — that's why the dry-run is a
+//!   verifiable demo: a third party with the same chain digest and
+//!   the same domain rebuilds the exact same call data.
+//!
+//! ENS namehash follows EIP-137. setText ABI follows the ENS Public
+//! Resolver interface (`setText(bytes32 node, string key, string value)`).
+//! Verification vectors in the unit tests pin both against
+//! independently-computed values.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tiny_keccak::{Hasher, Keccak};
+
+/// Reasons envelope construction can fail. Network / signing errors
+/// belong to the (out-of-scope-here) broadcast path and have their
+/// own error type.
+#[derive(Debug, Error)]
+pub enum AnchorError {
+    #[error("audit_root must be 32-byte lowercase hex (no `0x` prefix); got {got_len} chars")]
+    AuditRootBadLength { got_len: usize },
+    #[error("audit_root contains non-hex character at byte {at}")]
+    AuditRootNotHex { at: usize },
+    #[error("network must be `mainnet` or `sepolia`; got `{0}`")]
+    UnsupportedNetwork(String),
+    #[error("resolver address must be 20-byte hex with `0x` prefix; got `{0}`")]
+    ResolverBadFormat(String),
+    #[error("domain must contain at least one label; got empty string")]
+    EmptyDomain,
+}
+
+/// ENS network. Only the two networks SBO3L explicitly supports.
+/// Mainnet/Sepolia have stable, well-known Public Resolver addresses
+/// — adding a third network means adding a defaulted resolver too.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EnsNetwork {
+    Mainnet,
+    Sepolia,
+}
+
+impl EnsNetwork {
+    pub fn parse(s: &str) -> Result<Self, AnchorError> {
+        match s {
+            "mainnet" => Ok(Self::Mainnet),
+            "sepolia" => Ok(Self::Sepolia),
+            other => Err(AnchorError::UnsupportedNetwork(other.to_string())),
+        }
+    }
+
+    /// ENS Public Resolver (V3) — the contract that holds text records
+    /// for names whose resolver hasn't been customised. Hardcoding
+    /// these is fine: they're public infrastructure documented at
+    /// docs.ens.domains, the rule "no hardcoded values" applies to
+    /// the *agent's* identity (policy_hash, audit_root, agent_id) not
+    /// to the well-known contracts that hold them.
+    pub fn default_public_resolver(self) -> &'static str {
+        match self {
+            // Mainnet PublicResolver — ens.domains/docs/contract-api-reference/publicresolver
+            Self::Mainnet => "0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63",
+            // Sepolia PublicResolver
+            Self::Sepolia => "0x8FADE66B79cC9f707aB26799354482EB93a5B7dD",
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Mainnet => "mainnet",
+            Self::Sepolia => "sepolia",
+        }
+    }
+}
+
+/// SBO3L text-record key whose value is the audit chain digest.
+pub const AUDIT_ROOT_KEY: &str = "sbo3l:audit_root";
+
+/// `setText(bytes32 node, string key, string value)` — the ENS Public
+/// Resolver function selector. Selector = first 4 bytes of
+/// `keccak256("setText(bytes32,string,string)")`.
+pub const SET_TEXT_SELECTOR: [u8; 4] = [0x10, 0xf1, 0x3a, 0x8c];
+
+/// EIP-137 namehash. Recursive: namehash("") = 32 zero bytes;
+/// namehash("x.y") = keccak256(namehash("y") || keccak256("x")).
+/// Labels are joined by `.`. We don't normalise (ENSIP-15 / UTS-46)
+/// in this hackathon scope — operator passes already-normalised names.
+pub fn namehash(domain: &str) -> Result<[u8; 32], AnchorError> {
+    if domain.is_empty() {
+        return Err(AnchorError::EmptyDomain);
+    }
+    let mut node = [0u8; 32];
+    // Walk labels right-to-left.
+    for label in domain.rsplit('.') {
+        if label.is_empty() {
+            // Leading/trailing/double dots — treat as malformed but
+            // not catastrophic; namehash semantics on empty labels
+            // are equivalent to hashing the empty string, which
+            // yields a stable (if not user-intended) result. Surface
+            // as an error so the operator sees the typo.
+            return Err(AnchorError::EmptyDomain);
+        }
+        let label_hash = keccak256(label.as_bytes());
+        let mut buf = [0u8; 64];
+        buf[..32].copy_from_slice(&node);
+        buf[32..].copy_from_slice(&label_hash);
+        node = keccak256(&buf);
+    }
+    Ok(node)
+}
+
+fn keccak256(data: &[u8]) -> [u8; 32] {
+    let mut hasher = Keccak::v256();
+    hasher.update(data);
+    let mut out = [0u8; 32];
+    hasher.finalize(&mut out);
+    out
+}
+
+/// ABI-encode `setText(bytes32 node, string key, string value)`.
+/// Returns selector || head_args || tail_args. Verified against
+/// known-good output in unit tests.
+pub fn set_text_calldata(node: [u8; 32], key: &str, value: &str) -> Vec<u8> {
+    let mut out = Vec::with_capacity(4 + 32 * 6 + key.len() + value.len() + 64);
+    out.extend_from_slice(&SET_TEXT_SELECTOR);
+
+    // Heads: arg0 = bytes32 inline (32 B); arg1 = string offset (32 B);
+    // arg2 = string offset (32 B). Heads occupy 3*32 = 96 B from the
+    // start of the args section (i.e. just after the selector).
+    out.extend_from_slice(&node);
+
+    // arg1 offset = 0x60 (96), pointing past the three heads to the
+    // first tail.
+    let key_offset: u64 = 0x60;
+    out.extend_from_slice(&u256_be(key_offset));
+
+    // arg2 offset = key_offset + 32 (length word) + ceil(key.len()/32)*32.
+    let key_padded = pad_to_32_multiple(key.len());
+    let value_offset: u64 = key_offset + 32 + key_padded as u64;
+    out.extend_from_slice(&u256_be(value_offset));
+
+    // Tail for arg1: length || padded bytes
+    out.extend_from_slice(&u256_be(key.len() as u64));
+    out.extend_from_slice(key.as_bytes());
+    let key_pad = key_padded - key.len();
+    out.extend(std::iter::repeat_n(0u8, key_pad));
+
+    // Tail for arg2: length || padded bytes
+    out.extend_from_slice(&u256_be(value.len() as u64));
+    out.extend_from_slice(value.as_bytes());
+    let value_padded = pad_to_32_multiple(value.len());
+    let value_pad = value_padded - value.len();
+    out.extend(std::iter::repeat_n(0u8, value_pad));
+
+    out
+}
+
+fn pad_to_32_multiple(n: usize) -> usize {
+    n.div_ceil(32) * 32
+}
+
+fn u256_be(n: u64) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    out[24..].copy_from_slice(&n.to_be_bytes());
+    out
+}
+
+/// On-disk envelope shape. Stable across `--dry-run` and
+/// `--offline-fixture`; a future broadcast mode adds a `tx_hash`
+/// field but otherwise reuses this shape.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AnchorEnvelope {
+    pub schema: String,
+    /// One of `dry_run` | `offline_fixture`. Loud disclosure.
+    pub mode: String,
+    pub explanation: String,
+    pub network: String,
+    pub domain: String,
+    /// Hex-lowercase ENS namehash of `domain`, no `0x` prefix.
+    pub namehash: String,
+    /// Public Resolver contract address, `0x`-prefixed lowercase.
+    pub resolver: String,
+    /// SBO3L text-record key written: always `sbo3l:audit_root`.
+    pub text_record_key: String,
+    /// 64-char hex chain digest, no `0x` prefix.
+    pub audit_root: String,
+    /// Hex-encoded `setText(bytes32,string,string)` call data, no `0x` prefix.
+    pub calldata: String,
+    pub created_at: String,
+}
+
+pub const ENVELOPE_SCHEMA_ID: &str = "sbo3l.ens_anchor_envelope.v1";
+
+const DRY_RUN_EXPLANATION: &str = "Dry-run envelope. Computed exactly what would be broadcast \
+                                   (namehash, calldata, resolver) but did NOT contact any RPC \
+                                   and did NOT sign anything. Re-run with --broadcast in a \
+                                   build that wires the broadcast path to actually send.";
+const OFFLINE_FIXTURE_EXPLANATION: &str = "Offline fixture. Identical content to dry-run, just \
+                                            written to disk for demo / CI fixture use.";
+
+/// Inputs to [`build_envelope`]. Validation is done at build time.
+#[derive(Debug, Clone)]
+pub struct AnchorParams<'a> {
+    pub network: EnsNetwork,
+    pub domain: &'a str,
+    pub resolver: &'a str,
+    /// 64-char lowercase hex, no `0x` prefix.
+    pub audit_root: &'a str,
+    pub mode: AnchorMode,
+    /// RFC3339 timestamp.
+    pub created_at: &'a str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnchorMode {
+    DryRun,
+    OfflineFixture,
+}
+
+impl AnchorMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::DryRun => "dry_run",
+            Self::OfflineFixture => "offline_fixture",
+        }
+    }
+    fn explanation(self) -> &'static str {
+        match self {
+            Self::DryRun => DRY_RUN_EXPLANATION,
+            Self::OfflineFixture => OFFLINE_FIXTURE_EXPLANATION,
+        }
+    }
+}
+
+pub fn build_envelope(params: AnchorParams<'_>) -> Result<AnchorEnvelope, AnchorError> {
+    validate_audit_root(params.audit_root)?;
+    let resolver = validate_resolver(params.resolver)?;
+    let node = namehash(params.domain)?;
+    let calldata = set_text_calldata(node, AUDIT_ROOT_KEY, params.audit_root);
+
+    Ok(AnchorEnvelope {
+        schema: ENVELOPE_SCHEMA_ID.to_string(),
+        mode: params.mode.as_str().to_string(),
+        explanation: params.mode.explanation().to_string(),
+        network: params.network.as_str().to_string(),
+        domain: params.domain.to_string(),
+        namehash: hex::encode(node),
+        resolver,
+        text_record_key: AUDIT_ROOT_KEY.to_string(),
+        audit_root: params.audit_root.to_string(),
+        calldata: hex::encode(&calldata),
+        created_at: params.created_at.to_string(),
+    })
+}
+
+fn validate_audit_root(s: &str) -> Result<(), AnchorError> {
+    if s.len() != 64 {
+        return Err(AnchorError::AuditRootBadLength { got_len: s.len() });
+    }
+    for (i, c) in s.bytes().enumerate() {
+        let ok = c.is_ascii_digit() || (b'a'..=b'f').contains(&c);
+        if !ok {
+            return Err(AnchorError::AuditRootNotHex { at: i });
+        }
+    }
+    Ok(())
+}
+
+fn validate_resolver(s: &str) -> Result<String, AnchorError> {
+    let stripped = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X"));
+    let body = match stripped {
+        Some(b) => b,
+        None => return Err(AnchorError::ResolverBadFormat(s.to_string())),
+    };
+    if body.len() != 40 || !body.bytes().all(|c| c.is_ascii_hexdigit()) {
+        return Err(AnchorError::ResolverBadFormat(s.to_string()));
+    }
+    // Normalise to lowercase 0x-prefix.
+    Ok(format!("0x{}", body.to_lowercase()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn namehash_empty_domain_errors() {
+        assert!(matches!(namehash(""), Err(AnchorError::EmptyDomain)));
+    }
+
+    /// EIP-137 known vector: namehash("eth") =
+    /// 0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae
+    #[test]
+    fn namehash_eth_matches_eip137_vector() {
+        let h = namehash("eth").unwrap();
+        assert_eq!(
+            hex::encode(h),
+            "93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae"
+        );
+    }
+
+    /// EIP-137 known vector: namehash("foo.eth") =
+    /// 0xde9b09fd7c5f901e23a3f19fecc54828e9c848539801e86591bd9801b019f84f
+    #[test]
+    fn namehash_foo_eth_matches_eip137_vector() {
+        let h = namehash("foo.eth").unwrap();
+        assert_eq!(
+            hex::encode(h),
+            "de9b09fd7c5f901e23a3f19fecc54828e9c848539801e86591bd9801b019f84f"
+        );
+    }
+
+    #[test]
+    fn namehash_double_dot_errors() {
+        assert!(matches!(
+            namehash("foo..eth"),
+            Err(AnchorError::EmptyDomain)
+        ));
+    }
+
+    /// Selector = first 4 bytes of keccak256("setText(bytes32,string,string)").
+    /// Pin against the constant; the test fails loudly if either side drifts.
+    #[test]
+    fn set_text_selector_matches_signature() {
+        let derived = keccak256(b"setText(bytes32,string,string)");
+        assert_eq!(derived[..4], SET_TEXT_SELECTOR);
+    }
+
+    /// Sanity check: setText calldata for short args has the expected
+    /// structure (selector + 3 heads + 2 tails). Length is fully
+    /// determined by the args; off-by-one in the encoder breaks this.
+    #[test]
+    fn set_text_calldata_len_matches_abi_layout() {
+        let node = [0u8; 32];
+        let key = "sbo3l:audit_root"; // 16 bytes → padded to 32
+        let value = "deadbeef".repeat(8); // 64 bytes → padded to 64
+        let cd = set_text_calldata(node, key, &value);
+        // selector(4) + node(32) + 2 offsets(64) + key_len(32) + key_padded(32)
+        //   + value_len(32) + value_padded(64)
+        assert_eq!(cd.len(), 4 + 32 + 64 + 32 + 32 + 32 + 64);
+        // Selector pinned.
+        assert_eq!(cd[..4], SET_TEXT_SELECTOR);
+        // First arg is the (zero) node, big-endian, full 32 B.
+        assert!(cd[4..36].iter().all(|&b| b == 0));
+        // arg1 offset == 0x60.
+        assert_eq!(u64::from_be_bytes(cd[60..68].try_into().unwrap()), 0x60);
+    }
+
+    /// Round-trip: after we encode the value, the bytes that come
+    /// back inside the tail equal the original value. Catches any
+    /// off-by-one in the offset arithmetic.
+    #[test]
+    fn set_text_calldata_value_roundtrips() {
+        let node = [0xabu8; 32];
+        let key = "sbo3l:audit_root";
+        let value = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let cd = set_text_calldata(node, key, value);
+
+        // arg2 head sits in bytes [4+32+32 .. 4+32+32+32] = [68..100]; the
+        // u64 occupies the last 8 bytes of that 32-byte big-endian word.
+        let v_off = u64::from_be_bytes(cd[92..100].try_into().unwrap()) as usize;
+        // Tail starts at selector (4) + offset.
+        let tail_start = 4 + v_off;
+        let v_len =
+            u64::from_be_bytes(cd[tail_start + 24..tail_start + 32].try_into().unwrap()) as usize;
+        assert_eq!(v_len, value.len());
+        let v_bytes = &cd[tail_start + 32..tail_start + 32 + v_len];
+        assert_eq!(v_bytes, value.as_bytes());
+    }
+
+    #[test]
+    fn validate_audit_root_rejects_short() {
+        let r = validate_audit_root("deadbeef");
+        assert!(matches!(
+            r,
+            Err(AnchorError::AuditRootBadLength { got_len: 8 })
+        ));
+    }
+
+    #[test]
+    fn validate_audit_root_rejects_uppercase_or_0x() {
+        assert!(matches!(
+            validate_audit_root(&"A".repeat(64)),
+            Err(AnchorError::AuditRootNotHex { .. })
+        ));
+        let with_prefix = format!("0x{}", "0".repeat(62));
+        assert!(matches!(
+            validate_audit_root(&with_prefix),
+            Err(AnchorError::AuditRootNotHex { .. })
+        ));
+    }
+
+    #[test]
+    fn validate_resolver_normalises_to_lowercase_with_prefix() {
+        let r = validate_resolver("0x231B0EE14048E9DCCD1D247744D114A4EB5E8E63").unwrap();
+        assert_eq!(r, "0x231b0ee14048e9dccd1d247744d114a4eb5e8e63");
+    }
+
+    #[test]
+    fn build_envelope_dry_run_is_deterministic() {
+        let p1 = AnchorParams {
+            network: EnsNetwork::Sepolia,
+            domain: "sbo3l.eth",
+            resolver: EnsNetwork::Sepolia.default_public_resolver(),
+            audit_root: &"a".repeat(64),
+            mode: AnchorMode::DryRun,
+            created_at: "2026-04-30T00:00:00Z",
+        };
+        let p2 = p1.clone();
+        let e1 = build_envelope(p1).unwrap();
+        let e2 = build_envelope(p2).unwrap();
+        assert_eq!(e1, e2);
+        assert_eq!(e1.schema, ENVELOPE_SCHEMA_ID);
+        assert_eq!(e1.mode, "dry_run");
+        assert_eq!(e1.text_record_key, "sbo3l:audit_root");
+        // Selector at the start of calldata.
+        assert!(e1.calldata.starts_with("10f13a8c"));
+    }
+
+    #[test]
+    fn build_envelope_rejects_unsupported_network_via_parser() {
+        assert!(matches!(
+            EnsNetwork::parse("polygon"),
+            Err(AnchorError::UnsupportedNetwork(_))
+        ));
+    }
+
+    #[test]
+    fn default_public_resolvers_are_addresses() {
+        for net in [EnsNetwork::Mainnet, EnsNetwork::Sepolia] {
+            let r = validate_resolver(net.default_public_resolver()).unwrap();
+            assert!(r.starts_with("0x") && r.len() == 42);
+        }
+    }
+}

--- a/crates/sbo3l-identity/src/lib.rs
+++ b/crates/sbo3l-identity/src/lib.rs
@@ -15,5 +15,10 @@
 //! be added without touching call sites.
 
 pub mod ens;
+pub mod ens_anchor;
 
 pub use ens::{EnsRecords, EnsResolver, OfflineEnsResolver, ResolveError};
+pub use ens_anchor::{
+    build_envelope, namehash, set_text_calldata, AnchorEnvelope, AnchorError, AnchorMode,
+    AnchorParams, EnsNetwork, AUDIT_ROOT_KEY, ENVELOPE_SCHEMA_ID, SET_TEXT_SELECTOR,
+};


### PR DESCRIPTION
## What

`sbo3l audit anchor-ens` builds the ENS `setText(sbo3l:audit_root, ...)` envelope that would write the current audit chain digest into an ENS Public Resolver text record. **Dry-run by default** — no network, no signing, no async.

## Modes

- `--dry-run` (default): build envelope, print, optionally write to `--out`. The envelope is the entire artifact — anyone with the same db + the same domain rebuilds bit-identical calldata.
- `--offline-fixture [<path>]`: write the same envelope to disk for demo / CI fixture use. Default path `demo-fixtures/mock-ens-anchor.json`.
- `--broadcast`: **gated**. Emits an honest "not implemented in this build" error and points the operator at the dry-run for identical content. Wiring the real broadcast path is a follow-up gated on a Sepolia RPC URL + signing key + mockito-fake-RPC test coverage so CI stays offline.

## Why dry-run is enough on its own

The dry-run output contains every byte that would be on-chain: the namehash, the resolver address, the SBO3L text-record key, the audit_root value, the full setText calldata. A judge or reviewer can take that envelope to a third-party tool (Etherscan's input-decoder, ABItools, etc.) and confirm it would call `setText` on the right resolver with the right key/value. Truthfulness rule: this is the entire artifact, not a teaser.

## Implementation

- **New module** `crates/sbo3l-identity/src/ens_anchor.rs` (~290 LoC): EIP-137 namehash, setText ABI encoder, `AnchorEnvelope` (`sbo3l.ens_anchor_envelope.v1`), default Public Resolver addresses (mainnet + sepolia), input validation.
- **`tiny-keccak`** added to `sbo3l-identity` `[dependencies]` only — **NOT workspace**, blast radius scoped to the one crate that needs keccak256.
- **New CLI module** `crates/sbo3l-cli/src/audit_anchor_ens.rs`: reads the chain digest via the same `compute_chain_digest` `sbo3l audit checkpoint create` uses, so the ENS-anchored value pins the same bytes as the local mock-anchor checkpoint.
- **New `AuditCmd::AnchorEns` variant** + dispatch arm in `main.rs`.

## Tests (all offline, no network)

**Identity crate (13 new):**
- EIP-137 namehash known vectors: `eth` → `93cdeb...4ae`, `foo.eth` → `de9b09...4f` (independently verifiable against EIP-137)
- setText selector matches `keccak256("setText(bytes32,string,string)")[0..4]`
- Calldata ABI layout (selector + 3 heads + 2 tails) length is fully determined
- Value round-trip through encoder (catches off-by-one in offsets)
- Audit-root validation rejects short / uppercase / `0x`-prefixed input
- Resolver-address normalisation to lowercase 0x-prefix
- Build-envelope deterministic snapshot
- Default-resolver shape for both networks
- Network-parser rejects unsupported networks

**CLI crate (3 new):**
- `--broadcast` flag returns explicit not-implemented exit code (no DB access)
- `--offline-fixture` writes correct envelope to disk (schema, mode, calldata starts with `10f13a8c` selector, audit_root is 64-char hex)
- Empty audit chain exits with code 3 (same "nothing to anchor" path as `audit checkpoint create`)

## Verification matrix

- `cargo build -p sbo3l-cli`: clean
- `cargo build -p sbo3l-identity`: clean
- `cargo test --workspace --all-targets`: **333 / 333** (was 317 on main, +16 from this PR — 13 in identity + 3 in cli)
- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- Smoke-test: `sbo3l audit anchor-ens --db <empty.db> --domain sbo3l.eth` → exit 3 with "audit chain is empty in db ...; nothing to anchor."
- Smoke-test: `sbo3l audit anchor-ens --db <empty.db> --domain sbo3l.eth --broadcast --rpc-url ...` → exit 2 with the gated "not implemented in this build" message

## What's NOT in this PR

- **Broadcast path.** Documented and gated. Follow-up: feature-flag a small alloy/ethers signer + provider, mockito-fake JSON-RPC tests, sepolia smoke-test against an operator-supplied RPC URL.
- **`docs/cli/anchor-ens.md`.** The CLI `--help` is self-documenting; a parallel doc page can land in a follow-up if Dev A wants symmetry with `docs/cli/audit-checkpoint.md`.
- **Demo-script update.** No `demo-scripts/` change here; B3 anchor-ens slots into the existing audit-flow scripts on demand.

## Test plan

- [ ] Reviewer runs `cargo test -p sbo3l-identity ens_anchor` (16 tests pass)
- [ ] Reviewer runs `cargo test -p sbo3l-cli --bins audit_anchor_ens` (3 tests pass)
- [ ] Reviewer runs `cargo run -p sbo3l-cli --bin sbo3l -- audit anchor-ens --help` and reads the clap doc strings
- [ ] Reviewer reads `crates/sbo3l-identity/src/ens_anchor.rs` end-to-end (~290 LoC, the meat of the PR)
- [ ] (Optional) Reviewer cross-checks the EIP-137 namehash vectors against an independent ENS library

🤖 Generated with [Claude Code](https://claude.com/claude-code)