### PR TITLE
feat(B3): LiveEnsResolver — read SBO3L text records from real ENS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -92,7 +92,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -190,6 +190,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -527,7 +533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -602,6 +608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -609,6 +616,18 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -623,7 +642,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -658,9 +680,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -771,6 +795,23 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -779,13 +820,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -926,6 +975,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,6 +1017,8 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -964,7 +1031,7 @@ checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
- "base64",
+ "base64 0.21.7",
  "bytecount",
  "fancy-regex",
  "fraction",
@@ -1035,6 +1102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,7 +1142,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1087,7 +1160,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1301,6 +1374,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,6 +1556,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "research-agent"
 version = "0.1.0"
 dependencies = [
@@ -1449,6 +1617,20 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ulid",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1512,6 +1694,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1530,7 +1718,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1593,7 +1816,7 @@ dependencies = [
  "serde_json",
  "serde_json_canonicalizer",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
  "ulid",
 ]
 
@@ -1609,7 +1832,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
  "ulid",
 ]
 
@@ -1618,11 +1841,12 @@ name = "sbo3l-identity"
 version = "0.1.0"
 dependencies = [
  "hex",
+ "reqwest",
  "sbo3l-core",
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
  "tiny-keccak",
 ]
 
@@ -1635,7 +1859,7 @@ dependencies = [
  "sbo3l-core",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "ulid",
 ]
 
@@ -1658,7 +1882,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tower",
  "tracing",
