### PR TITLE
feat(B3): rename sbo3l:receipt_schema → sbo3l:proof_uri + ens_live smoke

### DIFF
--- a/crates/sbo3l-identity/examples/ens_live_smoke.rs
+++ b/crates/sbo3l-identity/examples/ens_live_smoke.rs
@@ -1,0 +1,82 @@
+//! B3 live smoke: resolve an ENS name's `sbo3l:*` text records via
+//! [`LiveEnsResolver`]. Operator-supplied env vars:
+//!
+//!   SBO3L_ENS_RPC_URL     — required (e.g. Alchemy mainnet free-tier)
+//!   SBO3L_ENS_NAME        — defaults to `sbo3lagent.eth`
+//!   SBO3L_ENS_NETWORK     — defaults to `mainnet`; `sepolia` also valid
+//!
+//! Use:
+//!
+//!   export SBO3L_ENS_RPC_URL='https://eth-mainnet.g.alchemy.com/v2/...'
+//!   cargo run -p sbo3l-identity --example ens_live_smoke
+//!
+//! Prints the five SBO3L text records read from chain. Does NOT log
+//! the RPC URL itself (it's a credential — operator supplies via env,
+//! we never echo). CI does not run this example: no RPC URL.
+//!
+//! Exit codes:
+//! - 0 — all five records resolved
+//! - 1 — IO / configuration error (env var missing, RPC unreachable)
+//! - 2 — resolution failure (UnknownName, MissingRecord, malformed
+//!   response)
+
+use std::process::ExitCode;
+
+use sbo3l_identity::ens::EnsResolver;
+use sbo3l_identity::{EnsNetwork, LiveEnsResolver, ResolveError};
+
+fn main() -> ExitCode {
+    let network_raw = std::env::var("SBO3L_ENS_NETWORK").unwrap_or_else(|_| "mainnet".to_string());
+    let network = match EnsNetwork::parse(&network_raw) {
+        Ok(n) => n,
+        Err(e) => {
+            eprintln!(
+                "ens_live_smoke: SBO3L_ENS_NETWORK={network_raw} invalid: {e}. \
+                 Use `mainnet` or `sepolia`."
+            );
+            return ExitCode::from(1);
+        }
+    };
+
+    let name = std::env::var("SBO3L_ENS_NAME").unwrap_or_else(|_| "sbo3lagent.eth".to_string());
+
+    let resolver = match LiveEnsResolver::from_env(network) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("ens_live_smoke: configuration error: {e}");
+            eprintln!(
+                "Required env: SBO3L_ENS_RPC_URL. Optional: SBO3L_ENS_NAME \
+                 (default: sbo3lagent.eth), SBO3L_ENS_NETWORK (default: mainnet)."
+            );
+            return ExitCode::from(1);
+        }
+    };
+
+    println!("ens_live_smoke: resolving {name} on {}", network.as_str());
+    match resolver.resolve(&name) {
+        Ok(records) => {
+            println!("  agent_id:    {}", records.agent_id);
+            println!("  endpoint:    {}", records.endpoint);
+            println!("  policy_hash: {}", records.policy_hash);
+            println!("  audit_root:  {}", records.audit_root);
+            println!("  proof_uri:   {}", records.proof_uri);
+            ExitCode::SUCCESS
+        }
+        Err(ResolveError::Io(e)) => {
+            eprintln!("ens_live_smoke: IO/RPC error: {e}");
+            ExitCode::from(1)
+        }
+        Err(ResolveError::UnknownName(n)) => {
+            eprintln!("ens_live_smoke: UnknownName: {n} has no resolver set");
+            ExitCode::from(2)
+        }
+        Err(ResolveError::MissingRecord(field, n)) => {
+            eprintln!("ens_live_smoke: MissingRecord: {n} has no sbo3l:{field} text record");
+            ExitCode::from(2)
+        }
+        Err(other) => {
+            eprintln!("ens_live_smoke: unexpected error: {other}");
+            ExitCode::from(2)
+        }
+    }
+}

