### PR TITLE
feat(orchestrator): Linear webhook for nonstop agent operation

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -1,0 +1,40 @@
+name: Orchestrator (TypeScript)
+
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - "apps/orchestrator/**"
+      - ".github/workflows/orchestrator.yml"
+  pull_request:
+    paths:
+      - "apps/orchestrator/**"
+      - ".github/workflows/orchestrator.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    name: typecheck + test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/orchestrator
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: apps/orchestrator/package-lock.json
+
+      - name: Install
+        run: npm ci || npm install
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test

--- a/apps/orchestrator/.env.example
+++ b/apps/orchestrator/.env.example
@@ -1,0 +1,23 @@
+# Linear API (https://linear.app/settings/account/security)
+LINEAR_API_KEY=lin_api_REPLACE_WITH_YOUR_KEY
+
+# Webhook signing secret (set when creating webhook in Linear → Settings → Webhooks)
+LINEAR_WEBHOOK_SECRET=REPLACE_WITH_RANDOM_HEX_64_CHARS
+
+# Linear state IDs — fetch with `curl https://api.linear.app/graphql` or copy from Linear UI
+# In Progress state UUID for the SBO3L workspace
+LINEAR_STATE_IN_PROGRESS=REPLACE_WITH_STATE_UUID
+
+# Discord webhook URLs (one per slot's prompt channel + one for coordination)
+# Slot prompt channels — orchestrator posts the rendered prompt here for the agent runtime to pick up.
+DISCORD_WEBHOOK_DEV1_URL=https://discord.com/api/webhooks/REPLACE
+DISCORD_WEBHOOK_DEV2_URL=https://discord.com/api/webhooks/REPLACE
+DISCORD_WEBHOOK_DEV3_URL=https://discord.com/api/webhooks/REPLACE
+DISCORD_WEBHOOK_DEV4_URL=https://discord.com/api/webhooks/REPLACE
+DISCORD_WEBHOOK_QA_URL=https://discord.com/api/webhooks/REPLACE
+
+# Coordination channel — queue-empty notifications, errors
+DISCORD_WEBHOOK_COORDINATION_URL=https://discord.com/api/webhooks/REPLACE
+
+# Optional: dry-run mode (logs prompts without sending to Discord, no Linear state mutation)
+ORCHESTRATOR_DRY_RUN=0

--- a/apps/orchestrator/.gitignore
+++ b/apps/orchestrator/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.env
+.env.local
+.vercel/
+*.log

--- a/apps/orchestrator/README.md
+++ b/apps/orchestrator/README.md
@@ -1,0 +1,171 @@
+# `@sbo3l/orchestrator` — Linear webhook → next-ticket auto-prompt
+
+**Audience:** Daniel + the QA + Release agent operating the 4+1 nonstop loop.
+**Outcome:** when an agent's ticket transitions to Done in Linear, this service auto-renders the next-ticket prompt and delivers it to that agent's Discord channel — no human in the loop.
+
+This is the **Friction 3 fix** from
+[`docs/win-backlog/11-nonstop-operation-guide.md`](../../docs/win-backlog/11-nonstop-operation-guide.md):
+without it, agents idle between tickets waiting for Daniel to send the next prompt.
+
+## How it works
+
+```
+Linear "Done" event ─► /api/linear-webhook (Vercel Function)
+                       │
+                       │ 1. verify HMAC-SHA256 signature
+                       │ 2. parse webhook envelope
+                       │ 3. resolve assignee.name → 4+1 slot ("Dev 1" etc.)
+                       │ 4. query Linear for next unblocked ticket for that slot
+                       │ 5. render prompt from docs/win-backlog/09-prompt-template.md
+                       │ 6. POST prompt to slot's Discord webhook
+                       │ 7. mark next ticket as In Progress in Linear
+                       ▼
+                Agent runtime (watching its Discord channel) picks up the prompt
+                and starts the next ticket on branch agent/<slot>/<ticket-id>.
+```
+
+## Reaction matrix
+
+| Webhook event | Action |
+|---|---|
+| Non-Issue (Comment, Project, ...) | ignored |
+| Issue, action ≠ "update" | ignored |
+| Issue, state.type ≠ "completed" | ignored |
+| Issue, completed, no recognised slot assignee | ignored (Daniel handles manually) |
+| Issue, completed, slot queue empty | post to coordination channel, no dispatch |
+| Issue, completed, next ticket found | render prompt + deliver + mark in progress |
+
+## File layout
+
+```
+apps/orchestrator/
+├── api/
+│   ├── linear-webhook.ts   # Vercel HTTP entry — verifies signature, calls handler
+│   └── health.ts           # GET /api/health liveness probe
+├── src/
+│   ├── linear-webhook.ts   # core handler (pure, easy to unit-test)
+│   ├── render-prompt.ts    # 09-prompt-template.md filler + phase inference
+│   ├── agent-bridge.ts     # Discord webhook transport + status posts
+│   ├── linear-client.ts    # GraphQL queries against api.linear.app
+│   ├── signature.ts        # HMAC-SHA256 webhook verification
+│   ├── slot-mapping.ts     # Linear assignee.name → 4+1 slot
+│   ├── types.ts            # LinearWebhookEvent, Slot, etc.
+│   └── local-server.ts     # `npm run dev` shim (not deployed)
+├── test/                    # vitest suite
+└── vercel.json              # function runtime + maxDuration config
+```
+
+## Setup (one-time)
+
+1. **Create Linear webhook**
+   - Linear → Settings → API → Webhooks → New
+   - URL: `https://<vercel-deployment>/api/linear-webhook`
+   - Resource types: **Issue**
+   - Copy the signing secret → `LINEAR_WEBHOOK_SECRET`
+2. **Get Linear API key**
+   - Linear → Settings → Account → Security → Personal API key → New
+   - Scope: `Read`, `Write` (write needed to mark next ticket In Progress)
+   - → `LINEAR_API_KEY`
+3. **Get Linear "In Progress" state UUID**
+   - Run a one-off `workflowStates` GraphQL query (see Linear docs) and copy
+     the UUID for the workspace's "In Progress" state → `LINEAR_STATE_IN_PROGRESS`
+4. **Discord webhook per slot**
+   - Discord → server settings → Integrations → Webhooks → New (one per channel)
+   - One channel per slot (`#sbo3l-dev1-prompts`, `#sbo3l-dev2-prompts`, ...)
+   - Plus one for `#sbo3l-coordination`
+   - URLs go in `DISCORD_WEBHOOK_DEV{1..4}_URL`, `DISCORD_WEBHOOK_QA_URL`, `DISCORD_WEBHOOK_COORDINATION_URL`
+5. **Linear assignee names**
+   - In Linear, name the agent users **exactly** `Dev 1`, `Dev 2`, `Dev 3`, `Dev 4`, `QA + Release`
+   - These strings are matched literally; misspellings cause the orchestrator to ignore the event.
+6. **Linear "unblocked" label**
+   - Create a single workspace label called `unblocked`. Tickets only get it once their `Depends:` chain is merged.
+
+See `.env.example` for the full env var list.
+
+## Deploy on Vercel
+
+```bash
+# From repo root
+cd apps/orchestrator
+vercel link        # one-time, point at sbo3l-orchestrator project
+vercel --prod
+```
+
+The root [`vercel.json`](../../vercel.json) currently points at `apps/marketing`, so deploy this orchestrator as a **separate Vercel project** rooted at `apps/orchestrator/`. Set `Root Directory: apps/orchestrator` in the Vercel dashboard.
+
+Set the env vars (Vercel dashboard → Project → Settings → Environment Variables) per `.env.example`. Production deploys read them from there; local dev reads `.env`.
+
+## Local development
+
+```bash
+cd apps/orchestrator
+npm install
+cp .env.example .env   # then fill values
+
+npm run dev            # http://localhost:3000
+npm test               # vitest
+npm run typecheck      # tsc --noEmit
+```
+
+Hit it locally with a signed payload using `curl`:
+
+```bash
+SECRET="<value of LINEAR_WEBHOOK_SECRET>"
+BODY='{"action":"update","type":"Issue","data":{...}}'
+SIG=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" -hex | awk '{print $2}')
+curl -sS http://localhost:3000/api/linear-webhook \
+  -H "Content-Type: application/json" \
+  -H "linear-signature: $SIG" \
+  -d "$BODY"
+```
+
+## Dry-run mode
+
+Set `ORCHESTRATOR_DRY_RUN=1` to exercise the full pipeline without posting to Discord or mutating Linear state. The handler returns `{ kind: "dispatched", ... }` as if it had succeeded, but the prompt only goes to logs. Useful for replaying historical webhook payloads.
+
+> **Caveat:** dry-run currently swaps only the Discord transport for an in-memory shim — Linear `markInProgress` calls still go through. To suppress those too, run against a Linear scratch workspace.
+
+## QA test plan (Heidi runs literally before merge)
+
+```bash
+cd apps/orchestrator
+npm install
+npm run typecheck
+npm test
+```
+
+Expect: typecheck clean (no `any`, no diagnostics), all vitest suites green.
+
+Optional smoke (hits Discord — only run with throwaway webhook URLs):
+
+```bash
+ORCHESTRATOR_DRY_RUN=1 \
+LINEAR_API_KEY=fake \
+LINEAR_WEBHOOK_SECRET=test-secret \
+LINEAR_STATE_IN_PROGRESS=fake-state \
+DISCORD_WEBHOOK_DEV1_URL=https://example.invalid \
+npm run dev &
+
+sleep 1
+SECRET=test-secret
+BODY='{"action":"update","type":"Issue","data":{"id":"t","identifier":"F-1","title":"x","priority":2,"state":{"id":"s","name":"Done","type":"completed"},"assignee":{"id":"u","name":"Dev 1"}}}'
+SIG=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" -hex | awk '{print $2}')
+curl -sf http://localhost:3000/api/linear-webhook \
+  -H "Content-Type: application/json" \
+  -H "linear-signature: $SIG" \
+  -d "$BODY"
+
+# Expect: 200 OK with body like {"kind":"queue_empty","slot":"Dev 1"} or {"kind":"dispatched",...}
+pkill -f tsx
+```
+
+## Out of scope (deliberate)
+
+- **No tmux/SSH paste-into-Claude-Code yet.** MVP transport is Discord webhook posting; agent runtimes either watch the channel or Daniel re-pastes manually. Real auto-injection is a follow-up.
+- **No Linear "Depends:" graph evaluation.** We trust the workspace `unblocked` label as the gate. Daniel adds/removes the label when dependencies change.
+- **No retry queue.** Linear retries failed webhook deliveries automatically; idempotency comes from the next-ticket selection being a query, not a state machine on our side.
+- **No multi-instance coordination.** Single Vercel deployment; no leader election needed.
+
+## Maintainers
+
+QA + Release owns this. Bug reports → `#sbo3l-incidents` if blocking, otherwise GitHub issue.

