### PR TITLE
feat(B7): UniswapExecutor::live() — real Sepolia QuoterV2 quote

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -92,7 +92,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -190,6 +190,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -527,7 +533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -602,6 +608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -609,6 +616,18 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -623,7 +642,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -658,9 +680,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -771,6 +795,23 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -779,13 +820,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -926,6 +975,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,6 +1017,8 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -964,7 +1031,7 @@ checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
- "base64",
+ "base64 0.21.7",
  "bytecount",
  "fancy-regex",
  "fraction",
@@ -1035,6 +1102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,7 +1142,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1087,7 +1160,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1301,6 +1374,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,6 +1556,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "research-agent"
 version = "0.1.0"
 dependencies = [
@@ -1449,6 +1617,20 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ulid",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1512,6 +1694,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1530,7 +1718,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1593,7 +1816,7 @@ dependencies = [
  "serde_json",
  "serde_json_canonicalizer",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
  "ulid",
 ]
 
@@ -1603,13 +1826,15 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "hex",
+ "reqwest",
  "rust_decimal",
  "sbo3l-core",
  "sbo3l-keeperhub-adapter",
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
+ "tiny-keccak",
  "ulid",
 ]
 
@@ -1622,7 +1847,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
  "tiny-keccak",
 ]
 
@@ -1635,7 +1860,7 @@ dependencies = [
  "sbo3l-core",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "ulid",
 ]
 
@@ -1658,7 +1883,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tower",
  "tracing",
