### PR TITLE
feat(infra): docker-compose.yml + sbo3l-mcp profile + compose CI smoke

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "Dockerfile"
       - ".dockerignore"
+      - "docker-compose.yml"
       - "Cargo.lock"
       - "Cargo.toml"
       - "crates/**"
@@ -17,6 +18,7 @@ on:
     paths:
       - "Dockerfile"
       - ".dockerignore"
+      - "docker-compose.yml"
       - "Cargo.lock"
       - "Cargo.toml"
       - "crates/**"
@@ -40,12 +42,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build sbo3l/server:test
+      - name: Build sbo3l/server (test + latest tags)
         uses: docker/build-push-action@v6
         with:
           context: .
           load: true
-          tags: sbo3l/server:test
+          tags: |
+            sbo3l/server:test
+            sbo3l/server:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -120,3 +124,154 @@ jobs:
       - name: Stop container
         if: always()
         run: docker stop sbo3l-test || true
+
+  compose:
+    name: docker-compose smoke (F-8)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build via docker compose (hits GHA cache from build job)
+        run: |
+          set -euo pipefail
+          # `docker compose build` uses the workspace builder; cache-from
+          # GHA keeps this near-instant after the build job.
+          DOCKER_BUILDKIT=1 docker compose build --pull=false sbo3l
+
+      - name: Prepare host bind-mount (./data owned by container UID 65532)
+        run: |
+          set -euo pipefail
+          mkdir -p ./data
+          # The image runs as distroless `nonroot` (UID 65532). Bind-mounted
+          # host directory must be writable by that UID, otherwise SQLite
+          # write fails on first request. Documented in docs/cli/docker.md.
+          sudo chown -R 65532:65532 ./data
+
+      - name: docker compose up sbo3l -d
+        run: |
+          set -euo pipefail
+          docker compose up sbo3l -d
+          # 10s window per ticket AC for daemon to come up
+          for i in $(seq 1 10); do
+            STATUS=$(docker compose ps --format json sbo3l | jq -r '.[0].State // .State // "unknown"' 2>/dev/null || echo "unknown")
+            if [ "$STATUS" = "running" ]; then
+              echo "compose service running after ${i}s (state=$STATUS)"
+              break
+            fi
+            sleep 1
+          done
+          docker compose ps
+
+      - name: Smoke — POST golden APRP, expect decision=allow
+        run: |
+          set -euo pipefail
+          ALPHA32='0123456789ABCDEFGHJKMNPQRSTVWXYZ'
+          NONCE="${ALPHA32:$((RANDOM % 8)):1}"
+          for _ in $(seq 1 25); do
+            NONCE+="${ALPHA32:$((RANDOM % 32)):1}"
+          done
+          EXPIRY=$(date -u -d '+1 hour' +%Y-%m-%dT%H:%M:%SZ)
+          BODY=$(jq --arg e "$EXPIRY" --arg n "$NONCE" \
+                  '.expiry=$e | .nonce=$n' \
+                  test-corpus/aprp/golden_001_minimal.json)
+          # Daemon may take a beat after compose ps reports running; retry
+          # briefly without masking errors.
+          for i in $(seq 1 15); do
+            if RESP=$(echo "$BODY" | curl -fsS \
+                  -H "Content-Type: application/json" \
+                  -X POST --data-binary @- \
+                  http://localhost:8730/v1/payment-requests 2>/dev/null); then
+              break
+            fi
+            sleep 1
+          done
+          echo "$RESP" | jq .
+          DEC=$(echo "$RESP" | jq -r .decision)
+          if [ "$DEC" != "allow" ]; then
+            echo "::error::pre-restart decision was '$DEC', expected 'allow'"
+            docker compose logs sbo3l || true
+            exit 1
+          fi
+
+      - name: Verify SQLite persisted to ./data
+        run: |
+          set -euo pipefail
+          # The DB path inside the container is /var/lib/sbo3l/sbo3l.db,
+          # bind-mounted from ./data, so the host should see the file.
+          ls -la ./data
+          test -f ./data/sbo3l.db
+          # Size > 0 — schema migrations should have written by now.
+          [ -s ./data/sbo3l.db ]
+          echo "sbo3l.db size: $(stat -c%s ./data/sbo3l.db) bytes"
+
+      - name: docker compose restart sbo3l (state should survive)
+        run: |
+          set -euo pipefail
+          docker compose restart sbo3l
+          for i in $(seq 1 10); do
+            STATUS=$(docker compose ps --format json sbo3l | jq -r '.[0].State // .State // "unknown"' 2>/dev/null || echo "unknown")
+            if [ "$STATUS" = "running" ]; then
+              echo "compose service running after restart in ${i}s"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Smoke — POST APRP after restart, expect decision=allow
+        run: |
+          set -euo pipefail
+          ALPHA32='0123456789ABCDEFGHJKMNPQRSTVWXYZ'
+          NONCE="${ALPHA32:$((RANDOM % 8)):1}"
+          for _ in $(seq 1 25); do
+            NONCE+="${ALPHA32:$((RANDOM % 32)):1}"
+          done
+          EXPIRY=$(date -u -d '+1 hour' +%Y-%m-%dT%H:%M:%SZ)
+          BODY=$(jq --arg e "$EXPIRY" --arg n "$NONCE" \
+                  '.expiry=$e | .nonce=$n' \
+                  test-corpus/aprp/golden_001_minimal.json)
+          for i in $(seq 1 15); do
+            if RESP=$(echo "$BODY" | curl -fsS \
+                  -H "Content-Type: application/json" \
+                  -X POST --data-binary @- \
+                  http://localhost:8730/v1/payment-requests 2>/dev/null); then
+              break
+            fi
+            sleep 1
+          done
+          echo "$RESP" | jq .
+          DEC=$(echo "$RESP" | jq -r .decision)
+          if [ "$DEC" != "allow" ]; then
+            echo "::error::post-restart decision was '$DEC', expected 'allow'"
+            docker compose logs sbo3l || true
+            exit 1
+          fi
+
+      - name: Smoke — MCP profile via stdio (tools/list)
+        run: |
+          set -euo pipefail
+          # `compose run -T` disables TTY so the stdin pipe is honoured.
+          # We send one NDJSON request, expect one NDJSON response.
+          REQ='{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+          RESP=$(printf '%s\n' "$REQ" | \
+            timeout 30 docker compose --profile mcp run --rm -T sbo3l-mcp \
+            2>/tmp/mcp-stderr.log | head -1 || true)
+          echo "stderr from mcp:"
+          cat /tmp/mcp-stderr.log || true
+          echo "stdout (first line):"
+          echo "$RESP"
+          # Validate: jsonrpc=="2.0", id==1, result is an array
+          echo "$RESP" | jq -e '.jsonrpc == "2.0" and .id == 1 and (.result | type == "array")' >/dev/null
+
+      - name: Compose logs (always)
+        if: always()
+        run: docker compose logs --no-color || true
+
+      - name: docker compose down -v
+        if: always()
+        run: docker compose down -v --remove-orphans || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,11 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/build/target,sharing=locked \
     cargo build --release --locked \
         --bin sbo3l-server \
-        --bin sbo3l && \
+        --bin sbo3l \
+        --bin sbo3l-mcp && \
     install -Dm0755 target/release/sbo3l-server /out/usr/local/bin/sbo3l-server && \
     install -Dm0755 target/release/sbo3l        /out/usr/local/bin/sbo3l && \
+    install -Dm0755 target/release/sbo3l-mcp    /out/usr/local/bin/sbo3l-mcp && \
     mkdir -p /out/usr/local/share/sbo3l && \
     cp -r migrations /out/usr/local/share/sbo3l/migrations && \
     install -d -m 0700 -o 65532 -g 65532 /out/var/lib/sbo3l
@@ -59,8 +61,11 @@ LABEL org.opencontainers.image.title="sbo3l-server" \
       org.opencontainers.image.licenses="Apache-2.0"
 
 # Binaries + embedded migrations + writable data dir.
+# `sbo3l-mcp` ships in the same image so docker-compose can spin up a stdio
+# JSON-RPC MCP server (profile `mcp`) without a second build.
 COPY --from=builder /out/usr/local/bin/sbo3l-server     /usr/local/bin/sbo3l-server
 COPY --from=builder /out/usr/local/bin/sbo3l            /usr/local/bin/sbo3l
+COPY --from=builder /out/usr/local/bin/sbo3l-mcp        /usr/local/bin/sbo3l-mcp
 COPY --from=builder /out/usr/local/share/sbo3l          /usr/local/share/sbo3l
 COPY --from=builder --chown=nonroot:nonroot /out/var/lib/sbo3l /var/lib/sbo3l
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,93 @@
+# SBO3L docker-compose: single-command development + smoke environment.
+#
+# Default service:
+#   docker compose up sbo3l -d
+# Spins up the daemon on http://localhost:8730 with persistent SQLite under
+# ./data (bind-mounted, survives `restart` and `down -v` modes documented
+# below). Auth is bypassed by default for local dev (set
+# SBO3L_BEARER_TOKEN_HASH or SBO3L_JWT_PUBKEY for prod).
+#
+# Optional MCP profile:
+#   docker compose --profile mcp run --rm sbo3l-mcp
+# Spawns the stdio JSON-RPC MCP server (Passport P3.1) attached to your
+# terminal. `up` won't keep it running because MCP is request-driven over
+# stdin/stdout — `run --rm` is the correct invocation for a one-shot
+# session. Both services share the same image; the MCP binary is shipped
+# alongside the daemon (see Dockerfile).
+#
+# Volume layout:
+#   ./data → /var/lib/sbo3l        (host-bind, owned by UID 65532 — see
+#                                   docs/cli/docker.md "Persistent SQLite"
+#                                   for permission caveats)
+#
+# Health check:
+#   The image runs distroless/cc-debian12 — no shell, no curl, no nc — so
+#   compose's healthcheck `test:` runs the in-image `sbo3l` CLI. We use
+#   `sbo3l schema aprp` because it (a) is exec-form (no shell needed),
+#   (b) exits 0 deterministically when the binary stack is intact,
+#   (c) does not require the daemon to have come up yet (so it races
+#   correctly with `start_period`). It is a *binary-alive* probe, not an
+#   HTTP-liveness probe — once the server crate gains a /health endpoint
+#   (see follow-up to F-1), this should become an HTTP probe via a future
+#   `sbo3l ping` subcommand or a sidecar `wget`.
+
+services:
+  sbo3l:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: sbo3l/server:latest
+    container_name: sbo3l
+    restart: unless-stopped
+    ports:
+      - "8730:8730"
+    volumes:
+      - ./data:/var/lib/sbo3l
+    environment:
+      # Default-deny is the daemon's safe default; flip on the dev bypass
+      # for local docker-compose use. Override per-environment in prod.
+      SBO3L_ALLOW_UNAUTHENTICATED: "1"
+      # Embedded migrations + image-default SBO3L_DB path are sufficient.
+      # Override SBO3L_DB to ":memory:" if you don't want a host volume.
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/sbo3l", "schema", "aprp"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    # Surface stderr in `docker compose logs` so the F-1 unauthenticated
+    # banner + F-4 unsafe-public-bind warning are visible.
+    tty: false
+    stdin_open: false
+
+  sbo3l-mcp:
+    profiles: ["mcp"]
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: sbo3l/server:latest
+    container_name: sbo3l-mcp
+    # No restart policy: MCP stdio is one-shot per `compose run --rm`.
+    entrypoint: ["/usr/local/bin/sbo3l-mcp"]
+    # MCP stdio is line-oriented JSON-RPC over stdin/stdout. `tty: false`
+    # because MCP clients send raw NDJSON, not interactive ANSI.
+    stdin_open: true
+    tty: false
+    volumes:
+      # Read-only mount so the MCP tool catalogue can `audit_lookup` etc.
+      # against the daemon's database without ever writing to it. The
+      # daemon owns writes; MCP queries.
+      - ./data:/var/lib/sbo3l:ro
+    environment:
+      # Pointed at the same DB the daemon uses; default-readonly is
+      # enforced above by the volume mode flag.
+      SBO3L_DB: /var/lib/sbo3l/sbo3l.db
+
+volumes:
+  # Documentation-only — all real persistence is bind-mounted at
+  # ./data above, per the F-8 acceptance criterion. Listed here so
+  # `docker compose config` shows the intended persistent surface.
+  sbo3l-data:
+    name: sbo3l-data
+    driver: local
+    external: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,13 +74,18 @@ services:
     stdin_open: true
     tty: false
     volumes:
-      # Read-only mount so the MCP tool catalogue can `audit_lookup` etc.
-      # against the daemon's database without ever writing to it. The
-      # daemon owns writes; MCP queries.
-      - ./data:/var/lib/sbo3l:ro
+      # Read-write — `sbo3l-mcp` exposes pipeline-touching tools
+      # (`sbo3l.decide`, `sbo3l.run_guarded_execution`) which append audit
+      # rows + claim nonces, so the SQLite file must be writable. Codex
+      # P1 (PR #99) caught the `:ro` mistake.
+      #
+      # Concurrency note: SQLite uses file-level write locks; running
+      # `sbo3l-server` and `sbo3l-mcp` against the same DB simultaneously
+      # serializes writes via SQLite's busy-handler. Acceptable for the
+      # demo profile; production deployments should split daemons or use
+      # WAL mode (already enabled in `Storage::open`).
+      - ./data:/var/lib/sbo3l
     environment:
-      # Pointed at the same DB the daemon uses; default-readonly is
-      # enforced above by the volume mode flag.
       SBO3L_DB: /var/lib/sbo3l/sbo3l.db
 
 volumes:

--- a/docs/cli/docker.md
+++ b/docs/cli/docker.md
@@ -12,14 +12,14 @@ The repository ships a multi-stage `Dockerfile` at the project root.
 
 | Stage  | Base                                  | Role                                                |
 |--------|---------------------------------------|-----------------------------------------------------|
-| build  | `rust:1-bookworm` (latest 1.x stable) | `cargo build --release --locked --bin sbo3l-server --bin sbo3l` with `RUSTFLAGS="-C strip=symbols"` |
+| build  | `rust:1-bookworm` (latest 1.x stable) | `cargo build --release --locked --bin sbo3l-server --bin sbo3l --bin sbo3l-mcp` with `RUSTFLAGS="-C strip=symbols"` |
 | runtime| `gcr.io/distroless/cc-debian12:nonroot` | runs as UID 65532, no shell, no package manager     |
 
 Final image is **under 100 MB**. The runtime layer ships the
-`sbo3l-server` daemon, the `sbo3l` CLI, and the `migrations/` tree (the
-server already embeds them via `include_str!`; the on-disk copy at
-`/usr/local/share/sbo3l/migrations` is a belt-and-suspenders artefact for
-offline inspection).
+`sbo3l-server` daemon, the `sbo3l` CLI, the `sbo3l-mcp` stdio JSON-RPC
+server, and the `migrations/` tree (the server already embeds migrations
+via `include_str!`; the on-disk copy at `/usr/local/share/sbo3l/migrations`
+is a belt-and-suspenders artefact for offline inspection).
 
 ## Build
 
@@ -68,6 +68,89 @@ curl -fsS http://localhost:8730/v1/payment-requests -X POST \
 >   curl -fsS http://localhost:8730/v1/payment-requests -X POST \
 >     -H "Content-Type: application/json" --data-binary @- | jq -r .decision
 > ```
+
+## docker-compose (single-command up)
+
+For a one-command development stack with persistent SQLite under `./data`,
+use the `docker-compose.yml` shipped at the repo root:
+
+```bash
+mkdir -p ./data
+sudo chown -R 65532:65532 ./data    # nonroot UID, see "Persistent SQLite"
+docker compose up sbo3l -d
+```
+
+The `sbo3l` service:
+
+- Builds the image from the local `Dockerfile` on first `up`.
+- Maps `localhost:8730` → container `:8730`.
+- Bind-mounts `./data` → `/var/lib/sbo3l` so SQLite survives `restart`
+  and `down` (it does **not** survive `down -v`, which clears volumes).
+- Sets `SBO3L_ALLOW_UNAUTHENTICATED=1` for local dev. Override per
+  environment in production by editing `docker-compose.override.yml` or
+  passing `-e SBO3L_BEARER_TOKEN_HASH=...`.
+- `restart: unless-stopped` so a daemon crash auto-recovers.
+- Compose-side healthcheck runs `sbo3l schema aprp` (in-image binary, no
+  shell needed). This is a *binary-alive* check, not an HTTP-liveness
+  probe; the latter waits on a `/health` endpoint follow-up to F-1.
+
+Smoke test the running stack:
+
+```bash
+NONCE=$(LC_ALL=C tr -dc '0-9A-HJKMNPQRSTVWXYZ' </dev/urandom | head -c 26)
+EXPIRY=$(date -u -d '+1 hour' +%Y-%m-%dT%H:%M:%SZ)
+jq --arg e "$EXPIRY" --arg n "$NONCE" '.expiry=$e | .nonce=$n' \
+    test-corpus/aprp/golden_001_minimal.json | \
+  curl -fsS http://localhost:8730/v1/payment-requests -X POST \
+    -H "Content-Type: application/json" --data-binary @- | jq -r .decision
+# expect: allow
+```
+
+Persistence check (state survives a process restart):
+
+```bash
+docker compose restart sbo3l
+sleep 3
+ls -la ./data        # sbo3l.db should still be there
+# repeat the smoke POST — same fixture but a fresh nonce — still "allow"
+```
+
+Tear down without losing data:
+
+```bash
+docker compose down            # keeps ./data
+```
+
+Tear down + nuke data:
+
+```bash
+docker compose down -v         # also removes the named volume
+rm -rf ./data                  # removes the bind-mounted SQLite
+```
+
+### MCP profile (stdio JSON-RPC)
+
+The same image ships `sbo3l-mcp`, the Passport P3.1 stdio JSON-RPC
+server. Run it as a one-shot session attached to your terminal:
+
+```bash
+docker compose --profile mcp run --rm sbo3l-mcp
+```
+
+The container reads NDJSON requests from stdin and writes NDJSON
+responses to stdout (logs go to stderr). The MCP read-only mounts
+`./data` so its `sbo3l.audit_lookup` tool can query the same SQLite the
+daemon writes — handy for letting an LLM client introspect your daemon's
+audit chain. Example interaction:
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | \
+  docker compose --profile mcp run --rm -T sbo3l-mcp | head -1
+# {"jsonrpc":"2.0","id":1,"result":[{"name":"sbo3l.validate_aprp", ...}]}
+```
+
+`-T` disables TTY allocation so the stdin pipe is honoured. See
+`docs/cli/mcp.md` for the full tool catalogue.
 
 ## Persistent SQLite storage
 

--- a/docs/cli/docker.md
+++ b/docs/cli/docker.md
@@ -84,8 +84,11 @@ The `sbo3l` service:
 
 - Builds the image from the local `Dockerfile` on first `up`.
 - Maps `localhost:8730` → container `:8730`.
-- Bind-mounts `./data` → `/var/lib/sbo3l` so SQLite survives `restart`
-  and `down` (it does **not** survive `down -v`, which clears volumes).
+- Bind-mounts `./data` → `/var/lib/sbo3l` so SQLite survives `restart`,
+  `down`, **and** `down -v`. Bind-mount contents on the host are NOT
+  removed by `docker compose down -v` — the `-v` flag only removes
+  named/anonymous Docker-managed volumes. To clear bind-mounted state
+  intentionally, run `rm -rf ./data` after `down`.
 - Sets `SBO3L_ALLOW_UNAUTHENTICATED=1` for local dev. Override per
   environment in production by editing `docker-compose.override.yml` or
   passing `-e SBO3L_BEARER_TOKEN_HASH=...`.


### PR DESCRIPTION
## Summary
- New root `docker-compose.yml` with two services. Default `sbo3l` brings up the daemon on `localhost:8730` with persistent SQLite under `./data`. Optional `sbo3l-mcp` (profile `mcp`) ships the Passport P3.1 stdio JSON-RPC server attached to your terminal.
- Dockerfile builder now also produces the `sbo3l-mcp` binary; runtime stage COPYs it alongside `sbo3l-server` and `sbo3l`. Same image, three binaries.
- Compose-level healthcheck runs the in-image `sbo3l schema aprp` CLI (no shell, no curl needed in distroless). It is a *binary-alive* probe; an HTTP `/health` probe waits on a future server-side follow-up to F-1.
- `restart: unless-stopped` so a daemon crash is auto-recovered. ./data → `/var/lib/sbo3l` bind-mount survives `compose restart` and `compose down`; `compose down -v` clears the named volume.
- `.github/workflows/docker.yml` gains a `compose` job (depends_on `build`) that runs the ticket's QA test plan: `compose up sbo3l -d`, POST golden APRP → `decision=allow`, verify `./data/sbo3l.db` exists, `compose restart sbo3l`, POST with fresh nonce → still `allow` (state persisted), MCP `tools/list` round-trip via stdio pipe, `compose down -v`. Existing `build` job now tags both `:test` and `:latest`.
- `docs/cli/docker.md` gains a "docker-compose (single-command up)" section + "MCP profile" sub-section. Every code block remains copy-paste runnable.

## Why
Closes **F-8** (`docs/win-backlog/05-phase-1.md`). KH adoption surface needs a one-command-deploy story so judges and operators can stand up the daemon + MCP without reading the Dockerfile. Compose also gives the CI a reproducible end-to-end harness (build → up → smoke → restart → smoke → down) that mirrors what an external integrator would do.

## Verification
**Local Docker is unavailable in this dev environment** (same as F-7), so the canonical verification is the new CI `compose` job. It implements the ticket QA test plan literally:

- [ ] CI: `Docker / docker-compose smoke (F-8)` green — covers all four AC.
- [ ] CI: `Docker / Build + size + smoke` still green (image now also includes `sbo3l-mcp`; size cap is < 100 MiB).
- [ ] CI: `Rust check`, `Validate JSON schemas / OpenAPI` green (no Rust changes here).

### Acceptance criteria coverage (CI mapping)

| AC                                                              | Verified by                                  |
|------------------------------------------------------------------|----------------------------------------------|
| `docker compose up sbo3l -d` brings daemon up < 10s              | `compose up sbo3l -d` step + 10-iteration `compose ps` poll |
| Daemon survives `docker compose restart` (sqlite persisted)      | "Verify SQLite persisted" + post-restart POST step |
| `docker compose down` cleans up cleanly                          | `compose down -v --remove-orphans` final step (always-run) |
| `docker compose --profile mcp run --rm sbo3l-mcp` exposes stdio  | "MCP profile via stdio (tools/list)" step    |

## Image-size note
Adding `sbo3l-mcp` to the runtime grows the image. Estimate: `sbo3l-mcp` is dependency-light (no axum/tokio HTTP server stack), should add ~5-10 MiB. CI's 100 MiB cap remains; the size step will fail loudly if exceeded.

## Out of scope
- Adding a `/health` HTTP endpoint to `sbo3l-server` (server-side; should be a one-line F-1 follow-up). Once landed, swap the compose healthcheck to an HTTP probe.
- A docker-compose.override.yml example for production bearer auth — `docs/cli/docker.md` already documents the env-var path.
- Multi-arch (linux/arm64) builds — same as F-7; amd64 only.
- Pushing the image to a registry — local-engine only.
- Hadolint / dive / trivy security-scan steps — can layer in later if Heidi wants.

Closes F-8.

Co-Authored-By: Dev 4 (Infra + On-chain + Distributed) <dev4@sbo3l.dev>