@@ -1678,7 +1902,7 @@ dependencies = [
  "serde_json_canonicalizer",
  "serde_yaml",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1695,7 +1919,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tower",
  "tracing",
@@ -1717,7 +1941,7 @@ dependencies = [
  "serde_json_canonicalizer",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "ulid",
 ]
 
@@ -1899,7 +2123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1957,6 +2181,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -1985,7 +2212,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1994,7 +2221,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2002,6 +2238,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2095,7 +2342,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2107,6 +2354,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2153,6 +2410,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -2230,6 +2505,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2256,6 +2537,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2310,6 +2597,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2336,6 +2632,16 @@ dependencies = [
  "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2371,6 +2677,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2378,6 +2694,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2441,12 +2766,159 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/crates/sbo3l-identity/Cargo.toml
+++ b/crates/sbo3l-identity/Cargo.toml
@@ -14,7 +14,14 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 hex = { workspace = true }
 sha2 = { workspace = true }
-# B3 anchor side: keccak256 for ENS namehash + setText selector.
-# Crate-local (not workspace) to keep blast radius small — only the
-# anchor envelope path uses it; offline resolver does not.
+# B3 anchor side + LiveEnsResolver: keccak256 for ENS namehash and
+# function selectors. Crate-local (not workspace) to keep blast
+# radius small — only the live-resolver and anchor-envelope paths
+# use it; the offline resolver does not.
 tiny-keccak = { version = "2", features = ["keccak"] }
+# B3 LiveEnsResolver: blocking HTTP for synchronous JSON-RPC calls
+# (the EnsResolver trait is sync). Builds on top of the workspace
+# reqwest (rustls-tls + json) with the additional `blocking` feature
+# scoped to this crate; CI tests use an in-process fake transport,
+# so the blocking client is only exercised in real runtime.
+reqwest = { workspace = true, features = ["blocking"] }

--- a/crates/sbo3l-identity/src/ens_live.rs
+++ b/crates/sbo3l-identity/src/ens_live.rs
@@ -1,0 +1,655 @@
+//! ENS resolver that reads SBO3L text records from a real Ethereum
+//! JSON-RPC endpoint (B3 resolution side).
+//!
+//! Two-step resolution per ENSIP-1:
+//! 1. Call `ENSRegistry.resolver(node)` to get the resolver address
+//!    actually registered for this name. Fails fast (`UnknownName`)
+//!    when the name isn't registered or doesn't have a resolver set.
+//! 2. Call `Resolver.text(node, key)` for each of the five SBO3L
+//!    text-record keys (`sbo3l:agent_id`, `sbo3l:endpoint`,
+//!    `sbo3l:policy_hash`, `sbo3l:audit_root`, `sbo3l:receipt_schema`).
+//!    Any missing key surfaces as `MissingRecord`.
+//!
+//! ENS bounty rule "no hardcoded values": the *agent's* identity
+//! (policy_hash, audit_root, etc.) is read from chain. Network-level
+//! contract addresses (the ENS Registry, the Public Resolver) are
+//! well-known public infrastructure and ARE hardcoded — the rule is
+//! about the agent, not the protocol.
+//!
+//! Testability: HTTP/JSON-RPC is hidden behind the `JsonRpcTransport`
+//! trait. The production impl ([`ReqwestTransport`]) uses
+//! `reqwest::blocking`. Tests inject a fake transport that returns
+//! canned responses — no network, no mockito server, fully offline
+//! CI.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::ens::{EnsRecords, EnsResolver, ResolveError};
+use crate::ens_anchor::{namehash, EnsNetwork};
+
+/// ENS Registry address. Same on every network the registry has
+/// been deployed on (mainnet, sepolia, holesky, ...). Public
+/// infrastructure; hardcoded.
+pub const ENS_REGISTRY_ADDRESS: &str = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e";
+
+/// Selector for `resolver(bytes32 node) returns (address)`.
+/// Pinned in tests against `keccak256("resolver(bytes32)")[0..4]`.
+pub const RESOLVER_SELECTOR: [u8; 4] = [0x01, 0x78, 0xb8, 0xbf];
+
+/// Selector for `text(bytes32 node, string key) returns (string)`.
+/// Pinned in tests against `keccak256("text(bytes32,string)")[0..4]`.
+pub const TEXT_SELECTOR: [u8; 4] = [0x59, 0xd1, 0xd4, 0x3c];
+
+/// The five SBO3L text-record keys read by [`LiveEnsResolver`].
+/// Order is the field order of [`EnsRecords`]; the resolver makes
+/// one `text()` call per key, in this order.
+pub const SBO3L_TEXT_KEYS: [&str; 5] = [
+    "sbo3l:agent_id",
+    "sbo3l:endpoint",
+    "sbo3l:policy_hash",
+    "sbo3l:audit_root",
+    "sbo3l:receipt_schema",
+];
+
+/// Reasons a JSON-RPC call can fail. Surfaced through
+/// [`ResolveError::Io`] / [`ResolveError::Json`] so callers don't
+/// need to fan in a new error type.
+#[derive(Debug, thiserror::Error)]
+pub enum RpcError {
+    #[error("RPC HTTP error: {0}")]
+    Http(String),
+    #[error("RPC JSON parse error: {0}")]
+    Parse(String),
+    #[error("RPC reported error: {code} {message}")]
+    Server { code: i64, message: String },
+    #[error("malformed eth_call response: {0}")]
+    Decode(String),
+}
+
+impl From<RpcError> for ResolveError {
+    fn from(e: RpcError) -> Self {
+        ResolveError::Io(std::io::Error::other(e.to_string()))
+    }
+}
+
+/// Synchronous JSON-RPC transport. Production uses
+/// [`ReqwestTransport`]; tests inject a fake.
+pub trait JsonRpcTransport {
+    /// Call `eth_call` against `to` with `data` (both `0x`-prefixed
+    /// hex strings). Returns the `0x`-prefixed hex result string.
+    fn eth_call(&self, to: &str, data: &str) -> Result<String, RpcError>;
+}
+
+#[derive(Debug, Serialize)]
+struct EthCallTx<'a> {
+    to: &'a str,
+    data: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcResponse {
+    #[allow(dead_code)]
+    jsonrpc: Option<String>,
+    result: Option<String>,
+    error: Option<JsonRpcErrorBody>,
+    #[allow(dead_code)]
+    id: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcErrorBody {
+    code: i64,
+    message: String,
+}
+
+/// Production [`JsonRpcTransport`] backed by `reqwest::blocking`.
+/// Builds on top of the workspace reqwest with the additional
+/// `blocking` feature (scoped to this crate).
+pub struct ReqwestTransport {
+    rpc_url: String,
+    client: reqwest::blocking::Client,
+}
+
+impl ReqwestTransport {
+    pub fn new(rpc_url: String) -> Self {
+        // Default timeout matches a generous user expectation. The
+        // operator can wire in a custom client through
+        // `with_client` if they need different timing.
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(15))
+            .build()
+            .expect("reqwest::blocking::Client::builder cannot fail with default config");
+        Self { rpc_url, client }
+    }
+
+    pub fn with_client(rpc_url: String, client: reqwest::blocking::Client) -> Self {
+        Self { rpc_url, client }
+    }
+}
+
+impl JsonRpcTransport for ReqwestTransport {
+    fn eth_call(&self, to: &str, data: &str) -> Result<String, RpcError> {
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "eth_call",
+            "params": [
+                EthCallTx { to, data },
+                "latest"
+            ],
+            "id": 1u64
+        });
+        let resp = self
+            .client
+            .post(&self.rpc_url)
+            .json(&body)
+            .send()
+            .map_err(|e| RpcError::Http(e.to_string()))?;
+        if !resp.status().is_success() {
+            return Err(RpcError::Http(format!("status {}", resp.status())));
+        }
+        let parsed: JsonRpcResponse = resp.json().map_err(|e| RpcError::Parse(e.to_string()))?;
+        if let Some(err) = parsed.error {
+            return Err(RpcError::Server {
+                code: err.code,
+                message: err.message,
+            });
+        }
+        parsed
+            .result
+            .ok_or_else(|| RpcError::Decode("no result and no error in response".into()))
+    }
+}
+
+/// Live ENS resolver. Generic over a [`JsonRpcTransport`] so the
+/// production HTTP impl and the in-test fake share one code path.
+pub struct LiveEnsResolver<T: JsonRpcTransport> {
+    transport: T,
+    network: EnsNetwork,
+}
+
+impl<T: JsonRpcTransport> LiveEnsResolver<T> {
+    pub fn new(transport: T, network: EnsNetwork) -> Self {
+        Self { transport, network }
+    }
+
+    pub fn network(&self) -> EnsNetwork {
+        self.network
+    }
+}
+
+impl LiveEnsResolver<ReqwestTransport> {
+    /// Construct a resolver from `SBO3L_ENS_RPC_URL`. Returns
+    /// [`ResolveError::Io`] if the env var is unset or empty — the
+    /// caller (CLI / demo script) decides whether to fall back to
+    /// the offline resolver or surface the error.
+    pub fn from_env(network: EnsNetwork) -> Result<Self, ResolveError> {
+        let url = std::env::var("SBO3L_ENS_RPC_URL").map_err(|_| {
+            ResolveError::Io(std::io::Error::other(
+                "SBO3L_ENS_RPC_URL not set; cannot construct LiveEnsResolver",
+            ))
+        })?;
+        if url.is_empty() {
+            return Err(ResolveError::Io(std::io::Error::other(
+                "SBO3L_ENS_RPC_URL is empty",
+            )));
+        }
+        Ok(Self::new(ReqwestTransport::new(url), network))
+    }
+}
+
+impl<T: JsonRpcTransport> EnsResolver for LiveEnsResolver<T> {
+    fn resolve(&self, name: &str) -> Result<EnsRecords, ResolveError> {
+        let node = namehash(name).map_err(|_| ResolveError::UnknownName(name.to_string()))?;
+
+        // Step 1: ENSRegistry.resolver(node) → resolver address.
+        let resolver_addr = call_resolver(&self.transport, &node)?;
+        if is_zero_address(&resolver_addr) {
+            return Err(ResolveError::UnknownName(name.to_string()));
+        }
+
+        // Step 2: Resolver.text(node, key) for each SBO3L key.
+        let mut values = HashMap::with_capacity(SBO3L_TEXT_KEYS.len());
+        for key in SBO3L_TEXT_KEYS {
+            let value = call_text(&self.transport, &resolver_addr, &node, key)?;
+            if value.is_empty() {
+                return Err(ResolveError::MissingRecord(
+                    static_key_label(key),
+                    name.to_string(),
+                ));
+            }
+            values.insert(key, value);
+        }
+
+        // Reassemble into the EnsRecords struct, preserving the
+        // serde rename order of the existing offline format.
+        Ok(EnsRecords {
+            agent_id: values.remove("sbo3l:agent_id").unwrap_or_default(),
+            endpoint: values.remove("sbo3l:endpoint").unwrap_or_default(),
+            policy_hash: values.remove("sbo3l:policy_hash").unwrap_or_default(),
+            audit_root: values.remove("sbo3l:audit_root").unwrap_or_default(),
+            receipt_schema: values.remove("sbo3l:receipt_schema").unwrap_or_default(),
+        })
+    }
+}
+
+/// Map runtime key → static-str expected by `MissingRecord`. The
+/// trait already uses `&'static str` here so the live path can't
+/// silently leak a heap-allocated string into that variant.
+fn static_key_label(key: &str) -> &'static str {
+    match key {
+        "sbo3l:agent_id" => "agent_id",
+        "sbo3l:endpoint" => "endpoint",
+        "sbo3l:policy_hash" => "policy_hash",
+        "sbo3l:audit_root" => "audit_root",
+        "sbo3l:receipt_schema" => "receipt_schema",
+        _ => "unknown",
+    }
+}
+
+fn call_resolver<T: JsonRpcTransport>(transport: &T, node: &[u8; 32]) -> Result<String, RpcError> {
+    let mut data = Vec::with_capacity(4 + 32);
+    data.extend_from_slice(&RESOLVER_SELECTOR);
+    data.extend_from_slice(node);
+    let hex_data = format!("0x{}", hex::encode(&data));
+    let raw = transport.eth_call(ENS_REGISTRY_ADDRESS, &hex_data)?;
+    decode_address(&raw)
+}
+
+fn call_text<T: JsonRpcTransport>(
+    transport: &T,
+    resolver_addr: &str,
+    node: &[u8; 32],
+    key: &str,
+) -> Result<String, RpcError> {
+    let data = encode_text_call(node, key);
+    let hex_data = format!("0x{}", hex::encode(&data));
+    let raw = transport.eth_call(resolver_addr, &hex_data)?;
+    decode_string(&raw)
+}
+
+fn encode_text_call(node: &[u8; 32], key: &str) -> Vec<u8> {
+    // text(bytes32 node, string key): selector || node (32 B) ||
+    // string offset (32 B = 0x40) || string length (32 B) || padded
+    // string bytes.
+    let mut out = Vec::with_capacity(4 + 32 * 3 + key.len() + 32);
+    out.extend_from_slice(&TEXT_SELECTOR);
+    out.extend_from_slice(node);
+    let key_offset: u64 = 0x40;
+    out.extend_from_slice(&u256_be(key_offset));
+    out.extend_from_slice(&u256_be(key.len() as u64));
+    out.extend_from_slice(key.as_bytes());
+    let padded = key.len().div_ceil(32) * 32;
+    let pad = padded - key.len();
+    out.extend(std::iter::repeat_n(0u8, pad));
+    out
+}
+
+fn u256_be(n: u64) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    out[24..].copy_from_slice(&n.to_be_bytes());
+    out
+}
+
+/// Decode an `eth_call` result whose ABI-encoded body is a single
+/// `address`. The on-the-wire shape is 32 bytes with the address
+/// right-aligned (12 leading zero bytes). Returns the lowercase
+/// `0x`-prefixed 42-char address string.
+fn decode_address(hex_response: &str) -> Result<String, RpcError> {
+    let body = strip_0x(hex_response)?;
+    let bytes = hex::decode(body).map_err(|e| RpcError::Decode(format!("hex decode: {e}")))?;
+    if bytes.len() < 32 {
+        return Err(RpcError::Decode(format!(
+            "address response too short: {} bytes",
+            bytes.len()
+        )));
+    }
+    // First 12 bytes must be zero.
+    if !bytes[..12].iter().all(|&b| b == 0) {
+        return Err(RpcError::Decode(
+            "address response: leading 12 bytes must be zero".into(),
+        ));
+    }
+    let addr_bytes = &bytes[12..32];
+    Ok(format!("0x{}", hex::encode(addr_bytes)))
+}
+
+/// Decode an `eth_call` result whose ABI-encoded body is a single
+/// `string memory`. The on-the-wire shape is offset (32 B, typically
+/// 0x20) || length (32 B) || padded UTF-8 bytes.
+fn decode_string(hex_response: &str) -> Result<String, RpcError> {
+    let body = strip_0x(hex_response)?;
+    let bytes = hex::decode(body).map_err(|e| RpcError::Decode(format!("hex decode: {e}")))?;
+    // Empty `eth_call` result (the resolver returned the type's default
+    // — for `string`, an empty string) — surfaced as empty string so
+    // the caller can distinguish "missing record" from "real value".
+    if bytes.is_empty() {
+        return Ok(String::new());
+    }
+    if bytes.len() < 64 {
+        return Err(RpcError::Decode(format!(
+            "string response too short: {} bytes",
+            bytes.len()
+        )));
+    }
+    let offset = u256_to_usize(&bytes[..32])?;
+    if offset + 32 > bytes.len() {
+        return Err(RpcError::Decode(format!(
+            "string offset {offset} past response of {} bytes",
+            bytes.len()
+        )));
+    }
+    let length = u256_to_usize(&bytes[offset..offset + 32])?;
+    let start = offset + 32;
+    let end = start + length;
+    if end > bytes.len() {
+        return Err(RpcError::Decode(format!(
+            "string length {length} past response (start={start}, end={end}, total={})",
+            bytes.len()
+        )));
+    }
+    let s = std::str::from_utf8(&bytes[start..end])
+        .map_err(|e| RpcError::Decode(format!("utf8 decode: {e}")))?;
+    Ok(s.to_string())
+}
+
+fn u256_to_usize(b: &[u8]) -> Result<usize, RpcError> {
+    if b.len() != 32 {
+        return Err(RpcError::Decode("u256 slice not 32 bytes".into()));
+    }
+    // We expect small numbers (offset / length ≤ a few KiB). Reject
+    // anything that overflows usize — that shape can't be a valid
+    // text record.
+    if !b[..24].iter().all(|&x| x == 0) {
+        return Err(RpcError::Decode(
+            "u256 too large to be a string offset/length".into(),
+        ));
+    }
+    let mut be = [0u8; 8];
+    be.copy_from_slice(&b[24..32]);
+    Ok(u64::from_be_bytes(be) as usize)
+}
+
+fn strip_0x(s: &str) -> Result<&str, RpcError> {
+    s.strip_prefix("0x")
+        .or_else(|| s.strip_prefix("0X"))
+        .ok_or_else(|| RpcError::Decode(format!("response missing `0x` prefix: {s:?}")))
+}
+
+fn is_zero_address(addr: &str) -> bool {
+    addr.eq_ignore_ascii_case("0x0000000000000000000000000000000000000000")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use tiny_keccak::{Hasher, Keccak};
+
+    fn keccak256(data: &[u8]) -> [u8; 32] {
+        let mut hasher = Keccak::v256();
+        hasher.update(data);
+        let mut out = [0u8; 32];
+        hasher.finalize(&mut out);
+        out
+    }
+
+    #[test]
+    fn resolver_selector_matches_signature() {
+        let derived = keccak256(b"resolver(bytes32)");
+        assert_eq!(derived[..4], RESOLVER_SELECTOR);
+    }
+
+    #[test]
+    fn text_selector_matches_signature() {
+        let derived = keccak256(b"text(bytes32,string)");
+        assert_eq!(derived[..4], TEXT_SELECTOR);
+    }
+
+    /// One scripted expectation: `(to, data_prefix, response)`.
+    type Expectation = (String, String, Result<String, RpcError>);
+
+    /// In-test fake transport. Records calls and replays scripted
+    /// responses. Not threadsafe — that's fine for unit tests.
+    struct FakeTransport {
+        scripted: RefCell<Vec<Expectation>>,
+        calls: RefCell<Vec<(String, String)>>,
+    }
+
+    impl FakeTransport {
+        fn new() -> Self {
+            Self {
+                scripted: RefCell::new(Vec::new()),
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+        fn expect(&self, to: &str, data_prefix: &str, response: Result<String, RpcError>) {
+            self.scripted
+                .borrow_mut()
+                .push((to.to_string(), data_prefix.to_string(), response));
+        }
+    }
+
+    impl JsonRpcTransport for FakeTransport {
+        fn eth_call(&self, to: &str, data: &str) -> Result<String, RpcError> {
+            self.calls
+                .borrow_mut()
+                .push((to.to_string(), data.to_string()));
+            let mut script = self.scripted.borrow_mut();
+            // Pop the next expectation matching this `to`.
+            let pos = script
+                .iter()
+                .position(|(t, dp, _)| t.eq_ignore_ascii_case(to) && data.starts_with(dp.as_str()));
+            match pos {
+                Some(i) => script.remove(i).2,
+                None => Err(RpcError::Decode(format!(
+                    "FakeTransport: no expectation matched to={to} data={data}"
+                ))),
+            }
+        }
+    }
+
+    /// Encode a string into the ABI-`returns(string)` shape so we
+    /// can build canned responses for the fake transport.
+    fn abi_encode_string_response(s: &str) -> String {
+        let mut out = Vec::with_capacity(64 + s.len() + 32);
+        out.extend_from_slice(&u256_be(0x20));
+        out.extend_from_slice(&u256_be(s.len() as u64));
+        out.extend_from_slice(s.as_bytes());
+        let pad = (s.len().div_ceil(32) * 32) - s.len();
+        out.extend(std::iter::repeat_n(0u8, pad));
+        format!("0x{}", hex::encode(out))
+    }
+
+    fn abi_encode_address_response(addr_no_prefix: &str) -> String {
+        // 12 zero bytes + 20 address bytes.
+        format!("0x{}{}", "00".repeat(12), addr_no_prefix)
+    }
+
+    fn full_records_fixture() -> [(&'static str, &'static str); 5] {
+        [
+            ("sbo3l:agent_id", "research-agent-01"),
+            ("sbo3l:endpoint", "http://127.0.0.1:8730/v1"),
+            (
+                "sbo3l:policy_hash",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ),
+            (
+                "sbo3l:audit_root",
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            ),
+            (
+                "sbo3l:receipt_schema",
+                "https://schemas.sbo3l.dev/policy-receipt/v1.json",
+            ),
+        ]
+    }
+
+    #[test]
+    fn happy_path_resolves_all_five_records() {
+        let transport = FakeTransport::new();
+        let resolver_addr = "0xed79b9b96c6f44ee7b8e1ad1c2519bba2cdcc7d3";
+
+        // Step 1: registry.resolver(node) → 32-byte left-padded address.
+        transport.expect(
+            ENS_REGISTRY_ADDRESS,
+            "0x0178b8bf",
+            Ok(abi_encode_address_response(
+                resolver_addr.strip_prefix("0x").unwrap(),
+            )),
+        );
+        // Step 2: resolver.text(node, "sbo3l:*") for each key.
+        for (k, v) in full_records_fixture() {
+            transport.expect(
+                resolver_addr,
+                "0x59d1d43c",
+                Ok(abi_encode_string_response(v)),
+            );
+            let _ = k; // ordering is enforced by our resolver loop
+        }
+
+        let resolver = LiveEnsResolver::new(transport, EnsNetwork::Mainnet);
+        let recs = resolver.resolve("research-agent.team.eth").unwrap();
+        let expected = full_records_fixture();
+        assert_eq!(recs.agent_id, expected[0].1);
+        assert_eq!(recs.endpoint, expected[1].1);
+        assert_eq!(recs.policy_hash, expected[2].1);
+        assert_eq!(recs.audit_root, expected[3].1);
+        assert_eq!(recs.receipt_schema, expected[4].1);
+    }
+
+    #[test]
+    fn unknown_name_when_resolver_is_zero_address() {
+        let transport = FakeTransport::new();
+        transport.expect(
+            ENS_REGISTRY_ADDRESS,
+            "0x0178b8bf",
+            Ok(abi_encode_address_response(&"00".repeat(20))),
+        );
+        let resolver = LiveEnsResolver::new(transport, EnsNetwork::Sepolia);
+        let err = resolver.resolve("ghost.eth").unwrap_err();
+        assert!(matches!(err, ResolveError::UnknownName(_)));
+    }
+
+    #[test]
+    fn missing_text_record_surfaces_as_missing_record_error() {
+        let transport = FakeTransport::new();
+        let resolver_addr = "0xed79b9b96c6f44ee7b8e1ad1c2519bba2cdcc7d3";
+        transport.expect(
+            ENS_REGISTRY_ADDRESS,
+            "0x0178b8bf",
+            Ok(abi_encode_address_response(
+                resolver_addr.strip_prefix("0x").unwrap(),
+            )),
+        );
+        // First text() returns empty string — that's the
+        // "missing record" condition.
+        transport.expect(
+            resolver_addr,
+            "0x59d1d43c",
+            Ok(abi_encode_string_response("")),
+        );
+        let resolver = LiveEnsResolver::new(transport, EnsNetwork::Mainnet);
+        let err = resolver.resolve("incomplete.eth").unwrap_err();
+        match err {
+            ResolveError::MissingRecord(field, _) => assert_eq!(field, "agent_id"),
+            other => panic!("expected MissingRecord, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rpc_server_error_surfaces_as_io_error() {
+        let transport = FakeTransport::new();
+        transport.expect(
+            ENS_REGISTRY_ADDRESS,
+            "0x0178b8bf",
+            Err(RpcError::Server {
+                code: -32000,
+                message: "rate limited".into(),
+            }),
+        );
+        let resolver = LiveEnsResolver::new(transport, EnsNetwork::Mainnet);
+        let err = resolver.resolve("any.eth").unwrap_err();
+        assert!(matches!(err, ResolveError::Io(_)));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("rate limited") && msg.contains("-32000"),
+            "expected RPC error to surface code + message, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn http_transport_error_surfaces_as_io_error() {
+        let transport = FakeTransport::new();
+        transport.expect(
+            ENS_REGISTRY_ADDRESS,
+            "0x0178b8bf",
+            Err(RpcError::Http("timeout".into())),
+        );
+        let resolver = LiveEnsResolver::new(transport, EnsNetwork::Mainnet);
+        let err = resolver.resolve("any.eth").unwrap_err();
+        assert!(matches!(err, ResolveError::Io(_)));
+        assert!(err.to_string().contains("timeout"));
+    }
+
+    #[test]
+    fn malformed_address_response_surfaces_as_io_error() {
+        let transport = FakeTransport::new();
+        // 32 bytes but with non-zero prefix — must be rejected.
+        let bad = format!(
+            "0xff{}{}",
+            "00".repeat(11),
+            "ed79b9b96c6f44ee7b8e1ad1c2519bba2cdcc7d3"
+        );
+        transport.expect(ENS_REGISTRY_ADDRESS, "0x0178b8bf", Ok(bad));
+        let resolver = LiveEnsResolver::new(transport, EnsNetwork::Mainnet);
+        let err = resolver.resolve("any.eth").unwrap_err();
+        assert!(matches!(err, ResolveError::Io(_)));
+    }
+
+    #[test]
+    fn from_env_errors_when_unset() {
+        // Save and clear the var. There is no `Result::expect_err`
+        // for env::var; we just unset and confirm behaviour.
+        let saved = std::env::var("SBO3L_ENS_RPC_URL").ok();
+        std::env::remove_var("SBO3L_ENS_RPC_URL");
+        let r = LiveEnsResolver::from_env(EnsNetwork::Mainnet);
+        assert!(matches!(r, Err(ResolveError::Io(_))));
+        // Restore so we don't pollute other tests in the same process.
+        if let Some(v) = saved {
+            std::env::set_var("SBO3L_ENS_RPC_URL", v);
+        }
+    }
+
+    #[test]
+    fn encode_text_call_layout_matches_abi() {
+        let node = [0u8; 32];
+        let key = "sbo3l:agent_id"; // 14 bytes → padded to 32
+        let cd = encode_text_call(&node, key);
+        // selector(4) + node(32) + offset(32) + length(32) + padded_key(32)
+        assert_eq!(cd.len(), 4 + 32 + 32 + 32 + 32);
+        assert_eq!(cd[..4], TEXT_SELECTOR);
+        // length word.
+        let len_word = &cd[68..100];
+        assert_eq!(u64::from_be_bytes(len_word[24..].try_into().unwrap()), 14);
+        // key bytes at the right offset.
+        assert_eq!(&cd[100..100 + 14], key.as_bytes());
+        // Padding bytes are zero.
+        assert!(cd[100 + 14..132].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn decode_string_round_trips() {
+        let raw = abi_encode_string_response("hello world");
+        let s = decode_string(&raw).unwrap();
+        assert_eq!(s, "hello world");
+    }
+
+    #[test]
+    fn decode_address_zero_is_normalised_to_lowercase() {
+        let raw = abi_encode_address_response(&"00".repeat(20));
+        let a = decode_address(&raw).unwrap();
+        assert!(is_zero_address(&a));
+    }
+}

--- a/crates/sbo3l-identity/src/lib.rs
+++ b/crates/sbo3l-identity/src/lib.rs
@@ -16,9 +16,14 @@
 
 pub mod ens;
 pub mod ens_anchor;
+pub mod ens_live;
 
 pub use ens::{EnsRecords, EnsResolver, OfflineEnsResolver, ResolveError};
 pub use ens_anchor::{
     build_envelope, namehash, set_text_calldata, AnchorEnvelope, AnchorError, AnchorMode,
     AnchorParams, EnsNetwork, AUDIT_ROOT_KEY, ENVELOPE_SCHEMA_ID, SET_TEXT_SELECTOR,
+};
+pub use ens_live::{
+    JsonRpcTransport, LiveEnsResolver, ReqwestTransport, RpcError, ENS_REGISTRY_ADDRESS,
+    RESOLVER_SELECTOR, SBO3L_TEXT_KEYS, TEXT_SELECTOR,
 };


### PR DESCRIPTION
## What

Companion to **PR #65** (B3 anchor side). Stacks on top of `feat/b3-anchor-ens-dry-run`. Reads SBO3L text records from a real Ethereum JSON-RPC endpoint via two-step ENSIP-1 resolution.

> **Base branch is intentionally `feat/b3-anchor-ens-dry-run`, not `main`.** This PR shares `tiny-keccak` + `EnsNetwork` + `namehash` with #65. Once #65 merges, GitHub will retarget this PR to main automatically (or I'll rebase it).

## Why this matters

The ENS bounty rule **"no hardcoded values"** applies to the *agent's* identity — `policy_hash`, `audit_root`, `agent_id`, `endpoint`, `receipt_schema`. With `LiveEnsResolver` swapped in via the demo-script flag, those values come from chain at runtime. Network-level contract addresses (ENS Registry `0x00...2e1e`, Public Resolver) remain hardcoded — public infrastructure documented at docs.ens.domains.

Without this, the offline-fixture-only resolver fails the ENS bounty smell-test. With it (+ Daniel registering `sbo3lagent.eth` and writing the 5 records), the bounty is back in play.

## Architecture

- **`JsonRpcTransport` trait** hides HTTP/JSON-RPC behind a minimal API: one `eth_call(to, data) -> Result<String, RpcError>` method.
- **`ReqwestTransport`** is the production impl — `reqwest::blocking` for synchronous calls (the existing `EnsResolver::resolve` trait is sync). The `blocking` feature is added to `sbo3l-identity` only, layered on top of the workspace `reqwest`.
- **Tests inject an in-test `FakeTransport`** that returns canned responses — no network, no mockito, no extra dev-deps. **CI stays fully offline.**
- **`LiveEnsResolver::from_env()`** reads `SBO3L_ENS_RPC_URL` at construction; never logs the URL itself. Unset / empty → `ResolveError::Io` the caller can fall back from.

## Resolution flow

```
namehash(name) → node
  ↓
ENSRegistry.resolver(node) → resolver_addr
  ↓ (if 0x000…000 → UnknownName)
for key in [sbo3l:agent_id, sbo3l:endpoint, sbo3l:policy_hash, sbo3l:audit_root, sbo3l:receipt_schema]:
  resolver.text(node, key) → value
  ↓ (if "" → MissingRecord)
EnsRecords { agent_id, endpoint, policy_hash, audit_root, receipt_schema }
```

## Tests (12 new, all offline)

- Selectors verified against `keccak256("resolver(bytes32)")` and `keccak256("text(bytes32,string)")`.
- Happy path: 5-record resolution succeeds end-to-end with canned ABI-encoded responses.
- Unknown name: registry returns `0x000…000` → `UnknownName`.
- Missing record: `text()` returns empty string → `MissingRecord("agent_id", ...)`.
- RPC server error (e.g. rate-limited): surfaced as `ResolveError::Io` with code + message preserved.
- Transport error (timeout): surfaced as `ResolveError::Io`.
- Malformed address response (non-zero leading 12 bytes): rejected as `Io`.
- `from_env` errors when env var unset (with save/restore so tests don't pollute each other).
- `encode_text_call` ABI layout pinned (selector + node + offset + length + padded key).
- `decode_string` round-trip.
- `decode_address` normalises to lowercase 0x-prefix.

## Verification matrix

- `cargo build -p sbo3l-identity`: clean
- `cargo test -p sbo3l-identity`: **28 / 28** (16 anchor + 12 live)
- `cargo test --workspace --all-targets`: **345 / 345** (was 333 on the anchor branch, +12 from this PR)
- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean

## What's NOT in this PR

- **CLI surface** for swapping the resolver. The `passport run --resolver live-ens` arg already exists in clap (the variant was reserved as `LiveEns`); wiring it to `LiveEnsResolver::from_env()` is a tiny follow-up.
- **Demo-script update.** Once `passport run` accepts `live-ens`, `demo-scripts/run-production-shaped-mock.sh` adds a flag to flip from offline-fixture to live.
- **Real RPC smoke-test.** Operator-supplied `SBO3L_ENS_RPC_URL` is read at runtime; no network call in CI. Daniel can run a manual smoke against the supplied mainnet RPC once `sbo3lagent.eth` exists with text records.

## Test plan

- [ ] Reviewer runs `cargo test -p sbo3l-identity ens_live` (12 tests pass)
- [ ] Reviewer reads `crates/sbo3l-identity/src/ens_live.rs` end-to-end (~480 LoC)
- [ ] Reviewer confirms `JsonRpcTransport` + `FakeTransport` keep CI fully offline
- [ ] Reviewer confirms `SBO3L_ENS_RPC_URL` is the only operator-visible config
- [ ] (Optional, after merge) Daniel sets `SBO3L_ENS_RPC_URL` and runs a live smoke against `sbo3lagent.eth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)