### PR TITLE
feat(B3): rename sbo3l:receipt_schema → sbo3l:proof_uri + ens_live smoke (re-open of #70)

### DIFF
--- a/crates/sbo3l-identity/examples/ens_live_smoke.rs
+++ b/crates/sbo3l-identity/examples/ens_live_smoke.rs
@@ -1,0 +1,82 @@
+//! B3 live smoke: resolve an ENS name's `sbo3l:*` text records via
+//! [`LiveEnsResolver`]. Operator-supplied env vars:
+//!
+//!   SBO3L_ENS_RPC_URL     — required (e.g. Alchemy mainnet free-tier)
+//!   SBO3L_ENS_NAME        — defaults to `sbo3lagent.eth`
+//!   SBO3L_ENS_NETWORK     — defaults to `mainnet`; `sepolia` also valid
+//!
+//! Use:
+//!
+//!   export SBO3L_ENS_RPC_URL='https://eth-mainnet.g.alchemy.com/v2/...'
+//!   cargo run -p sbo3l-identity --example ens_live_smoke
+//!
+//! Prints the five SBO3L text records read from chain. Does NOT log
+//! the RPC URL itself (it's a credential — operator supplies via env,
+//! we never echo). CI does not run this example: no RPC URL.
+//!
+//! Exit codes:
+//! - 0 — all five records resolved
+//! - 1 — IO / configuration error (env var missing, RPC unreachable)
+//! - 2 — resolution failure (UnknownName, MissingRecord, malformed
+//!   response)
+
+use std::process::ExitCode;
+
+use sbo3l_identity::ens::EnsResolver;
+use sbo3l_identity::{EnsNetwork, LiveEnsResolver, ResolveError};
+
+fn main() -> ExitCode {
+    let network_raw = std::env::var("SBO3L_ENS_NETWORK").unwrap_or_else(|_| "mainnet".to_string());
+    let network = match EnsNetwork::parse(&network_raw) {
+        Ok(n) => n,
+        Err(e) => {
+            eprintln!(
+                "ens_live_smoke: SBO3L_ENS_NETWORK={network_raw} invalid: {e}. \
+                 Use `mainnet` or `sepolia`."
+            );
+            return ExitCode::from(1);
+        }
+    };
+
+    let name = std::env::var("SBO3L_ENS_NAME").unwrap_or_else(|_| "sbo3lagent.eth".to_string());
+
+    let resolver = match LiveEnsResolver::from_env(network) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("ens_live_smoke: configuration error: {e}");
+            eprintln!(
+                "Required env: SBO3L_ENS_RPC_URL. Optional: SBO3L_ENS_NAME \
+                 (default: sbo3lagent.eth), SBO3L_ENS_NETWORK (default: mainnet)."
+            );
+            return ExitCode::from(1);
+        }
+    };
+
+    println!("ens_live_smoke: resolving {name} on {}", network.as_str());
+    match resolver.resolve(&name) {
+        Ok(records) => {
+            println!("  agent_id:    {}", records.agent_id);
+            println!("  endpoint:    {}", records.endpoint);
+            println!("  policy_hash: {}", records.policy_hash);
+            println!("  audit_root:  {}", records.audit_root);
+            println!("  proof_uri:   {}", records.proof_uri);
+            ExitCode::SUCCESS
+        }
+        Err(ResolveError::Io(e)) => {
+            eprintln!("ens_live_smoke: IO/RPC error: {e}");
+            ExitCode::from(1)
+        }
+        Err(ResolveError::UnknownName(n)) => {
+            eprintln!("ens_live_smoke: UnknownName: {n} has no resolver set");
+            ExitCode::from(2)
+        }
+        Err(ResolveError::MissingRecord(field, n)) => {
+            eprintln!("ens_live_smoke: MissingRecord: {n} has no sbo3l:{field} text record");
+            ExitCode::from(2)
+        }
+        Err(other) => {
+            eprintln!("ens_live_smoke: unexpected error: {other}");
+            ExitCode::from(2)
+        }
+    }
+}

