### PR TITLE
chore: add .vercelignore (fixes ENOENT on target/) + .vercel to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ __pycache__/
 *.log
 _site/
 .claude/
+.vercel

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,69 @@
+# Rust build artifacts (huge, breaks Vercel uploads)
+target/
+**/target/
+
+# Node modules (any from SDKs, examples, integrations)
+node_modules/
+**/node_modules/
+
+# Python venvs and caches
+__pycache__/
+**/__pycache__/
+*.pyc
+.venv/
+**/.venv/
+.pytest_cache/
+**/.pytest_cache/
+
+# Build outputs (any frontend/SDK builds)
+dist/
+**/dist/
+build/
+**/build/
+.next/
+.astro/
+.svelte-kit/
+
+# Local databases
+*.db
+*.db-journal
+*.db-wal
+*.db-shm
+
+# Environment + secrets
+.env
+.env.*
+!.env.example
+
+# IDE / OS noise
+.idea/
+.vscode/
+*.swp
+.DS_Store
+
+# Everything else NOT in apps/marketing/ — we only deploy the static site
+# (Vercel still respects vercel.json's outputDirectory, but uploaded set
+#  should be minimal. apps/marketing/ + vercel.json + .vercelignore is enough.)
+crates/
+demo-agents/
+demo-fixtures/
+demo-scripts/
+docs/
+fuzz/
+operator-console/
+schemas/
+scripts/
+sdks/
+site/
+test-corpus/
+trust-badge/
+*.md
+LICENSE
+Cargo.toml
+Cargo.lock
+rust-toolchain.toml
+.github/
+
+# Don't ignore vercel.json or apps/marketing/
+!vercel.json
+!apps/marketing/**


### PR DESCRIPTION
Fixes Vercel deploy: first attempt blew up trying to upload target/debug/deps/ (~GB Rust build artifacts). .vercelignore restricts uploaded set to apps/marketing/ + vercel.json + .vercelignore. .gitignore adds .vercel (vercel link's local project config).