@@ -1678,7 +1903,7 @@ dependencies = [
  "serde_json_canonicalizer",
  "serde_yaml",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1695,7 +1920,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tower",
  "tracing",
@@ -1717,7 +1942,7 @@ dependencies = [
  "serde_json_canonicalizer",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "ulid",
 ]
 
@@ -1899,7 +2124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1957,6 +2182,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -1985,7 +2213,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1994,7 +2222,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2002,6 +2239,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2095,7 +2343,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2107,6 +2355,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2153,6 +2411,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -2230,6 +2506,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2256,6 +2538,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2310,6 +2598,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2336,6 +2633,16 @@ dependencies = [
  "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2371,6 +2678,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2378,6 +2695,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2441,12 +2767,159 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/crates/sbo3l-execution/Cargo.toml
+++ b/crates/sbo3l-execution/Cargo.toml
@@ -21,3 +21,8 @@ sha2 = { workspace = true }
 ulid = { workspace = true }
 chrono = { workspace = true }
 rust_decimal = { workspace = true }
+# B7: keccak256 for the QuoterV2 function selector + Sepolia
+# JSON-RPC integration. Crate-local deps (NOT workspace) to keep
+# blast radius small — only the Uniswap live-quote path uses them.
+tiny-keccak = { version = "2", features = ["keccak"] }
+reqwest = { workspace = true, features = ["blocking"] }

--- a/crates/sbo3l-execution/examples/uniswap_live_smoke.rs
+++ b/crates/sbo3l-execution/examples/uniswap_live_smoke.rs
@@ -1,0 +1,111 @@
+//! B7 live smoke: call Sepolia QuoterV2 via the real reqwest
+//! transport + print the quote. Operator-supplied env vars:
+//!
+//!   SBO3L_UNISWAP_RPC_URL          — required (e.g. Alchemy free-tier)
+//!   SBO3L_UNISWAP_TOKEN_OUT        — required (Sepolia ERC20 address)
+//!   SBO3L_UNISWAP_TOKEN_IN         — defaults to Sepolia WETH
+//!   SBO3L_UNISWAP_FEE_TIER         — defaults to 3000 (V3 0.3% tier)
+//!   SBO3L_UNISWAP_AMOUNT_IN_WEI    — defaults to 1e18 (1 WETH)
+//!
+//! Use:
+//!
+//!   cargo run -p sbo3l-execution --example uniswap_live_smoke
+//!
+//! Prints the four QuoteResult fields (amount_out, sqrt_price_x96_after,
+//! initialized_ticks_crossed, gas_estimate) and exits with the usual
+//! sponsor-error mapping (BackendOffline → 1, Integration → 2). CI
+//! does NOT run this example — it requires a real RPC URL and is
+//! not part of the test suite.
+
+use std::process::ExitCode;
+
+use sbo3l_core::aprp::PaymentRequest;
+use sbo3l_core::execution::{ExecutionError, GuardedExecutor};
+use sbo3l_core::receipt::{
+    Decision, EmbeddedSignature, PolicyReceipt, ReceiptType, SignatureAlgorithm,
+};
+use sbo3l_execution::UniswapExecutor;
+
+fn main() -> ExitCode {
+    let exec = match UniswapExecutor::live_from_env() {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("uniswap_live_smoke: configuration error: {e}");
+            eprintln!(
+                "Required env vars: SBO3L_UNISWAP_RPC_URL, \
+                 SBO3L_UNISWAP_TOKEN_OUT. Optional: SBO3L_UNISWAP_TOKEN_IN \
+                 (default: Sepolia WETH), SBO3L_UNISWAP_FEE_TIER \
+                 (default: 3000), SBO3L_UNISWAP_AMOUNT_IN_WEI \
+                 (default: 1e18)."
+            );
+            return ExitCode::from(2);
+        }
+    };
+
+    let request = stub_payment_request();
+    let receipt = stub_allow_receipt();
+
+    match exec.execute(&request, &receipt) {
+        Ok(r) => {
+            println!("uniswap_live_smoke: SUCCESS");
+            println!("  sponsor:       {}", r.sponsor);
+            println!("  execution_ref: {}", r.execution_ref);
+            println!("  mock:          {}", r.mock);
+            println!("  note:          {}", r.note);
+            if let Some(evidence) = r.evidence.as_ref() {
+                println!("  evidence:");
+                let pretty = serde_json::to_string_pretty(evidence)
+                    .unwrap_or_else(|e| format!("<serialise failed: {e}>"));
+                for line in pretty.lines() {
+                    println!("    {line}");
+                }
+            }
+            ExitCode::SUCCESS
+        }
+        Err(ExecutionError::BackendOffline(msg)) => {
+            eprintln!("uniswap_live_smoke: BackendOffline: {msg}");
+            ExitCode::from(1)
+        }
+        Err(ExecutionError::Integration(msg)) => {
+            eprintln!("uniswap_live_smoke: Integration: {msg}");
+            ExitCode::from(2)
+        }
+        Err(other) => {
+            eprintln!("uniswap_live_smoke: unexpected error: {other}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+/// Load the workspace's golden APRP fixture. The smoke binary just
+/// needs *some* valid PaymentRequest to drive the live quote — the
+/// PaymentRequest content is opaque to the live path (the live
+/// quote uses LiveConfig for token addresses + amount, not the
+/// APRP fields).
+fn stub_payment_request() -> PaymentRequest {
+    let raw = include_str!("../../../test-corpus/aprp/golden_001_minimal.json");
+    let v: serde_json::Value = serde_json::from_str(raw).expect("golden APRP must parse as JSON");
+    serde_json::from_value(v).expect("golden APRP must deserialise into PaymentRequest")
+}
+
+fn stub_allow_receipt() -> PolicyReceipt {
+    PolicyReceipt {
+        receipt_type: ReceiptType::PolicyReceiptV1,
+        version: 1,
+        agent_id: "research-agent-01".to_string(),
+        decision: Decision::Allow,
+        deny_code: None,
+        request_hash: "1".repeat(64),
+        policy_hash: "2".repeat(64),
+        policy_version: Some(1),
+        audit_event_id: "evt-smoke-uniswap-live".to_string(),
+        execution_ref: None,
+        issued_at: chrono::Utc::now(),
+        expires_at: None,
+        signature: EmbeddedSignature {
+            algorithm: SignatureAlgorithm::Ed25519,
+            key_id: "smoke".to_string(),
+            signature_hex: "0".repeat(128),
+        },
+    }
+}

--- a/crates/sbo3l-execution/src/lib.rs
+++ b/crates/sbo3l-execution/src/lib.rs
@@ -19,12 +19,18 @@
 //! today; crates.io once published) — that's the IP-4 win.
 
 pub mod uniswap;
+pub mod uniswap_live;
 
 pub use sbo3l_core::execution::{ExecutionError, ExecutionReceipt, GuardedExecutor};
 pub use sbo3l_keeperhub_adapter::{build_envelope, KeeperHubExecutor, KeeperHubMode};
 pub use uniswap::{
     evaluate_swap, SwapCheck, SwapPolicy, SwapPolicyOutcome, SwapQuote, SwapToken, UniswapExecutor,
     UniswapMode,
+};
+pub use uniswap_live::{
+    quote_exact_input_single, JsonRpcTransport, LiveConfig, QuoteResult, ReqwestTransport,
+    RpcError, QUOTE_EXACT_INPUT_SINGLE_SELECTOR, SEPOLIA_CHAIN_ID, SEPOLIA_QUOTER_V2_ADDRESS,
+    SEPOLIA_WETH,
 };
 
 /// Back-compat re-export of the old `keeperhub` submodule. Existing

--- a/crates/sbo3l-execution/src/uniswap.rs
+++ b/crates/sbo3l-execution/src/uniswap.rs
@@ -18,12 +18,18 @@
 //! enforceable limits.*
 
 use std::str::FromStr;
+use std::sync::Arc;
 
 use rust_decimal::Decimal;
 use sbo3l_core::aprp::PaymentRequest;
 use sbo3l_core::execution::{ExecutionError, ExecutionReceipt, GuardedExecutor};
 use sbo3l_core::receipt::{Decision, PolicyReceipt};
 use serde::{Deserialize, Serialize};
+
+use crate::uniswap_live::{
+    quote_exact_input_single, JsonRpcTransport, LiveConfig, QuoteResult, ReqwestTransport,
+    RpcError, SEPOLIA_WETH,
+};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -324,23 +330,120 @@ pub enum UniswapMode {
     LocalMock,
 }
 
-#[derive(Debug, Clone)]
+/// Live-mode context: the Uniswap V3 QuoterV2 RPC config + the
+/// transport carrying the eth_call. Stored behind `Arc` so the
+/// `Clone`-able `UniswapExecutor` doesn't duplicate the underlying
+/// HTTP client. Absent (`None` on `UniswapExecutor.live_context`)
+/// means the executor was built via the bare `Self::live()` ctor —
+/// `execute()` returns `BackendOffline` in that case, mirroring the
+/// pre-B7 "live mode without credentials fails loudly" contract.
+pub struct LiveContext {
+    pub config: LiveConfig,
+    pub transport: Arc<dyn JsonRpcTransport>,
+}
+
+#[derive(Clone)]
 pub struct UniswapExecutor {
     pub mode: UniswapMode,
+    /// Set on the live path (`live_from_env` or `live_with_context`).
+    /// Bare `live()` leaves this `None` — execute() routes to a loud
+    /// `BackendOffline` error in that case (back-compat with the
+    /// pre-B7 test).
+    pub(crate) live_context: Option<Arc<LiveContext>>,
+}
+
+impl std::fmt::Debug for UniswapExecutor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UniswapExecutor")
+            .field("mode", &self.mode)
+            .field("live_context_present", &self.live_context.is_some())
+            .finish()
+    }
+}
+
+/// Reasons `live_from_env` can refuse to construct. Surfaces the
+/// missing env var so the operator knows which to set.
+#[derive(Debug, thiserror::Error)]
+pub enum LiveConfigError {
+    #[error("env var {0} is not set")]
+    MissingEnvVar(&'static str),
+    #[error("env var {var} is set but invalid: {detail}")]
+    BadEnvVar { var: &'static str, detail: String },
 }
 
 impl UniswapExecutor {
     pub fn local_mock() -> Self {
         Self {
             mode: UniswapMode::LocalMock,
+            live_context: None,
         }
     }
 
+    /// Bare live ctor — no transport, no config. Kept for back-compat
+    /// with pre-B7 call sites; `execute()` returns `BackendOffline`
+    /// because there's nothing to talk to. Use [`Self::live_from_env`]
+    /// or [`Self::live_with_context`] for an actually-functional
+    /// live executor.
     pub fn live() -> Self {
         Self {
             mode: UniswapMode::Live,
+            live_context: None,
         }
     }
+
+    /// Live ctor wired to a real Sepolia QuoterV2 via env config:
+    /// - `SBO3L_UNISWAP_RPC_URL` (required)
+    /// - `SBO3L_UNISWAP_TOKEN_IN` (default: Sepolia WETH)
+    /// - `SBO3L_UNISWAP_TOKEN_OUT` (required)
+    /// - `SBO3L_UNISWAP_FEE_TIER` (default: `3000`)
+    /// - `SBO3L_UNISWAP_AMOUNT_IN_WEI` (default: `1000000000000000000`)
+    pub fn live_from_env() -> Result<Self, LiveConfigError> {
+        let rpc_url = read_env("SBO3L_UNISWAP_RPC_URL")?;
+        let token_in =
+            std::env::var("SBO3L_UNISWAP_TOKEN_IN").unwrap_or_else(|_| SEPOLIA_WETH.to_string());
+        let token_out = read_env("SBO3L_UNISWAP_TOKEN_OUT")?;
+        let fee_tier_raw =
+            std::env::var("SBO3L_UNISWAP_FEE_TIER").unwrap_or_else(|_| "3000".to_string());
+        let fee_tier: u32 = fee_tier_raw.parse().map_err(|e: std::num::ParseIntError| {
+            LiveConfigError::BadEnvVar {
+                var: "SBO3L_UNISWAP_FEE_TIER",
+                detail: e.to_string(),
+            }
+        })?;
+        let amount_in_wei = std::env::var("SBO3L_UNISWAP_AMOUNT_IN_WEI")
+            .unwrap_or_else(|_| "1000000000000000000".to_string());
+
+        let config = LiveConfig::sepolia_default(
+            token_in,
+            token_out,
+            fee_tier,
+            amount_in_wei,
+            rpc_url.clone(),
+        );
+        let transport = Arc::new(ReqwestTransport::new(rpc_url));
+        Ok(Self::live_with_context(LiveContext { config, transport }))
+    }
+
+    /// Live ctor that takes a fully-built [`LiveContext`]. Production
+    /// uses [`Self::live_from_env`]; tests build an in-process
+    /// transport and pass it here.
+    pub fn live_with_context(ctx: LiveContext) -> Self {
+        Self {
+            mode: UniswapMode::Live,
+            live_context: Some(Arc::new(ctx)),
+        }
+    }
+}
+
+fn read_env(var: &'static str) -> Result<String, LiveConfigError> {
+    let v = std::env::var(var).map_err(|_| LiveConfigError::MissingEnvVar(var))?;
+    if v.trim().is_empty() {
+        return Err(LiveConfigError::BadEnvVar {
+            var,
+            detail: "empty".into(),
+        });
+    }
+    Ok(v)
 }
 
 impl GuardedExecutor for UniswapExecutor {
@@ -380,11 +483,267 @@ impl GuardedExecutor for UniswapExecutor {
                     evidence: Some(evidence),
                 })
             }
-            UniswapMode::Live => Err(ExecutionError::BackendOffline(
-                "live Uniswap backend not configured for this hackathon build; \
-                 switch to UniswapMode::LocalMock or wire credentials"
-                    .to_string(),
+            UniswapMode::Live => {
+                let ctx = self.live_context.as_ref().ok_or_else(|| {
+                    ExecutionError::BackendOffline(
+                        "live Uniswap backend has no LiveContext; build via \
+                         UniswapExecutor::live_from_env() or live_with_context()"
+                            .to_string(),
+                    )
+                })?;
+                let quote = quote_exact_input_single(ctx.transport.as_ref(), &ctx.config)
+                    .map_err(map_rpc_err)?;
+                let evidence = build_live_evidence(request, &ctx.config, &quote);
+                Ok(ExecutionReceipt {
+                    sponsor: "uniswap",
+                    execution_ref: format!("uni-{}", ulid::Ulid::new()),
+                    mock: false,
+                    note: format!(
+                        "live: Sepolia QuoterV2 at {} returned amountOut={} gasEstimate={}",
+                        ctx.config.quoter, quote.amount_out, quote.gas_estimate
+                    ),
+                    evidence: Some(evidence),
+                })
+            }
+        }
+    }
+}
+
+/// Map a JSON-RPC error to the right `ExecutionError` variant.
+/// Transport-level (HTTP, parse) → `BackendOffline`; protocol-level
+/// (server reverted, decode) → `Integration`. Keeps the existing
+/// "BackendOffline = sponsor unreachable" contract.
+fn map_rpc_err(e: RpcError) -> ExecutionError {
+    match e {
+        RpcError::Http(s) | RpcError::Parse(s) => {
+            ExecutionError::BackendOffline(format!("uniswap RPC: {s}"))
+        }
+        RpcError::Server { code, message } => {
+            ExecutionError::Integration(format!("uniswap RPC server error {code}: {message}"))
+        }
+        RpcError::Decode(s) => ExecutionError::Integration(format!("uniswap RPC decode: {s}")),
+    }
+}
+
+/// Build the evidence payload for a live allow-path quote. Reuses
+/// the 10 [`UniswapQuoteEvidence`] fields the mock path emits and
+/// extends with 4 live-only fields (`chain_id`, `amount_out`,
+/// `sqrt_price_x96_after`, `gas_estimate`) — the capsule schema
+/// permits `additionalProperties` on `executor_evidence`, so the
+/// extra fields land cleanly without a schema bump.
+///
+/// `quote_source` carries the network + quoter address verbatim so
+/// an auditor reading the capsule sees exactly which contract
+/// answered.
+fn build_live_evidence(
+    request: &PaymentRequest,
+    config: &LiveConfig,
+    quote: &QuoteResult,
+) -> serde_json::Value {
+    let now = chrono::Utc::now().timestamp();
+    let _ = request; // request is forwarded for future routing decisions
+    let in_token = TokenRef {
+        symbol: "TOKEN_IN".to_string(),
+        address: config.token_in.clone(),
+    };
+    let out_token = TokenRef {
+        symbol: "TOKEN_OUT".to_string(),
+        address: config.token_out.clone(),
+    };
+    serde_json::json!({
+        "quote_id": format!("uni-{}", ulid::Ulid::new()),
+        "quote_source": format!(
+            "uniswap-v3-quoter-sepolia-{}",
+            config.quoter.to_lowercase()
+        ),
+        "input_token": in_token,
+        "output_token": out_token,
+        "route_tokens": [in_token.clone(), out_token.clone()],
+        "notional_in": config.amount_in_wei,
+        "slippage_cap_bps": 0u32,
+        "quote_timestamp_unix": now,
+        "quote_freshness_seconds": 30u32,
+        "recipient_address": "0x0000000000000000000000000000000000000000",
+        // Live-only fields (extra to UniswapQuoteEvidence shape):
+        "chain_id": config.chain_id,
+        "amount_out": quote.amount_out,
+        "sqrt_price_x96_after": quote.sqrt_price_x96_after,
+        "initialized_ticks_crossed": quote.initialized_ticks_crossed,
+        "gas_estimate": quote.gas_estimate,
+    })
+}
+
+#[cfg(test)]
+mod live_tests {
+    use super::*;
+    use crate::uniswap_live::tests_support::{abi_encode_quad, FakeTransport};
+    use crate::uniswap_live::{SEPOLIA_CHAIN_ID, SEPOLIA_QUOTER_V2_ADDRESS};
+
+    fn aprp() -> PaymentRequest {
+        let raw = include_str!("../../../test-corpus/aprp/golden_001_minimal.json");
+        let v: serde_json::Value = serde_json::from_str(raw).unwrap();
+        serde_json::from_value(v).unwrap()
+    }
+
+    fn allow_receipt() -> PolicyReceipt {
+        use sbo3l_core::receipt::{EmbeddedSignature, ReceiptType, SignatureAlgorithm};
+        PolicyReceipt {
+            receipt_type: ReceiptType::PolicyReceiptV1,
+            version: 1,
+            agent_id: "research-agent-01".to_string(),
+            decision: Decision::Allow,
+            deny_code: None,
+            request_hash: "1".repeat(64),
+            policy_hash: "2".repeat(64),
+            policy_version: Some(1),
+            audit_event_id: "evt-01HTAWX5K3R8YV9NQB7C6P2DGS".to_string(),
+            execution_ref: None,
+            issued_at: chrono::Utc::now(),
+            expires_at: None,
+            signature: EmbeddedSignature {
+                algorithm: SignatureAlgorithm::Ed25519,
+                key_id: "test".to_string(),
+                signature_hex: "0".repeat(128),
+            },
+        }
+    }
+
+    fn live_cfg() -> LiveConfig {
+        LiveConfig::sepolia_default(
+            SEPOLIA_WETH.to_string(),
+            "0x0000000000000000000000000000000000000022".to_string(),
+            3000,
+            "1000000000000000000".to_string(),
+            "http://example.invalid".to_string(),
+        )
+    }
+
+    #[test]
+    fn live_path_emits_executor_evidence_with_real_amount_out() {
+        let t = FakeTransport::new();
+        t.expect(
+            SEPOLIA_QUOTER_V2_ADDRESS,
+            "0xc6a5026a",
+            Ok(abi_encode_quad(
+                "2500000000000000000",
+                "1234567",
+                3,
+                "85000",
             )),
+        );
+        let exec = UniswapExecutor::live_with_context(LiveContext {
+            config: live_cfg(),
+            transport: Arc::new(t),
+        });
+        let receipt = exec.execute(&aprp(), &allow_receipt()).unwrap();
+        assert!(!receipt.mock, "live mode must NOT mark mock=true");
+        assert_eq!(receipt.sponsor, "uniswap");
+        assert!(receipt.execution_ref.starts_with("uni-"));
+        let evidence = receipt
+            .evidence
+            .expect("live path must emit executor_evidence");
+        assert_eq!(
+            evidence["amount_out"].as_str().unwrap(),
+            "2500000000000000000"
+        );
+        assert_eq!(evidence["chain_id"].as_u64().unwrap(), SEPOLIA_CHAIN_ID);
+        assert!(evidence["quote_source"]
+            .as_str()
+            .unwrap()
+            .contains("sepolia"));
+        assert!(evidence["quote_source"]
+            .as_str()
+            .unwrap()
+            .contains(&SEPOLIA_QUOTER_V2_ADDRESS.to_lowercase()));
+    }
+
+    #[test]
+    fn live_path_server_revert_surfaces_as_integration_error() {
+        let t = FakeTransport::new();
+        t.expect(
+            SEPOLIA_QUOTER_V2_ADDRESS,
+            "0xc6a5026a",
+            Err(RpcError::Server {
+                code: 3,
+                message: "execution reverted: insufficient liquidity".into(),
+            }),
+        );
+        let exec = UniswapExecutor::live_with_context(LiveContext {
+            config: live_cfg(),
+            transport: Arc::new(t),
+        });
+        let err = exec.execute(&aprp(), &allow_receipt()).unwrap_err();
+        match err {
+            ExecutionError::Integration(msg) => {
+                assert!(msg.contains("insufficient liquidity"));
+                assert!(msg.contains("3"));
+            }
+            other => panic!("expected Integration, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn live_path_http_timeout_surfaces_as_backend_offline() {
+        let t = FakeTransport::new();
+        t.expect(
+            SEPOLIA_QUOTER_V2_ADDRESS,
+            "0xc6a5026a",
+            Err(RpcError::Http("request timed out".into())),
+        );
+        let exec = UniswapExecutor::live_with_context(LiveContext {
+            config: live_cfg(),
+            transport: Arc::new(t),
+        });
+        let err = exec.execute(&aprp(), &allow_receipt()).unwrap_err();
+        match err {
+            ExecutionError::BackendOffline(msg) => {
+                assert!(msg.contains("timed out"));
+                assert!(msg.contains("uniswap RPC"));
+            }
+            other => panic!("expected BackendOffline, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn live_path_denied_receipt_never_calls_rpc() {
+        let t = FakeTransport::new();
+        // No expectations registered — any eth_call hit would fail.
+        let exec = UniswapExecutor::live_with_context(LiveContext {
+            config: live_cfg(),
+            transport: Arc::new(t),
+        });
+        let mut deny = allow_receipt();
+        deny.decision = Decision::Deny;
+        let err = exec.execute(&aprp(), &deny).unwrap_err();
+        assert!(matches!(err, ExecutionError::NotApproved(_)));
+    }
+
+    #[test]
+    fn live_from_env_errors_when_rpc_url_missing() {
+        // Save and clear all five vars to ensure a clean state.
+        let saved: Vec<(&str, Option<String>)> = [
+            "SBO3L_UNISWAP_RPC_URL",
+            "SBO3L_UNISWAP_TOKEN_IN",
+            "SBO3L_UNISWAP_TOKEN_OUT",
+            "SBO3L_UNISWAP_FEE_TIER",
+            "SBO3L_UNISWAP_AMOUNT_IN_WEI",
+        ]
+        .iter()
+        .map(|v| (*v, std::env::var(v).ok()))
+        .collect();
+        for (v, _) in &saved {
+            std::env::remove_var(v);
+        }
+        let r = UniswapExecutor::live_from_env();
+        assert!(matches!(
+            r,
+            Err(LiveConfigError::MissingEnvVar("SBO3L_UNISWAP_RPC_URL"))
+        ));
+        // Restore.
+        for (v, val) in saved {
+            if let Some(val) = val {
+                std::env::set_var(v, val);
+            }
         }
     }
 }

--- a/crates/sbo3l-execution/src/uniswap_live.rs
+++ b/crates/sbo3l-execution/src/uniswap_live.rs
@@ -1,0 +1,576 @@
+//! B7 — Uniswap V3 QuoterV2 live quote on Sepolia.
+//!
+//! Calls `quoteExactInputSingle((address,address,uint256,uint24,uint160))`
+//! on the QuoterV2 contract via JSON-RPC `eth_call`. The function
+//! uses the revert-and-decode trick internally, but its OUTER
+//! signature returns the four uint values directly via the regular
+//! return path, so an `eth_call` simulation produces normal return
+//! data (the simulation includes the revert/catch dance internally).
+//!
+//! The integration is structured around a [`JsonRpcTransport`]
+//! trait so the production HTTP path and offline tests share one
+//! code path. CI uses an in-process [`FakeTransport`] (private to
+//! tests); production uses [`ReqwestTransport`] backed by
+//! `reqwest::blocking`.
+//!
+//! Truthfulness rules:
+//!
+//! - The selector is **derived in tests** from the canonical type
+//!   string — hardcoding without that pin is the kind of drift that
+//!   silently breaks live integration. The test would fail loudly if
+//!   the constant ever drifted from `keccak256(...)`.
+//! - The Sepolia QuoterV2 address (`0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3`)
+//!   is documented at developers.uniswap.org/contracts/v3/reference
+//!   /deployments/ethereum-deployments. Hardcoding well-known public
+//!   infrastructure is fine; the agent's parameters (token addresses,
+//!   amount, fee tier) come from operator-supplied env / context.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+#[cfg(test)]
+use tiny_keccak::{Hasher, Keccak};
+
+/// Sepolia QuoterV2 deployment address. Source:
+/// developers.uniswap.org/contracts/v3/reference/deployments/ethereum-deployments
+pub const SEPOLIA_QUOTER_V2_ADDRESS: &str = "0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3";
+
+/// EIP-155 Sepolia chain id. Surfaced into the evidence so an
+/// auditor can confirm the quote came from Sepolia, not mainnet.
+pub const SEPOLIA_CHAIN_ID: u64 = 11_155_111;
+
+/// Sepolia WETH9 token address. Surfaced as the safe default
+/// `token_in` when the operator provides no override.
+pub const SEPOLIA_WETH: &str = "0xfff9976782d46cc05630d1f6ebab18b2324d6b14";
+
+/// Selector for `quoteExactInputSingle((address,address,uint256,uint24,uint160))`.
+/// Pinned in tests against `keccak256(canonical_type_string)[0..4]`.
+pub const QUOTE_EXACT_INPUT_SINGLE_SELECTOR: [u8; 4] = [0xc6, 0xa5, 0x02, 0x6a];
+
+/// Reasons a JSON-RPC call can fail. Surfaces back to the executor
+/// caller through `ExecutionError::BackendOffline` (transport / IO)
+/// or `ExecutionError::Integration` (decode / server-rejected).
+#[derive(Debug, thiserror::Error)]
+pub enum RpcError {
+    #[error("RPC HTTP error: {0}")]
+    Http(String),
+    #[error("RPC reported error: code={code} message={message}")]
+    Server { code: i64, message: String },
+    #[error("malformed eth_call response: {0}")]
+    Decode(String),
+    #[error("RPC parse error: {0}")]
+    Parse(String),
+}
+
+/// Synchronous JSON-RPC transport. Production uses
+/// [`ReqwestTransport`]; tests inject a fake.
+pub trait JsonRpcTransport: Send + Sync {
+    /// Call `eth_call` against `to` with `data` (both `0x`-prefixed
+    /// hex). Returns the `0x`-prefixed hex result string.
+    fn eth_call(&self, to: &str, data: &str) -> Result<String, RpcError>;
+}
+
+#[derive(Debug, Serialize)]
+struct EthCallTx<'a> {
+    to: &'a str,
+    data: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcResponse {
+    #[allow(dead_code)]
+    jsonrpc: Option<String>,
+    result: Option<String>,
+    error: Option<JsonRpcErrorBody>,
+    #[allow(dead_code)]
+    id: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcErrorBody {
+    code: i64,
+    message: String,
+}
+
+/// Production [`JsonRpcTransport`] backed by `reqwest::blocking`.
+pub struct ReqwestTransport {
+    rpc_url: String,
+    client: reqwest::blocking::Client,
+}
+
+impl ReqwestTransport {
+    pub fn new(rpc_url: String) -> Self {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(15))
+            .build()
+            .expect("reqwest::blocking::Client builder cannot fail with default config");
+        Self { rpc_url, client }
+    }
+
+    pub fn with_client(rpc_url: String, client: reqwest::blocking::Client) -> Self {
+        Self { rpc_url, client }
+    }
+}
+
+impl JsonRpcTransport for ReqwestTransport {
+    fn eth_call(&self, to: &str, data: &str) -> Result<String, RpcError> {
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "eth_call",
+            "params": [
+                EthCallTx { to, data },
+                "latest"
+            ],
+            "id": 1u64
+        });
+        let resp = self
+            .client
+            .post(&self.rpc_url)
+            .json(&body)
+            .send()
+            .map_err(|e| RpcError::Http(e.to_string()))?;
+        if !resp.status().is_success() {
+            return Err(RpcError::Http(format!("status {}", resp.status())));
+        }
+        let parsed: JsonRpcResponse = resp.json().map_err(|e| RpcError::Parse(e.to_string()))?;
+        if let Some(err) = parsed.error {
+            return Err(RpcError::Server {
+                code: err.code,
+                message: err.message,
+            });
+        }
+        parsed
+            .result
+            .ok_or_else(|| RpcError::Decode("no result and no error in response".into()))
+    }
+}
+
+/// Operator-supplied Uniswap config. `token_in`, `token_out` and
+/// `fee_tier` are required for any live quote; the rest carry
+/// sensible Sepolia defaults via [`Self::sepolia_default`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LiveConfig {
+    /// JSON-RPC endpoint URL. Stored only so the evidence can record
+    /// `quote_source` carrying the network + quoter; the actual HTTP
+    /// transport ([`JsonRpcTransport`]) holds its own copy.
+    pub rpc_url: String,
+    pub quoter: String,
+    pub chain_id: u64,
+    pub token_in: String,
+    pub token_out: String,
+    pub fee_tier: u32,
+    /// `amountIn` in token base units (wei for 18-decimal tokens).
+    /// Decimal string for serde stability.
+    pub amount_in_wei: String,
+}
+
+impl LiveConfig {
+    /// Sepolia config with sane defaults. Caller fills in
+    /// `token_out` (and `token_in` if not WETH).
+    pub fn sepolia_default(
+        token_in: String,
+        token_out: String,
+        fee_tier: u32,
+        amount_in_wei: String,
+        rpc_url: String,
+    ) -> Self {
+        Self {
+            rpc_url,
+            quoter: SEPOLIA_QUOTER_V2_ADDRESS.to_string(),
+            chain_id: SEPOLIA_CHAIN_ID,
+            token_in,
+            token_out,
+            fee_tier,
+            amount_in_wei,
+        }
+    }
+}
+
+/// Decoded `quoteExactInputSingle` return tuple. All values
+/// rendered as decimal strings so the evidence struct stays JSON-
+/// safe regardless of decimal precision.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct QuoteResult {
+    pub amount_out: String,
+    pub sqrt_price_x96_after: String,
+    pub initialized_ticks_crossed: u32,
+    pub gas_estimate: String,
+}
+
+/// Build the calldata for `quoteExactInputSingle`. Public so
+/// callers can pre-build, log, or attach it to the evidence.
+pub fn encode_quote_call(config: &LiveConfig) -> Result<Vec<u8>, RpcError> {
+    let mut out = Vec::with_capacity(4 + 5 * 32);
+    out.extend_from_slice(&QUOTE_EXACT_INPUT_SINGLE_SELECTOR);
+    // Static struct: encoded inline, 5 * 32 = 160 bytes.
+    out.extend_from_slice(&address_padded(&config.token_in)?);
+    out.extend_from_slice(&address_padded(&config.token_out)?);
+    out.extend_from_slice(&dec_uint256_be(&config.amount_in_wei)?);
+    out.extend_from_slice(&u32_to_uint256_be(config.fee_tier));
+    // sqrtPriceLimitX96 = 0 (no limit).
+    out.extend_from_slice(&[0u8; 32]);
+    Ok(out)
+}
+
+pub fn quote_exact_input_single<T: JsonRpcTransport + ?Sized>(
+    transport: &T,
+    config: &LiveConfig,
+) -> Result<QuoteResult, RpcError> {
+    let data = encode_quote_call(config)?;
+    let hex_data = format!("0x{}", hex::encode(&data));
+    let raw = transport.eth_call(&config.quoter, &hex_data)?;
+    decode_quote_response(&raw)
+}
+
+fn decode_quote_response(hex_response: &str) -> Result<QuoteResult, RpcError> {
+    let body = strip_0x(hex_response)?;
+    let bytes = hex::decode(body).map_err(|e| RpcError::Decode(format!("hex decode: {e}")))?;
+    if bytes.len() < 4 * 32 {
+        return Err(RpcError::Decode(format!(
+            "quote response too short: {} bytes (need 128)",
+            bytes.len()
+        )));
+    }
+    let amount_out = uint256_be_to_dec(&bytes[0..32])?;
+    let sqrt_price_x96_after = uint256_be_to_dec(&bytes[32..64])?;
+    let initialized_ticks_crossed = uint256_be_to_u32(&bytes[64..96])?;
+    let gas_estimate = uint256_be_to_dec(&bytes[96..128])?;
+    Ok(QuoteResult {
+        amount_out,
+        sqrt_price_x96_after,
+        initialized_ticks_crossed,
+        gas_estimate,
+    })
+}
+
+fn strip_0x(s: &str) -> Result<&str, RpcError> {
+    s.strip_prefix("0x")
+        .or_else(|| s.strip_prefix("0X"))
+        .ok_or_else(|| RpcError::Decode(format!("response missing `0x` prefix: {s:?}")))
+}
+
+fn address_padded(addr: &str) -> Result<[u8; 32], RpcError> {
+    let stripped = strip_0x(addr)?;
+    if stripped.len() != 40 {
+        return Err(RpcError::Decode(format!(
+            "address must be 20 bytes (40 hex chars): {addr}"
+        )));
+    }
+    let bytes =
+        hex::decode(stripped).map_err(|e| RpcError::Decode(format!("address hex decode: {e}")))?;
+    let mut padded = [0u8; 32];
+    padded[12..].copy_from_slice(&bytes);
+    Ok(padded)
+}
+
+fn u32_to_uint256_be(n: u32) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    out[28..].copy_from_slice(&n.to_be_bytes());
+    out
+}
+
+/// Parse a u256 decimal string (e.g. "1000000000000000000") into
+/// a 32-byte big-endian buffer. Rejects values larger than 2^256
+/// implicitly (won't fit) and any non-decimal-digit input.
+fn dec_uint256_be(decimal: &str) -> Result<[u8; 32], RpcError> {
+    if decimal.is_empty() {
+        return Err(RpcError::Decode("amount_in_wei is empty".into()));
+    }
+    if !decimal.bytes().all(|c| c.is_ascii_digit()) {
+        return Err(RpcError::Decode(format!(
+            "amount_in_wei must be decimal digits: {decimal}"
+        )));
+    }
+    // Left-fold base-10. Caps at 32 bytes; anything overflowing is
+    // surfaced as Decode.
+    let mut buf = [0u8; 32];
+    for c in decimal.bytes() {
+        let d = c - b'0';
+        let mut carry = d as u16;
+        for byte in buf.iter_mut().rev() {
+            let prod = (*byte as u16) * 10 + carry;
+            *byte = (prod & 0xff) as u8;
+            carry = prod >> 8;
+        }
+        if carry != 0 {
+            return Err(RpcError::Decode(format!(
+                "amount_in_wei overflows uint256: {decimal}"
+            )));
+        }
+    }
+    Ok(buf)
+}
+
+fn uint256_be_to_dec(b: &[u8]) -> Result<String, RpcError> {
+    if b.len() != 32 {
+        return Err(RpcError::Decode(format!(
+            "uint256 slice not 32 bytes: {}",
+            b.len()
+        )));
+    }
+    if b.iter().all(|&x| x == 0) {
+        return Ok("0".to_string());
+    }
+    // Repeated divide-by-10. Up to ~78 digits. O(n^2) is fine here.
+    let mut buf = b.to_vec();
+    let mut digits = Vec::with_capacity(80);
+    while !buf.iter().all(|&x| x == 0) {
+        let mut rem: u32 = 0;
+        for byte in buf.iter_mut() {
+            let v = (rem << 8) | *byte as u32;
+            *byte = (v / 10) as u8;
+            rem = v % 10;
+        }
+        digits.push((rem as u8 + b'0') as char);
+    }
+    digits.reverse();
+    Ok(digits.into_iter().collect())
+}
+
+fn uint256_be_to_u32(b: &[u8]) -> Result<u32, RpcError> {
+    if b.len() != 32 {
+        return Err(RpcError::Decode("uint256 slice not 32 bytes".into()));
+    }
+    if !b[..28].iter().all(|&x| x == 0) {
+        return Err(RpcError::Decode("uint256 doesn't fit in u32".into()));
+    }
+    let mut be = [0u8; 4];
+    be.copy_from_slice(&b[28..32]);
+    Ok(u32::from_be_bytes(be))
+}
+
+#[cfg(test)]
+fn keccak256(data: &[u8]) -> [u8; 32] {
+    let mut hasher = Keccak::v256();
+    hasher.update(data);
+    let mut out = [0u8; 32];
+    hasher.finalize(&mut out);
+    out
+}
+
+/// Test-only helpers re-exposed so the cross-module live-mode
+/// integration tests in `uniswap.rs` can reuse the same fake
+/// transport + ABI helper rather than duplicating them. Compiled
+/// only in `#[cfg(test)]`.
+#[cfg(test)]
+pub(crate) mod tests_support {
+    use super::*;
+    use std::sync::Mutex;
+
+    type Expectation = (String, String, Result<String, RpcError>);
+
+    pub struct FakeTransport {
+        scripted: Mutex<Vec<Expectation>>,
+        calls: Mutex<Vec<(String, String)>>,
+    }
+
+    impl FakeTransport {
+        pub fn new() -> Self {
+            Self {
+                scripted: Mutex::new(Vec::new()),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+        pub fn expect(&self, to: &str, data_prefix: &str, response: Result<String, RpcError>) {
+            self.scripted
+                .lock()
+                .unwrap()
+                .push((to.to_string(), data_prefix.to_string(), response));
+        }
+        pub fn calls(&self) -> Vec<(String, String)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    impl JsonRpcTransport for FakeTransport {
+        fn eth_call(&self, to: &str, data: &str) -> Result<String, RpcError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((to.to_string(), data.to_string()));
+            let mut script = self.scripted.lock().unwrap();
+            let pos = script
+                .iter()
+                .position(|(t, dp, _)| t.eq_ignore_ascii_case(to) && data.starts_with(dp.as_str()));
+            match pos {
+                Some(i) => script.remove(i).2,
+                None => Err(RpcError::Decode(format!(
+                    "FakeTransport: no expectation matched to={to} data={data}"
+                ))),
+            }
+        }
+    }
+
+    pub fn abi_encode_quad(amount_out: &str, sqrt_price: &str, ticks: u32, gas: &str) -> String {
+        let mut out = Vec::with_capacity(128);
+        out.extend_from_slice(&dec_uint256_be(amount_out).unwrap());
+        out.extend_from_slice(&dec_uint256_be(sqrt_price).unwrap());
+        out.extend_from_slice(&u32_to_uint256_be(ticks));
+        out.extend_from_slice(&dec_uint256_be(gas).unwrap());
+        format!("0x{}", hex::encode(out))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tests_support::{abi_encode_quad, FakeTransport};
+    use super::*;
+
+    /// Pinned: derive selector from the canonical type string, assert
+    /// it matches `QUOTE_EXACT_INPUT_SINGLE_SELECTOR`. This is the
+    /// load-bearing test — drift here means live mode talks to the
+    /// wrong function and silently returns garbage.
+    #[test]
+    fn quote_selector_matches_canonical_signature() {
+        let derived = keccak256(b"quoteExactInputSingle((address,address,uint256,uint24,uint160))");
+        assert_eq!(
+            derived[..4],
+            QUOTE_EXACT_INPUT_SINGLE_SELECTOR,
+            "QUOTE_EXACT_INPUT_SINGLE_SELECTOR drifted; expected {:?}, got {:?}",
+            &derived[..4],
+            QUOTE_EXACT_INPUT_SINGLE_SELECTOR
+        );
+    }
+
+    #[test]
+    fn dec_uint256_round_trips_through_be() {
+        for &n in &[0u128, 1, 42, 1_000_000_000_000_000_000, u128::MAX] {
+            let s = n.to_string();
+            let be = dec_uint256_be(&s).unwrap();
+            let back = uint256_be_to_dec(&be).unwrap();
+            assert_eq!(back, s, "round-trip failed for {n}");
+        }
+    }
+
+    #[test]
+    fn dec_uint256_rejects_non_digits() {
+        assert!(matches!(dec_uint256_be("0x123"), Err(RpcError::Decode(_))));
+        assert!(matches!(dec_uint256_be("123abc"), Err(RpcError::Decode(_))));
+        assert!(matches!(dec_uint256_be(""), Err(RpcError::Decode(_))));
+    }
+
+    #[test]
+    fn address_padded_left_zero_pads_20_bytes() {
+        let p = address_padded("0x1111111111111111111111111111111111111111").unwrap();
+        // First 12 bytes zero, last 20 bytes the address.
+        assert!(p[..12].iter().all(|&b| b == 0));
+        assert_eq!(&p[12..], &[0x11u8; 20]);
+    }
+
+    #[test]
+    fn address_padded_rejects_short() {
+        assert!(matches!(address_padded("0x1234"), Err(RpcError::Decode(_))));
+    }
+
+    #[test]
+    fn encode_quote_call_layout_pinned() {
+        let cfg = LiveConfig {
+            rpc_url: "http://x.invalid".into(),
+            quoter: SEPOLIA_QUOTER_V2_ADDRESS.into(),
+            chain_id: SEPOLIA_CHAIN_ID,
+            token_in: SEPOLIA_WETH.into(),
+            token_out: "0x0000000000000000000000000000000000000022".into(),
+            fee_tier: 3000,
+            amount_in_wei: "1000000000000000000".into(),
+        };
+        let cd = encode_quote_call(&cfg).unwrap();
+        // selector(4) + 5 * uint256(32) = 164.
+        assert_eq!(cd.len(), 164);
+        assert_eq!(cd[..4], QUOTE_EXACT_INPUT_SINGLE_SELECTOR);
+        // Last 32 bytes = sqrtPriceLimitX96 = 0.
+        assert!(cd[132..].iter().all(|&b| b == 0));
+        // Fee tier (3000 = 0x0BB8) at the right offset (4 + 32*3).
+        let fee_word = &cd[4 + 32 * 3..4 + 32 * 4];
+        assert_eq!(u32::from_be_bytes(fee_word[28..].try_into().unwrap()), 3000);
+    }
+
+    fn cfg() -> LiveConfig {
+        LiveConfig::sepolia_default(
+            SEPOLIA_WETH.to_string(),
+            "0x0000000000000000000000000000000000000022".to_string(),
+            3000,
+            "1000000000000000000".to_string(),
+            "http://example.invalid".to_string(),
+        )
+    }
+
+    #[test]
+    fn happy_path_decodes_quad_return() {
+        let t = FakeTransport::new();
+        t.expect(
+            SEPOLIA_QUOTER_V2_ADDRESS,
+            "0xc6a5026a",
+            Ok(abi_encode_quad(
+                "2500000000000000000",
+                "1234567890123456789",
+                7,
+                "85000",
+            )),
+        );
+        let q = quote_exact_input_single(&t, &cfg()).unwrap();
+        assert_eq!(q.amount_out, "2500000000000000000");
+        assert_eq!(q.sqrt_price_x96_after, "1234567890123456789");
+        assert_eq!(q.initialized_ticks_crossed, 7);
+        assert_eq!(q.gas_estimate, "85000");
+        // Verify the call hit the right contract.
+        let calls = t.calls();
+        assert_eq!(calls.len(), 1);
+        assert!(calls[0].0.eq_ignore_ascii_case(SEPOLIA_QUOTER_V2_ADDRESS));
+        assert!(calls[0].1.starts_with("0xc6a5026a"));
+    }
+
+    #[test]
+    fn server_error_surfaces_as_rpc_error_server() {
+        let t = FakeTransport::new();
+        t.expect(
+            SEPOLIA_QUOTER_V2_ADDRESS,
+            "0xc6a5026a",
+            Err(RpcError::Server {
+                code: 3,
+                message: "execution reverted".into(),
+            }),
+        );
+        let err = quote_exact_input_single(&t, &cfg()).unwrap_err();
+        match err {
+            RpcError::Server { code, message } => {
+                assert_eq!(code, 3);
+                assert!(message.contains("execution reverted"));
+            }
+            other => panic!("expected Server, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn http_timeout_surfaces_as_rpc_error_http() {
+        let t = FakeTransport::new();
+        t.expect(
+            SEPOLIA_QUOTER_V2_ADDRESS,
+            "0xc6a5026a",
+            Err(RpcError::Http("timeout".into())),
+        );
+        let err = quote_exact_input_single(&t, &cfg()).unwrap_err();
+        assert!(matches!(err, RpcError::Http(_)));
+        assert!(err.to_string().contains("timeout"));
+    }
+
+    #[test]
+    fn malformed_response_surfaces_as_decode_error() {
+        let t = FakeTransport::new();
+        // 64 bytes — only 2 of the 4 expected uint256s.
+        let short = format!("0x{}", "00".repeat(64));
+        t.expect(SEPOLIA_QUOTER_V2_ADDRESS, "0xc6a5026a", Ok(short));
+        let err = quote_exact_input_single(&t, &cfg()).unwrap_err();
+        assert!(matches!(err, RpcError::Decode(_)));
+    }
+
+    #[test]
+    fn missing_0x_prefix_surfaces_as_decode_error() {
+        let t = FakeTransport::new();
+        let response = "no_prefix_here".to_string();
+        t.expect(SEPOLIA_QUOTER_V2_ADDRESS, "0xc6a5026a", Ok(response));
+        let err = quote_exact_input_single(&t, &cfg()).unwrap_err();
+        assert!(matches!(err, RpcError::Decode(_)));
+    }
+}

--- a/demo-scripts/sponsors/uniswap-guarded-swap.sh
+++ b/demo-scripts/sponsors/uniswap-guarded-swap.sh
@@ -14,11 +14,27 @@
 #      engine denies (`policy.deny_recipient_not_allowlisted`). The Uniswap
 #      executor refuses to run on the denied receipt.
 #
-# The live executor (`UniswapExecutor::live()`) is intentionally stubbed in
-# this hackathon build and would error with `BackendOffline`. There is no
-# env-var feature flag — the demo always uses `local_mock()`. See FEEDBACK.md.
+# B7: `UniswapExecutor::live()` now wires to the real Sepolia QuoterV2
+# (0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3). Default behaviour is mock
+# for CI determinism. To exercise the live path locally:
+#
+#   export SBO3L_UNISWAP_RPC_URL='https://sepolia.example/...'
+#   export SBO3L_UNISWAP_TOKEN_OUT='0x...'   # required Sepolia ERC20 address
+#   ./demo-scripts/sponsors/uniswap-guarded-swap.sh --live
+#
+# The `--live` segment runs the `uniswap_live_smoke` example, which calls
+# `quoteExactInputSingle` via `UniswapExecutor::live_from_env()` and prints
+# the four QuoterV2 return values. CI never runs this segment (no RPC URL).
 set -euo pipefail
 cd "$(dirname "$0")/../.."
+
+LIVE_MODE=0
+for arg in "$@"; do
+  case "$arg" in
+    --live) LIVE_MODE=1 ;;
+    *) echo "uniswap-guarded-swap.sh: unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
 
 cargo build --quiet --bin research-agent
 
@@ -79,3 +95,24 @@ jq '.execution.executor_evidence' "$CAPSULE"
 
 echo
 ./target/debug/sbo3l passport verify --path "$CAPSULE"
+
+# --------------------------------------------------------------------------
+# B7 — optional live segment. Skipped unless `--live` is passed AND the
+# SBO3L_UNISWAP_RPC_URL env var is set. CI does not invoke either, so the
+# block above remains the always-green default.
+# --------------------------------------------------------------------------
+if [ "$LIVE_MODE" -eq 1 ]; then
+  echo
+  bold "Uniswap guarded swap — LIVE Sepolia QuoterV2 (B7)"
+  echo
+  if [ -z "${SBO3L_UNISWAP_RPC_URL:-}" ]; then
+    echo "  --live requested, but SBO3L_UNISWAP_RPC_URL is unset. Skipping."
+    echo "  Set the env var (and SBO3L_UNISWAP_TOKEN_OUT) and rerun to exercise"
+    echo "  the live path. The mock segments above continue to work without it."
+  else
+    echo "  RPC: $SBO3L_UNISWAP_RPC_URL"
+    echo "  Quoter: 0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3 (Sepolia QuoterV2)"
+    echo
+    cargo run --quiet -p sbo3l-execution --example uniswap_live_smoke
+  fi
+fi


### PR DESCRIPTION
## What

Wires `UniswapExecutor::live()` to a real Ethereum JSON-RPC endpoint via Uniswap V3 **QuoterV2 on Sepolia** (`0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3`). Default behaviour stays mock for CI determinism; the `--live` segment of the demo script and the `examples/uniswap_live_smoke.rs` binary are operator-runnable when env vars are set.

## Why this matters

Without a real quote integration, the Uniswap bounty's **"build agentic finance via Uniswap API for ONCHAIN swaps"** requirement is unmet. With this, an agent that wants to trade through Uniswap can get a real Sepolia quote bounded by SBO3L's policy boundary — the demo line *"agentic finance is only useful if agents can trade within enforceable limits"* gets concrete proof.

## Implementation

- **New module** `crates/sbo3l-execution/src/uniswap_live.rs` (~390 LoC):
  - `JsonRpcTransport` trait + `ReqwestTransport` (`reqwest::blocking`).
  - Constants: `SEPOLIA_QUOTER_V2_ADDRESS`, `SEPOLIA_CHAIN_ID` (11155111), `SEPOLIA_WETH`, `QUOTE_EXACT_INPUT_SINGLE_SELECTOR` (`0xc6a5026a`).
  - **Selector verified in tests** against `keccak256("quoteExactInputSingle((address,address,uint256,uint24,uint160))")` — load-bearing pin against silent drift.
  - ABI encoders (address-padding, u256 decimal-to-be-bytes, static-tuple struct inline) + ABI decoders (4-uint quad return).
  - `quote_exact_input_single<T: JsonRpcTransport>` — generic over transport so production HTTP and offline tests share one code path. **No mockito needed** — tests inject a `FakeTransport` (zero new dev-deps).

- **`LiveContext { config, transport: Arc<dyn JsonRpcTransport> }`** added to `UniswapExecutor` as `Option<Arc<LiveContext>>`. Bare `live()` ctor stays back-compat (still returns `BackendOffline` at execute time when context absent — pre-B7 test passes unchanged). New ctors:
  - `live_from_env()` — reads `SBO3L_UNISWAP_RPC_URL` + `SBO3L_UNISWAP_TOKEN_IN/OUT/FEE_TIER/AMOUNT_IN_WEI`
  - `live_with_context(ctx)` — for tests; injects fake transport

- **Live `execute()`** builds the quote, maps `RpcError` into `ExecutionError`:
  - `Http` / `Parse` → `BackendOffline` (sponsor unreachable)
  - `Server` / `Decode` → `Integration` (protocol-level)
  
  Emits `executor_evidence` preserving the existing 10 `UniswapQuoteEvidence` fields **AND** 4 live-only fields (`chain_id`, `amount_out`, `sqrt_price_x96_after`, `gas_estimate`). The capsule schema permits `additionalProperties` on `executor_evidence` so the extra fields land cleanly without a schema bump.
  
  `quote_source` carries `"uniswap-v3-quoter-sepolia-0xed1f...2fb3"` verbatim so an auditor can grep for it.

- **`examples/uniswap_live_smoke.rs`** — operator-runnable smoke. `cargo run -p sbo3l-execution --example uniswap_live_smoke` calls `live_from_env()` and prints the four `QuoteResult` fields. Does NOT run in CI.

- **Demo script** `demo-scripts/sponsors/uniswap-guarded-swap.sh` gains a `--live` flag that runs the smoke when `SBO3L_UNISWAP_RPC_URL` is set; default invocation stays mock-only and CI-green.

## Tests (all offline, no real network)

**`uniswap_live::tests` (11 new):**
- Selector matches canonical signature (load-bearing)
- `dec_uint256` round-trips through big-endian (incl. `u128::MAX`)
- `dec_uint256` rejects non-digits, `0x` prefix, empty
- Address-padded layout (12 zero bytes + 20 address bytes)
- Address rejects short input
- `encode_quote_call` layout pinned (selector + 5 uint256s = 164 B; fee tier at byte offset `4+96`; `sqrtPriceLimitX96 = 0`)
- Happy path decodes the quad return
- Server error → `RpcError::Server`
- HTTP timeout → `RpcError::Http`
- Malformed response (too short) → `RpcError::Decode`
- Missing `0x` prefix → `RpcError::Decode`

**`uniswap::live_tests` (5 new):**
- Live path emits `executor_evidence` with real `amount_out` (pins `quote_source` containing `sepolia` + the quoter address)
- Server revert (e.g. `"execution reverted: insufficient liquidity"`) → `ExecutionError::Integration` with code+message
- HTTP timeout → `ExecutionError::BackendOffline`
- Denied receipt never calls RPC (`NotApproved` short-circuits before any transport call)
- `live_from_env` errors when `SBO3L_UNISWAP_RPC_URL` missing (with env save/restore)

## Verification matrix

- `cargo build -p sbo3l-execution`: clean
- `cargo build -p sbo3l-execution --example uniswap_live_smoke`: clean
- `cargo test -p sbo3l-execution`: **26/26**
- `cargo test --workspace --all-targets`: **333/333** (was 317 on main, +16 from this PR)
- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `bash demo-scripts/sponsors/uniswap-guarded-swap.sh` (mock only): passes
- `bash demo-scripts/sponsors/uniswap-guarded-swap.sh --live` (no RPC URL set): skips live segment with clear "set this env var" message; mock segments still pass

## What's NOT in this PR

- **`FEEDBACK.md` §Uniswap "What broke when we hit Sepolia"** — deferred per the brief's own gating: *"once you have real-network experience"*. I have not yet hit Sepolia myself; that text would be fabrication. Daniel can update FEEDBACK after running the smoke against the real RPC URL — much more credible as a real dev-experience note. PR-body-only acknowledgement.
- **CLI `passport run --mode live --executor uniswap`** — the CLI gates `--mode live` at a higher layer (truthfulness rule: live claims require real evidence in the capsule's `live_evidence` slot). Wiring that through is its own design question (P5.1/P6.1). The smoke binary in this PR is the operator-visible live path.
- **Real Sepolia smoke**. With `SBO3L_UNISWAP_RPC_URL` + `SBO3L_UNISWAP_TOKEN_OUT` set, an operator can run the smoke and see the four QuoterV2 return values. CI never runs this.

## Test plan

- [ ] Reviewer runs `cargo test -p sbo3l-execution` (26 tests pass)
- [ ] Reviewer reads `crates/sbo3l-execution/src/uniswap_live.rs` end-to-end
- [ ] Reviewer confirms the selector test (`quote_selector_matches_canonical_signature`) is the load-bearing pin
- [ ] Reviewer confirms the live evidence preserves the existing 10-field `UniswapQuoteEvidence` shape
- [ ] (Optional, after merge) Daniel sets `SBO3L_UNISWAP_RPC_URL` + `SBO3L_UNISWAP_TOKEN_OUT` and runs `bash demo-scripts/sponsors/uniswap-guarded-swap.sh --live` to exercise the real Sepolia quote
- [ ] (Optional follow-up) Update `FEEDBACK.md` §Uniswap with concrete Sepolia dev-experience pain after the live smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)