--- a/crates/sbo3l-identity/src/ens.rs
+++ b/crates/sbo3l-identity/src/ens.rs
@@ -30,8 +30,14 @@ pub struct EnsRecords {
     pub policy_hash: String,
     #[serde(rename = "sbo3l:audit_root")]
     pub audit_root: String,
-    #[serde(rename = "sbo3l:receipt_schema")]
-    pub receipt_schema: String,
+    /// URL to the published proof capsule for this agent. Renamed
+    /// from `receipt_schema` to match the actually-deployed
+    /// `sbo3lagent.eth` text records on Ethereum mainnet (the
+    /// previous name pointed at a static JSON Schema; the new name
+    /// points at a specific deployed proof instance, which is the
+    /// useful thing for an agent registry).
+    #[serde(rename = "sbo3l:proof_uri")]
+    pub proof_uri: String,
 }
 
 impl EnsRecords {
@@ -88,7 +94,7 @@ mod tests {
                 "sbo3l:endpoint": "http://127.0.0.1:8730/v1",
                 "sbo3l:policy_hash": "e044f13c5acb792dd3109f1be3a98536168b0990e25595b3cedc131d02e666cf",
                 "sbo3l:audit_root": "0000000000000000000000000000000000000000000000000000000000000000",
-                "sbo3l:receipt_schema": "https://schemas.sbo3l.dev/policy-receipt/v1.json"
+                "sbo3l:proof_uri": "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/capsule.json"
             }
         }"#
     }

--- a/crates/sbo3l-identity/src/ens_live.rs
+++ b/crates/sbo3l-identity/src/ens_live.rs
@@ -7,7 +7,7 @@
 //!    when the name isn't registered or doesn't have a resolver set.
 //! 2. Call `Resolver.text(node, key)` for each of the five SBO3L
 //!    text-record keys (`sbo3l:agent_id`, `sbo3l:endpoint`,
-//!    `sbo3l:policy_hash`, `sbo3l:audit_root`, `sbo3l:receipt_schema`).
+//!    `sbo3l:policy_hash`, `sbo3l:audit_root`, `sbo3l:proof_uri`).
 //!    Any missing key surfaces as `MissingRecord`.
 //!
 //! ENS bounty rule "no hardcoded values": the *agent's* identity
@@ -50,7 +50,7 @@ pub const SBO3L_TEXT_KEYS: [&str; 5] = [
     "sbo3l:endpoint",
     "sbo3l:policy_hash",
     "sbo3l:audit_root",
-    "sbo3l:receipt_schema",
+    "sbo3l:proof_uri",
 ];
 
 /// Reasons a JSON-RPC call can fail. Surfaced through
@@ -229,7 +229,7 @@ impl<T: JsonRpcTransport> EnsResolver for LiveEnsResolver<T> {
             endpoint: values.remove("sbo3l:endpoint").unwrap_or_default(),
             policy_hash: values.remove("sbo3l:policy_hash").unwrap_or_default(),
             audit_root: values.remove("sbo3l:audit_root").unwrap_or_default(),
-            receipt_schema: values.remove("sbo3l:receipt_schema").unwrap_or_default(),
+            proof_uri: values.remove("sbo3l:proof_uri").unwrap_or_default(),
         })
     }
 }
@@ -243,7 +243,7 @@ fn static_key_label(key: &str) -> &'static str {
         "sbo3l:endpoint" => "endpoint",
         "sbo3l:policy_hash" => "policy_hash",
         "sbo3l:audit_root" => "audit_root",
-        "sbo3l:receipt_schema" => "receipt_schema",
+        "sbo3l:proof_uri" => "proof_uri",
         _ => "unknown",
     }
 }
@@ -480,8 +480,8 @@ mod tests {
                 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
             ),
             (
-                "sbo3l:receipt_schema",
-                "https://schemas.sbo3l.dev/policy-receipt/v1.json",
+                "sbo3l:proof_uri",
+                "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/capsule.json",
             ),
         ]
     }
@@ -516,7 +516,7 @@ mod tests {
         assert_eq!(recs.endpoint, expected[1].1);
         assert_eq!(recs.policy_hash, expected[2].1);
         assert_eq!(recs.audit_root, expected[3].1);
-        assert_eq!(recs.receipt_schema, expected[4].1);
+        assert_eq!(recs.proof_uri, expected[4].1);
     }
 
     #[test]

--- a/crates/sbo3l-identity/src/lib.rs
+++ b/crates/sbo3l-identity/src/lib.rs
@@ -7,7 +7,7 @@
 //! * `sbo3l:endpoint`
 //! * `sbo3l:policy_hash`
 //! * `sbo3l:audit_root`
-//! * `sbo3l:receipt_schema`
+//! * `sbo3l:proof_uri`
 //!
 //! The trait abstracts the resolution backend so a live testnet ENS lookup and
 //! an offline fixture can plug in interchangeably. The hackathon demo defaults