--- a/apps/orchestrator/api/health.ts
+++ b/apps/orchestrator/api/health.ts
@@ -1,0 +1,17 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+/** Liveness probe — returns 200 OK with version + commit. */
+export default function handler(
+  _req: IncomingMessage,
+  res: ServerResponse,
+): void {
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "application/json");
+  res.end(
+    JSON.stringify({
+      service: "sbo3l-orchestrator",
+      version: "0.1.0",
+      commit: process.env["VERCEL_GIT_COMMIT_SHA"] ?? "dev",
+    }),
+  );
+}

--- a/apps/orchestrator/api/linear-webhook.ts
+++ b/apps/orchestrator/api/linear-webhook.ts
@@ -1,0 +1,99 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+import { DiscordWebhookTransport, DryRunTransport } from "../src/agent-bridge.js";
+import { LinearGraphQLClient } from "../src/linear-client.js";
+import { handleLinearWebhook } from "../src/linear-webhook.js";
+import { verifyLinearSignature } from "../src/signature.js";
+import type { LinearWebhookEvent } from "../src/types.js";
+
+/**
+ * Vercel HTTP entry point. Verifies the Linear webhook signature against the
+ * raw body, parses, dispatches to the core handler, returns 2xx on success
+ * (so Linear stops retrying) or 401/400/500 on validation/processing errors.
+ */
+export default async function handler(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  if (req.method !== "POST") {
+    res.statusCode = 405;
+    res.setHeader("Allow", "POST");
+    res.end("Method Not Allowed");
+    return;
+  }
+
+  let raw: string;
+  try {
+    raw = await readRawBody(req);
+  } catch (err) {
+    res.statusCode = 400;
+    res.end(`bad body: ${(err as Error).message}`);
+    return;
+  }
+
+  const secret = process.env["LINEAR_WEBHOOK_SECRET"];
+  if (!secret) {
+    res.statusCode = 500;
+    res.end("server misconfigured: LINEAR_WEBHOOK_SECRET missing");
+    return;
+  }
+
+  const sigHeader = headerValue(req.headers["linear-signature"]);
+  if (!verifyLinearSignature(raw, sigHeader, secret)) {
+    res.statusCode = 401;
+    res.end("invalid signature");
+    return;
+  }
+
+  let event: LinearWebhookEvent;
+  try {
+    event = JSON.parse(raw) as LinearWebhookEvent;
+  } catch (err) {
+    res.statusCode = 400;
+    res.end(`bad json: ${(err as Error).message}`);
+    return;
+  }
+
+  try {
+    const apiKey = required("LINEAR_API_KEY");
+    const inProgressStateId = required("LINEAR_STATE_IN_PROGRESS");
+    const linear = new LinearGraphQLClient(apiKey, inProgressStateId);
+    const dryRun = process.env["ORCHESTRATOR_DRY_RUN"] === "1";
+    const transport = dryRun
+      ? new DryRunTransport()
+      : new DiscordWebhookTransport();
+
+    const outcome = await handleLinearWebhook(event, {
+      linear,
+      transport,
+      env: process.env,
+    });
+
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify(outcome));
+  } catch (err) {
+    res.statusCode = 500;
+    res.end(`handler error: ${(err as Error).message}`);
+  }
+}
+
+function readRawBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`missing required env var ${name}`);
+  return v;
+}

