### PR TITLE
feat(server): persistent budget store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,11 +2044,13 @@ dependencies = [
  "hex",
  "rust_decimal",
  "sbo3l-core",
+ "sbo3l-storage",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
  "serde_yaml",
  "sha2",
+ "tempfile",
  "thiserror 1.0.69",
 ]
 
@@ -2087,6 +2089,7 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "rusqlite",
+ "rust_decimal",
  "sbo3l-core",
  "serde",
  "serde_json",

--- a/SECURITY_NOTES.md
+++ b/SECURITY_NOTES.md
@@ -13,13 +13,16 @@ This is a hackathon-scope demo. SBO3L's daemon and CLI are labelled `⚠ DEV ONL
 
 Default-deny: a request without `Authorization` is rejected with HTTP 401 + `auth.required` (RFC 7807). The development-only bypass `SBO3L_ALLOW_UNAUTHENTICATED=1` is advertised at startup with a stderr `⚠ UNAUTHENTICATED MODE — DEV ONLY ⚠` banner; never enable in production. The auth gate runs before idempotency, before the nonce gate, and before any signing — a rejected request produces zero side effects.
 
+## Budget persistence (F-2, ACID across restart)
+
+Budget caps (`per_tx`, `daily`, `monthly`, `per_provider`) persist in SQLite via the V008 `budget_state` table ([`crates/sbo3l-storage/src/budget_store.rs`](crates/sbo3l-storage/src/budget_store.rs)). On the request path, [`BudgetTracker::commit`](crates/sbo3l-policy/src/budget.rs) wraps the budget upsert AND the audit append in a single rusqlite transaction via `Storage::finalize_decision`: both writes either land or roll back together. Daemon restart against the same SQLite file replays committed spend; deny on restart with the spec-canonical `policy.budget_exceeded` is exercised by `cargo test --test test_budget_persistence`.
+
+`per_tx` is a single-request cap and is intentionally never persisted — its row is never written, only the request amount is compared.
+
 ## Known limitations (scope-cut for submission)
 
 ### Production signer wiring
 `sbo3l-server` constructs `AppState::new()` directly today, which uses the deterministic public dev seed. `AppState::new()` is documented `⚠ DEV ONLY ⚠`. Production path: `AppState::with_signers(...)` injects a real KMS-backed `SignerBackend`; daemon refuses startup if `SBO3L_SIGNER_BACKEND` is unset. Mock-KMS persistence (PSM-A1.9, V005) is the production-shaped lifecycle preview, not the production signer. Tracked.
-
-### Budget tracker persistence
-Budget caps (`per_tx`, `daily`, `monthly`, `per_provider`) are an in-memory `HashMap` inside `AppState`. They reset on daemon restart; they don't survive multi-process deployment. Production path: SQLite-backed budget rows committed transactionally alongside the nonce-replay claim and the audit append. Tracked.
 
 ### Idempotency in-flight semantics
 `Idempotency-Key` cache lookup happens before the pipeline runs; cache write happens after the pipeline returns 200. Concurrent same-key requests can race and both pass the lookup. Production path: a `processing` / `succeeded` / `failed` state machine with an atomic reservation on first lookup, so a second concurrent request blocks or returns 409 instead of running the pipeline twice. Tracked.

--- a/crates/sbo3l-policy/Cargo.toml
+++ b/crates/sbo3l-policy/Cargo.toml
@@ -9,6 +9,7 @@ description = "SBO3L policy: YAML/JSON policy parsing and rule evaluation."
 
 [dependencies]
 sbo3l-core = { workspace = true }
+sbo3l-storage = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
@@ -18,3 +19,6 @@ sha2 = { workspace = true }
 hex = { workspace = true }
 serde_json_canonicalizer = { workspace = true }
 chrono = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/sbo3l-policy/src/budget.rs
+++ b/crates/sbo3l-policy/src/budget.rs
@@ -1,30 +1,51 @@
-//! In-memory budget tracker.
+//! SQLite-backed budget tracker (F-2).
 //!
-//! Implements `per_tx`, `daily`, `monthly` and `per_provider` budget scopes
-//! defined in `schemas/policy_v1.json`. Persistence is the responsibility of
-//! `sbo3l-storage`; this module only enforces caps against spend the caller
-//! reports as committed.
+//! `BudgetTracker` enforces the four budget scopes defined in
+//! `schemas/policy_v1.json` (`per_tx`, `daily`, `monthly`, `per_provider`)
+//! against per-bucket spend rows persisted in `sbo3l-storage`. Persistence
+//! survives daemon restart and multi-process deployment — the
+//! pre-F-2 in-memory `HashMap` lifetime no longer applies.
+//!
+//! Two operations:
+//!
+//! - [`BudgetTracker::check`] — read-only; consults
+//!   `Storage::budget_spent_cents` for each applicable bucket and returns
+//!   the first cap breach as a [`BudgetDeny`]. No writes.
+//! - [`BudgetTracker::commit`] — wraps **policy + budget + audit** in a
+//!   single rusqlite transaction via `Storage::finalize_decision`. On
+//!   error the transaction is rolled back; no partial budget rows, no
+//!   audit row without its budget commit.
+//!
+//! Per-tx is a single-request cap and never accumulates: rows with
+//! `scope = 'per_tx'` are not written by this module.
 
-use std::collections::HashMap;
 use std::str::FromStr;
 
-use chrono::{DateTime, Datelike, Utc};
+use chrono::{DateTime, Datelike, NaiveDate, NaiveTime, TimeZone, Utc};
 use rust_decimal::Decimal;
 use thiserror::Error;
 
 use sbo3l_core::aprp::PaymentRequest;
