### PR TITLE
docs(api): mark openapi.json as DRAFT — partial implementation

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1,9 +1,9 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "SBO3L API",
+    "title": "SBO3L API (DRAFT — partial implementation)",
     "version": "1.0.0-draft",
-    "description": "Normative REST surface for the sbo3l daemon. This file is generated/maintained from 09_api_design.md and 17_interface_contracts.md until implementation can generate it from code."
+    "description": "**DRAFT spec — partial implementation on `main`.**\n\nNormative REST surface for the SBO3L daemon. This file is generated/maintained from `docs/spec/09_api_design.md` and `docs/spec/17_interface_contracts.md` until implementation can generate it from code.\n\n**What is actually wired on `main` today** (verifiable with `cargo test --workspace --all-targets` against `crates/sbo3l-server/src/lib.rs`):\n\n- `GET /v1/health` — fully implemented.\n- `POST /v1/payment-requests` — fully implemented, including `Idempotency-Key` semantics (PSM-A2), persistent SQLite-backed nonce-replay (V002), policy / budget / audit / sign pipeline. **Response body shape diverges from this spec**: server returns `{status, decision, deny_code, matched_rule_id, request_hash, policy_hash, audit_event_id, receipt}`, not the `{payment_request_id, status, policy_version, ...}` documented here.\n\n**What is forward-looking design** (in this spec, NOT on `main`):\n\n- `GET /v1/payment-requests/{id}`, `POST /.../approve`, `POST /.../reject` — async / human-in-the-loop flow not implemented.\n- `/agents`, `/agents/{id}/policies`, `/budgets`, `/audit-log`, `/emergency/stop`, `/emergency/resume` — endpoints not implemented.\n- `agentMtls`, `adminMtls`, `agentJwt`, `auditJwt` security schemes — not enforced. `POST /v1/payment-requests` has **no auth** in this build (daemon binds 127.0.0.1 by default and is documented `⚠ DEV ONLY ⚠`; see `SECURITY_NOTES.md` §Daemon authentication for the production path).\n- `application/problem+json` envelope — server emits `application/json` with a smaller `{type, title, status, detail, code}` shape; full RFC 7807 conformance is forward-looking.\n\nThe schemas this spec references under `schemas/*.json` (APRP, policy, policy receipt, decision token, audit event, x402, passport capsule) are the **canonical wire-format contracts** and are validated against the test corpus in CI."
   },
   "servers": [
     {


### PR DESCRIPTION
## Summary

The schema/API correctness audit (5-agent 360° review) flagged three critical drifts between `docs/api/openapi.json` and the actual server on `main`:

- **C1**: server `Problem` envelope (`{type,title,status,detail,code}` + `application/json`) does not match the OpenAPI `Problem` schema (RFC 7807 with `instance`, `request_id`, `application/problem+json`).
- **C2**: `PaymentRequestResponse` schema requires `{payment_request_id, status, policy_version, ...}`; server actually returns `{status, decision, deny_code, matched_rule_id, request_hash, policy_hash, audit_event_id, receipt}`.
- **C3**: OpenAPI documents 9 endpoints across `/agents`, `/budgets`, `/audit-log`, `/emergency/*`, `/payment-requests/{id}/approve` etc. — server implements 2 (`/v1/health`, `/v1/payment-requests`). Four security schemes are documented but none enforced.

Two paths to close the drift: (a) trim the OpenAPI to only the implemented surface, (b) keep the spec as forward-looking and label clearly. Path (a) is invasive and risky for the 3-day window; path (b) is a 1-line metadata change that fully discloses the gap.

This PR takes path (b): rewrites `info.title` to flag DRAFT, and expands `info.description` into a clear inventory of:

- what is actually wired on `main` (verifiable with `cargo test`)
- what is forward-looking (not on main)
- which schemas DO carry the canonical contracts (the JSON Schema files under `schemas/`, validated against the corpus in CI)

## Why this matters

A judge or sponsor reviewer who copy-pastes the OpenAPI into Stoplight / Postman expects it to describe the running daemon. Today they would hit the `PaymentRequestResponse` shape mismatch on the very first request. The clear DRAFT label + per-endpoint disclosure means the divergence is now self-documenting, not silent.

The schemas under `schemas/` (APRP, policy, receipt, decision token, audit event, x402, passport capsule) remain the authoritative wire-format contracts and continue to validate against the test corpus.

## Test plan

- [x] `python3 scripts/validate_openapi.py` → ok
- [x] `python3 scripts/validate_schemas.py` → ok (7 schemas + 14 fixtures)
- [x] No code, no schemas, no tests modified — single doc field change

🤖 Generated with [Claude Code](https://claude.com/claude-code)