--- a/apps/orchestrator/package-lock.json
+++ b/apps/orchestrator/package-lock.json
@@ -1,0 +1,2119 @@
+{
+  "name": "@sbo3l/orchestrator",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@sbo3l/orchestrator",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@linear/sdk": "^32.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.12.0",
+        "tsx": "^4.16.0",
+        "typescript": "^5.5.4",
+        "vitest": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@linear/sdk": {
+      "version": "32.0.0",
+      "resolved": "https://registry.npmjs.org/@linear/sdk/-/sdk-32.0.0.tgz",
+      "integrity": "sha512-ZENFrq3JIztYSEmHRmt+HYgfEAqCd/vIVJNDNp3vpedz+0M/FZZSnxe1qTOQToIASvxWbaJtc2M6QT/cIcXRyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.0",
+        "graphql": "^15.4.0",
+        "isomorphic-unfetch": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12.x",
+        "yarn": "1.x"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "15.10.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.10.2.tgz",
+      "integrity": "sha512-1PRqdDPAmViWr4h1GVBT8RoPZfWSGZa7kDzleTilOfVIslsgf+cia3Nl95v1KDmR4iERPaT7WzQ+tN4MJmbg3w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/isomorphic-unfetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "unfetch": "^4.2.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@sbo3l/orchestrator",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Linear webhook → next-ticket auto-prompt orchestrator (4+1 nonstop operation, Friction 3 fix per docs/win-backlog/11-nonstop-operation-guide.md)",
+  "license": "MIT",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "dev": "tsx src/local-server.ts"
+  },
+  "dependencies": {
+    "@linear/sdk": "^32.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.0",
+    "tsx": "^4.16.0",
+    "typescript": "^5.5.4",
+    "vitest": "^2.1.0"
+  }
+}

--- a/apps/orchestrator/src/agent-bridge.ts
+++ b/apps/orchestrator/src/agent-bridge.ts
@@ -1,0 +1,89 @@
+import type { Slot, SlotConfig } from "./types.js";
+
+/**
+ * Transport interface for delivering a rendered prompt to an agent runtime.
+ *
+ * The MVP implementation posts to a Discord webhook for the slot's prompt
+ * channel. Future transports (tmux SSH paste, Claude Code API injection,
+ * SQS, etc.) implement the same shape.
+ */
+export interface AgentTransport {
+  send(slot: Slot, prompt: string, config: SlotConfig): Promise<void>;
+}
+
+/** Posts the prompt to Discord as a fenced code block in the slot's channel. */
+export class DiscordWebhookTransport implements AgentTransport {
+  constructor(private readonly fetchImpl: typeof fetch = fetch) {}
+
+  async send(slot: Slot, prompt: string, config: SlotConfig): Promise<void> {
+    const body = formatDiscordPayload(prompt);
+    const res = await this.fetchImpl(config.discordWebhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const detail = await safeReadBody(res);
+      throw new Error(
+        `Discord webhook delivery failed for ${slot}: ${res.status} ${res.statusText} — ${detail}`,
+      );
+    }
+  }
+}
+
+/** No-op transport used when ORCHESTRATOR_DRY_RUN=1. Captures sends in memory. */
+export class DryRunTransport implements AgentTransport {
+  public readonly sent: Array<{ slot: Slot; prompt: string }> = [];
+
+  send(slot: Slot, prompt: string, _config: SlotConfig): Promise<void> {
+    this.sent.push({ slot, prompt });
+    return Promise.resolve();
+  }
+}
+
+const DISCORD_MAX_CONTENT = 2000;
+
+/**
+ * Discord caps webhook content at 2000 chars. Long prompts are split into
+ * an intro line and a code-fenced body; if still too long, we send sequential
+ * messages so the agent reads them in order.
+ */
+export function formatDiscordPayload(prompt: string): {
+  username: string;
+  content: string;
+} {
+  const username = "SBO3L Orchestrator";
+  const fenced = "```\n" + prompt + "\n```";
+  if (fenced.length <= DISCORD_MAX_CONTENT) {
+    return { username, content: fenced };
+  }
+  // Truncate with marker; full prompt is also in orchestrator logs for audit.
+  const trimmed = prompt.slice(0, DISCORD_MAX_CONTENT - 64);
+  return {
+    username,
+    content:
+      "```\n" + trimmed + "\n```\n_(prompt truncated — see orchestrator logs)_",
+  };
+}
+
+async function safeReadBody(res: Response): Promise<string> {
+  try {
+    return (await res.text()).slice(0, 256);
+  } catch {
+    return "<no body>";
+  }
+}
+
+/** Posts a one-line status update (queue empty, error, etc.) to coordination. */
+export async function postCoordinationStatus(
+  message: string,
+  url: string | undefined,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  if (!url) return;
+  await fetchImpl(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username: "SBO3L Orchestrator", content: message }),
+  });
+}

--- a/apps/orchestrator/src/linear-client.ts
+++ b/apps/orchestrator/src/linear-client.ts
@@ -1,0 +1,137 @@
+import type { LinearIssue, Slot } from "./types.js";
+
+/**
+ * Minimal Linear API surface the orchestrator depends on. Wrapping the SDK
+ * behind an interface keeps the webhook handler trivially mockable in tests
+ * without booting `@linear/sdk` or hitting the network.
+ */
+export interface LinearClient {
+  /**
+   * Returns the next ticket for `slot` that:
+   *  - is in `unstarted` state
+   *  - is labelled "unblocked"
+   *  - has the highest priority (Linear treats 0 = none, 1 = urgent, 4 = low)
+   *
+   * Highest priority = lowest non-zero number; ties broken by created date asc.
+   * Returns null if the slot's queue is empty.
+   */
+  nextTicketForSlot(slot: Slot): Promise<LinearIssue | null>;
+
+  /** Move an issue into the configured "In Progress" workflow state. */
+  markInProgress(issueId: string): Promise<void>;
+}
+
+interface LinearGraphQLEdge<T> {
+  node: T;
+}
+
+interface LinearIssuesResponse {
+  data?: {
+    issues?: {
+      nodes?: LinearIssue[];
+      edges?: LinearGraphQLEdge<LinearIssue>[];
+    };
+  };
+  errors?: { message: string }[];
+}
+
+const LINEAR_GQL_ENDPOINT = "https://api.linear.app/graphql";
+
+/**
+ * Production implementation backed by Linear's GraphQL API. We use raw fetch
+ * (rather than `@linear/sdk`'s typed client) to keep the dependency surface
+ * minimal in serverless cold-starts and to make our own queries explicit.
+ */
+export class LinearGraphQLClient implements LinearClient {
+  constructor(
+    private readonly apiKey: string,
+    private readonly inProgressStateId: string,
+    private readonly fetchImpl: typeof fetch = fetch,
+  ) {}
+
+  async nextTicketForSlot(slot: Slot): Promise<LinearIssue | null> {
+    const query = /* GraphQL */ `
+      query NextTicket($slot: String!) {
+        issues(
+          filter: {
+            assignee: { name: { eq: $slot } }
+            state: { type: { eq: "unstarted" } }
+            labels: { name: { eq: "unblocked" } }
+          }
+          orderBy: createdAt
+          first: 25
+        ) {
+          nodes {
+            id
+            identifier
+            title
+            priority
+            state { id name type }
+            assignee { id name }
+            labels { nodes { name } }
+          }
+        }
+      }
+    `;
+
+    const res = await this.fetchImpl(LINEAR_GQL_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: this.apiKey,
+      },
+      body: JSON.stringify({ query, variables: { slot } }),
+    });
+    if (!res.ok) {
+      throw new Error(`Linear GraphQL ${res.status} ${res.statusText}`);
+    }
+
+    const json = (await res.json()) as LinearIssuesResponse;
+    if (json.errors?.length) {
+      throw new Error(
+        `Linear GraphQL errors: ${json.errors.map((e) => e.message).join("; ")}`,
+      );
+    }
+
+    const candidates = json.data?.issues?.nodes ?? [];
+    return pickHighestPriority(candidates);
+  }
+
+  async markInProgress(issueId: string): Promise<void> {
+    const mutation = /* GraphQL */ `
+      mutation MarkInProgress($id: String!, $stateId: String!) {
+        issueUpdate(id: $id, input: { stateId: $stateId }) { success }
+      }
+    `;
+    const res = await this.fetchImpl(LINEAR_GQL_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: this.apiKey,
+      },
+      body: JSON.stringify({
+        query: mutation,
+        variables: { id: issueId, stateId: this.inProgressStateId },
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(
+        `Linear issueUpdate failed: ${res.status} ${res.statusText}`,
+      );
+    }
+  }
+}
+
+/**
+ * Sort Linear's `priority` (0 = none, 1 = urgent, 2 = high, 3 = medium, 4 = low)
+ * such that urgent comes first, then 2/3/4, with 0 (none) last.
+ */
+export function pickHighestPriority(
+  issues: readonly LinearIssue[],
+): LinearIssue | null {
+  if (issues.length === 0) return null;
+
+  const score = (p: number): number => (p === 0 ? Number.POSITIVE_INFINITY : p);
+  return [...issues].sort((a, b) => score(a.priority) - score(b.priority))[0]
+    ?? null;
+}

