### PR TITLE
feat: Vercel-deployable starter marketing site at apps/marketing/

### DIFF
--- a/apps/marketing/README.md
+++ b/apps/marketing/README.md
@@ -1,0 +1,50 @@
+# SBO3L Marketing Site (Starter)
+
+Static landing page for `sbo3l.dev` (or any host). Plain HTML + CSS, no JS, no external CDNs, no fetch.
+
+## Local preview
+
+```bash
+# Any static server. Examples:
+python3 -m http.server -d apps/marketing 8080
+# or
+npx serve apps/marketing
+```
+
+Open `http://localhost:8080`.
+
+## Deploy on Vercel
+
+This repo's root `vercel.json` configures Vercel to serve `apps/marketing/` as the static output directory. After connecting the repo:
+
+1. Vercel auto-detects on push to `main`
+2. Production deploy → assigned `*.vercel.app` URL
+3. Custom domain (`sbo3l.dev`) added in Vercel dashboard → DNS A record → done
+
+## Roadmap
+
+This is the starter Eve replaces in Phase 2 ticket **CTI-3-2** with a full Astro/Next.js marketing site (richer features, blog, case studies, animations). See `docs/win-backlog/06-phase-2.md#cti-3-2`.
+
+## Files
+
+- `index.html` — single-page landing
+- `style.css` — handcrafted CSS (no Tailwind, no preprocessor)
+- `vercel.json` — security headers + cache rules
+- `README.md` — this file
+
+## Security headers
+
+Set via `vercel.json`:
+- `Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'` — no external resources
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `Permissions-Policy: camera=(), microphone=(), geolocation=()`
+
+## What this page is NOT
+
+- Not the proof page (redirects to `/proof` → GitHub Pages capsule download)
+- Not the docs site (CTI-3-3, deploys at `docs.sbo3l.dev`)
+- Not the hosted app (CTI-3-4, deploys at `app.sbo3l.dev`)
+
+This page is the front door at `sbo3l.dev` — pitch + numbers + evidence + links.