--- a/crates/sbo3l-identity/src/ens.rs
+++ b/crates/sbo3l-identity/src/ens.rs
@@ -30,8 +30,14 @@ pub struct EnsRecords {
     pub policy_hash: String,
     #[serde(rename = "sbo3l:audit_root")]
     pub audit_root: String,
-    #[serde(rename = "sbo3l:receipt_schema")]
-    pub receipt_schema: String,
+    /// URL to the published proof capsule for this agent. Renamed
+    /// from `receipt_schema` to match the actually-deployed
+    /// `sbo3lagent.eth` text records on Ethereum mainnet (the
+    /// previous name pointed at a static JSON Schema; the new name
+    /// points at a specific deployed proof instance, which is the
+    /// useful thing for an agent registry).
+    #[serde(rename = "sbo3l:proof_uri")]
+    pub proof_uri: String,
 }
 
 impl EnsRecords {
@@ -88,7 +94,7 @@ mod tests {
                 "sbo3l:endpoint": "http://127.0.0.1:8730/v1",
                 "sbo3l:policy_hash": "e044f13c5acb792dd3109f1be3a98536168b0990e25595b3cedc131d02e666cf",
                 "sbo3l:audit_root": "0000000000000000000000000000000000000000000000000000000000000000",
-                "sbo3l:receipt_schema": "https://schemas.sbo3l.dev/policy-receipt/v1.json"
+                "sbo3l:proof_uri": "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/capsule.json"
             }
         }"#
     }

--- a/crates/sbo3l-identity/src/ens_live.rs
+++ b/crates/sbo3l-identity/src/ens_live.rs
@@ -7,7 +7,7 @@
 //!    when the name isn't registered or doesn't have a resolver set.
 //! 2. Call `Resolver.text(node, key)` for each of the five SBO3L
 //!    text-record keys (`sbo3l:agent_id`, `sbo3l:endpoint`,
-//!    `sbo3l:policy_hash`, `sbo3l:audit_root`, `sbo3l:receipt_schema`).
+//!    `sbo3l:policy_hash`, `sbo3l:audit_root`, `sbo3l:proof_uri`).
 //!    Any missing key surfaces as `MissingRecord`.
 //!
 //! ENS bounty rule "no hardcoded values": the *agent's* identity
@@ -50,7 +50,7 @@ pub const SBO3L_TEXT_KEYS: [&str; 5] = [
     "sbo3l:endpoint",
     "sbo3l:policy_hash",
     "sbo3l:audit_root",
-    "sbo3l:receipt_schema",
+    "sbo3l:proof_uri",
 ];
 
 /// Reasons a JSON-RPC call can fail. Surfaced through
@@ -229,7 +229,7 @@ impl<T: JsonRpcTransport> EnsResolver for LiveEnsResolver<T> {
             endpoint: values.remove("sbo3l:endpoint").unwrap_or_default(),
             policy_hash: values.remove("sbo3l:policy_hash").unwrap_or_default(),
             audit_root: values.remove("sbo3l:audit_root").unwrap_or_default(),
-            receipt_schema: values.remove("sbo3l:receipt_schema").unwrap_or_default(),
+            proof_uri: values.remove("sbo3l:proof_uri").unwrap_or_default(),
         })
     }
 }
@@ -243,7 +243,7 @@ fn static_key_label(key: &str) -> &'static str {
         "sbo3l:endpoint" => "endpoint",
         "sbo3l:policy_hash" => "policy_hash",
         "sbo3l:audit_root" => "audit_root",
-        "sbo3l:receipt_schema" => "receipt_schema",
+        "sbo3l:proof_uri" => "proof_uri",
         _ => "unknown",
     }
 }
@@ -480,8 +480,8 @@ mod tests {
                 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
             ),
             (
-                "sbo3l:receipt_schema",
-                "https://schemas.sbo3l.dev/policy-receipt/v1.json",
+                "sbo3l:proof_uri",
+                "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/capsule.json",
             ),
         ]
     }
@@ -516,7 +516,7 @@ mod tests {
         assert_eq!(recs.endpoint, expected[1].1);
         assert_eq!(recs.policy_hash, expected[2].1);
         assert_eq!(recs.audit_root, expected[3].1);
-        assert_eq!(recs.receipt_schema, expected[4].1);
+        assert_eq!(recs.proof_uri, expected[4].1);
     }
 
     #[test]