--- a/apps/orchestrator/src/linear-webhook.ts
+++ b/apps/orchestrator/src/linear-webhook.ts
@@ -1,0 +1,80 @@
+import type { LinearClient } from "./linear-client.js";
+import type { AgentTransport } from "./agent-bridge.js";
+import { postCoordinationStatus } from "./agent-bridge.js";
+import { inferPhase, renderAgentPrompt } from "./render-prompt.js";
+import { isSlot, loadSlotConfig } from "./slot-mapping.js";
+import type { HandleOutcome, LinearWebhookEvent, Slot } from "./types.js";
+
+export interface HandlerDeps {
+  linear: LinearClient;
+  transport: AgentTransport;
+  env: NodeJS.ProcessEnv;
+  /** Optional override for the coordination Discord webhook (tests inject). */
+  coordinationWebhookUrl?: string | undefined;
+  /** Injectable fetch used for coordination posts. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Core webhook handler. Pure of HTTP concerns — takes a parsed event and
+ * returns a structured outcome. The Vercel `api/linear-webhook.ts` entry
+ * point handles signature verification + body parsing then calls this.
+ *
+ * Reaction matrix:
+ *   - non-Issue events            → ignored
+ *   - non-update actions          → ignored
+ *   - Issue not transitioned to a `completed` state → ignored
+ *   - completed Issue, no recognised assignee       → ignored (Daniel manual)
+ *   - completed Issue, slot queue empty             → coordination post, no dispatch
+ *   - completed Issue, next ticket found            → render prompt, deliver, mark in_progress
+ */
+export async function handleLinearWebhook(
+  event: LinearWebhookEvent,
+  deps: HandlerDeps,
+): Promise<HandleOutcome> {
+  if (event.type !== "Issue") {
+    return { kind: "ignored", reason: `non-issue event type=${event.type}` };
+  }
+  if (event.action !== "update") {
+    return { kind: "ignored", reason: `non-update action=${event.action}` };
+  }
+  if (event.data.state.type !== "completed") {
+    return {
+      kind: "ignored",
+      reason: `state.type=${event.data.state.type} (not completed)`,
+    };
+  }
+
+  const assigneeName = event.data.assignee?.name;
+  if (!isSlot(assigneeName)) {
+    return {
+      kind: "ignored",
+      reason: `assignee not a 4+1 slot: ${assigneeName ?? "<unassigned>"}`,
+    };
+  }
+  const slot: Slot = assigneeName;
+
+  const next = await deps.linear.nextTicketForSlot(slot);
+  if (!next) {
+    await postCoordinationStatus(
+      `🔔 ${slot} queue empty (just completed ${event.data.identifier}). Waiting for Daniel batch assignment.`,
+      deps.coordinationWebhookUrl ?? deps.env["DISCORD_WEBHOOK_COORDINATION_URL"],
+      deps.fetchImpl ?? fetch,
+    );
+    return { kind: "queue_empty", slot };
+  }
+
+  const slotConfig = loadSlotConfig(slot, deps.env);
+  const prompt = renderAgentPrompt({
+    slot,
+    branchSlug: slotConfig.branchSlug,
+    ticketIdentifier: next.identifier,
+    ticketTitle: next.title,
+    phase: inferPhase(next.identifier),
+  });
+
+  await deps.transport.send(slot, prompt, slotConfig);
+  await deps.linear.markInProgress(next.id);
+
+  return { kind: "dispatched", slot, nextTicket: next.identifier };
+}

--- a/apps/orchestrator/src/local-server.ts
+++ b/apps/orchestrator/src/local-server.ts
@@ -1,0 +1,36 @@
+import { createServer } from "node:http";
+
+import linearWebhook from "../api/linear-webhook.js";
+import health from "../api/health.js";
+
+/**
+ * Local dev shim — mounts the Vercel-style handlers on a plain Node http
+ * server so `npm run dev` exposes them at http://localhost:3000.
+ *
+ * Production deployment runs the same handlers on Vercel Functions; this
+ * file is not packaged for prod (excluded from tsconfig.build.json).
+ */
+const PORT = Number.parseInt(process.env["PORT"] ?? "3000", 10);
+
+const server = createServer((req, res) => {
+  void (async () => {
+    try {
+      if (req.url === "/api/linear-webhook") {
+        await linearWebhook(req, res);
+      } else if (req.url === "/api/health" || req.url === "/") {
+        health(req, res);
+      } else {
+        res.statusCode = 404;
+        res.end("not found");
+      }
+    } catch (err) {
+      res.statusCode = 500;
+      res.end(`error: ${(err as Error).message}`);
+    }
+  })();
+});
+
+server.listen(PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`orchestrator listening on http://localhost:${PORT}`);
+});

--- a/apps/orchestrator/src/render-prompt.ts
+++ b/apps/orchestrator/src/render-prompt.ts
@@ -1,0 +1,76 @@
+import type { RenderPromptInput } from "./types.js";
+
+const PHASE_FILE: Record<1 | 2 | 3, string> = {
+  1: "docs/win-backlog/05-phase-1.md",
+  2: "docs/win-backlog/06-phase-2.md",
+  3: "docs/win-backlog/07-phase-3.md",
+};
+
+/**
+ * Maps a ticket identifier prefix (e.g. "F-1", "T-3-4", "CTI-4-2") to its
+ * backlog phase. Default is phase 2 for ambiguous T-1-* mid-range; Daniel
+ * can override by including phase metadata in the Linear issue if needed.
+ *
+ * Mapping basis: docs/win-backlog/{05,06,07}-phase-N.md ticket indexes.
+ */
+export function inferPhase(identifier: string): 1 | 2 | 3 {
+  const id = identifier.toUpperCase();
+
+  if (id.startsWith("F-")) return 1;
+  if (id.startsWith("T-2-")) return 1;
+
+  if (id.startsWith("T-3-")) return 2;
+  if (id.startsWith("T-4-")) return 2;
+  if (id.startsWith("T-5-")) return 2;
+  if (id.startsWith("CTI-3-")) return 2;
+
+  if (id.startsWith("T-6-")) return 3;
+  if (id.startsWith("T-7-")) return 3;
+  if (id.startsWith("T-8-")) return 3;
+  if (id.startsWith("CTI-4-")) return 3;
+
+  if (id.startsWith("T-1-")) {
+    const trailing = Number.parseInt(id.slice("T-1-".length), 10);
+    return Number.isFinite(trailing) && trailing >= 7 ? 3 : 2;
+  }
+
+  return 2;
+}
+
+/**
+ * Renders the Universal prompt from docs/win-backlog/09-prompt-template.md
+ * with the slot, ticket, and branch fields filled in. The shape (sections,
+ * order, headings) mirrors the template literally so agents pattern-match
+ * the prompt the way Daniel hand-writes them.
+ */
+export function renderAgentPrompt(input: RenderPromptInput): string {
+  const phaseFile = PHASE_FILE[input.phase];
+  return [
+    `You are ${input.slot}.`,
+    ``,
+    `Your full operating profile is at docs/win-backlog/03-agents.md (find your section by name).`,
+    ``,
+    `Read the win backlog folder before doing anything else, in this order:`,
+    `  1. docs/win-backlog/00-readme.md       — mission + how-to-use`,
+    `  2. docs/win-backlog/01-identity.md     — locked product identity`,
+    `  3. docs/win-backlog/02-standards.md    — dev + QA + PR + testing standards`,
+    `  4. docs/win-backlog/03-agents.md       — your operating profile (your section)`,
+    `  5. docs/win-backlog/04-orchestration.md — branch strategy + dependencies + daily rhythm`,
+    ``,
+    `Your assigned ticket: ${input.ticketIdentifier} (${input.ticketTitle})`,
+    `Ticket location: ${phaseFile} (search for ${input.ticketIdentifier})`,
+    ``,
+    `Constraints:`,
+    `- Branch: agent/${input.branchSlug}/${input.ticketIdentifier}`,
+    `- One ticket = one PR`,
+    `- PR title = ticket title verbatim`,
+    `- Wait for unmet dependencies; do not attempt workarounds`,
+    `- Submit PR when all acceptance criteria met`,
+    `- Daniel + Heidi approve before merge`,
+    ``,
+    `If blocked, post in #sbo3l-blockers (or coordination channel). Do not proceed.`,
+    `If clarification needed, post in #sbo3l-coordination, tag @daniel.`,
+    ``,
+    `Begin reading the backlog now.`,
+  ].join("\n");
+}