--- a/apps/marketing/index.html
+++ b/apps/marketing/index.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>SBO3L — Don't give your agent a wallet. Give it a mandate.</title>
+<meta name="description" content="SBO3L is the cryptographically verifiable trust layer for autonomous AI agents. Policy + budget + signed receipts + audit chain + offline-verifiable Passport capsule.">
+<meta property="og:title" content="SBO3L — Agent Trust Layer">
+<meta property="og:description" content="Don't give your agent a wallet. Give it a mandate.">
+<meta property="og:type" content="website">
+<link rel="stylesheet" href="/style.css">
+</head>
+<body>
+
+<header>
+  <nav>
+    <a href="/" class="brand">SBO3L</a>
+    <div class="links">
+      <a href="https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026">GitHub</a>
+      <a href="/proof">Proof</a>
+      <a href="https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/QUICKSTART.md">Quickstart</a>
+    </div>
+  </nav>
+</header>
+
+<section class="hero">
+  <h1>Don't give your agent a wallet.<br>Give it a mandate.</h1>
+  <p class="lede">SBO3L is the cryptographically verifiable <strong>trust layer</strong> for autonomous AI agents. Every action your agent takes — pay, swap, store, compute, coordinate — passes through SBO3L's policy boundary first. Output: a self-contained Passport capsule anyone can verify offline.</p>
+  <div class="cta">
+    <a class="btn primary" href="https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/QUICKSTART.md">Start in 5 minutes</a>
+    <a class="btn ghost" href="https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026">View source</a>
+  </div>
+</section>
+
+<section class="numbers">
+  <div class="number"><strong>377/377</strong> tests passing</div>
+  <div class="number"><strong>13/13</strong> demo gates green</div>
+  <div class="number"><strong>8/8</strong> adversarial inputs fail-closed</div>
+  <div class="number"><strong>3 sponsor live paths</strong> verified end-to-end</div>
+</section>
+
+<section class="panel">
+  <h2>What SBO3L is</h2>
+  <p>A Rust workspace implementing a local <strong>policy + budget + receipt + audit firewall</strong> for AI agents. Every <code>POST /v1/payment-requests</code> goes through:</p>
+  <ol>
+    <li>Schema validation (<code>serde(deny_unknown_fields)</code>)</li>
+    <li>JCS-canonical request hashing</li>
+    <li>APRP nonce-replay gate (HTTP 409 on reuse)</li>
+    <li>Deterministic policy decision</li>
+    <li>Multi-scope budget commit</li>
+    <li>Hash-chained audit append</li>
+    <li>Ed25519-signed PolicyReceipt back to agent</li>
+  </ol>
+  <p>Allow → routes to sponsor executor (KeeperHub, Uniswap). Deny → executor never called. Every decision can be wrapped in a Passport capsule that anyone can verify offline against the agent's published Ed25519 pubkey alone.</p>
+</section>
+
+<section class="panel">
+  <h2>What SBO3L blocks</h2>
+  <p>Every input below is rejected fail-closed by the daemon, with the exact error code SBO3L returns:</p>
+  <ul class="blocks">
+    <li><strong>Empty body</strong> → <code>HTTP 400</code> + <code>schema.missing_field</code></li>
+    <li><strong>Unknown field</strong> → <code>HTTP 400</code> + <code>schema.unknown_field</code></li>
+    <li><strong>Reused APRP nonce</strong> → <code>HTTP 409</code> + <code>protocol.nonce_replay</code></li>
+    <li><strong>Prompt-injection request</strong> → <code>HTTP 200</code> + <code>decision=deny</code> + <code>policy.deny_unknown_provider</code></li>
+    <li><strong>Oversized payload (~100 KB)</strong> → <code>HTTP 400</code> rejected before pipeline</li>
+    <li><strong>Same Idempotency-Key, different body</strong> → <code>HTTP 409</code> + <code>protocol.idempotency_conflict</code></li>
+    <li><strong>Audit-chain byte-flip</strong> → strict-hash verifier rejects (<code>rc=1</code>)</li>
+    <li><strong>Capsule with mismatched <code>request_hash</code></strong> → <code>capsule.request_hash_mismatch</code> (<code>rc=2</code>)</li>
+    <li><strong>Capsule claiming live mode without evidence</strong> → <code>capsule.live_mode_empty_evidence</code></li>
+    <li><strong>Capsule claiming deny but carrying <code>execution_ref</code></strong> → <code>capsule.deny_with_execution_ref</code></li>
+    <li><strong>9 tampered passport fixtures</strong> → all reject with <code>rc=2</code></li>
+  </ul>
+</section>
+
+<section class="panel">
+  <h2>Live integration evidence (2026-04-30)</h2>
+  <p>Real outputs from running the corresponding live smoke against real infrastructure during the submission window. Independently re-verifiable by anyone with public RPC access.</p>
+
+  <h3>ENS mainnet — <code>sbo3lagent.eth</code></h3>
+<pre><code>agent_id:    research-agent-01
+endpoint:    http://127.0.0.1:8730/v1
+policy_hash: e044f13c5acb792dd3109f1be3a98536168b0990e25595b3cedc131d02e666cf  ← matches offline fixture exactly
+audit_root:  0x0000000000000000000000000000000000000000000000000000000000000000  ← canonical genesis
+proof_uri:   https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/capsule.json</code></pre>
+
+  <h3>Uniswap Sepolia QuoterV2 — <code>0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3</code></h3>
+<pre><code>quote_source:            uniswap-v3-quoter-sepolia-0xed1f6473345f45b75f8179591dd5ba1888cf2fb3
+route_tokens:            [WETH 0xfff9…, USDC 0x1c7D4B19…]
+quote_timestamp_unix:    1777572056
+sqrt_price_x96_after:    863470429016487749123863152837655
+quote_freshness_seconds: 30</code></pre>
+
+  <h3>KeeperHub workflow — <code>m4t4cnpmhv8qquce3bv3c</code></h3>
+<pre><code>sponsor:        keeperhub
+mock:           false
+execution_ref:  kh-172o77rxov7mhwvpssc3x   ← KH-issued executionId, not a ULID</code></pre>
+</section>
+
+<section class="panel">
+  <h2>Reproduce yourself</h2>
+  <p>Every claim above is reproducible from a fresh clone. Public RPCs work — no API keys required for read paths.</p>
+<pre><code>git clone https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026
+cd SBO3L-ethglobal-openagents-2026
+
+# Full vertical demo (13 gates, ~10 seconds)
+bash demo-scripts/run-openagents-final.sh
+
+# Production-shaped runner (26 real / 0 mock / 1 skipped)
+bash demo-scripts/run-production-shaped-mock.sh
+
+# Live ENS smoke (mainnet)
+SBO3L_ENS_RPC_URL=https://ethereum-rpc.publicnode.com \
+  cargo run -p sbo3l-identity --example ens_live_smoke
+
+# Live Uniswap Sepolia smoke
+SBO3L_UNISWAP_RPC_URL=https://ethereum-sepolia-rpc.publicnode.com \
+SBO3L_UNISWAP_TOKEN_OUT=0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238 \
+  cargo run -p sbo3l-execution --example uniswap_live_smoke</code></pre>
+</section>
+
+<section class="panel">
+  <h2>Architecture</h2>
+  <p>The agent never holds a key. SBO3L decides, signs, audits, and routes — in that order. Deny blocks every downstream sponsor call.</p>
+  <svg viewBox="0 0 800 360" class="arch-diagram" role="img" aria-label="SBO3L architecture sequence: agent posts APRP, SBO3L decides + signs + audits, routes to sponsor only on allow">
+    <!-- simplified architecture sequence -->
+    <defs>
+      <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+      </marker>
+    </defs>
+    <rect x="20" y="40" width="160" height="280" rx="10" stroke="currentColor" fill="none" stroke-width="2"/>
+    <text x="100" y="65" text-anchor="middle" font-weight="700">Agent</text>
+    <text x="100" y="85" text-anchor="middle" font-size="12" opacity="0.7">(no signing key)</text>
+    <rect x="320" y="40" width="160" height="280" rx="10" stroke="currentColor" fill="none" stroke-width="2"/>
+    <text x="400" y="65" text-anchor="middle" font-weight="700">SBO3L</text>
+    <text x="400" y="85" text-anchor="middle" font-size="11" opacity="0.7">schema · policy · budget</text>
+    <text x="400" y="100" text-anchor="middle" font-size="11" opacity="0.7">audit · sign</text>
+    <rect x="620" y="40" width="160" height="280" rx="10" stroke="currentColor" fill="none" stroke-width="2"/>
+    <text x="700" y="65" text-anchor="middle" font-weight="700">Sponsor</text>
+    <text x="700" y="85" text-anchor="middle" font-size="12" opacity="0.7">KH · Uniswap · ENS</text>
+    <line x1="180" y1="160" x2="320" y2="160" stroke="currentColor" stroke-width="2" marker-end="url(#arrow)"/>
+    <text x="250" y="150" text-anchor="middle" font-size="11">APRP intent</text>
+    <line x1="480" y1="200" x2="620" y2="200" stroke="currentColor" stroke-width="2" stroke-dasharray="5,5" marker-end="url(#arrow)"/>
+    <text x="550" y="190" text-anchor="middle" font-size="11">if allow</text>
+    <line x1="320" y1="240" x2="180" y2="240" stroke="currentColor" stroke-width="2" marker-end="url(#arrow)"/>
+    <text x="250" y="230" text-anchor="middle" font-size="11">signed receipt</text>
+  </svg>
+</section>
+
+<section class="panel">
+  <h2>Resources</h2>
+  <ul>
+    <li><a href="https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/QUICKSTART.md">Quickstart — daemon + curl in 5 minutes</a></li>
+    <li><a href="https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/README.md">README — full architecture + status</a></li>
+    <li><a href="https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/IMPLEMENTATION_STATUS.md">Implementation Status — what's shipped</a></li>
+    <li><a href="https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/SECURITY_NOTES.md">Security Notes — production deployment limits</a></li>
+    <li><a href="https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/tree/main/docs/win-backlog">Win Backlog — 100-day attack plan</a></li>
+    <li><a href="https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/">Public proof page (GitHub Pages, current)</a></li>
+  </ul>
+</section>
+
+<footer>
+  <p>SBO3L · ETHGlobal Open Agents 2026 submission · <a href="https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026">B2JK-Industry/SBO3L-ethglobal-openagents-2026</a></p>
+  <p>This is a starter landing page. The proper marketing site (CTI-3-2 in the win backlog) replaces this in Phase 2.</p>
+</footer>
+
+</body>
+</html>

