### PR TITLE
fix(infra): bump Dockerfile rustc to 1-bookworm (unbreak F-7 build on main)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,11 @@
 #
 # SBO3L server + CLI multi-stage image.
 #
-# Stage 1: rust:1.85-bookworm — builds the `sbo3l-server` daemon and the
-#          `sbo3l` CLI in release mode with debug symbols stripped.
+# Stage 1: rust:1-bookworm — builds the `sbo3l-server` daemon and the
+#          `sbo3l` CLI in release mode with debug symbols stripped. Tracks
+#          the latest 1.x stable; some workspace transitive deps (icu_*,
+#          time-macros) demand rustc >= 1.88, so a fixed minor pin would
+#          drift out of compliance over time.
 # Stage 2: gcr.io/distroless/cc-debian12:nonroot — minimal runtime, glibc
 #          + libgcc only, no shell, runs as UID 65532. The migrations/ tree
 #          is also copied into /usr/local/share/sbo3l/migrations as a
@@ -18,7 +21,7 @@
 # See docs/cli/docker.md for full operator notes (env vars, volume layout,
 # health check, security caveats around SBO3L_ALLOW_UNSAFE_PUBLIC_BIND=1).
 
-ARG RUST_VERSION=1.85
+ARG RUST_VERSION=1
 ARG DEBIAN_VERSION=bookworm
 ARG DISTROLESS_TAG=nonroot
 

--- a/docs/cli/docker.md
+++ b/docs/cli/docker.md
@@ -12,7 +12,7 @@ The repository ships a multi-stage `Dockerfile` at the project root.
 
 | Stage  | Base                                  | Role                                                |
 |--------|---------------------------------------|-----------------------------------------------------|
-| build  | `rust:1.85-bookworm`                  | `cargo build --release --locked --bin sbo3l-server --bin sbo3l` with `RUSTFLAGS="-C strip=symbols"` |
+| build  | `rust:1-bookworm` (latest 1.x stable) | `cargo build --release --locked --bin sbo3l-server --bin sbo3l` with `RUSTFLAGS="-C strip=symbols"` |
 | runtime| `gcr.io/distroless/cc-debian12:nonroot` | runs as UID 65532, no shell, no package manager     |
 
 Final image is **under 100 MB**. The runtime layer ships the


### PR DESCRIPTION
## Summary
- Dockerfile builder image: `rust:1.85-bookworm` → `rust:1-bookworm` (latest 1.x stable).
- Doc table in `docs/cli/docker.md` updated to match.

## Why
PR #93 (F-7) auto-merged before its own brand-new `Docker / Build + size + smoke` job appeared in the required-checks list, so a broken-on-main Dockerfile slipped through. The original ticket spec named `rust:1.85-bookworm`, but workspace transitive deps in the current `Cargo.lock` need ≥ 1.88:

```
icu_collections@2.2.0   requires rustc 1.86
icu_locale_core@2.2.0   requires rustc 1.86
icu_normalizer@2.2.0    requires rustc 1.86
icu_properties@2.2.0    requires rustc 1.86
time@0.3.47             requires rustc 1.88.0
time-macros@0.2.27      requires rustc 1.88.0
```

`rust:1-bookworm` tracks the latest 1.x stable image (the same release stream `dtolnay/rust-toolchain@stable` follows in `ci.yml`), so this matches the rustc the existing Rust check job already validates against.

## Test plan
- [ ] CI: `Docker / Build + size + smoke` green on this PR (was failing on main as of `f4ca925`).
- [ ] CI: `Rust check`, `Validate JSON schemas / OpenAPI` green.
- [ ] After merge: `Docker` job on `main` flips back to green.

## Out of scope
- Pinning to a specific minor version. Can tighten in a follow-up if reproducibility on rustc point releases becomes an issue.
- The required-checks list on `main` (Daniel's repo-settings call). Ideally `Docker / Build + size + smoke` is added before the next infra-touching PR.

## Postmortem note
Auto-merge raced against required-checks configuration: a workflow introduced in the same PR that adds it cannot guard its own first run unless it is *already* listed as required. Consider one of: (a) introduce new CI workflows in a separate PR before the work that needs them, then add to required-checks, then merge the dependent work; (b) flip auto-merge off for any PR that adds a new workflow; (c) accept the small risk and fix forward (this PR).

Co-Authored-By: Dev 4 (Infra + On-chain + Distributed) <dev4@sbo3l.dev>