### PR TITLE
chore: P0a truthfulness cleanup — URL allowlist + passport verify wording

### DIFF
--- a/demo-fixtures/test_fixtures.py
+++ b/demo-fixtures/test_fixtures.py
@@ -53,16 +53,28 @@ HERE = Path(__file__).resolve().parent
 #
 #   - exact hosts:
 #       127.0.0.1, localhost, schemas.sbo3l.dev,
+#       b2jk-industry.github.io,
 #       example.com, example.net, example.org
 #   - safe suffixes (RFC 2606 / 6761 reserved + RFC 2606 §3 docs):
 #       .invalid, .example, .test, .localhost,
 #       .example.com, .example.net, .example.org
 #     The leading dot is required so "evilexample" does NOT end with
 #     ".example" and "evilexample.com" does NOT end with ".example.com".
+#
+# `b2jk-industry.github.io` is the canonical public GitHub Pages host
+# for SBO3L's static proof site (deployed from `main` by
+# `.github/workflows/pages.yml`). ENS fixtures publish a
+# `sbo3l:proof_uri` pointing at `https://b2jk-industry.github.io/SBO3L-…/capsule.json`,
+# which flows into the runtime Passport capsule and from there into
+# any fixture / artefact a URL scanner traverses. Listed as an EXACT
+# host (not a suffix) so `evil.b2jk-industry.github.io.attacker.com`
+# is still rejected by the same infix-bypass guard the comment block
+# above describes for `schemas.sbo3l.dev`.
 SAFE_HOSTS_EXACT = frozenset({
     "127.0.0.1",
     "localhost",
     "schemas.sbo3l.dev",
+    "b2jk-industry.github.io",
     "example.com",
     "example.net",
     "example.org",

--- a/demo-scripts/sponsors/uniswap-guarded-swap.sh
+++ b/demo-scripts/sponsors/uniswap-guarded-swap.sh
@@ -125,9 +125,14 @@ mkdir -p "$ARTIFACTS"
       fields: quote_id, quote_source, input/output token, route,
       notional_in, slippage_cap_bps, quote_timestamp_unix,
       quote_freshness_seconds, recipient_address);
-    - `sbo3l passport verify --path <capsule>` re-derives every
-      claim from the capsule alone using only the agent's published
-      Ed25519 pubkey (read off the receipt's signature.key_id).
+    - `sbo3l passport verify --path <capsule>` re-verifies the schema
+      and every cross-field invariant offline by default
+      (deny→no execution, live→evidence, request/policy hash
+      internal-consistency); to additionally re-derive cryptography
+      from the capsule alone, pass `--strict --policy <file>
+      --receipt-pubkey <hex> --audit-bundle <file>`. Both modes work
+      with the agent's published Ed25519 pubkey only — no daemon, no
+      network, no RPC.
 
   Offline. Post-hoc. Single file. That's the SBO3L story.
 EOF

--- a/operator-console/test_build.py
+++ b/operator-console/test_build.py
@@ -55,6 +55,12 @@ SAFE_HOSTS_EXACT = frozenset({
     "127.0.0.1",
     "localhost",
     "schemas.sbo3l.dev",
+    # Canonical public GitHub Pages host for SBO3L's static proof
+    # site. ENS fixtures publish `sbo3l:proof_uri` here, which flows
+    # into the runtime Passport capsule the operator-console renders.
+    # Listed as EXACT host (not suffix) so a `*.attacker.com`
+    # infix-bypass on this label is still rejected.
+    "b2jk-industry.github.io",
     "example.com",
     "example.net",
     "example.org",

--- a/site/index.html
+++ b/site/index.html
@@ -71,7 +71,7 @@ footer a:hover{text-decoration:underline}
 
 <li>
 <a href="capsule.json">SBO3L Passport capsule — <code>sbo3l.passport_capsule.v1</code></a>
-<div class="desc">A self-contained, offline-verifiable proof artefact for one Allow decision. Schema + structural verifier shipped in PR #42; the passport CLI MVP shipped in PR #44. Download this file and run <code>sbo3l passport verify --path capsule.json</code> from a fresh clone — every signature, hash, and link should re-derive without any daemon.</div>
+<div class="desc">A self-contained, offline-verifiable proof artefact for one Allow decision. Schema + structural verifier shipped in PR #42; the passport CLI MVP shipped in PR #44. Download this file and run <code>sbo3l passport verify --path capsule.json</code> from a fresh clone — the schema and every cross-field invariant (deny→no execution, live→evidence, request/policy hash internal-consistency) re-verifies offline; pass <code>--strict</code> with <code>--policy</code> / <code>--receipt-pubkey</code> / <code>--audit-bundle</code> to additionally re-derive cryptography from the capsule alone.</div>
 </li>
 
 </ul>

--- a/trust-badge/test_build.py
+++ b/trust-badge/test_build.py
@@ -53,6 +53,13 @@ SAFE_HOSTS_EXACT = frozenset({
     "127.0.0.1",
     "localhost",
     "schemas.sbo3l.dev",
+    # Canonical public GitHub Pages host for SBO3L's static proof
+    # site. ENS fixtures publish `sbo3l:proof_uri` here; if the
+    # trust-badge renderer ever surfaces that URL into the rendered
+    # HTML, the URL-scan stays clean. Kept consistent with the same
+    # constant in `demo-fixtures/test_fixtures.py` +
+    # `operator-console/test_build.py`.
+    "b2jk-industry.github.io",
     "example.com",
     "example.net",
     "example.org",


### PR DESCRIPTION
## Summary

- Add `b2jk-industry.github.io` to URL allowlists in three stdlib regression tests
  (`demo-fixtures/test_fixtures.py`, `operator-console/test_build.py`,
  `trust-badge/test_build.py`) so they pass after PR #75 introduced the live Pages URL
  into ENS fixtures. Listed as EXACT host (not suffix) — infix-bypass guard preserved.
- Reword Passport verify copy in `site/index.html` + `demo-scripts/sponsors/uniswap-guarded-swap.sh`
  to match shipped behaviour: structural+invariants by default, `--strict` opt-in for
  crypto re-derive (with `--policy` / `--receipt-pubkey` / `--audit-bundle`).

## Why now

QA agent flagged both as security-judge risk:

1. **Allowlist drift (silent fail).** `.github/workflows/ci.yml` stops at the
   trust-badge test, so the demo-fixtures + operator-console regressions don't
   show up as red on `main`. Locally, after the production-shaped runner emits the
   runtime Passport capsules (which carry the `sbo3l:proof_uri` from the ENS
   fixture), both tests fail with `unsafe URL(s) in fixture`. Adding the host as
   an exact (not suffix) entry passes the URL scan and keeps the existing
   infix-bypass guard the comment block above the constant describes.
2. **Marketing copy overstates default verifier scope vs `SECURITY_NOTES.md:22`.**
   `crates/sbo3l-cli/src/main.rs:129` documents `passport verify` as
   **structural-only** by default; crypto re-derive is opt-in via `--strict`.
   Public Pages copy + sponsor demo claimed "every signature, hash, and link
   re-derives without any daemon" / "every claim from the capsule alone" — both
   read as crypto re-derive guarantees. Reworded to honestly distinguish the two
   modes and name the `--strict` upgrade path verbatim.

## Test plan

- [x] `python3 demo-fixtures/test_fixtures.py` → `PASS: all 4 mock fixture(s) clean + url self-test`
- [x] `python3 operator-console/test_build.py` → `PASS: 118 checks ok`
- [x] `python3 trust-badge/test_build.py` → `PASS: 49 checks ok`
- [x] `bash demo-scripts/run-openagents-final.sh` → 13/13 gates green, transcript written
- [x] `bash demo-scripts/run-production-shaped-mock.sh` → `Tally: 26 real, 0 mock, 1 skipped`
- [x] `bash demo-scripts/sponsors/uniswap-guarded-swap.sh` → new `--strict` wording renders verbatim; `python3 demo-scripts/sponsors/test_demo_uniswap_evidence.py` still 6/6
- [x] `cargo test --workspace` → unchanged (no Rust touched in this PR)

## Diff

5 files, +34/-4 LoC.

| File | Change |
| --- | --- |
| `demo-fixtures/test_fixtures.py` | +12 / -0 — add `b2jk-industry.github.io` to `SAFE_HOSTS_EXACT`; expand comment block above the constant with the rationale |
| `operator-console/test_build.py` | +6 / -0 — same exact-host addition with inline comment |
| `trust-badge/test_build.py` | +7 / -0 — same exact-host addition (3rd allowlist spot found via `grep -rn 'schemas.sbo3l.dev' --include='*.py' .`); kept consistent even though this test currently passes (its URL scan is rendered-HTML-scoped, not capsule-content-scoped) |
| `site/index.html` | +1 / -1 — reword Passport-capsule `<div class="desc">`; HTML structure unchanged, no new tag/section |
| `demo-scripts/sponsors/uniswap-guarded-swap.sh` | +8 / -3 — reword the `passport verify` bullet in the differentiator framing block; same indent/cap |

## Out of scope (Dev B parallel scope per brief NON-GOALS)

- `IMPLEMENTATION_STATUS.md` HEAD / open-PR refresh
- `SUBMISSION_FORM_DRAFT.md` L117 / L183 live-shipped truth fix
- `README` / `FEEDBACK` / `CHANGELOG` edits
- CI workflow change to add the Python tests (follow-up PR scope)