+use sbo3l_core::audit::SignedAuditEvent;
+use sbo3l_core::signer::DevSigner;
+use sbo3l_storage::audit_store::NewAuditEvent;
+use sbo3l_storage::budget_store::{usd_str_to_cents, BudgetIncrement};
+use sbo3l_storage::{Storage, StorageError};
 
 use crate::model::{Budget, BudgetScope, Policy};
 use crate::util::same_origin;
 
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Error)]
 pub enum BudgetError {
-    #[error("budget value '{0}' is not a decimal")]
+    #[error("budget value '{0}' is not a decimal in whole cents")]
     BadValue(String),
+    #[error("storage failure: {0}")]
+    Storage(#[from] StorageError),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BudgetDeny {
+    /// Always `policy.budget_exceeded` per win-backlog standards (F-2).
     pub deny_code: &'static str,
     pub scope: BudgetScope,
     pub scope_key: Option<String>,
@@ -33,19 +54,24 @@ pub struct BudgetDeny {
     pub requested_usd: Decimal,
 }
 
+/// Stateless namespace; F-2 moved all per-bucket spend out of the process
+/// memory and into SQLite. The struct is kept for API stability with
+/// pre-F-2 callers: every public method is associated, none take `self`.
 #[derive(Debug, Default)]
-pub struct BudgetTracker {
-    // (agent_id, scope, bucket_key) -> committed spend.
-    buckets: HashMap<(String, BudgetScope, String), Decimal>,
-}
+pub struct BudgetTracker;
 
 impl BudgetTracker {
+    /// Identity-only constructor — `BudgetTracker` carries no state.
     pub fn new() -> Self {
-        Self::default()
+        Self
     }
 
+    /// Pure read: ask `storage` for current spend on every bucket the
+    /// `policy` declares for `request.agent_id`, and surface the first
+    /// (request_amount + bucket_spent > cap) breach as a [`BudgetDeny`].
+    /// Returns `Ok(None)` when every applicable bucket is under cap.
     pub fn check(
-        &self,
+        storage: &Storage,
         policy: &Policy,
         request: &PaymentRequest,
         now: DateTime<Utc>,
@@ -59,21 +85,20 @@ impl BudgetTracker {
                 continue;
             }
             let cap = parse_decimal(&budget.cap_usd)?;
-            // PerTx is a single-request cap and never accumulates.
+            // PerTx is a single-request cap; never persisted, never
+            // accumulated, only compared to the request amount alone.
             let (spent, candidate) = if matches!(budget.scope, BudgetScope::PerTx) {
                 (Decimal::ZERO, amount)
             } else {
                 let key = bucket_key(budget, request, policy, now);
-                let s = self
-                    .buckets
-                    .get(&(request.agent_id.clone(), budget.scope, key))
-                    .copied()
-                    .unwrap_or(Decimal::ZERO);
-                (s, s + amount)
+                let scope_str = scope_repr(budget.scope);
+                let cents = storage.budget_spent_cents(&request.agent_id, scope_str, &key)?;
+                let spent_dec = cents_to_decimal(cents);
+                (spent_dec, spent_dec + amount)
             };
             if candidate > cap {
                 return Ok(Some(BudgetDeny {
-                    deny_code: "budget.hard_cap_exceeded",
+                    deny_code: "policy.budget_exceeded",
                     scope: budget.scope,
                     scope_key: budget.scope_key.clone(),
                     cap_usd: cap,
@@ -85,37 +110,81 @@ impl BudgetTracker {
         Ok(None)
     }
 
+    /// Atomic combo: persist every budget increment AND append the audit
+    /// event in a single transaction. Returns the signed audit event.
+    /// If any step fails the whole transaction rolls back and the error
+    /// is bubbled — neither budget rows nor the audit row are visible to
+    /// any subsequent reader.
+    ///
+    /// This is the F-2 "wraps policy + budget + audit in single
+    /// transaction" acceptance criterion.
     pub fn commit(
-        &mut self,
+        storage: &mut Storage,
         policy: &Policy,
         request: &PaymentRequest,
         now: DateTime<Utc>,
-    ) -> Result<(), BudgetError> {
-        let amount = parse_decimal(&request.amount.value)?;
-        for budget in &policy.budgets {
-            if budget.agent_id != request.agent_id {
-                continue;
-            }
-            if !applies_to_request(budget, request, policy) {
-                continue;
-            }
-            // PerTx is a single-request cap and is never persisted across commits.
-            if matches!(budget.scope, BudgetScope::PerTx) {
-                continue;
-            }
-            let key = bucket_key(budget, request, policy, now);
-            let entry = self
-                .buckets
-                .entry((request.agent_id.clone(), budget.scope, key))
-                .or_insert(Decimal::ZERO);
-            *entry += amount;
-        }
-        Ok(())
+        audit_event: NewAuditEvent,
+        audit_signer: &DevSigner,
+    ) -> Result<SignedAuditEvent, BudgetError> {
+        let increments = build_increments(policy, request, now)?;
+        let signed = storage.finalize_decision(&increments, audit_event, audit_signer)?;
+        Ok(signed)
     }
+}
+
+/// Translate `policy.budgets` rules + the incoming request into the set of
+/// `BudgetIncrement`s the SQLite layer should upsert. Returns an empty
+/// vector if no budget applies (e.g. policy has no budgets, or only
+/// `per_tx` which is never persisted).
+fn build_increments(
+    policy: &Policy,
+    request: &PaymentRequest,
+    now: DateTime<Utc>,
+) -> Result<Vec<BudgetIncrement>, BudgetError> {
+    let amount_cents = usd_str_to_cents(&request.amount.value)
+        .ok_or_else(|| BudgetError::BadValue(request.amount.value.clone()))?;
+    let mut out = Vec::new();
+    for budget in &policy.budgets {
+        if budget.agent_id != request.agent_id {
+            continue;
+        }
+        if !applies_to_request(budget, request, policy) {
+            continue;
+        }
+        // Per-tx caps are evaluated in `check`; they don't accumulate, so
+        // we never write a row for them.
+        if matches!(budget.scope, BudgetScope::PerTx) {
+            continue;
+        }
+        let cap_cents = usd_str_to_cents(&budget.cap_usd)
+            .ok_or_else(|| BudgetError::BadValue(budget.cap_usd.clone()))?;
+        out.push(BudgetIncrement {
+            agent_id: request.agent_id.clone(),
+            scope: scope_repr(budget.scope).to_string(),
+            scope_key: bucket_key(budget, request, policy, now),
+            delta_cents: amount_cents,
+            cap_cents,
+            reset_at_unix: reset_at_unix(budget.scope, now),
+        });
+    }
+    Ok(out)
 }
 
 fn parse_decimal(s: &str) -> Result<Decimal, BudgetError> {
     Decimal::from_str(s).map_err(|_| BudgetError::BadValue(s.to_string()))
+}
+
+fn cents_to_decimal(cents: i64) -> Decimal {
+    Decimal::new(cents, 2)
+}
+
+fn scope_repr(scope: BudgetScope) -> &'static str {
+    match scope {
+        BudgetScope::PerTx => "per_tx",
+        BudgetScope::Daily => "daily",
+        BudgetScope::Monthly => "monthly",
+        BudgetScope::PerProvider => "per_provider",
+    }
 }
 
 fn bucket_key(
@@ -128,17 +197,39 @@ fn bucket_key(
         BudgetScope::PerTx => "tx".to_string(),
         BudgetScope::Daily => now.format("%Y-%m-%d").to_string(),
         BudgetScope::Monthly => format!("{:04}-{:02}", now.year(), now.month()),
-        BudgetScope::PerProvider => {
-            // Bucket by the policy.providers entry whose URL matches the request,
-            // or by the raw URL if no policy entry exists.
-            let pid = policy
-                .providers
-                .iter()
-                .find(|p| same_origin(&p.url, &request.provider_url))
-                .map(|p| p.id.clone())
-                .unwrap_or_else(|| request.provider_url.clone());
-            pid
+        BudgetScope::PerProvider => policy
+            .providers
+            .iter()
+            .find(|p| same_origin(&p.url, &request.provider_url))
+            .map(|p| p.id.clone())
+            .unwrap_or_else(|| request.provider_url.clone()),
+    }
+}
+
+/// The next bucket boundary as a unix epoch second. Informational; not
+/// enforced by current logic — rollover is implicit in `bucket_key` (a new
+/// day's request creates a new row for the new `scope_key`).
+fn reset_at_unix(scope: BudgetScope, now: DateTime<Utc>) -> Option<i64> {
+    match scope {
+        BudgetScope::PerTx => None,
+        BudgetScope::Daily => {
+            // Midnight UTC after `now`.
+            let next = now.date_naive().succ_opt()?;
+            let dt = NaiveDate::and_time(&next, NaiveTime::from_hms_opt(0, 0, 0)?);
+            Some(Utc.from_utc_datetime(&dt).timestamp())
         }
+        BudgetScope::Monthly => {
+            // First of next month UTC.
+            let (y, m) = if now.month() == 12 {
+                (now.year() + 1, 1)
+            } else {
+                (now.year(), now.month() + 1)
+            };
+            let next = NaiveDate::from_ymd_opt(y, m, 1)?;
+            let dt = NaiveDate::and_time(&next, NaiveTime::from_hms_opt(0, 0, 0)?);
+            Some(Utc.from_utc_datetime(&dt).timestamp())
+        }
+        BudgetScope::PerProvider => None,
     }
 }
 
@@ -148,7 +239,6 @@ fn applies_to_request(budget: &Budget, request: &PaymentRequest, policy: &Policy
         BudgetScope::PerProvider => match &budget.scope_key {
             None => true,
             Some(key) => {
-                // scope_key may be the provider id; match by id or url.
                 if let Some(p) = policy
                     .providers
                     .iter()
@@ -167,7 +257,7 @@ fn applies_to_request(budget: &Budget, request: &PaymentRequest, policy: &Policy
 mod tests {
     use super::*;
 
-    fn policy() -> Policy {
+    fn policy_default() -> Policy {
         Policy::parse_json(include_str!(
             "../../../test-corpus/policy/reference_low_risk.json"
         ))
@@ -186,38 +276,58 @@ mod tests {
             .into()
     }
 
-    #[test]
-    fn fresh_tracker_passes_for_small_request() {
-        let p = policy();
-        let req = aprp_golden();
-        let t = BudgetTracker::new();
-        assert!(t.check(&p, &req, now()).unwrap().is_none());
+    fn signer() -> DevSigner {
+        DevSigner::from_seed("audit-signer-v1", [11u8; 32])
     }
 
-    #[test]
-    fn per_tx_cap_blocks_oversized_request() {
-        let mut p = policy();
-        // tighten per_tx cap to 0.01 USD
-        for b in &mut p.budgets {
-            if matches!(b.scope, BudgetScope::PerTx) {
-                b.cap_usd = "0.01".to_string();
-            }
+    fn audit_event_for(req: &PaymentRequest) -> NewAuditEvent {
+        NewAuditEvent {
+            event_type: "policy_decided".to_string(),
+            actor: "policy_engine".to_string(),
+            subject_id: format!("pr-{}", req.nonce),
+            payload_hash: "00".repeat(32),
+            metadata: serde_json::Map::new(),
+            policy_version: Some(1),
+            policy_hash: Some("00".repeat(32)),
+            attestation_ref: None,
+            ts: now(),
         }
-        let req = aprp_golden();
-        let t = BudgetTracker::new();
-        let deny = t.check(&p, &req, now()).unwrap().unwrap();
-        assert_eq!(deny.deny_code, "budget.hard_cap_exceeded");
-        assert_eq!(deny.scope, BudgetScope::PerTx);
     }
 
     fn minimal_policy_with(budgets: Vec<Budget>) -> Policy {
-        let mut p = policy();
+        let mut p = policy_default();
         p.budgets = budgets;
         p
     }
 
     #[test]
-    fn daily_cap_accumulates_across_commits() {
+    fn fresh_storage_passes_for_small_request() {
+        let s = Storage::open_in_memory().unwrap();
+        let p = policy_default();
+        let req = aprp_golden();
+        assert!(BudgetTracker::check(&s, &p, &req, now()).unwrap().is_none());
+    }
+
+    #[test]
+    fn per_tx_cap_blocks_oversized_request_without_writing_any_row() {
+        let s = Storage::open_in_memory().unwrap();
+        let mut p = policy_default();
+        for b in &mut p.budgets {
+            if matches!(b.scope, BudgetScope::PerTx) {
+                b.cap_usd = "0.01".to_string();
+            }
+        }
+        let req = aprp_golden(); // 0.05 USD
+        let deny = BudgetTracker::check(&s, &p, &req, now()).unwrap().unwrap();
+        assert_eq!(deny.deny_code, "policy.budget_exceeded");
+        assert_eq!(deny.scope, BudgetScope::PerTx);
+        // Per-tx never persists — table must be empty even after a deny.
+        assert_eq!(s.budget_state_count().unwrap(), 0);
+    }
+
+    #[test]
+    fn daily_cap_accumulates_across_commits_in_storage() {
+        let mut s = Storage::open_in_memory().unwrap();
         let p = minimal_policy_with(vec![Budget {
             agent_id: "research-agent-01".to_string(),
             scope: BudgetScope::Daily,
@@ -227,18 +337,24 @@ mod tests {
         }]);
         let req = aprp_golden(); // 0.05 USD
 
-        let mut t = BudgetTracker::new();
-        assert!(t.check(&p, &req, now()).unwrap().is_none()); // 0 + 0.05 ≤ 0.10
-        t.commit(&p, &req, now()).unwrap(); // 0.05 spent
-        assert!(t.check(&p, &req, now()).unwrap().is_none()); // 0.05 + 0.05 = 0.10 ≤ 0.10
-        t.commit(&p, &req, now()).unwrap(); // 0.10 spent
-        let next = t.check(&p, &req, now()).unwrap().unwrap(); // 0.10 + 0.05 > 0.10
+        // 0 + 0.05 ≤ 0.10 — pass.
+        assert!(BudgetTracker::check(&s, &p, &req, now()).unwrap().is_none());
+        BudgetTracker::commit(&mut s, &p, &req, now(), audit_event_for(&req), &signer()).unwrap();
+
+        // 0.05 + 0.05 = 0.10 ≤ 0.10 — pass.
+        assert!(BudgetTracker::check(&s, &p, &req, now()).unwrap().is_none());
+        BudgetTracker::commit(&mut s, &p, &req, now(), audit_event_for(&req), &signer()).unwrap();
+
+        // 0.10 + 0.05 > 0.10 — deny.
+        let next = BudgetTracker::check(&s, &p, &req, now()).unwrap().unwrap();
         assert_eq!(next.scope, BudgetScope::Daily);
         assert_eq!(next.cap_usd, Decimal::from_str("0.10").unwrap());
+        assert_eq!(next.deny_code, "policy.budget_exceeded");
     }
 
     #[test]
     fn per_provider_bucket_isolates_providers() {
+        let mut s = Storage::open_in_memory().unwrap();
         let p = minimal_policy_with(vec![Budget {
             agent_id: "research-agent-01".to_string(),
             scope: BudgetScope::PerProvider,
@@ -246,19 +362,19 @@ mod tests {
             cap_usd: "0.10".to_string(),
             soft_cap_usd: None,
         }]);
-        let req = aprp_golden(); // provider api.example.com, 0.05
+        let req = aprp_golden();
 
-        let mut t = BudgetTracker::new();
-        assert!(t.check(&p, &req, now()).unwrap().is_none());
-        t.commit(&p, &req, now()).unwrap();
-        t.commit(&p, &req, now()).unwrap(); // 0.10 spent
-        let next = t.check(&p, &req, now()).unwrap().unwrap();
+        assert!(BudgetTracker::check(&s, &p, &req, now()).unwrap().is_none());
+        BudgetTracker::commit(&mut s, &p, &req, now(), audit_event_for(&req), &signer()).unwrap();
+        BudgetTracker::commit(&mut s, &p, &req, now(), audit_event_for(&req), &signer()).unwrap();
+        let next = BudgetTracker::check(&s, &p, &req, now()).unwrap().unwrap();
         assert_eq!(next.scope, BudgetScope::PerProvider);
         assert_eq!(next.scope_key.as_deref(), Some("api.example.com"));
     }
 
     #[test]
-    fn per_tx_does_not_accumulate() {
+    fn per_tx_does_not_accumulate_in_storage() {
+        let mut s = Storage::open_in_memory().unwrap();
         let p = minimal_policy_with(vec![Budget {
             agent_id: "research-agent-01".to_string(),
             scope: BudgetScope::PerTx,
@@ -266,11 +382,58 @@ mod tests {
             cap_usd: "0.10".to_string(),
             soft_cap_usd: None,
         }]);
-        let req = aprp_golden(); // 0.05
-        let mut t = BudgetTracker::new();
-        for _ in 0..1000 {
-            assert!(t.check(&p, &req, now()).unwrap().is_none());
-            t.commit(&p, &req, now()).unwrap();
+        let req = aprp_golden(); // 0.05 USD
+        for _ in 0..50 {
+            assert!(BudgetTracker::check(&s, &p, &req, now()).unwrap().is_none());
+            BudgetTracker::commit(&mut s, &p, &req, now(), audit_event_for(&req), &signer())
+                .unwrap();
         }
+        // 50 audit events, but no budget rows — per-tx never persists.
+        assert_eq!(s.budget_state_count().unwrap(), 0);
+        assert_eq!(s.audit_count().unwrap(), 50);
+    }
+
+    #[test]
+    fn budget_state_persists_across_storage_reopen() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        let p = minimal_policy_with(vec![Budget {
+            agent_id: "research-agent-01".to_string(),
+            scope: BudgetScope::Daily,
+            scope_key: None,
+            cap_usd: "0.10".to_string(),
+            soft_cap_usd: None,
+        }]);
+        let req = aprp_golden();
+
+        {
+            let mut s = Storage::open(&path).unwrap();
+            BudgetTracker::commit(&mut s, &p, &req, now(), audit_event_for(&req), &signer())
+                .unwrap();
+        }
+        // Drop the in-memory state, reopen the same file. Spent must
+        // survive: 0.05 + 0.06 > 0.10 — deny.
+        let s = Storage::open(&path).unwrap();
+        let mut req2 = req.clone();
+        req2.amount.value = "0.06".to_string();
+        let deny = BudgetTracker::check(&s, &p, &req2, now()).unwrap().unwrap();
+        assert_eq!(deny.deny_code, "policy.budget_exceeded");
+        assert_eq!(deny.scope, BudgetScope::Daily);
+    }
+
+    #[test]
+    fn commit_with_no_applicable_budget_still_appends_audit_event() {
+        // A policy with zero applicable budgets must still produce a
+        // signed audit event for the decision — the audit chain is
+        // unconditional even when there's nothing to charge.
+        let mut s = Storage::open_in_memory().unwrap();
+        let p = minimal_policy_with(vec![]); // no budgets
+        let req = aprp_golden();
+        let signed =
+            BudgetTracker::commit(&mut s, &p, &req, now(), audit_event_for(&req), &signer())
+                .unwrap();
+        assert_eq!(signed.event.seq, 1);
+        assert_eq!(s.budget_state_count().unwrap(), 0);
+        assert_eq!(s.audit_count().unwrap(), 1);
     }
 }

--- a/crates/sbo3l-server/src/lib.rs
+++ b/crates/sbo3l-server/src/lib.rs
@@ -45,7 +45,6 @@ pub struct AppState(pub Arc<AppInner>);
 pub struct AppInner {
     pub policy: Policy,
     pub storage: Mutex<Storage>,
-    pub budgets: Mutex<BudgetTracker>,
     pub audit_signer: DevSigner,
     pub receipt_signer: DevSigner,
     pub auth: AuthConfig,
@@ -112,7 +111,6 @@ impl AppState {
         Self(Arc::new(AppInner {
             policy,
             storage: Mutex::new(storage),
-            budgets: Mutex::new(BudgetTracker::new()),
             audit_signer,
             receipt_signer,
             auth,
@@ -453,30 +451,25 @@ async fn run_pipeline(
     let mut final_decision = outcome.decision.clone();
     let mut final_deny_code = outcome.deny_code.clone();
 
+    // F-2: storage-backed budget check. Reads current per-bucket spend
+    // from `budget_state` (V008). On a deny we still emit a signed audit
+    // row downstream — the budget table itself is left untouched (no
+    // persisted side effect).
     if matches!(outcome.decision, EngineDecision::Allow) {
-        let mut budgets = inner.budgets.lock().expect("budget lock");
-        match budgets.check(&inner.policy, &aprp, now) {
+        let storage = inner.storage.lock().expect("storage lock");
+        match BudgetTracker::check(&storage, &inner.policy, &aprp, now) {
             Ok(Some(deny)) => {
                 final_decision = EngineDecision::Deny;
                 final_deny_code = Some(deny.deny_code.to_string());
             }
             Ok(None) => {
-                // commit() can fail only with `BudgetError::BadValue` — i.e. a
-                // malformed `cap_usd` decimal in the loaded policy. That is a
-                // server-side configuration error, not a business denial; use
-                // a distinct code so callers don't confuse it with a real cap
-                // breach (which surfaces via `Ok(Some(deny))` above with code
-                // `budget.hard_cap_exceeded`).
-                budgets.commit(&inner.policy, &aprp, now).map_err(|e| {
-                    problem(
-                        "policy.config_error",
-                        500,
-                        "policy config error",
-                        e.to_string(),
-                    )
-                })?;
+                // The actual increment + audit append happens below in a
+                // single transaction (`BudgetTracker::commit`), satisfying
+                // the F-2 acceptance criterion that "policy + budget +
+                // audit wrap in single transaction".
             }
             Err(e) => {
+                drop(storage);
                 return Err(problem(
                     "policy.config_error",
                     500,
@@ -525,10 +518,23 @@ async fn run_pipeline(
         ts: now,
     };
 
+    // F-2: on allow, delegate to `BudgetTracker::commit` which wraps
+    // budget upserts AND the audit append in a single transaction. On
+    // deny / requires_human there is no budget to charge, so we go
+    // straight to the same atomic seam (`Storage::finalize_decision`)
+    // with an empty increments slice — the two writes always either
+    // both land or both roll back, regardless of decision.
     let signed_event: SignedAuditEvent = {
         let mut storage = inner.storage.lock().expect("storage lock");
-        storage
-            .audit_append(audit_event, &inner.audit_signer)
+        if matches!(final_decision, EngineDecision::Allow) {
+            BudgetTracker::commit(
+                &mut storage,
+                &inner.policy,
+                &aprp,
+                now,
+                audit_event,
+                &inner.audit_signer,
+            )
             .map_err(|e| {
                 problem(
                     "audit.write_failed",
@@ -537,6 +543,18 @@ async fn run_pipeline(
                     e.to_string(),
                 )
             })?
+        } else {
+            storage
+                .finalize_decision(&[], audit_event, &inner.audit_signer)
+                .map_err(|e| {
+                    problem(
+                        "audit.write_failed",
+                        500,
+                        "audit append failed",
+                        e.to_string(),
+                    )
+                })?
+        }
     };
 
     let receipt = UnsignedReceipt {

--- a/crates/sbo3l-server/src/main.rs
+++ b/crates/sbo3l-server/src/main.rs
@@ -1,12 +1,14 @@
 use std::io::IsTerminal;
 use std::net::SocketAddr;
 
+use sbo3l_policy::Policy;
 use sbo3l_server::{reference_policy, router, AppState, AuthConfig};
 use sbo3l_storage::Storage;
 
 const DEFAULT_LISTEN: &str = "127.0.0.1:8730";
 const ENV_LISTEN: &str = "SBO3L_LISTEN";
 const ENV_ALLOW_UNSAFE_PUBLIC_BIND: &str = "SBO3L_ALLOW_UNSAFE_PUBLIC_BIND";
+const ENV_POLICY: &str = "SBO3L_POLICY";
 const UNSAFE_BIND_EXIT_CODE: i32 = 2;
 
 #[tokio::main]
@@ -59,7 +61,15 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
-    let policy = reference_policy();
+    let policy = match std::env::var(ENV_POLICY).ok() {
+        None => reference_policy(),
+        Some(path) => {
+            let raw = std::fs::read_to_string(&path)
+                .map_err(|e| anyhow::anyhow!("failed to read {ENV_POLICY}={path}: {e}"))?;
+            Policy::parse_json(&raw)
+                .map_err(|e| anyhow::anyhow!("failed to parse policy at {path}: {e}"))?
+        }
+    };
     let state = AppState::with_auth_config(policy, storage, auth);
     let app = router(state);
 

--- a/crates/sbo3l-server/tests/test_budget_persistence.rs
+++ b/crates/sbo3l-server/tests/test_budget_persistence.rs
@@ -1,0 +1,174 @@
+//! F-2 integration tests: persistent budget store.
+//!
+//! Exercises the headline AC: budget commits survive a daemon restart.
+//! The test plan walked here is the in-process equivalent of the QA test
+//! plan in `docs/win-backlog/05-phase-1.md`:
+//!
+//! 1. Open a tempfile-backed `Storage`. Spend $0.05 against a tight-cap
+//!    daily-budget policy ($0.10/day). Confirm allow.
+//! 2. Drop every in-memory handle (drop the `AppState`, drop the
+//!    `Storage`).
+//! 3. Reopen the same SQLite file in a fresh `AppState`. Spend $0.06.
+//!    Confirm deny with `policy.budget_exceeded` — proof that the
+//!    $0.05 commit from step 1 survived the restart.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use sbo3l_policy::Policy;
+use sbo3l_server::{router, AppState};
+use sbo3l_storage::Storage;
+use serde_json::Value;
+use tower::ServiceExt;
+
+const TIGHT_DAILY_POLICY: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../test-corpus/policy/tight_daily_budget_demo.json"
+));
+
+const APRP_GOLDEN: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../test-corpus/aprp/golden_001_minimal.json"
+));
+
+fn tight_policy() -> Policy {
+    Policy::parse_json(TIGHT_DAILY_POLICY).expect("tight_daily_budget_demo.json must parse")
+}
+
+fn body_with(amount: &str, nonce: &str) -> Value {
+    let mut v: Value = serde_json::from_str(APRP_GOLDEN).unwrap();
+    v["amount"]["value"] = Value::String(amount.to_string());
+    v["nonce"] = Value::String(nonce.to_string());
+    v
+}
+
+async fn post(app: axum::Router, body: Value) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/payment-requests")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes).unwrap();
+    (status, v)
+}
+
+#[tokio::test]
+async fn budget_state_persists_across_daemon_restart() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let db_path = tmp.path().to_path_buf();
+
+    // -------- daemon instance #1: spend $0.05 --------
+    {
+        let storage = Storage::open(&db_path).unwrap();
+        let app = router(AppState::new(tight_policy(), storage));
+        let (status, v) = post(app, body_with("0.05", "01HTAWX5K3R8YV9NQB7C6P2D81")).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(v["status"], "auto_approved");
+        assert_eq!(v["decision"], "allow");
+    }
+
+    // -------- daemon instance #2 against same db: $0.06 must deny --------
+    let storage = Storage::open(&db_path).unwrap();
+    let app = router(AppState::new(tight_policy(), storage));
+    let (status, v) = post(app, body_with("0.06", "01HTAWX5K3R8YV9NQB7C6P2D82")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        v["decision"], "deny",
+        "0.05 + 0.06 > 0.10 daily cap; budget commit must have survived restart"
+    );
+    assert_eq!(v["deny_code"], "policy.budget_exceeded");
+}
+
+#[tokio::test]
+async fn second_request_below_cap_passes_after_restart() {
+    // Mirror of the headline test, sanity-checking that a second request
+    // *under* the cap still passes after a restart. Pins that the
+    // restart didn't somehow inflate the bucket beyond what was
+    // committed.
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let db_path = tmp.path().to_path_buf();
+    {
+        let storage = Storage::open(&db_path).unwrap();
+        let app = router(AppState::new(tight_policy(), storage));
+        let (s, _) = post(app, body_with("0.04", "01HTAWX5K3R8YV9NQB7C6P2D83")).await;
+        assert_eq!(s, StatusCode::OK);
+    }
+    let storage = Storage::open(&db_path).unwrap();
+    let app = router(AppState::new(tight_policy(), storage));
+    // 0.04 + 0.04 = 0.08 ≤ 0.10 — pass.
+    let (status, v) = post(app, body_with("0.04", "01HTAWX5K3R8YV9NQB7C6P2D84")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(v["decision"], "allow");
+}
+
+#[tokio::test]
+async fn deny_request_does_not_consume_budget_after_restart() {
+    // F-2 is a single-transaction commit: a deny path produces a signed
+    // audit row but writes zero budget rows. Pin that property by
+    // pushing a request that exceeds per_tx (so `decide` allows it
+    // because per_tx is checked at allow time, but daily already at
+    // 0.05... actually, simpler pin):
+    //
+    // Drive the cap directly: after persisting 0.05 against the tight
+    // 0.10 daily, send 0.06 → deny; then 0.05 → still deny (0.05+0.05
+    // would be exactly cap, but the previous deny did NOT consume the
+    // budget). After restart, $0.05 should still pass.
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let db_path = tmp.path().to_path_buf();
+
+    // Phase 1: commit 0.05.
+    {
+        let storage = Storage::open(&db_path).unwrap();
+        let app = router(AppState::new(tight_policy(), storage));
+        let (s, _) = post(app, body_with("0.05", "01HTAWX5K3R8YV9NQB7C6P2D91")).await;
+        assert_eq!(s, StatusCode::OK);
+    }
+
+    // Phase 2: 0.06 denies (would put bucket at 0.11 > 0.10).
+    {
+        let storage = Storage::open(&db_path).unwrap();
+        let app = router(AppState::new(tight_policy(), storage));
+        let (s, v) = post(app, body_with("0.06", "01HTAWX5K3R8YV9NQB7C6P2D92")).await;
+        assert_eq!(s, StatusCode::OK);
+        assert_eq!(v["decision"], "deny");
+        assert_eq!(v["deny_code"], "policy.budget_exceeded");
+    }
+
+    // Phase 3: 0.05 still allowed (0.05 + 0.05 = 0.10 ≤ 0.10). The
+    // previous deny did not increment the bucket beyond 0.05.
+    let storage = Storage::open(&db_path).unwrap();
+    let app = router(AppState::new(tight_policy(), storage));
+    let (s, v) = post(app, body_with("0.05", "01HTAWX5K3R8YV9NQB7C6P2D93")).await;
+    assert_eq!(s, StatusCode::OK);
+    assert_eq!(v["decision"], "allow");
+}
+
+#[tokio::test]
+async fn audit_chain_remains_continuous_across_restart() {
+    // Atomic `finalize_decision` must keep the hash chain coherent: an
+    // allow at seq=1 then an allow at seq=2 (after restart) chains
+    // correctly. We don't decode the chain here — the inline audit_store
+    // tests cover that — but we assert seq monotonically increments
+    // across the restart.
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let db_path = tmp.path().to_path_buf();
+
+    let event_id_1: String;
+    {
+        let storage = Storage::open(&db_path).unwrap();
+        let app = router(AppState::new(tight_policy(), storage));
+        let (_, v) = post(app, body_with("0.04", "01HTAWX5K3R8YV9NQB7C6P2DA1")).await;
+        event_id_1 = v["audit_event_id"].as_str().unwrap().to_string();
+        assert!(event_id_1.starts_with("evt-"));
+    }
+
+    let storage = Storage::open(&db_path).unwrap();
+    let app = router(AppState::new(tight_policy(), storage));
+    let (_, v) = post(app, body_with("0.04", "01HTAWX5K3R8YV9NQB7C6P2DA2")).await;
+    let event_id_2 = v["audit_event_id"].as_str().unwrap().to_string();
+    assert_ne!(event_id_2, event_id_1, "second event must have a new id");
+}

--- a/crates/sbo3l-storage/Cargo.toml
+++ b/crates/sbo3l-storage/Cargo.toml
@@ -19,6 +19,8 @@ hex = { workspace = true }
 chrono = { workspace = true }
 ed25519-dalek = { workspace = true }
 ulid = { workspace = true }
+# F-2: USD-string → cents conversion lives at the policy/storage boundary.
+rust_decimal = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/sbo3l-storage/src/budget_store.rs
+++ b/crates/sbo3l-storage/src/budget_store.rs
@@ -1,0 +1,429 @@
+//! Persistent budget state (F-2).
+//!
+//! Backs the SQLite-backed `BudgetTracker` in `sbo3l-policy`. Rows persist
+//! the committed spend per (agent_id, scope, scope_key) bucket so the cap
+//! enforcement survives daemon restart. See migration V008 in
+//! `migrations/V008__budget_state.sql` for the schema and column semantics.
+//!
+//! Two API surfaces:
+//!
+//! 1. [`Storage::budget_state_get`] / [`Storage::budget_spent_cents`] — pure
+//!    reads used by `BudgetTracker::check`. They take `&Storage` (not `&mut`)
+//!    so multiple read paths can hold the connection lock concurrently if
+//!    that ever becomes the design.
+//!
+//! 2. [`Storage::finalize_decision`] — the ACID combo used by
+//!    `BudgetTracker::commit` on the request path. It opens one rusqlite
+//!    transaction, upserts every applicable budget row, appends the audit
+//!    event, and commits. A failure at any step rolls back: no partial
+//!    writes, no audit row without its budget commit, no budget commit
+//!    without its audit row.
+
+use chrono::Utc;
+use rusqlite::{params, OptionalExtension};
+use sbo3l_core::audit::{AuditEvent, SignedAuditEvent, ZERO_HASH};
+use sbo3l_core::receipt::{EmbeddedSignature, SignatureAlgorithm};
+use sbo3l_core::signer::DevSigner;
+
+use crate::audit_store::NewAuditEvent;
+use crate::error::{StorageError, StorageResult};
+use crate::Storage;
+
+/// One row of `budget_state`. Mirrors the columns 1:1; the `scope` field is
+/// the textual repr (`'per_tx' | 'daily' | 'monthly' | 'per_provider'`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BudgetStateRow {
+    pub agent_id: String,
+    pub scope: String,
+    pub scope_key: String,
+    pub spent_cents: i64,
+    pub cap_cents: i64,
+    pub reset_at_unix: Option<i64>,
+}
+
+/// One budget bucket to add `delta_cents` to under a single transaction.
+/// `cap_cents` and `reset_at_unix` are upserted alongside so a row that
+/// already existed with a stale cap is brought forward to the current
+/// policy's cap.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BudgetIncrement {
+    pub agent_id: String,
+    pub scope: String,
+    pub scope_key: String,
+    pub delta_cents: i64,
+    pub cap_cents: i64,
+    pub reset_at_unix: Option<i64>,
+}
+
+impl Storage {
+    /// Read the row for one bucket. Returns `Ok(None)` if the bucket has
+    /// never received a commit (the convention is "missing row = 0 spent").
+    pub fn budget_state_get(
+        &self,
+        agent_id: &str,
+        scope: &str,
+        scope_key: &str,
+    ) -> StorageResult<Option<BudgetStateRow>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT agent_id, scope, scope_key, spent_cents, cap_cents, reset_at_unix
+             FROM budget_state
+             WHERE agent_id = ?1 AND scope = ?2 AND scope_key = ?3",
+        )?;
+        let row = stmt
+            .query_row(params![agent_id, scope, scope_key], |r| {
+                Ok(BudgetStateRow {
+                    agent_id: r.get(0)?,
+                    scope: r.get(1)?,
+                    scope_key: r.get(2)?,
+                    spent_cents: r.get(3)?,
+                    cap_cents: r.get(4)?,
+                    reset_at_unix: r.get(5)?,
+                })
+            })
+            .optional()?;
+        Ok(row)
+    }
+
+    /// Convenience read used by `BudgetTracker::check`. Treats a missing row
+    /// as 0 spent.
+    pub fn budget_spent_cents(
+        &self,
+        agent_id: &str,
+        scope: &str,
+        scope_key: &str,
+    ) -> StorageResult<i64> {
+        Ok(self
+            .budget_state_get(agent_id, scope, scope_key)?
+            .map(|r| r.spent_cents)
+            .unwrap_or(0))
+    }
+
+    /// Diagnostic: total number of budget rows currently in the table.
+    pub fn budget_state_count(&self) -> StorageResult<u64> {
+        let n: i64 = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM budget_state", [], |r| r.get(0))?;
+        Ok(n as u64)
+    }
+
+    /// Atomic combo: append the audit event AND apply every budget
+    /// increment under a single transaction. On any error the whole tx is
+    /// rolled back.
+    ///
+    /// This is the production-shape commit path used by
+    /// `sbo3l-policy::BudgetTracker::commit` — wrapping policy + budget +
+    /// audit in one transaction (F-2 acceptance criterion).
+    pub fn finalize_decision(
+        &mut self,
+        increments: &[BudgetIncrement],
+        audit_event: NewAuditEvent,
+        audit_signer: &DevSigner,
+    ) -> StorageResult<SignedAuditEvent> {
+        let tx = self.conn.transaction()?;
+
+        // 1. Upsert every applicable budget row.
+        for inc in increments {
+            tx.execute(
+                "INSERT INTO budget_state
+                    (agent_id, scope, scope_key, spent_cents, cap_cents, reset_at_unix)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                 ON CONFLICT(agent_id, scope, scope_key) DO UPDATE
+                   SET spent_cents   = budget_state.spent_cents + excluded.spent_cents,
+                       cap_cents     = excluded.cap_cents,
+                       reset_at_unix = excluded.reset_at_unix",
+                params![
+                    inc.agent_id,
+                    inc.scope,
+                    inc.scope_key,
+                    inc.delta_cents,
+                    inc.cap_cents,
+                    inc.reset_at_unix,
+                ],
+            )?;
+        }
+
+        // 2. Append the audit event using the same transaction. Inlined
+        // from `Storage::audit_append` so the read of `audit_last` and the
+        // INSERT both happen under the tx — a parallel writer is blocked
+        // by SQLite's database-level write lock until we COMMIT.
+        let last = audit_last_via_tx(&tx)?;
+        let next_seq = last.as_ref().map(|e| e.event.seq + 1).unwrap_or(1);
+        let prev_hash = last
+            .map(|e| e.event_hash)
+            .unwrap_or_else(|| ZERO_HASH.to_string());
+        let event = AuditEvent {
+            version: 1,
+            seq: next_seq,
+            id: format!("evt-{}", ulid::Ulid::new()),
+            ts: audit_event.ts,
+            event_type: audit_event.event_type,
+            actor: audit_event.actor,
+            subject_id: audit_event.subject_id,
+            payload_hash: audit_event.payload_hash,
+            metadata: audit_event.metadata,
+            policy_version: audit_event.policy_version,
+            policy_hash: audit_event.policy_hash,
+            attestation_ref: audit_event.attestation_ref,
+            prev_event_hash: prev_hash,
+        };
+        let signed = SignedAuditEvent::sign(event, audit_signer)?;
+        tx.execute(
+            "INSERT INTO audit_events
+                (seq, id, ts, type, actor, subject_id, payload_hash, metadata_json,
+                 policy_version, policy_hash, attestation_ref, prev_event_hash,
+                 event_hash, signature_alg, signature_key_id, signature_hex)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+            params![
+                signed.event.seq as i64,
+                signed.event.id,
+                signed.event.ts.to_rfc3339(),
+                signed.event.event_type,
+                signed.event.actor,
+                signed.event.subject_id,
+                signed.event.payload_hash,
+                serde_json::Value::Object(signed.event.metadata.clone()).to_string(),
+                signed.event.policy_version.map(|v| v as i64),
+                signed.event.policy_hash,
+                signed.event.attestation_ref,
+                signed.event.prev_event_hash,
+                signed.event_hash,
+                "ed25519",
+                signed.signature.key_id,
+                signed.signature.signature_hex,
+            ],
+        )?;
+
+        // 3. Commit. Drop on error rolls back the whole tx automatically.
+        tx.commit()?;
+        Ok(signed)
+    }
+}
+
+/// Read the highest-seq audit event using the supplied connection-like (so
+/// the read happens inside the caller's transaction). Mirrors
+/// `Storage::audit_last` but parameterised on a `Connection` reference.
+fn audit_last_via_tx(conn: &rusqlite::Connection) -> StorageResult<Option<SignedAuditEvent>> {
+    let mut stmt = conn.prepare(
+        "SELECT seq, id, ts, type, actor, subject_id, payload_hash, metadata_json, \
+         policy_version, policy_hash, attestation_ref, prev_event_hash, event_hash, \
+         signature_alg, signature_key_id, signature_hex \
+         FROM audit_events ORDER BY seq DESC LIMIT 1",
+    )?;
+    match stmt.query_row([], |r| {
+        let metadata_json: String = r.get(7)?;
+        let metadata: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(&metadata_json).map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    7,
+                    rusqlite::types::Type::Text,
+                    Box::new(e),
+                )
+            })?;
+        let ts: String = r.get(2)?;
+        let ts_parsed = chrono::DateTime::parse_from_rfc3339(&ts)
+            .map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    2,
+                    rusqlite::types::Type::Text,
+                    Box::new(e),
+                )
+            })?
+            .with_timezone(&Utc);
+        let event = AuditEvent {
+            version: 1,
+            seq: r.get::<_, i64>(0)? as u64,
+            id: r.get(1)?,
+            ts: ts_parsed,
+            event_type: r.get(3)?,
+            actor: r.get(4)?,
+            subject_id: r.get(5)?,
+            payload_hash: r.get(6)?,
+            metadata,
+            policy_version: r.get::<_, Option<i64>>(8)?.map(|v| v as u32),
+            policy_hash: r.get(9)?,
+            attestation_ref: r.get(10)?,
+            prev_event_hash: r.get(11)?,
+        };
+        let signature = EmbeddedSignature {
+            algorithm: SignatureAlgorithm::Ed25519,
+            key_id: r.get(14)?,
+            signature_hex: r.get(15)?,
+        };
+        let event_hash: String = r.get(12)?;
+        let _alg: String = r.get(13)?;
+        Ok(SignedAuditEvent {
+            event,
+            event_hash,
+            signature,
+        })
+    }) {
+        Ok(row) => Ok(Some(row)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(StorageError::Sqlite(e)),
+    }
+}
+
+/// Best-effort: parse a USD decimal string (e.g. `"0.05"`) to integer cents.
+/// Rejects values with > 2 fractional digits and any value that overflows
+/// `i64` after scaling. Used by `BudgetTracker` to bridge the policy's
+/// `cap_usd: String` field and this table's `cap_cents` column.
+pub fn usd_str_to_cents(s: &str) -> Option<i64> {
+    use rust_decimal::prelude::ToPrimitive;
+    use rust_decimal::Decimal;
+    use std::str::FromStr;
+    let dec = Decimal::from_str(s).ok()?;
+    if dec < Decimal::ZERO {
+        return None;
+    }
+    let scaled = dec * Decimal::new(100, 0);
+    if scaled.fract() != Decimal::ZERO {
+        // sub-cent precision rejected; F-2 budgets are in whole cents.
+        return None;
+    }
+    scaled.trunc().to_i64()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::DateTime;
+
+    fn ts() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-04-30T12:00:00Z")
+            .unwrap()
+            .into()
+    }
+
+    fn signer() -> DevSigner {
+        DevSigner::from_seed("audit-signer-v1", [11u8; 32])
+    }
+
+    fn audit_event() -> NewAuditEvent {
+        NewAuditEvent {
+            event_type: "policy_decided".to_string(),
+            actor: "policy_engine".to_string(),
+            subject_id: "pr-test".to_string(),
+            payload_hash: "deadbeef".to_string(),
+            metadata: serde_json::Map::new(),
+            policy_version: Some(1),
+            policy_hash: Some("00".repeat(32)),
+            attestation_ref: None,
+            ts: ts(),
+        }
+    }
+
+    #[test]
+    fn usd_to_cents_basic() {
+        assert_eq!(usd_str_to_cents("0.05"), Some(5));
+        assert_eq!(usd_str_to_cents("0.10"), Some(10));
+        assert_eq!(usd_str_to_cents("10.00"), Some(1000));
+        assert_eq!(usd_str_to_cents("0"), Some(0));
+    }
+
+    #[test]
+    fn usd_to_cents_rejects_sub_cent_and_negatives() {
+        assert_eq!(usd_str_to_cents("0.001"), None);
+        assert_eq!(usd_str_to_cents("-1.00"), None);
+        assert_eq!(usd_str_to_cents("not-decimal"), None);
+    }
+
+    #[test]
+    fn budget_state_get_returns_none_for_missing_bucket() {
+        let s = Storage::open_in_memory().unwrap();
+        assert!(s
+            .budget_state_get("research-agent-01", "daily", "2026-04-30")
+            .unwrap()
+            .is_none());
+        assert_eq!(
+            s.budget_spent_cents("research-agent-01", "daily", "2026-04-30")
+                .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn finalize_decision_inserts_budget_row_and_audit_event() {
+        let mut s = Storage::open_in_memory().unwrap();
+        let inc = BudgetIncrement {
+            agent_id: "research-agent-01".to_string(),
+            scope: "daily".to_string(),
+            scope_key: "2026-04-30".to_string(),
+            delta_cents: 5,
+            cap_cents: 10,
+            reset_at_unix: Some(1714521600),
+        };
+        let signed = s
+            .finalize_decision(&[inc], audit_event(), &signer())
+            .unwrap();
+        assert_eq!(signed.event.seq, 1);
+        assert_eq!(s.audit_count().unwrap(), 1);
+        let row = s
+            .budget_state_get("research-agent-01", "daily", "2026-04-30")
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.spent_cents, 5);
+        assert_eq!(row.cap_cents, 10);
+        assert_eq!(row.reset_at_unix, Some(1714521600));
+    }
+
+    #[test]
+    fn finalize_decision_accumulates_on_repeat_commits() {
+        let mut s = Storage::open_in_memory().unwrap();
+        let mk = |delta: i64| BudgetIncrement {
+            agent_id: "research-agent-01".to_string(),
+            scope: "daily".to_string(),
+            scope_key: "2026-04-30".to_string(),
+            delta_cents: delta,
+            cap_cents: 10,
+            reset_at_unix: Some(1714521600),
+        };
+        s.finalize_decision(&[mk(5)], audit_event(), &signer())
+            .unwrap();
+        s.finalize_decision(&[mk(3)], audit_event(), &signer())
+            .unwrap();
+        let row = s
+            .budget_state_get("research-agent-01", "daily", "2026-04-30")
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.spent_cents, 8);
+        assert_eq!(s.audit_count().unwrap(), 2);
+    }
+
+    #[test]
+    fn finalize_decision_persists_across_storage_reopen() {
+        // The reason F-2 exists: a budget commit must survive daemon
+        // restart against the same SQLite file.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        {
+            let mut s = Storage::open(&path).unwrap();
+            let inc = BudgetIncrement {
+                agent_id: "research-agent-01".to_string(),
+                scope: "daily".to_string(),
+                scope_key: "2026-04-30".to_string(),
+                delta_cents: 7,
+                cap_cents: 10,
+                reset_at_unix: None,
+            };
+            s.finalize_decision(&[inc], audit_event(), &signer())
+                .unwrap();
+        }
+        let s = Storage::open(&path).unwrap();
+        assert_eq!(
+            s.budget_spent_cents("research-agent-01", "daily", "2026-04-30")
+                .unwrap(),
+            7
+        );
+    }
+
+    #[test]
+    fn finalize_decision_with_no_increments_still_appends_audit_event() {
+        // A pure deny has zero increments but still needs a hash-chained
+        // audit row. The combo path must accept that.
+        let mut s = Storage::open_in_memory().unwrap();
+        let signed = s.finalize_decision(&[], audit_event(), &signer()).unwrap();
+        assert_eq!(signed.event.seq, 1);
+        assert_eq!(s.audit_count().unwrap(), 1);
+        assert_eq!(s.budget_state_count().unwrap(), 0);
+    }
+}

--- a/crates/sbo3l-storage/src/db.rs
+++ b/crates/sbo3l-storage/src/db.rs
@@ -13,12 +13,14 @@ pub const V004_SQL: &str = include_str!("../../../migrations/V004__idempotency_k
 pub const V005_SQL: &str = include_str!("../../../migrations/V005__mock_kms_keys.sql");
 pub const V006_SQL: &str = include_str!("../../../migrations/V006__active_policy.sql");
 pub const V007_SQL: &str = include_str!("../../../migrations/V007__audit_checkpoints.sql");
+pub const V008_SQL: &str = include_str!("../../../migrations/V008__budget_state.sql");
 
 // V003 reserved for an experiment that did not land. V004 = PSM-A2
 // (idempotency_keys, PR #23). V005 = PSM-A1.9 (mock_kms_keys, PR #28).
 // V006 = PSM-A3 (active_policy, PR #35). V007 = PSM-A4 (audit
-// checkpoints, this PR). Sparse numbering kept intentional so
-// parallel branches don't collide on the same number.
+// checkpoints, PR #44). V008 = F-2 (budget_state, this PR). Sparse
+// numbering kept intentional so parallel branches don't collide on the
+// same number.
 const MIGRATIONS: &[(i64, &str, &str)] = &[
     (1, "init", V001_SQL),
     (2, "nonce_replay", V002_SQL),
@@ -26,6 +28,7 @@ const MIGRATIONS: &[(i64, &str, &str)] = &[
     (5, "mock_kms_keys", V005_SQL),
     (6, "active_policy", V006_SQL),
     (7, "audit_checkpoints", V007_SQL),
+    (8, "budget_state", V008_SQL),
 ];
 
 pub struct Storage {

--- a/crates/sbo3l-storage/src/lib.rs
+++ b/crates/sbo3l-storage/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod audit_checkpoint_store;
 pub mod audit_store;
+pub mod budget_store;
 pub mod db;
 pub mod error;
 pub mod idempotency_store;
@@ -11,6 +12,7 @@ pub mod policy_store;
 
 pub use audit_checkpoint_store::AuditCheckpointRecord;
 pub use audit_store::NewAuditEvent;
+pub use budget_store::{usd_str_to_cents, BudgetIncrement, BudgetStateRow};
 pub use db::Storage;
 pub use error::{StorageError, StorageResult};
 pub use policy_store::ActivePolicyRecord;

--- a/demo-scripts/run-production-shaped-mock.sh
+++ b/demo-scripts/run-production-shaped-mock.sh
@@ -271,7 +271,13 @@ SERVER_LOG="$TMPDIR_PSM/idempotency-server.log"
 
 # Spawn a fresh sbo3l-server. EXIT trap was set in step 5 to clean
 # $TMPDIR_PSM; we extend it to also kill the server PID.
+#
+# Auth is required by default since F-1 (PR #91) — the production-shaped
+# mock runs every request unauthenticated, so we engage the dev bypass
+# explicitly. The stderr "⚠ UNAUTHENTICATED MODE — DEV ONLY ⚠" banner is
+# expected and part of the production-shaped surface for a local mock.
 SBO3L_DB="$IDEM_DB" SBO3L_LISTEN="127.0.0.1:${IDEM_PORT}" \
+  SBO3L_ALLOW_UNAUTHENTICATED=1 \
   ./target/debug/sbo3l-server >"$SERVER_LOG" 2>&1 &
 SERVER_PID=$!
 trap 'kill "${SERVER_PID:-0}" 2>/dev/null || true; rm -rf "$TMPDIR_PSM"' EXIT

--- a/docs/spec/17_interface_contracts.md
+++ b/docs/spec/17_interface_contracts.md
@@ -251,7 +251,7 @@ pub enum Error {
 | `policy.deny_attestation_drift` | PolicyError::DenyAttestationDrift | 423 | critical |
 | `policy.escalation_required` | PolicyError::EscalationRequired | 202 | info |
 | `policy.insufficient_signatures` | PolicyError::InsufficientSignatures | 401 | warning |
-| `budget.hard_cap_exceeded` | BudgetError::HardCapExceeded | 403 | warning |
+| `policy.budget_exceeded` | BudgetError::CapExceeded | 403 | warning |
 | `budget.soft_cap_warning` | BudgetError::SoftCapWarning | 202 | info |
 | `signer.missing_decision_token` | SignerError::MissingDecisionToken | 401 | critical |
 | `signer.invalid_decision_token` | SignerError::InvalidDecisionToken | 401 | critical |

--- a/docs/win-backlog/08-exit-gates.md
+++ b/docs/win-backlog/08-exit-gates.md
@@ -56,9 +56,11 @@ RC=$(curl -sw "%{http_code}" -o /dev/null :8730/v1/payment-requests -X POST \
 [ "$RC" = "401" ] || (echo "F-1 unauth FAIL"; exit 1)
 pkill sbo3l-server
 
-# F-2: Budget persistence
+# F-2: Budget persistence (uses tight-cap demo policy via SBO3L_POLICY so
+# the literal $0.05 + $0.06 > $0.10 daily flow exercises the cap).
 rm -f /tmp/budget-exit.db
 SBO3L_DB=/tmp/budget-exit.db SBO3L_ALLOW_UNAUTHENTICATED=1 \
+  SBO3L_POLICY=test-corpus/policy/tight_daily_budget_demo.json \
   cargo run --bin sbo3l-server > /dev/null 2>&1 &
 sleep 2
 PAYLOAD=$(jq '.amount.value = "0.05" | .nonce = "01HTAWX5K3R8YV9NQB7C6P2D81"' test-corpus/aprp/golden_001_minimal.json)
@@ -66,6 +68,7 @@ curl -s :8730/v1/payment-requests -X POST -H "Content-Type: application/json" -d
 pkill sbo3l-server
 sleep 1
 SBO3L_DB=/tmp/budget-exit.db SBO3L_ALLOW_UNAUTHENTICATED=1 \
+  SBO3L_POLICY=test-corpus/policy/tight_daily_budget_demo.json \
   cargo run --bin sbo3l-server > /dev/null 2>&1 &
 sleep 2
 PAYLOAD=$(jq '.amount.value = "0.06" | .nonce = "01HTAWX5K3R8YV9NQB7C6P2D82"' test-corpus/aprp/golden_001_minimal.json)

--- a/migrations/V008__budget_state.sql
+++ b/migrations/V008__budget_state.sql
@@ -1,0 +1,46 @@
+-- SBO3L V008: persistent budget state (F-2).
+--
+-- Backs `sbo3l-policy::BudgetTracker` and the daemon's
+-- `POST /v1/payment-requests` enforcement so a budget commit survives
+-- daemon restart, crashes, and multi-process deployment. Replaces the
+-- in-memory `HashMap<(agent_id, scope, scope_key), Decimal>` previously
+-- held in `AppState::budgets`.
+--
+-- Rows model committed spend per (agent, scope, scope_key) bucket:
+--   * scope = 'per_tx'        — informational only; the per-tx cap is
+--                                evaluated against the request's own
+--                                amount, never accumulated, never
+--                                persisted (no rows are inserted with
+--                                this scope; the CHECK accepts it for
+--                                forward-compat with future per-tx
+--                                instrumentation).
+--   * scope = 'daily'         — scope_key is the UTC date in
+--                                `%Y-%m-%d`; rolls over implicitly when
+--                                a new day's request creates a new row.
+--   * scope = 'monthly'       — scope_key is `%Y-%m` UTC.
+--   * scope = 'per_provider'  — scope_key is the provider id (or, when
+--                                the policy has no entry, the verbatim
+--                                request `provider_url`).
+--
+-- `cap_cents` is denormalised into the row at upsert time so a strict
+-- offline verifier can re-derive the deny decision from the row alone
+-- without re-reading the policy. `reset_at_unix` records the next
+-- bucket boundary as a unix epoch second; it is informational for
+-- diagnostics today and the field a future GC sweep would key on.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS budget_state (
+  agent_id      TEXT NOT NULL,
+  scope         TEXT NOT NULL CHECK (scope IN ('per_tx', 'daily', 'monthly', 'per_provider')),
+  scope_key     TEXT NOT NULL,
+  spent_cents   INTEGER NOT NULL DEFAULT 0 CHECK (spent_cents >= 0),
+  cap_cents     INTEGER NOT NULL CHECK (cap_cents >= 0),
+  reset_at_unix INTEGER,
+  PRIMARY KEY (agent_id, scope, scope_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_budget_state_agent
+  ON budget_state(agent_id, scope);
+
+COMMIT;

--- a/test-corpus/policy/tight_daily_budget_demo.json
+++ b/test-corpus/policy/tight_daily_budget_demo.json
@@ -1,0 +1,83 @@
+{
+  "version": 1,
+  "policy_id": "tight-daily-budget-demo",
+  "description": "F-2 demo policy: identical to reference_low_risk except daily cap is 0.10 USD. Used by the QA test plan and exit gate to exercise budget persistence across daemon restart in 2 requests (0.05 + 0.06 > 0.10). Loaded via SBO3L_POLICY=test-corpus/policy/tight_daily_budget_demo.json.",
+  "default_decision": "deny",
+  "agents": [
+    {
+      "agent_id": "research-agent-01",
+      "status": "active",
+      "policy_role": "research"
+    }
+  ],
+  "budgets": [
+    {
+      "agent_id": "research-agent-01",
+      "scope": "per_tx",
+      "cap_usd": "0.50"
+    },
+    {
+      "agent_id": "research-agent-01",
+      "scope": "daily",
+      "cap_usd": "0.10"
+    },
+    {
+      "agent_id": "research-agent-01",
+      "scope": "per_provider",
+      "scope_key": "api.example.com",
+      "cap_usd": "5.00"
+    }
+  ],
+  "providers": [
+    {
+      "id": "api.example.com",
+      "url": "https://api.example.com",
+      "status": "trusted",
+      "cert_pin_sha256": null
+    }
+  ],
+  "recipients": [
+    {
+      "address": "0x1111111111111111111111111111111111111111",
+      "chain": "base",
+      "status": "allowed",
+      "label": "example-api-x402-recipient"
+    },
+    {
+      "address": "0x9999999999999999999999999999999999999999",
+      "chain": "base-sepolia",
+      "status": "denied",
+      "label": "ethprague-attacker-demo"
+    }
+  ],
+  "rules": [
+    {
+      "id": "deny-emergency-freeze",
+      "effect": "deny",
+      "deny_code": "policy.deny_emergency_frozen",
+      "when": "input.emergency.freeze_all == true"
+    },
+    {
+      "id": "deny-unknown-provider",
+      "effect": "deny",
+      "deny_code": "policy.deny_unknown_provider",
+      "when": "not input.provider.trusted"
+    },
+    {
+      "id": "deny-recipient-not-allowlisted",
+      "effect": "deny",
+      "deny_code": "policy.deny_recipient_not_allowlisted",
+      "when": "not input.recipient.allowed"
+    },
+    {
+      "id": "allow-small-x402-api-call",
+      "effect": "allow",
+      "deny_code": null,
+      "when": "input.intent == \"purchase_api_call\" and input.payment_protocol == \"x402\" and input.amount_usd <= 0.50 and input.provider.trusted and input.recipient.allowed"
+    }
+  ],
+  "emergency": {
+    "freeze_all": false,
+    "paused_agents": []
+  }
+}


### PR DESCRIPTION
## Summary
- New migration **V008__budget_state.sql** — `(agent_id, scope, scope_key, spent_cents, cap_cents, reset_at_unix)` PRIMARY KEY `(agent_id, scope, scope_key)`. CHECK constraint pins scope to the four canonical values.
- New `crates/sbo3l-storage/src/budget_store.rs` — `BudgetStateRow`, `BudgetIncrement`, `Storage::budget_state_get` / `budget_spent_cents` / `budget_state_count`, **`Storage::finalize_decision`** (the ACID combo: budget upserts + audit append in one rusqlite transaction).
- `BudgetTracker` (`sbo3l-policy`) is now stateless. `BudgetTracker::check(&Storage, ...)` reads current spend; `BudgetTracker::commit(&mut Storage, ..., audit_event, signer)` delegates to `Storage::finalize_decision` — wrapping policy + budget + audit in one transaction (F-2 AC).
- `Mutex<BudgetTracker>` removed from `AppInner`. Server handler holds the storage lock for the whole budget check + commit cycle.
- Cap-breach deny code renamed `budget.hard_cap_exceeded` → **`policy.budget_exceeded`** per win-backlog standards (`docs/win-backlog/02-standards.md`, `08-exit-gates.md` F-2).
- `SBO3L_POLICY=<path>` env var loads a custom policy at daemon startup (falls back to bundled reference policy when unset).
- New fixture `test-corpus/policy/tight_daily_budget_demo.json` (daily cap $0.10) so the literal $0.05 + $0.06 flow exercises the cap.
- `demo-scripts/run-production-shaped-mock.sh` sets `SBO3L_ALLOW_UNAUTHENTICATED=1` when spawning the daemon (post-F-1 auth requires this for the local mock; tally unchanged at 26 real / 0 mock / 1 skipped).
- F-2 exit gate in `docs/win-backlog/08-exit-gates.md` updated to load the tight-cap policy via `SBO3L_POLICY`.

## Why
Closes [F-2](docs/win-backlog/05-phase-1.md). Budget caps were an in-memory `HashMap` that reset on every daemon restart. F-2 lifts them into SQLite with an ACID transaction across budget + audit so a deploy / restart / multi-process server can't silently drop a committed spend.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --all-targets` green — 416 passing (+18 from F-2: 7 storage, 7 policy, 4 server)
- [x] `cargo test --test test_budget_persistence` — 4 tests including the headline restart-then-deny scenario
- [x] `bash demo-scripts/run-production-shaped-mock.sh` — 26 real / 0 mock / 1 skipped (unchanged)
- [x] **Literal QA test plan via daemon binary** — `cargo run` with `SBO3L_DB=/tmp/budget.db SBO3L_POLICY=test-corpus/policy/tight_daily_budget_demo.json SBO3L_ALLOW_UNAUTHENTICATED=1`; spend $0.05 → allow; restart; spend $0.06 → deny + `policy.budget_exceeded`. Verified end-to-end on this branch.
- [x] Migration V008 applies cleanly on a fresh DB; `schema_migrations.sha256` content invariant preserved (verified via `Storage::open_in_memory()` migration replay across all 49 storage unit tests).
- [x] `BudgetTracker::commit()` wraps policy + budget + audit in single `rusqlite::Transaction` via `Storage::finalize_decision` (`crates/sbo3l-storage/src/budget_store.rs:116-204`).
- [x] `per_tx` rows are never written (verified by `per_tx_does_not_accumulate_in_storage` in `sbo3l-policy/src/budget.rs`).
- [x] Deny path produces audit row with zero budget rows (verified by `deny_request_does_not_consume_budget_after_restart` and `commit_with_no_applicable_budget_still_appends_audit_event`).
- [x] `SECURITY_NOTES.md` updated: "Budget tracker persistence" limitation removed; new "Budget persistence (F-2, ACID across restart)" section added.
- [x] `docs/spec/17_interface_contracts.md` table renamed `budget.hard_cap_exceeded` → `policy.budget_exceeded`.

## Out of scope
- Idempotency atomicity / `processing` state machine (F-3 — depends on this PR)
- KMS abstraction (F-5 — depends on F-3)
- Capsule v2 schema bump (F-6 — depends on F-2 + F-3)
- Concurrent multi-process budget commits across separate daemons sharing one DB file (SQLite's database-level write lock serializes them, but a stress test for that lives with F-3's idempotency-race ticket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)