--- a/apps/orchestrator/src/signature.ts
+++ b/apps/orchestrator/src/signature.ts
@@ -1,0 +1,35 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/**
+ * Verifies a Linear webhook signature against the raw request body.
+ *
+ * Linear computes `HMAC-SHA256(secret, rawBody)` and sends the hex digest in
+ * the `linear-signature` header. We MUST verify on the raw body bytes — any
+ * pre-parsed JSON re-stringification will mismatch.
+ *
+ * Returns false (not throws) on length / format mismatch so the caller can
+ * respond with 401 + structured log entry rather than a stack trace.
+ */
+export function verifyLinearSignature(
+  rawBody: string | Buffer,
+  signatureHeader: string | undefined,
+  secret: string,
+): boolean {
+  if (!signatureHeader || !secret) return false;
+
+  const expected = createHmac("sha256", secret)
+    .update(rawBody)
+    .digest("hex");
+
+  // Reject up-front if lengths differ — timingSafeEqual throws otherwise.
+  if (expected.length !== signatureHeader.length) return false;
+
+  try {
+    return timingSafeEqual(
+      Buffer.from(expected, "utf8"),
+      Buffer.from(signatureHeader, "utf8"),
+    );
+  } catch {
+    return false;
+  }
+}

--- a/apps/orchestrator/src/slot-mapping.ts
+++ b/apps/orchestrator/src/slot-mapping.ts
@@ -1,0 +1,53 @@
+import type { Slot, SlotConfig } from "./types.js";
+
+/** All slot identifiers, in canonical order. */
+export const SLOTS: readonly Slot[] = [
+  "Dev 1",
+  "Dev 2",
+  "Dev 3",
+  "Dev 4",
+  "QA + Release",
+];
+
+const SLOT_BRANCH_SLUGS: Record<Slot, string> = {
+  "Dev 1": "dev1",
+  "Dev 2": "dev2",
+  "Dev 3": "dev3",
+  "Dev 4": "dev4",
+  "QA + Release": "qa",
+};
+
+/**
+ * Type-guard: is `name` a recognised slot? Names come from Linear's
+ * `assignee.name` field, which Daniel sets to "Dev 1" etc. when assigning.
+ */
+export function isSlot(name: string | undefined | null): name is Slot {
+  if (!name) return false;
+  return (SLOTS as readonly string[]).includes(name);
+}
+
+/** Maps `"Dev 1"` → `"dev1"` for branch names like `agent/dev1/F-1`. */
+export function slotBranchSlug(slot: Slot): string {
+  return SLOT_BRANCH_SLUGS[slot];
+}
+
+/** Slot → env var prefix; `Dev 1` → `DEV1`, `QA + Release` → `QA`. */
+function slotEnvKey(slot: Slot): string {
+  return slot === "QA + Release" ? "QA" : slot.replace(/\s+/g, "").toUpperCase();
+}
+
+/**
+ * Resolves the per-slot Discord webhook URL from env. Throws if the env var
+ * is missing — orchestrator is useless without a delivery channel for the
+ * slot whose ticket just merged.
+ */
+export function loadSlotConfig(slot: Slot, env: NodeJS.ProcessEnv): SlotConfig {
+  const key = `DISCORD_WEBHOOK_${slotEnvKey(slot)}_URL`;
+  const url = env[key];
+  if (!url) {
+    throw new Error(
+      `Missing env var ${key} (required to dispatch prompt to ${slot}).`,
+    );
+  }
+  return { discordWebhookUrl: url, branchSlug: slotBranchSlug(slot) };
+}

--- a/apps/orchestrator/src/types.ts
+++ b/apps/orchestrator/src/types.ts
@@ -1,0 +1,78 @@
+/**
+ * Linear webhook event subset that the orchestrator consumes.
+ *
+ * The Linear webhook payload is large; we only model the fields the handler
+ * actually reads. See https://developers.linear.app/docs/graphql/webhooks for
+ * the full schema.
+ */
+
+/** Linear assignee → 4+1 slot. The Linear assignee.name MUST match one of these. */
+export type Slot = "Dev 1" | "Dev 2" | "Dev 3" | "Dev 4" | "QA + Release";
+
+/** Recognised Linear workflow state types we care about. */
+export type LinearStateType =
+  | "triage"
+  | "backlog"
+  | "unstarted"
+  | "started"
+  | "completed"
+  | "canceled";
+
+export interface LinearLabel {
+  name: string;
+}
+
+export interface LinearAssignee {
+  id: string;
+  name: string;
+}
+
+export interface LinearState {
+  id: string;
+  name: string;
+  type: LinearStateType;
+}
+
+/** Issue payload as it appears inside webhook events and SDK queries. */
+export interface LinearIssue {
+  id: string;
+  identifier: string;
+  title: string;
+  /** Linear's numeric priority: 0 (none) → 1 (urgent) → 4 (low). */
+  priority: number;
+  state: LinearState;
+  assignee?: LinearAssignee | undefined;
+  labels?: LinearLabel[] | undefined;
+}
+
+/** The subset of Linear webhook envelope the orchestrator inspects. */
+export interface LinearWebhookEvent {
+  /** "create" | "update" | "remove" — we only react to "update". */
+  action: string;
+  /** "Issue" | "Comment" | ... — we only react to "Issue". */
+  type: string;
+  data: LinearIssue;
+}
+
+/** Resolved configuration for one slot (Dev 1 etc.) — set via env. */
+export interface SlotConfig {
+  /** Discord webhook URL for prompt delivery. */
+  discordWebhookUrl: string;
+  /** kebab form used in branch names: "Dev 1" → "dev1". */
+  branchSlug: string;
+}
+
+/** Outcome record returned by the handler — useful for tests + logs. */
+export type HandleOutcome =
+  | { kind: "ignored"; reason: string }
+  | { kind: "queue_empty"; slot: Slot }
+  | { kind: "dispatched"; slot: Slot; nextTicket: string };
+
+export interface RenderPromptInput {
+  slot: Slot;
+  branchSlug: string;
+  ticketIdentifier: string;
+  ticketTitle: string;
+  /** Phase number 1-3 — derived from the ticket prefix (F-/T-2-/T-3-...). */
+  phase: 1 | 2 | 3;
+}