--- a/demo-fixtures/ens-records.json
+++ b/demo-fixtures/ens-records.json
@@ -4,6 +4,6 @@
     "sbo3l:endpoint": "http://127.0.0.1:8730/v1",
     "sbo3l:policy_hash": "e044f13c5acb792dd3109f1be3a98536168b0990e25595b3cedc131d02e666cf",
     "sbo3l:audit_root": "0000000000000000000000000000000000000000000000000000000000000000",
-    "sbo3l:receipt_schema": "https://schemas.sbo3l.dev/policy-receipt/v1.json"
+    "sbo3l:proof_uri": "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/capsule.json"
   }
 }

--- a/demo-fixtures/mock-ens-registry.json
+++ b/demo-fixtures/mock-ens-registry.json
@@ -9,21 +9,21 @@
       "sbo3l:endpoint": "http://127.0.0.1:8730/v1",
       "sbo3l:policy_hash": "e044f13c5acb792dd3109f1be3a98536168b0990e25595b3cedc131d02e666cf",
       "sbo3l:audit_root": "0000000000000000000000000000000000000000000000000000000000000000",
-      "sbo3l:receipt_schema": "https://schemas.sbo3l.dev/policy-receipt/v1.json"
+      "sbo3l:proof_uri": "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/capsule.json"
     },
     "trading-agent.team.eth": {
       "sbo3l:agent_id": "trading-agent-01",
       "sbo3l:endpoint": "http://127.0.0.1:8731/v1",
       "sbo3l:policy_hash": "1111111111111111111111111111111111111111111111111111111111111111",
       "sbo3l:audit_root": "0000000000000000000000000000000000000000000000000000000000000000",
-      "sbo3l:receipt_schema": "https://schemas.sbo3l.dev/policy-receipt/v1.json"
+      "sbo3l:proof_uri": "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/capsule.json"
     },
     "support-agent.team.eth": {
       "sbo3l:agent_id": "support-agent-01",
       "sbo3l:endpoint": "http://127.0.0.1:8732/v1",
       "sbo3l:policy_hash": "2222222222222222222222222222222222222222222222222222222222222222",
       "sbo3l:audit_root": "0000000000000000000000000000000000000000000000000000000000000000",
-      "sbo3l:receipt_schema": "https://schemas.sbo3l.dev/policy-receipt/v1.json"
+      "sbo3l:proof_uri": "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/capsule.json"
     }
   }
 }


### PR DESCRIPTION
## Summary

Re-opening Dev B's polish PR — original #70 was auto-closed when its base branch (`feat/b3-live-ens-resolver`) was deleted on #69 squash-merge. This is the same single commit (`9c6b8af`) on top of new main.

Two changes:

1. **Rename `sbo3l:receipt_schema` → `sbo3l:proof_uri`** in `LiveEnsResolver`, fixtures, and supporting docs. Aligns with what Daniel actually set on `sbo3lagent.eth` mainnet text records (the canonical record name).
2. **Add `ens_live_smoke.rs` example** in `crates/sbo3l-identity/examples/` — operator-supplied `SBO3L_ENS_RPC_URL` smoke test against any live ENS name. Demo recording uses this against `sbo3lagent.eth` to show end-to-end live resolution.

## Files changed (6, +103/-15)

- `crates/sbo3l-identity/examples/ens_live_smoke.rs` (new)
- `crates/sbo3l-identity/src/ens.rs`, `ens_live.rs`, `lib.rs` — rename
- `demo-fixtures/ens-records.json`, `mock-ens-registry.json` — fixture rename

## Daniel-side context

Live ENS state on mainnet (verified):
- `sbo3lagent.eth` owned by `0xdc7EFA6b4Bd77d1a406DE4727F0DF567e597D231`
- 5 text records set: `sbo3l:agent_id`, `sbo3l:endpoint`, `sbo3l:policy_hash` (placeholder), `sbo3l:audit_root` (placeholder), `sbo3l:proof_uri`
- The `proof_uri` record value: `https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/capsule.json`

Smoke test command for the demo:
```bash
export SBO3L_ENS_RPC_URL="https://eth-mainnet.g.alchemy.com/v2/<ALCHEMY_KEY>"
cargo run -p sbo3l-identity --example ens_live_smoke -- sbo3lagent.eth
```

## Test plan

- [x] CI passes (Rust + JSON schemas)
- [x] Fixture validators clean
- [x] Smoke example compiles + offline tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)