### PR TITLE
feat(infra): multi-stage Dockerfile + distroless runtime + docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,76 @@
+# Keep build context lean. The builder stage runs `cargo build --release
+# --locked` against the workspace; everything outside that path is excluded
+# below to cut send-context time and to ensure local artefacts (target/,
+# node_modules/, sbo3l.db) don't leak into the image.
+
+# Build output
+target
+**/target
+
+# Local SQLite databases
+*.db
+*.db-shm
+*.db-wal
+sbo3l.db*
+demo-fixtures/**/*.db*
+
+# Node / TS / frontend build output
+node_modules
+**/node_modules
+.next
+.turbo
+.vercel
+dist
+**/dist
+build
+**/build
+
+# Python caches
+__pycache__
+**/__pycache__
+.venv
+.mypy_cache
+.pytest_cache
+.ruff_cache
+
+# Editor / OS noise
+.DS_Store
+.idea
+.vscode
+
+# Git metadata — not needed inside the image
+.git
+.gitattributes
+.gitignore
+.github
+
+# Local env / secrets — never copy into context
+.env
+.env.*
+!.env.example
+
+# CI / orchestrator fixtures unrelated to the runtime
+apps/orchestrator/dist
+apps/orchestrator/node_modules
+
+# Demo + docs artefacts (not needed by the daemon at runtime)
+demo-scripts/artifacts
+docs/_site
+
+# Markdown + non-source tooling
+*.md
+!QUICKSTART.md
+!SECURITY_NOTES.md
+docs
+README*
+LICENSE
+FEEDBACK.md
+FINAL_REVIEW*.md
+IMPLEMENTATION_STATUS.md
+SUBMISSION*.md
+AI_USAGE.md
+
+# This file itself
+.dockerignore
+Dockerfile
+docker-compose.yml

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,112 @@
+name: Docker
+
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/**"
+      - "demo-agents/**"
+      - "migrations/**"
+      - "test-corpus/**"
+      - ".github/workflows/docker.yml"
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/**"
+      - "demo-agents/**"
+      - "migrations/**"
+      - "test-corpus/**"
+      - ".github/workflows/docker.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build + size + smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build sbo3l/server:test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: sbo3l/server:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify image size < 100 MB
+        run: |
+          set -euo pipefail
+          BYTES=$(docker image inspect sbo3l/server:test --format='{{.Size}}')
+          MB=$(( BYTES / 1024 / 1024 ))
+          echo "image size: ${MB} MiB (${BYTES} bytes)"
+          if [ "$MB" -gt 100 ]; then
+            echo "::error::image exceeds 100 MiB cap (got ${MB} MiB)"
+            exit 1
+          fi
+
+      - name: Smoke — start container
+        run: |
+          set -euo pipefail
+          docker run -d --rm --name sbo3l-test \
+            -p 18730:8730 \
+            -e SBO3L_ALLOW_UNAUTHENTICATED=1 \
+            sbo3l/server:test
+          # wait for /v1/payment-requests to come up; tolerate slow start
+          for i in $(seq 1 30); do
+            if curl -fsS -o /dev/null -X POST \
+                 -H "Content-Type: application/json" \
+                 -d '{}' http://localhost:18730/v1/payment-requests \
+                 -w "%{http_code}" 2>/dev/null | grep -qE '^(400|422)$'; then
+              # 400/422 means the daemon is up and rejecting an empty body
+              # (which is the right behaviour). 200 would also be a "live"
+              # signal but we expect a malformed empty {} to deny.
+              echo "daemon up after ${i}s"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Smoke — POST golden APRP, expect decision=allow
+        run: |
+          set -euo pipefail
+          NONCE=$(LC_ALL=C tr -dc '0-9A-HJKMNPQRSTVWXYZ' </dev/urandom | head -c 26)
+          EXPIRY=$(date -u -d '+1 hour' +%Y-%m-%dT%H:%M:%SZ)
+          BODY=$(jq --arg e "$EXPIRY" --arg n "$NONCE" \
+                  '.expiry=$e | .nonce=$n' \
+                  test-corpus/aprp/golden_001_minimal.json)
+          echo "$BODY" | jq -c '{nonce, expiry}'
+          RESP=$(echo "$BODY" | curl -fsS \
+              -H "Content-Type: application/json" \
+              -X POST --data-binary @- \
+              http://localhost:18730/v1/payment-requests)
+          echo "$RESP" | jq .
+          DEC=$(echo "$RESP" | jq -r .decision)
+          if [ "$DEC" != "allow" ]; then
+            echo "::error::decision was '$DEC', expected 'allow'"
+            docker logs sbo3l-test || true
+            exit 1
+          fi
+
+      - name: Container logs (always)
+        if: always()
+        run: docker logs sbo3l-test || true
+
+      - name: Stop container
+        if: always()
+        run: docker stop sbo3l-test || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,78 @@
+# syntax=docker/dockerfile:1.7
+#
+# SBO3L server + CLI multi-stage image.
+#
+# Stage 1: rust:1.85-bookworm — builds the `sbo3l-server` daemon and the
+#          `sbo3l` CLI in release mode with debug symbols stripped.
+# Stage 2: gcr.io/distroless/cc-debian12:nonroot — minimal runtime, glibc
+#          + libgcc only, no shell, runs as UID 65532. The migrations/ tree
+#          is also copied into /usr/local/share/sbo3l/migrations as a
+#          belt-and-suspenders artifact (the server embeds them via
+#          include_str! so the runtime copy is informational, not used).
+#
+# Build:    docker build -t sbo3l/server .
+# Run:      docker run --rm -p 8730:8730 -e SBO3L_ALLOW_UNAUTHENTICATED=1 sbo3l/server
+# Persist:  docker run --rm -p 8730:8730 -v sbo3l-data:/var/lib/sbo3l \
+#               -e SBO3L_BEARER_TOKEN_HASH='$2b$...' sbo3l/server
+#
+# See docs/cli/docker.md for full operator notes (env vars, volume layout,
+# health check, security caveats around SBO3L_ALLOW_UNSAFE_PUBLIC_BIND=1).
+
+ARG RUST_VERSION=1.85
+ARG DEBIAN_VERSION=bookworm
+ARG DISTROLESS_TAG=nonroot
+
+# ---------- Stage 1: builder ----------
+FROM rust:${RUST_VERSION}-${DEBIAN_VERSION} AS builder
+
+WORKDIR /build
+
+# Strip symbols at link time so we don't depend on `strip` being present
+# in the rust image (binutils availability varies across rust-debian tags).
+ENV RUSTFLAGS="-C strip=symbols"
+ENV CARGO_TERM_COLOR=never
+ENV CARGO_NET_RETRY=5
+
+COPY . .
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/build/target,sharing=locked \
+    cargo build --release --locked \
+        --bin sbo3l-server \
+        --bin sbo3l && \
+    install -Dm0755 target/release/sbo3l-server /out/usr/local/bin/sbo3l-server && \
+    install -Dm0755 target/release/sbo3l        /out/usr/local/bin/sbo3l && \
+    mkdir -p /out/usr/local/share/sbo3l && \
+    cp -r migrations /out/usr/local/share/sbo3l/migrations && \
+    install -d -m 0700 -o 65532 -g 65532 /out/var/lib/sbo3l
+
+# ---------- Stage 2: runtime ----------
+FROM gcr.io/distroless/cc-debian12:${DISTROLESS_TAG}
+
+LABEL org.opencontainers.image.title="sbo3l-server" \
+      org.opencontainers.image.description="SBO3L cryptographically verifiable trust layer for autonomous AI agents" \
+      org.opencontainers.image.source="https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+# Binaries + embedded migrations + writable data dir.
+COPY --from=builder /out/usr/local/bin/sbo3l-server     /usr/local/bin/sbo3l-server
+COPY --from=builder /out/usr/local/bin/sbo3l            /usr/local/bin/sbo3l
+COPY --from=builder /out/usr/local/share/sbo3l          /usr/local/share/sbo3l
+COPY --from=builder --chown=nonroot:nonroot /out/var/lib/sbo3l /var/lib/sbo3l
+
+# In a container, public bind is the entire point. Both env vars are set so
+# `docker run` works with no extra flags. Unauthenticated mode is NOT set
+# here — operators opt in explicitly per environment.
+ENV SBO3L_LISTEN=0.0.0.0:8730 \
+    SBO3L_ALLOW_UNSAFE_PUBLIC_BIND=1 \
+    SBO3L_DB=/var/lib/sbo3l/sbo3l.db
+
+VOLUME ["/var/lib/sbo3l"]
+
+WORKDIR /var/lib/sbo3l
+USER nonroot:nonroot
+
+EXPOSE 8730
+
+ENTRYPOINT ["/usr/local/bin/sbo3l-server"]

--- a/docs/cli/docker.md
+++ b/docs/cli/docker.md
@@ -1,0 +1,162 @@
+# Running SBO3L in Docker
+
+**Audience:** operators deploying `sbo3l-server` as a long-lived container.
+
+**Outcome:** in five minutes you have a `sbo3l-server` container running in
+unauthenticated dev mode, and a curl from the host gets back a signed
+`allow` decision against the golden APRP fixture.
+
+## Image
+
+The repository ships a multi-stage `Dockerfile` at the project root.
+
+| Stage  | Base                                  | Role                                                |
+|--------|---------------------------------------|-----------------------------------------------------|
+| build  | `rust:1.85-bookworm`                  | `cargo build --release --locked --bin sbo3l-server --bin sbo3l` with `RUSTFLAGS="-C strip=symbols"` |
+| runtime| `gcr.io/distroless/cc-debian12:nonroot` | runs as UID 65532, no shell, no package manager     |
+
+Final image is **under 100 MB**. The runtime layer ships the
+`sbo3l-server` daemon, the `sbo3l` CLI, and the `migrations/` tree (the
+server already embeds them via `include_str!`; the on-disk copy at
+`/usr/local/share/sbo3l/migrations` is a belt-and-suspenders artefact for
+offline inspection).
+
+## Build
+
+```bash
+docker build -t sbo3l/server .
+```
+
+## Run (dev mode, unauthenticated)
+
+```bash
+docker run --rm -p 8730:8730 \
+  -e SBO3L_ALLOW_UNAUTHENTICATED=1 \
+  --name sbo3l \
+  sbo3l/server
+```
+
+The daemon prints a stderr banner reminding you that auth is bypassed:
+
+```
+UNSAFE PUBLIC BIND: sbo3l-server is listening on a non-loopback address 0.0.0.0:8730 …
+⚠ UNAUTHENTICATED MODE — DEV ONLY ⚠
+  SBO3L_ALLOW_UNAUTHENTICATED=1 is set; POST /v1/payment-requests will accept unauthenticated requests.
+```
+
+Both warnings are expected inside a container — see [Security caveats](#security-caveats).
+
+## Smoke test
+
+From a second shell:
+
+```bash
+curl -fsS http://localhost:8730/v1/payment-requests -X POST \
+  -H "Content-Type: application/json" \
+  -d @test-corpus/aprp/golden_001_minimal.json | jq -r .decision
+# expect: allow
+```
+
+> The golden fixture has a fixed `expiry`. If the date has passed,
+> override `expiry` and `nonce` inline:
+>
+> ```bash
+> NONCE=$(LC_ALL=C tr -dc '0-9A-HJKMNPQRSTVWXYZ' </dev/urandom | head -c 26)
+> EXPIRY=$(date -u -d '+1 hour' +%Y-%m-%dT%H:%M:%SZ)
+> jq --arg e "$EXPIRY" --arg n "$NONCE" '.expiry=$e | .nonce=$n' \
+>     test-corpus/aprp/golden_001_minimal.json | \
+>   curl -fsS http://localhost:8730/v1/payment-requests -X POST \
+>     -H "Content-Type: application/json" --data-binary @- | jq -r .decision
+> ```
+
+## Persistent SQLite storage
+
+The default `SBO3L_DB=/var/lib/sbo3l/sbo3l.db` lives on a volume:
+
+```bash
+docker volume create sbo3l-data
+docker run --rm -p 8730:8730 \
+  -v sbo3l-data:/var/lib/sbo3l \
+  -e SBO3L_ALLOW_UNAUTHENTICATED=1 \
+  sbo3l/server
+```
+
+The volume mount-point is owned by UID `65532` (the distroless `nonroot`
+user). Bind-mounting a host directory works only if the host directory is
+writable by UID 65532 — fix with `chown 65532:65532 /your/host/dir` or
+use a named docker volume as above.
+
+To run with an in-memory database (no persistence, fastest startup):
+
+```bash
+docker run --rm -p 8730:8730 \
+  -e SBO3L_ALLOW_UNAUTHENTICATED=1 \
+  -e SBO3L_DB=:memory: \
+  sbo3l/server
+```
+
+## Production: enable bearer auth
+
+Generate a bcrypt hash of your bearer token and pass it in:
+
+```bash
+TOKEN=$(openssl rand -hex 32)
+TOKEN_HASH=$(htpasswd -nBC 12 "" | tr -d ':\n' | sed 's/^/$2y$/' )
+# or any tool that emits a bcrypt hash; the `bcrypt` Rust crate accepts
+# $2a$, $2b$, and $2y$ variants.
+
+docker run -d --restart unless-stopped \
+  -p 8730:8730 \
+  -v sbo3l-data:/var/lib/sbo3l \
+  -e SBO3L_BEARER_TOKEN_HASH="$TOKEN_HASH" \
+  --name sbo3l \
+  sbo3l/server
+
+curl -H "Authorization: Bearer $TOKEN" \
+     http://localhost:8730/v1/payment-requests …
+```
+
+Without `SBO3L_BEARER_TOKEN_HASH` (and without the dev bypass), the server
+returns `401 auth.required`.
+
+## Environment reference
+
+| Variable                          | Default in image          | Notes                                                                         |
+|-----------------------------------|---------------------------|-------------------------------------------------------------------------------|
+| `SBO3L_LISTEN`                    | `0.0.0.0:8730`            | Bind address. Image sets the public bind because in a container, public bind is the point. |
+| `SBO3L_ALLOW_UNSAFE_PUBLIC_BIND`  | `1`                       | Override for the F-4 safety gate. Required while `SBO3L_LISTEN` is non-loopback. |
+| `SBO3L_DB`                        | `/var/lib/sbo3l/sbo3l.db` | Override to `:memory:` for ephemeral runs.                                    |
+| `SBO3L_ALLOW_UNAUTHENTICATED`     | unset (auth required)     | Set to `1` for dev mode. Logs a stderr banner.                                |
+| `SBO3L_BEARER_TOKEN_HASH`         | unset                     | bcrypt hash of the production bearer token.                                   |
+| `SBO3L_JWT_PUBKEY`                | unset                     | Ed25519 verifier pubkey for JWT auth (alternative to bearer).                 |
+
+## Security caveats
+
+1. **`SBO3L_ALLOW_UNSAFE_PUBLIC_BIND=1` is set in the image.** This is
+   correct *inside the container* — without it the F-4 gate would refuse
+   to start because `0.0.0.0` is non-loopback. **Do not** set this env on
+   a host running the daemon directly; use the loopback default
+   (`127.0.0.1:8730`) and put the daemon behind a reverse proxy.
+2. **The image runs as UID 65532 (`nonroot`).** Don't add `--user root`
+   unless you have a specific reason; the daemon never needs root.
+3. **The daemon is the only process.** No shell, no `apt`, no
+   `tini`/`dumb-init` shim. Signal handling is the responsibility of
+   `tokio` and the binary; `docker stop` sends SIGTERM and the runtime
+   exits cleanly.
+4. **No HTTPS termination inside the container.** Run a TLS-terminating
+   reverse proxy (nginx, Caddy, Cloudflare Tunnel) in front.
+
+## Troubleshooting
+
+- **Build fails with "could not find Cargo.lock"** — you ran from a
+  subdirectory. The build context has to be the repo root.
+- **Container starts then exits** — check `docker logs sbo3l`. The two
+  most common causes are (a) F-4 refusing because something else has
+  unset `SBO3L_ALLOW_UNSAFE_PUBLIC_BIND`, or (b) auth required and no
+  token hash configured.
+- **`401 auth.required` on every request** — set
+  `SBO3L_ALLOW_UNAUTHENTICATED=1` (dev) or
+  `SBO3L_BEARER_TOKEN_HASH=$2b$…` (prod) and pass
+  `Authorization: Bearer …` on the request.
+- **Bind-mount permission denied** — the daemon runs as UID 65532; fix
+  the host directory perms or use a named volume.


### PR DESCRIPTION
## Summary
- New root `Dockerfile`: builder `rust:1.85-bookworm` → runtime `gcr.io/distroless/cc-debian12:nonroot`, build cache mounts for cargo registry/git/target, debug symbols stripped via `RUSTFLAGS=-C strip=symbols`.
- Image runs as UID 65532, no shell, no package manager. Ships `sbo3l-server` and the `sbo3l` CLI plus a copy of `migrations/` (informational — the server embeds them via `include_str!`).
- Container ENV defaults: `SBO3L_LISTEN=0.0.0.0:8730`, `SBO3L_ALLOW_UNSAFE_PUBLIC_BIND=1`, `SBO3L_DB=/var/lib/sbo3l/sbo3l.db`. Volume `/var/lib/sbo3l` for SQLite persistence.
- New `.dockerignore` to keep build context lean (excludes `target/`, `node_modules/`, `*.db`, `.git/`, generated docs/marketing artefacts).
- New `docs/cli/docker.md`: copy-paste-runnable build, dev-mode run, smoke test, persistence, production bearer auth, env reference, security caveats.
- New `.github/workflows/docker.yml` runs the ticket's QA test plan on every PR that touches the build path: build, image-size assert (< 100 MiB), container boot, POST `/v1/payment-requests` against a freshened golden APRP fixture, assert `decision=allow`, dump container logs on failure.

## Why
Closes **F-7** (`docs/win-backlog/05-phase-1.md`). KH adoption surface needs a one-command-deploy story; "the daemon is just a service" is much easier to evaluate than "clone the repo and run cargo." Distroless + non-root + small surface also de-risks Phase 3 hosted preview at `app.sbo3l.dev`.

## Verification
**Local Docker is not available in this dev environment**, so verification lives in the new CI workflow rather than as inline shell output here. The CI job mirrors the ticket's QA test plan (with one robustness improvement: the smoke step rewrites `expiry` and `nonce` on the golden APRP so it is not time-sensitive).

Heidi: please confirm `Docker / Build + size + smoke` is green on this PR before approving — that job IS the QA gate for this ticket.

- [ ] CI: `Docker / Build + size + smoke` green (image builds, size < 100 MiB, smoke `decision=allow`).
- [ ] CI: existing `Rust check`, `Validate JSON schemas / OpenAPI` green (no Rust changes here, expected pass).
- [ ] Manual (Heidi, optional): `docker build -t sbo3l/server . && docker run --rm -p 8730:8730 -e SBO3L_ALLOW_UNAUTHENTICATED=1 sbo3l/server` then curl per `docs/cli/docker.md`.

## Image-size budget
| Component                       | est. size |
|---------------------------------|-----------|
| `gcr.io/distroless/cc-debian12:nonroot` base | ~24 MiB |
| `sbo3l-server` (release, stripped)           | ~20 MiB |
| `sbo3l` CLI (release, stripped)              | ~15 MiB |
| `migrations/` (7 files)                      | < 100 KiB |
| **Total estimate**                           | **~60 MiB** (well under the 100 MiB cap) |

CI will print the actual size and fail the job if it exceeds 100 MiB.

## Out of scope
- F-8 docker-compose.yml (separate ticket; depends on this).
- Multi-arch (linux/arm64) builds — single-arch (linux/amd64) only for now; the image is pulled into hosted infra (Fly/Railway) which is amd64.
- Pushing to a registry — no `docker push` in this PR; CI uses `load: true` for local-engine smoke only.
- F-1 auth-related env vars beyond what is documented — production hash generation is operator responsibility.
- Hadolint / dive / trivy scans — can be added in a follow-up if Heidi wants a security-scan step.

Closes F-7.

Co-Authored-By: Dev 4 (Infra + On-chain + Distributed) <dev4@sbo3l.dev>