--- a/apps/orchestrator/test/agent-bridge.test.ts
+++ b/apps/orchestrator/test/agent-bridge.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DiscordWebhookTransport,
+  formatDiscordPayload,
+} from "../src/agent-bridge.js";
+
+describe("formatDiscordPayload", () => {
+  it("wraps short prompts in a code fence", () => {
+    const payload = formatDiscordPayload("hello world");
+    expect(payload.username).toBe("SBO3L Orchestrator");
+    expect(payload.content.startsWith("```\n")).toBe(true);
+    expect(payload.content.endsWith("\n```")).toBe(true);
+    expect(payload.content).toContain("hello world");
+  });
+
+  it("truncates prompts over the 2000 char Discord limit", () => {
+    const big = "x".repeat(3000);
+    const payload = formatDiscordPayload(big);
+    expect(payload.content.length).toBeLessThanOrEqual(2000);
+    expect(payload.content).toContain("(prompt truncated");
+  });
+});
+
+describe("DiscordWebhookTransport", () => {
+  it("POSTs the payload to the slot's webhook URL", async () => {
+    const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+    const fakeFetch = (async (url: string | URL, init?: RequestInit) => {
+      calls.push({ url: String(url), init });
+      return new Response(null, { status: 204 });
+    }) as unknown as typeof fetch;
+
+    const transport = new DiscordWebhookTransport(fakeFetch);
+    await transport.send("Dev 1", "the-prompt", {
+      discordWebhookUrl: "https://discord.example/dev1",
+      branchSlug: "dev1",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe("https://discord.example/dev1");
+    expect(calls[0]?.init?.method).toBe("POST");
+    const body = String(calls[0]?.init?.body ?? "");
+    expect(body).toContain("the-prompt");
+  });
+
+  it("throws on non-2xx responses", async () => {
+    const fakeFetch = (async () =>
+      new Response("rate limited", { status: 429 })) as unknown as typeof fetch;
+
+    const transport = new DiscordWebhookTransport(fakeFetch);
+    await expect(
+      transport.send("Dev 1", "p", {
+        discordWebhookUrl: "https://discord.example/dev1",
+        branchSlug: "dev1",
+      }),
+    ).rejects.toThrow(/429/);
+  });
+});

--- a/apps/orchestrator/test/linear-client.test.ts
+++ b/apps/orchestrator/test/linear-client.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { pickHighestPriority } from "../src/linear-client.js";
+import type { LinearIssue } from "../src/types.js";
+
+function issue(id: string, priority: number): LinearIssue {
+  return {
+    id,
+    identifier: id,
+    title: `t-${id}`,
+    priority,
+    state: { id: "s", name: "Todo", type: "unstarted" },
+  };
+}
+
+describe("pickHighestPriority", () => {
+  it("returns null on empty input", () => {
+    expect(pickHighestPriority([])).toBeNull();
+  });
+
+  it("prefers urgent (1) over high/medium/low (2/3/4)", () => {
+    const picked = pickHighestPriority([issue("a", 3), issue("b", 1), issue("c", 4)]);
+    expect(picked?.id).toBe("b");
+  });
+
+  it("treats priority 0 (none) as the lowest", () => {
+    const picked = pickHighestPriority([issue("a", 0), issue("b", 4)]);
+    expect(picked?.id).toBe("b");
+  });
+
+  it("preserves stable order on ties", () => {
+    const picked = pickHighestPriority([issue("a", 2), issue("b", 2)]);
+    expect(picked?.id).toBe("a");
+  });
+});

--- a/apps/orchestrator/test/linear-webhook.test.ts
+++ b/apps/orchestrator/test/linear-webhook.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { DryRunTransport } from "../src/agent-bridge.js";
+import type { LinearClient } from "../src/linear-client.js";
+import { handleLinearWebhook } from "../src/linear-webhook.js";
+import type { LinearIssue, LinearWebhookEvent } from "../src/types.js";
+
+class FakeLinearClient implements LinearClient {
+  public next: LinearIssue | null = null;
+  public markedInProgress: string[] = [];
+  public nextCalls: string[] = [];
+
+  nextTicketForSlot(slot: string): Promise<LinearIssue | null> {
+    this.nextCalls.push(slot);
+    return Promise.resolve(this.next);
+  }
+
+  markInProgress(issueId: string): Promise<void> {
+    this.markedInProgress.push(issueId);
+    return Promise.resolve();
+  }
+}
+
+function completedIssueEvent(overrides: {
+  identifier: string;
+  assignee?: string;
+}): LinearWebhookEvent {
+  return {
+    action: "update",
+    type: "Issue",
+    data: {
+      id: `id-${overrides.identifier}`,
+      identifier: overrides.identifier,
+      title: "completed ticket",
+      priority: 2,
+      state: { id: "state-done", name: "Done", type: "completed" },
+      assignee:
+        overrides.assignee !== undefined
+          ? { id: "u-1", name: overrides.assignee }
+          : undefined,
+    },
+  };
+}
+
+const ENV: NodeJS.ProcessEnv = {
+  DISCORD_WEBHOOK_DEV1_URL: "https://discord.example/dev1",
+  DISCORD_WEBHOOK_DEV2_URL: "https://discord.example/dev2",
+  DISCORD_WEBHOOK_DEV3_URL: "https://discord.example/dev3",
+  DISCORD_WEBHOOK_DEV4_URL: "https://discord.example/dev4",
+  DISCORD_WEBHOOK_QA_URL: "https://discord.example/qa",
+  DISCORD_WEBHOOK_COORDINATION_URL: "https://discord.example/coord",
+};
+
+describe("handleLinearWebhook", () => {
+  let linear: FakeLinearClient;
+  let transport: DryRunTransport;
+
+  beforeEach(() => {
+    linear = new FakeLinearClient();
+    transport = new DryRunTransport();
+  });
+
+  it("ignores non-Issue events", async () => {
+    const out = await handleLinearWebhook(
+      {
+        action: "create",
+        type: "Comment",
+        data: completedIssueEvent({ identifier: "F-1" }).data,
+      },
+      { linear, transport, env: ENV },
+    );
+    expect(out.kind).toBe("ignored");
+    expect(transport.sent).toHaveLength(0);
+    expect(linear.markedInProgress).toHaveLength(0);
+  });
+
+  it("ignores non-update actions", async () => {
+    const ev = completedIssueEvent({ identifier: "F-1", assignee: "Dev 1" });
+    ev.action = "create";
+    const out = await handleLinearWebhook(ev, { linear, transport, env: ENV });
+    expect(out.kind).toBe("ignored");
+  });
+
+  it("ignores tickets that did not transition to completed", async () => {
+    const ev = completedIssueEvent({ identifier: "F-1", assignee: "Dev 1" });
+    ev.data.state = { id: "x", name: "In Progress", type: "started" };
+    const out = await handleLinearWebhook(ev, { linear, transport, env: ENV });
+    expect(out.kind).toBe("ignored");
+  });
+
+  it("ignores completed tickets without a recognised slot assignee", async () => {
+    const ev = completedIssueEvent({ identifier: "F-1", assignee: "Daniel" });
+    const out = await handleLinearWebhook(ev, { linear, transport, env: ENV });
+    expect(out.kind).toBe("ignored");
+    expect(linear.nextCalls).toHaveLength(0);
+  });
+
+  it("posts queue-empty status when no next ticket is available", async () => {
+    const ev = completedIssueEvent({ identifier: "F-1", assignee: "Dev 1" });
+    linear.next = null;
+
+    const fetched: Array<{ url: string; body: string }> = [];
+    const fakeFetch = (async (url: string | URL, init?: RequestInit) => {
+      fetched.push({
+        url: String(url),
+        body: typeof init?.body === "string" ? init.body : "",
+      });
+      return new Response("ok", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const out = await handleLinearWebhook(ev, {
+      linear,
+      transport,
+      env: ENV,
+      fetchImpl: fakeFetch,
+    });
+
+    expect(out).toEqual({ kind: "queue_empty", slot: "Dev 1" });
+    expect(transport.sent).toHaveLength(0);
+    expect(linear.markedInProgress).toHaveLength(0);
+    expect(fetched).toHaveLength(1);
+    expect(fetched[0]?.url).toBe(ENV["DISCORD_WEBHOOK_COORDINATION_URL"]);
+    expect(fetched[0]?.body).toContain("Dev 1 queue empty");
+  });
+
+  it("dispatches the next ticket and marks it in progress", async () => {
+    const ev = completedIssueEvent({ identifier: "F-1", assignee: "Dev 1" });
+    linear.next = {
+      id: "linear-uuid-F2",
+      identifier: "F-2",
+      title: "Persistent budget store",
+      priority: 2,
+      state: { id: "s-todo", name: "Todo", type: "unstarted" },
+      assignee: { id: "u-1", name: "Dev 1" },
+    };
+
+    const out = await handleLinearWebhook(ev, { linear, transport, env: ENV });
+
+    expect(out).toEqual({
+      kind: "dispatched",
+      slot: "Dev 1",
+      nextTicket: "F-2",
+    });
+    expect(transport.sent).toHaveLength(1);
+    expect(transport.sent[0]?.slot).toBe("Dev 1");
+    expect(transport.sent[0]?.prompt).toContain(
+      "Your assigned ticket: F-2 (Persistent budget store)",
+    );
+    expect(transport.sent[0]?.prompt).toContain("Branch: agent/dev1/F-2");
+    expect(linear.markedInProgress).toEqual(["linear-uuid-F2"]);
+  });
+
+  it("handles QA + Release slot dispatch", async () => {
+    const ev = completedIssueEvent({
+      identifier: "X-Y",
+      assignee: "QA + Release",
+    });
+    linear.next = {
+      id: "qa-uuid",
+      identifier: "F-1",
+      title: "Real auth middleware (bearer + JWT)",
+      priority: 1,
+      state: { id: "s-todo", name: "Todo", type: "unstarted" },
+      assignee: { id: "u-qa", name: "QA + Release" },
+    };
+
+    const out = await handleLinearWebhook(ev, { linear, transport, env: ENV });
+    expect(out.kind).toBe("dispatched");
+    expect(transport.sent[0]?.prompt).toContain("Branch: agent/qa/F-1");
+  });
+});

--- a/apps/orchestrator/test/render-prompt.test.ts
+++ b/apps/orchestrator/test/render-prompt.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { inferPhase, renderAgentPrompt } from "../src/render-prompt.js";
+
+describe("inferPhase", () => {
+  it.each([
+    ["F-1", 1],
+    ["F-13", 1],
+    ["T-2-1", 1],
+    ["T-3-4", 2],
+    ["T-4-2", 2],
+    ["T-5-5", 2],
+    ["CTI-3-2", 2],
+    ["T-1-3", 2],
+    ["T-1-7", 3],
+    ["T-6-1", 3],
+    ["T-7-1", 3],
+    ["T-8-3", 3],
+    ["CTI-4-5", 3],
+  ] as const)("%s → phase %i", (id, phase) => {
+    expect(inferPhase(id)).toBe(phase);
+  });
+
+  it("defaults unknown prefixes to phase 2", () => {
+    expect(inferPhase("X-99")).toBe(2);
+  });
+});
+
+describe("renderAgentPrompt", () => {
+  it("renders a prompt with all required sections", () => {
+    const out = renderAgentPrompt({
+      slot: "Dev 1",
+      branchSlug: "dev1",
+      ticketIdentifier: "F-2",
+      ticketTitle: "Persistent budget store",
+      phase: 1,
+    });
+
+    expect(out).toContain("You are Dev 1.");
+    expect(out).toContain("Your assigned ticket: F-2 (Persistent budget store)");
+    expect(out).toContain("docs/win-backlog/05-phase-1.md");
+    expect(out).toContain("Branch: agent/dev1/F-2");
+    expect(out).toContain("Begin reading the backlog now.");
+    expect(out).toContain("docs/win-backlog/03-agents.md");
+  });
+
+  it("uses Phase 2 backlog file for Phase 2 tickets", () => {
+    const out = renderAgentPrompt({
+      slot: "Dev 4",
+      branchSlug: "dev4",
+      ticketIdentifier: "T-3-1",
+      ticketTitle: "Durin issuance flow",
+      phase: 2,
+    });
+    expect(out).toContain("docs/win-backlog/06-phase-2.md");
+  });
+
+  it("uses Phase 3 backlog file for Phase 3 tickets", () => {
+    const out = renderAgentPrompt({
+      slot: "Dev 4",
+      branchSlug: "dev4",
+      ticketIdentifier: "T-6-1",
+      ticketTitle: "0G Storage capsule",
+      phase: 3,
+    });
+    expect(out).toContain("docs/win-backlog/07-phase-3.md");
+  });
+
+  it("matches the prompt-template surface (key constraint lines)", () => {
+    const out = renderAgentPrompt({
+      slot: "QA + Release",
+      branchSlug: "qa",
+      ticketIdentifier: "F-3",
+      ticketTitle: "Idempotency atomicity (state machine)",
+      phase: 1,
+    });
+
+    // Constraints section, verbatim from 09-prompt-template.md.
+    expect(out).toContain("- One ticket = one PR");
+    expect(out).toContain("- PR title = ticket title verbatim");
+    expect(out).toContain("- Daniel + Heidi approve before merge");
+    expect(out).toContain("- Wait for unmet dependencies; do not attempt workarounds");
+  });
+});

--- a/apps/orchestrator/test/signature.test.ts
+++ b/apps/orchestrator/test/signature.test.ts
@@ -1,0 +1,42 @@
+import { createHmac } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import { verifyLinearSignature } from "../src/signature.js";
+
+const SECRET = "test-secret-do-not-use-in-prod";
+
+function sign(body: string): string {
+  return createHmac("sha256", SECRET).update(body).digest("hex");
+}
+
+describe("verifyLinearSignature", () => {
+  it("accepts a valid signature", () => {
+    const body = '{"action":"update"}';
+    expect(verifyLinearSignature(body, sign(body), SECRET)).toBe(true);
+  });
+
+  it("rejects a tampered body", () => {
+    const body = '{"action":"update"}';
+    const sig = sign(body);
+    expect(verifyLinearSignature('{"action":"create"}', sig, SECRET)).toBe(false);
+  });
+
+  it("rejects a wrong secret", () => {
+    const body = '{"x":1}';
+    const sig = sign(body);
+    expect(verifyLinearSignature(body, sig, "different-secret")).toBe(false);
+  });
+
+  it("rejects a missing signature header without throwing", () => {
+    expect(verifyLinearSignature("{}", undefined, SECRET)).toBe(false);
+  });
+
+  it("rejects a wrong-length signature without throwing", () => {
+    expect(verifyLinearSignature("{}", "deadbeef", SECRET)).toBe(false);
+  });
+
+  it("rejects an empty secret without throwing", () => {
+    const body = '{"x":1}';
+    expect(verifyLinearSignature(body, sign(body), "")).toBe(false);
+  });
+});

--- a/apps/orchestrator/test/slot-mapping.test.ts
+++ b/apps/orchestrator/test/slot-mapping.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SLOTS,
+  isSlot,
+  loadSlotConfig,
+  slotBranchSlug,
+} from "../src/slot-mapping.js";
+
+describe("isSlot", () => {
+  it("recognises all canonical slot names", () => {
+    for (const s of SLOTS) {
+      expect(isSlot(s)).toBe(true);
+    }
+  });
+
+  it("rejects unknown / casing-shifted strings", () => {
+    expect(isSlot("dev 1")).toBe(false);
+    expect(isSlot("Dev1")).toBe(false);
+    expect(isSlot("Daniel")).toBe(false);
+    expect(isSlot(undefined)).toBe(false);
+    expect(isSlot(null)).toBe(false);
+    expect(isSlot("")).toBe(false);
+  });
+});
+
+describe("slotBranchSlug", () => {
+  it("maps slots to branch slugs", () => {
+    expect(slotBranchSlug("Dev 1")).toBe("dev1");
+    expect(slotBranchSlug("Dev 4")).toBe("dev4");
+    expect(slotBranchSlug("QA + Release")).toBe("qa");
+  });
+});
+
+describe("loadSlotConfig", () => {
+  it("loads webhook URL from per-slot env var", () => {
+    const env = {
+      DISCORD_WEBHOOK_DEV1_URL: "https://discord.example/dev1",
+    } as NodeJS.ProcessEnv;
+    const config = loadSlotConfig("Dev 1", env);
+    expect(config.discordWebhookUrl).toBe("https://discord.example/dev1");
+    expect(config.branchSlug).toBe("dev1");
+  });
+
+  it("uses QA prefix for the QA + Release slot", () => {
+    const env = {
+      DISCORD_WEBHOOK_QA_URL: "https://discord.example/qa",
+    } as NodeJS.ProcessEnv;
+    const config = loadSlotConfig("QA + Release", env);
+    expect(config.discordWebhookUrl).toBe("https://discord.example/qa");
+    expect(config.branchSlug).toBe("qa");
+  });
+
+  it("throws when the slot's env var is missing", () => {
+    expect(() => loadSlotConfig("Dev 2", {} as NodeJS.ProcessEnv)).toThrow(
+      /DISCORD_WEBHOOK_DEV2_URL/,
+    );
+  });
+});

--- a/apps/orchestrator/tsconfig.build.json
+++ b/apps/orchestrator/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  },
+  "include": ["src/**/*", "api/**/*"],
+  "exclude": ["node_modules", "dist", "test/**/*", "**/*.test.ts"]
+}

--- a/apps/orchestrator/tsconfig.json
+++ b/apps/orchestrator/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitAny": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "api/**/*", "test/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/orchestrator/vercel.json
+++ b/apps/orchestrator/vercel.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "functions": {
+    "api/linear-webhook.ts": {
+      "runtime": "@vercel/node@5.0.0",
+      "maxDuration": 30
+    },
+    "api/health.ts": {
+      "runtime": "@vercel/node@5.0.0",
+      "maxDuration": 10
+    }
+  }
+}

--- a/apps/orchestrator/vitest.config.ts
+++ b/apps/orchestrator/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+    reporters: ["default"],
+    testTimeout: 5000,
+  },
+});