--- a/crates/sbo3l-identity/src/lib.rs
+++ b/crates/sbo3l-identity/src/lib.rs
@@ -7,7 +7,7 @@
 //! * `sbo3l:endpoint`
 //! * `sbo3l:policy_hash`
 //! * `sbo3l:audit_root`
-//! * `sbo3l:receipt_schema`
+//! * `sbo3l:proof_uri`
 //!
 //! The trait abstracts the resolution backend so a live testnet ENS lookup and
 //! an offline fixture can plug in interchangeably. The hackathon demo defaults

--- a/demo-fixtures/ens-records.json
+++ b/demo-fixtures/ens-records.json
@@ -4,6 +4,6 @@
     "sbo3l:endpoint": "http://127.0.0.1:8730/v1",
     "sbo3l:policy_hash": "e044f13c5acb792dd3109f1be3a98536168b0990e25595b3cedc131d02e666cf",
     "sbo3l:audit_root": "0000000000000000000000000000000000000000000000000000000000000000",
-    "sbo3l:receipt_schema": "https://schemas.sbo3l.dev/policy-receipt/v1.json"
+    "sbo3l:proof_uri": "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/capsule.json"
   }
 }

--- a/demo-fixtures/mock-ens-registry.json
+++ b/demo-fixtures/mock-ens-registry.json
@@ -9,21 +9,21 @@
       "sbo3l:endpoint": "http://127.0.0.1:8730/v1",
       "sbo3l:policy_hash": "e044f13c5acb792dd3109f1be3a98536168b0990e25595b3cedc131d02e666cf",
       "sbo3l:audit_root": "0000000000000000000000000000000000000000000000000000000000000000",
-      "sbo3l:receipt_schema": "https://schemas.sbo3l.dev/policy-receipt/v1.json"
+      "sbo3l:proof_uri": "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/capsule.json"
     },
     "trading-agent.team.eth": {
       "sbo3l:agent_id": "trading-agent-01",
       "sbo3l:endpoint": "http://127.0.0.1:8731/v1",
       "sbo3l:policy_hash": "1111111111111111111111111111111111111111111111111111111111111111",
       "sbo3l:audit_root": "0000000000000000000000000000000000000000000000000000000000000000",
-      "sbo3l:receipt_schema": "https://schemas.sbo3l.dev/policy-receipt/v1.json"
+      "sbo3l:proof_uri": "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/capsule.json"
     },
     "support-agent.team.eth": {
       "sbo3l:agent_id": "support-agent-01",
       "sbo3l:endpoint": "http://127.0.0.1:8732/v1",
       "sbo3l:policy_hash": "2222222222222222222222222222222222222222222222222222222222222222",
       "sbo3l:audit_root": "0000000000000000000000000000000000000000000000000000000000000000",
-      "sbo3l:receipt_schema": "https://schemas.sbo3l.dev/policy-receipt/v1.json"
+      "sbo3l:proof_uri": "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/capsule.json"
     }
   }
 }


### PR DESCRIPTION
## What

Aligns `LiveEnsResolver` + offline fixtures with the actually-deployed `sbo3lagent.eth` text records on Ethereum mainnet. The deployed records use `sbo3l:proof_uri`, not `sbo3l:receipt_schema` — without this rename, `LiveEnsResolver::resolve("sbo3lagent.eth")` would surface `MissingRecord("receipt_schema", ...)` against the real chain.

