### PR TITLE
feat(B3): EnsRecords compares hashes 0x-prefix + case tolerantly

### DIFF
--- a/crates/sbo3l-identity/src/ens.rs
+++ b/crates/sbo3l-identity/src/ens.rs
@@ -13,6 +13,8 @@ pub enum ResolveError {
     MissingRecord(&'static str, String),
     #[error("policy_hash on ENS does not match active policy ({ens} vs {active})")]
     PolicyHashMismatch { ens: String, active: String },
+    #[error("audit_root on ENS does not match active root ({ens} vs {active})")]
+    AuditRootMismatch { ens: String, active: String },
     #[error(transparent)]
     Io(#[from] std::io::Error),
     #[error(transparent)]
@@ -34,11 +36,35 @@ pub struct EnsRecords {
     pub receipt_schema: String,
 }
 
+/// Strip an optional `0x` / `0X` prefix. Hex records on ENS
+/// idiomatically carry the prefix; SBO3L's internal hash format
+/// does not. Comparisons accept either form.
+fn strip_0x(s: &str) -> &str {
+    s.strip_prefix("0x")
+        .or_else(|| s.strip_prefix("0X"))
+        .unwrap_or(s)
+}
+
 impl EnsRecords {
+    /// Compare ENS-published policy hash against SBO3L's active hash.
+    /// Either side may carry a `0x` prefix; comparison is
+    /// prefix-tolerant and case-insensitive (hex `a` == `A`).
     pub fn verify_policy_hash(&self, active: &str) -> Result<(), ResolveError> {
-        if self.policy_hash != active {
+        if !strip_0x(&self.policy_hash).eq_ignore_ascii_case(strip_0x(active)) {
             return Err(ResolveError::PolicyHashMismatch {
                 ens: self.policy_hash.clone(),
+                active: active.to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Compare ENS-published audit root against SBO3L's active root.
+    /// Same prefix/case tolerance as [`Self::verify_policy_hash`].
+    pub fn verify_audit_root(&self, active: &str) -> Result<(), ResolveError> {
+        if !strip_0x(&self.audit_root).eq_ignore_ascii_case(strip_0x(active)) {
+            return Err(ResolveError::AuditRootMismatch {
+                ens: self.audit_root.clone(),
                 active: active.to_string(),
             });
         }
@@ -116,5 +142,39 @@ mod tests {
         assert!(rec.verify_policy_hash(&rec.policy_hash).is_ok());
         let err = rec.verify_policy_hash("deadbeef").unwrap_err();
         assert!(matches!(err, ResolveError::PolicyHashMismatch { .. }));
+    }
+
+    /// Hex records on ENS idiomatically carry a `0x` prefix; SBO3L's
+    /// internal hashes do not. Both `verify_policy_hash` and
+    /// `verify_audit_root` accept either form on either side, plus
+    /// case-insensitive hex.
+    #[test]
+    fn verify_methods_normalize_0x_prefix_and_case() {
+        let r = OfflineEnsResolver::from_json(fixture()).unwrap();
+        let mut rec = r.resolve("research-agent.team.eth").unwrap();
+        let bare_policy = rec.policy_hash.clone();
+        let prefixed_policy = format!("0x{}", bare_policy);
+        let upper_policy = bare_policy.to_uppercase();
+
+        // ens=bare, active=0x-prefixed → match
+        assert!(rec.verify_policy_hash(&prefixed_policy).is_ok());
+        // ens=0x-prefixed, active=bare → match
+        rec.policy_hash = prefixed_policy.clone();
+        assert!(rec.verify_policy_hash(&bare_policy).is_ok());
+        // case-insensitive
+        assert!(rec.verify_policy_hash(&upper_policy).is_ok());
+        // mismatch still fails (with `0x` on the wrong value)
+        let err = rec.verify_policy_hash("0xdeadbeef").unwrap_err();
+        assert!(matches!(err, ResolveError::PolicyHashMismatch { .. }));
+
+        // Same checks for audit_root, including the
+        // sbo3lagent.eth-shaped value `0x000…000` (66 chars).
+        let bare_root = rec.audit_root.clone();
+        let prefixed_root = format!("0x{}", bare_root);
+        rec.audit_root = prefixed_root.clone();
+        assert!(rec.verify_audit_root(&bare_root).is_ok());
+        assert!(rec.verify_audit_root(&prefixed_root).is_ok());
+        let err = rec.verify_audit_root("ffff").unwrap_err();
+        assert!(matches!(err, ResolveError::AuditRootMismatch { .. }));
     }
 }


### PR DESCRIPTION
## What

Tiny surgical fix on `EnsRecords` so the `policy_hash` / `audit_root` comparators tolerate a `0x` prefix on either side and case-insensitive hex. Unblocks the `sbo3lagent.eth` mainnet recording without forcing chain-side edits.

**Branched off `main` (not stacked on #71)** per your sequencing — neither blocks the other.

## Why

`sbo3lagent.eth` currently stores `policy_hash` and `audit_root` as the 66-char STRING `"0x" + 64 hex`, while SBO3L's internal hash format is the bare 64-char hex. The pre-existing `verify_policy_hash` did a literal `==` compare → false `PolicyHashMismatch`. This fix makes the comparators idempotent on the prefix.

## Diff

1 file, +61/-1 LoC (the bulk is the test).

- Private `strip_0x(&str) -> &str` helper.
- `verify_policy_hash` now compares with `strip_0x(...).eq_ignore_ascii_case(strip_0x(...))`.
- New `verify_audit_root` parallel method.
- New `ResolveError::AuditRootMismatch` variant to match the existing `PolicyHashMismatch`.

## Test (1, consolidated)

`verify_methods_normalize_0x_prefix_and_case` — exercises:
- `ens=bare, active=0x-prefixed` → match
- `ens=0x-prefixed, active=bare` → match
- Case-insensitive (lower vs upper hex)
- Mismatch still fails (PolicyHashMismatch)
- Same path verified for `audit_root` (AuditRootMismatch on mismatch)

## Verification

- `cargo test -p sbo3l-identity`: **29/29** (was 28, +1)
- `cargo test --workspace --all-targets`: **371/371** (was 370, +1)
- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean

## Coordination with #71

Touches different parts of the same file (`crates/sbo3l-identity/src/ens.rs`):
- **#71**: renames `receipt_schema` → `proof_uri` (struct field + serde rename + lib.rs doc + test fixture line).
- **This PR**: adds `verify_audit_root` + `strip_0x` + `AuditRootMismatch` + the new test.

No semantic conflict — both can merge in either order. Whichever lands second will get a small text-only rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)