### PR DESCRIPTION
## Summary

- New TypeScript service at `apps/orchestrator/` (Vercel Functions) implementing the **Friction 3 fix** from `docs/win-backlog/11-nonstop-operation-guide.md`: when a Linear ticket transitions to Done, render the next-ticket prompt and deliver it to the slot's Discord channel.
- Endpoint `POST /api/linear-webhook` verifies HMAC-SHA256 signatures, resolves Linear `assignee.name` → 4+1 slot (`Dev 1`/`Dev 2`/`Dev 3`/`Dev 4`/`QA + Release`), queries Linear for the next unblocked ticket, renders the universal prompt from `docs/win-backlog/09-prompt-template.md`, posts to Discord, marks the next ticket In Progress.
- 45 unit tests (vitest) covering the full reaction matrix + signature verification + prompt rendering + slot resolution. CI workflow at `.github/workflows/orchestrator.yml` runs `tsc --noEmit` + `npm test` on PR.

## Why

This is the **keystone** for 4+1 nonstop operation. Without it, agents idle between tickets waiting for Daniel to send the next prompt — capping per-agent uptime around 25-50%. With it, agents auto-pick up next tickets and uptime climbs to ~70-85% (per `11-nonstop-operation-guide.md` projections).

QA + Release Day 1 priority assignment per the spawn prompt; ~3-4h estimate.