--- a/apps/marketing/style.css
+++ b/apps/marketing/style.css
@@ -1,0 +1,64 @@
+:root {
+  --bg: #0a0a0f;
+  --fg: #e6e6ec;
+  --muted: #9999a8;
+  --accent: #4ad6a7;
+  --code-bg: #14141c;
+  --border: #2a2a3a;
+  --max: 920px;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; line-height: 1.55; }
+body { background: var(--bg); color: var(--fg); font-size: 16px; }
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+code { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 0.92em; background: var(--code-bg); padding: 0.1em 0.35em; border-radius: 4px; }
+pre { background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px; padding: 1.1em; overflow-x: auto; margin: 1em 0; line-height: 1.4; }
+pre code { background: none; padding: 0; font-size: 0.85em; }
+
+header { border-bottom: 1px solid var(--border); padding: 1em 1.5em; }
+nav { max-width: var(--max); margin: 0 auto; display: flex; justify-content: space-between; align-items: center; gap: 2em; flex-wrap: wrap; }
+.brand { font-weight: 700; font-size: 1.2em; color: var(--fg); }
+.brand:hover { text-decoration: none; color: var(--accent); }
+.links { display: flex; gap: 1.6em; flex-wrap: wrap; }
+
+.hero { max-width: var(--max); margin: 4em auto 3em; padding: 0 1.5em; }
+.hero h1 { font-size: clamp(1.8em, 4vw, 2.6em); font-weight: 700; line-height: 1.2; margin-bottom: 0.7em; }
+.hero .lede { font-size: 1.15em; color: var(--muted); margin-bottom: 1.5em; max-width: 700px; }
+.hero strong { color: var(--fg); }
+.cta { display: flex; gap: 1em; flex-wrap: wrap; }
+
+.btn { display: inline-block; padding: 0.7em 1.4em; border-radius: 6px; font-weight: 600; transition: all 0.15s; }
+.btn.primary { background: var(--accent); color: var(--bg); }
+.btn.primary:hover { opacity: 0.9; text-decoration: none; }
+.btn.ghost { border: 1px solid var(--border); color: var(--fg); }
+.btn.ghost:hover { border-color: var(--accent); color: var(--accent); text-decoration: none; }
+
+.numbers { max-width: var(--max); margin: 2em auto; padding: 1.5em; display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1.5em; border: 1px solid var(--border); border-radius: 12px; }
+.number { text-align: center; color: var(--muted); }
+.number strong { display: block; font-size: 1.6em; color: var(--accent); margin-bottom: 0.2em; font-weight: 700; }
+
+section.panel { max-width: var(--max); margin: 3em auto; padding: 0 1.5em; }
+section.panel h2 { font-size: 1.7em; margin-bottom: 0.7em; font-weight: 700; }
+section.panel h3 { font-size: 1.1em; margin: 1.4em 0 0.5em; font-weight: 600; }
+section.panel p { color: var(--muted); margin-bottom: 1em; }
+section.panel p strong { color: var(--fg); }
+section.panel ol, section.panel ul { color: var(--muted); padding-left: 1.5em; margin-bottom: 1em; }
+section.panel ol li, section.panel ul li { margin-bottom: 0.4em; }
+section.panel ul.blocks li { list-style: none; padding-left: 0; }
+section.panel ul.blocks li::before { content: "✓ "; color: var(--accent); font-weight: 700; }
+
+.arch-diagram { width: 100%; height: auto; color: var(--fg); margin: 1em 0; }
+
+footer { border-top: 1px solid var(--border); padding: 2em 1.5em; margin-top: 4em; text-align: center; color: var(--muted); font-size: 0.92em; }
+footer p { margin-bottom: 0.6em; }
+
+@media (max-width: 640px) {
+  .hero { margin: 2.5em auto 2em; }
+  nav { gap: 1em; }
+  .links { gap: 1em; font-size: 0.95em; }
+}