> **Base branch is `feat/b3-live-ens-resolver` (PR #69), NOT main.** This PR layers the rename on top of #69 so the diff is minimal. After #69 merges, this PR retargets to main automatically. If you want, you can also merge #69 first and I'll rebase.

## Why the rename

The `proof_uri` semantics are strictly more useful than `receipt_schema`:
- `receipt_schema` = URL to the JSON Schema for receipts (a constant — pinning it on chain costs gas without adding information).
- `proof_uri` = URL to a specific deployed proof capsule (the agent registry pattern's actual ask: "where can I see this agent's latest proof?").

## Live smoke confirmed

Ran locally against the supplied Alchemy mainnet RPC + `sbo3lagent.eth`:

```
namehash(sbo3lagent.eth) = 0x2e3bac2fc8b574ba1db508588f06102b98554282722141f568960bb66ec12713
registry.resolver(node)  → 0xf29100983e058b709f3d539b0c765937b804ac15
text(node, sbo3l:agent_id)   → "research-agent-01"
text(node, sbo3l:proof_uri)  → "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/capsule.json"
```

**End-to-end architecture verified against real ENS infrastructure.** Resolver address, namehash, ABI encoding/decoding all bit-correct. The RPC URL is only consumed via `SBO3L_ENS_RPC_URL` env var; never committed, never logged.

## Heads-up on chain state (separate from this PR)

When I ran the smoke I observed two on-chain things you'll want to address before recording:

1. **`sbo3l:endpoint` is empty** on chain (`length=0` in the raw `text()` response). Looks like that `setText` tx didn't land. Re-broadcast to populate.
2. **`policy_hash` and `audit_root`** are stored as the 66-char STRING `"0x" + 64 hex chars`, not the 64-char raw hex. `EnsRecords::verify_policy_hash` does a literal string compare against the active hash, so the SBO3L-side comparator must include the `0x` prefix or strip it on both sides. Easy to handle but flagging it.

These are on-chain state issues, not PR-blocking — once endpoint is set, `LiveEnsResolver::resolve("sbo3lagent.eth")` will return all five records cleanly.

## Implementation

**Code changes (`crates/sbo3l-identity/src/`):**
- `EnsRecords::receipt_schema` → `proof_uri` (with serde rename to `sbo3l:proof_uri`)
- `SBO3L_TEXT_KEYS[4]` swapped to `sbo3l:proof_uri`
- Resolver value-mapping + `static_key_label` updated
- `lib.rs` doc-comment lists the new key
- All in-crate test fixtures updated (the in-test fixture URL now points at the GitHub Pages capsule, matching what's on chain)

**Offline fixtures:**
- `demo-fixtures/ens-records.json` — single-agent demo
- `demo-fixtures/mock-ens-registry.json` — three-agent catalogue (3 entries updated)

Both now carry the public Pages capsule URL as `proof_uri` so the offline path resolves to the same target the on-chain record points at — judges running the offline demo see the same string as judges running the live demo.

**New example** `crates/sbo3l-identity/examples/ens_live_smoke.rs` (~80 LoC):
- Operator-runnable smoke
- Reads `SBO3L_ENS_RPC_URL` (required), `SBO3L_ENS_NAME` (default `sbo3lagent.eth`), `SBO3L_ENS_NETWORK` (default `mainnet`)
- Never logs the RPC URL (it's a credential)
- Prints the five resolved records, exits 0 on full resolution / 1 on IO/RPC / 2 on resolution error
- CI does NOT run this — no RPC URL set in CI

## Verification matrix

- `cargo build -p sbo3l-identity --example ens_live_smoke`: clean
- `cargo test --workspace --all-targets`: **370 / 370** (rebased onto current main with B1 + B2 + B3-anchor + B7 already merged)
- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- Live smoke against mainnet `sbo3lagent.eth`: resolver + agent_id + proof_uri verified bit-correct; endpoint surfaced as missing (chain-state issue, see above).

## Test plan

- [ ] Reviewer confirms the per-file rename is consistent (no dangling `receipt_schema` outside the explanatory doc-comment)
- [ ] Reviewer pulls the branch, sets `SBO3L_ENS_RPC_URL`, runs `cargo run -p sbo3l-identity --example ens_live_smoke` and sees the same resolver address (`0xf29100983e058b709f3d539b0c765937b804ac15`)
- [ ] (After merge + endpoint fix) Daniel re-broadcasts `setText(sbo3l:endpoint, "mcp://stdio:sbo3l-mcp")` and reruns the smoke — should now resolve all 5 records

## Note on breaking change

This is a **breaking change** to the `EnsRecords` public field name. Impact is internal to this workspace; `sbo3l-identity` is not published, so no third-party consumers exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)