## Test plan

- [x] `cd apps/orchestrator && npm install` clean
- [x] `npm run typecheck` clean (no `any`, strict tsconfig)
- [x] `npm test` — 6 files / 45 tests pass
- [x] Local smoke (dry-run mode):
  - [x] `GET /api/health` → 200 with `{service, version, commit}` JSON
  - [x] Bad signature → 401
  - [x] Valid signature on non-Issue event → 200 `{kind:"ignored", reason:"..."}`
- [x] No secrets committed (`.env.example` placeholders only; `.env` gitignored)
- [x] Conventional commit + Co-Authored-By trailer present

CI gates this PR via the new `Orchestrator (TypeScript)` workflow on the same paths.

## Out of scope

- **No tmux/SSH paste-into-Claude-Code transport.** MVP delivers prompts to Discord; agent runtimes either watch the channel or Daniel re-pastes manually. A real auto-injection transport plugs into `AgentTransport` later.
- **No Linear `Depends:` graph evaluation.** We trust the workspace `unblocked` label as the gate (matches the design in `11-nonstop-operation-guide.md`).
- **No retry queue.** Linear retries failed deliveries; idempotency comes from next-ticket selection being a stateless query.
- **No multi-instance coordination.** Single Vercel deployment; no leader election needed.
- **No changes to root `vercel.json`.** That continues to deploy `apps/marketing/`. The orchestrator is a **separate Vercel project** rooted at `apps/orchestrator/` per its README.

## Setup notes for Daniel

After merge, before this is operational:

1. Create a separate Vercel project pointed at `apps/orchestrator/` (Root Directory setting).
2. Set env vars per `apps/orchestrator/.env.example` (Linear API key, webhook secret, In Progress state UUID, 5× Discord webhook URLs).
3. In Linear → Settings → Webhooks, add `https://<deployment>/api/linear-webhook` for resource type **Issue**; copy the signing secret into `LINEAR_WEBHOOK_SECRET`.
4. Name the Linear users exactly `Dev 1`, `Dev 2`, `Dev 3`, `Dev 4`, `QA + Release` (the orchestrator matches `assignee.name` literally).
5. Create the workspace label `unblocked`; add it to tickets only when `Depends:` is satisfied.

Closes the orchestrator/linear-webhook deliverable from `11-nonstop-operation-guide.md` Friction 3.

Co-Authored-By: Heidi (QA + Release agent) <heidi@sbo3l.dev>