--- a/apps/marketing/vercel.json
+++ b/apps/marketing/vercel.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "cleanUrls": true,
+  "trailingSlash": false,
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'" }
+      ]
+    },
+    {
+      "source": "/(.*)\\.(css|js|svg|png|jpg|jpeg|woff|woff2)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    }
+  ],
+  "redirects": [
+    {
+      "source": "/proof",
+      "destination": "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/",
+      "permanent": false
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": null,
+  "installCommand": null,
+  "outputDirectory": "apps/marketing"
+}


### PR DESCRIPTION
Static HTML + CSS landing page deployable to Vercel as placeholder for `sbo3l.dev` until Eve ships full Astro/Next.js marketing site in Phase 2 ticket CTI-3-2.

## Content
- Hero: tagline + one-line positioning + 2 CTA buttons
- Numbers: 377/377 tests, 13/13 demo gates, 8/8 adversarial fail-closed, 3 sponsor live paths
- What SBO3L is: pipeline explanation
- What SBO3L blocks: 11-row adversarial fail-closed list
- Live evidence (2026-04-30): ENS mainnet + Uniswap Sepolia + KH workflow real outputs
- Reproduce yourself: 4 paste-able commands
- Architecture diagram (inline SVG, no JS)
- Resources panel: links to QUICKSTART, README, IMPLEMENTATION_STATUS, SECURITY_NOTES, win-backlog, GitHub Pages capsule

## Security
- No external CDNs (enforced via CSP header)
- No JavaScript
- No fetch/XHR
- Static-first, deterministic
- Lighthouse perf > 95 expected

## Deploy
1. Daniel connects repo to Vercel
2. Vercel auto-detects `vercel.json` → serves `apps/marketing/`
3. Add custom domain `sbo3l.dev` (when bought via CTI-3-1)
4. Auto-deploy on push to main

## Replaced by
Phase 2 ticket CTI-3-2 (Eve builds full marketing site). This starter is enough to claim the domain + have something live during Phase 1.

5 files added, +318 LoC. Pure docs/static, no Rust touched.