### PR TITLE
feat(autogen): `@sbo3l/autogen` — Microsoft AutoGen function adapter (T-1-4)

### DIFF
--- a/integrations/autogen/.gitignore
+++ b/integrations/autogen/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+coverage/
+*.tsbuildinfo
+.DS_Store
+package-lock.json

--- a/integrations/autogen/README.md
+++ b/integrations/autogen/README.md
@@ -1,0 +1,30 @@
+# `@sbo3l/autogen`
+
+Microsoft AutoGen function adapter wrapping SBO3L. Drop into a `ConversableAgent`'s function registry.
+
+> ⚠ **DRAFT (T-1-4):** depends on F-9 (`@sbo3l/sdk`).
+
+## Install
+
+```bash
+npm install @sbo3l/autogen @sbo3l/sdk
+```
+
+## Usage
+
+```ts
+import { SBO3LClient } from "@sbo3l/sdk";
+import { sbo3lFunction } from "@sbo3l/autogen";
+
+const client = new SBO3LClient({ endpoint: "http://localhost:8730" });
+const fn = sbo3lFunction({ client });
+
+// Register fn.name + fn.description + fn.parameters with the LLM,
+// route fn.name → fn.call.
+```
+
+The function descriptor's `parameters` field is the APRP v1 JSON Schema, so the LLM understands the required arguments. On `deny`, the LLM sees `deny_code` and can self-correct or escalate.
+
+## License
+
+MIT

--- a/integrations/autogen/package.json
+++ b/integrations/autogen/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@sbo3l/autogen",
+  "version": "0.1.0",
+  "description": "Microsoft AutoGen function adapter wrapping SBO3L — gate every agent payment intent through SBO3L's policy boundary.",
+  "license": "MIT",
+  "author": "Daniel Babjak <babjak_daniel@hotmail.com>",
+  "homepage": "https://sbo3l.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026.git",
+    "directory": "integrations/autogen"
+  },
+  "keywords": ["sbo3l", "autogen", "agent", "policy", "tool"],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": ["dist", "README.md"],
+  "sideEffects": false,
+  "engines": { "node": ">=18" },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --clean",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@sbo3l/sdk": "^0.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@sbo3l/sdk": { "optional": true }
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.5",
+    "tsup": "^8.0.2",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "publishConfig": { "access": "public" }
+}

--- a/integrations/autogen/src/index.ts
+++ b/integrations/autogen/src/index.ts
@@ -1,0 +1,152 @@
+/**
+ * `@sbo3l/autogen` — Microsoft AutoGen function adapter wrapping SBO3L.
+ *
+ * AutoGen agents call functions (OpenAI-style: name + description +
+ * parameters JSON Schema). This package exposes one such function:
+ * `sbo3l_payment_request`. Drop into a `ConversableAgent`'s function
+ * registry to gate every payment intent through SBO3L's policy boundary.
+ *
+ * Structural typing (`SBO3LClientLike` interface) — install `@sbo3l/sdk`
+ * separately as an optional peerDep.
+ */
+
+export interface SBO3LClientLike {
+  submit(
+    request: Record<string, unknown>,
+    options?: { idempotencyKey?: string },
+  ): Promise<SBO3LSubmitResult>;
+}
+
+export interface SBO3LSubmitResult {
+  decision: "allow" | "deny" | "requires_human";
+  deny_code: string | null;
+  matched_rule_id: string | null;
+  request_hash: string;
+  policy_hash: string;
+  audit_event_id: string;
+  receipt: { execution_ref: string | null; [k: string]: unknown };
+}
+
+export interface AutoGenFunctionDescriptor {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+  call: (args: Record<string, unknown>) => Promise<SBO3LFunctionResult>;
+}
+
+export interface SBO3LFunctionResult {
+  decision?: "allow" | "deny" | "requires_human";
+  deny_code?: string | null;
+  matched_rule_id?: string | null;
+  execution_ref?: string | null;
+  audit_event_id?: string;
+  request_hash?: string;
+  policy_hash?: string;
+  error?: string;
+  status?: number | null;
+  detail?: string;
+}
+
+export interface SBO3LFunctionOptions {
+  client: SBO3LClientLike;
+  name?: string;
+  description?: string;
+  idempotencyKey?: (args: Record<string, unknown>) => string;
+}
+
+const DEFAULT_NAME = "sbo3l_payment_request";
+const DEFAULT_DESCRIPTION =
+  "Submit an Agent Payment Request Protocol (APRP) to SBO3L for policy decision. " +
+  "Returns decision (allow|deny|requires_human), execution_ref (when allowed), " +
+  "and audit_event_id. On deny, branch on deny_code to self-correct or escalate.";
+
+const APRP_PARAMETERS: Record<string, unknown> = {
+  type: "object",
+  required: [
+    "agent_id",
+    "task_id",
+    "intent",
+    "amount",
+    "token",
+    "destination",
+    "payment_protocol",
+    "chain",
+    "provider_url",
+    "expiry",
+    "nonce",
+    "risk_class",
+  ],
+  properties: {
+    agent_id: { type: "string" },
+    task_id: { type: "string" },
+    intent: {
+      type: "string",
+      enum: [
+        "purchase_api_call",
+        "purchase_dataset",
+        "pay_compute_job",
+        "pay_agent_service",
+        "tip",
+      ],
+    },
+    amount: {
+      type: "object",
+      required: ["value", "currency"],
+      properties: {
+        value: { type: "string" },
+        currency: { type: "string", enum: ["USD"] },
+      },
+    },
+    token: { type: "string" },
+    destination: { type: "object" },
+    payment_protocol: {
+      type: "string",
+      enum: ["x402", "l402", "erc20_transfer", "smart_account_session"],
+    },
+    chain: { type: "string" },
+    provider_url: { type: "string" },
+    expiry: { type: "string", description: "RFC 3339" },
+    nonce: { type: "string", description: "ULID" },
+    risk_class: { type: "string", enum: ["low", "medium", "high", "critical"] },
+  },
+  additionalProperties: true,
+};
+
+export function sbo3lFunction(options: SBO3LFunctionOptions): AutoGenFunctionDescriptor {
+  const { client } = options;
+  const name = options.name ?? DEFAULT_NAME;
+  const description = options.description ?? DEFAULT_DESCRIPTION;
+
+  return {
+    name,
+    description,
+    parameters: APRP_PARAMETERS,
+    call: async (args: Record<string, unknown>): Promise<SBO3LFunctionResult> => {
+      const submitOpts =
+        options.idempotencyKey !== undefined
+          ? { idempotencyKey: options.idempotencyKey(args) }
+          : {};
+
+      try {
+        const r = await client.submit(args, submitOpts);
+        return {
+          decision: r.decision,
+          deny_code: r.deny_code,
+          matched_rule_id: r.matched_rule_id,
+          execution_ref: r.receipt.execution_ref,
+          audit_event_id: r.audit_event_id,
+          request_hash: r.request_hash,
+          policy_hash: r.policy_hash,
+        };
+      } catch (e) {
+        const code = (e as { code?: unknown })?.code;
+        const status = (e as { status?: unknown })?.status;
+        return {
+          error: typeof code === "string" ? code : "transport.failed",
+          status: typeof status === "number" ? status : null,
+          detail: e instanceof Error ? e.message : String(e),
+        };
+      }
+    },
+  };
+}

--- a/integrations/autogen/test/index.test.ts
+++ b/integrations/autogen/test/index.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  sbo3lFunction,
+  type SBO3LClientLike,
+  type SBO3LSubmitResult,
+} from "../src/index.js";
+
+const APRP = {
+  agent_id: "research-agent-01",
+  task_id: "demo-1",
+  intent: "purchase_api_call",
+} as Record<string, unknown>;
+
+const ALLOW: SBO3LSubmitResult = {
+  decision: "allow",
+  deny_code: null,
+  matched_rule_id: "allow-low-risk-x402",
+  request_hash: "c0bd2fab".repeat(8),
+  policy_hash: "e044f13c".repeat(8),
+  audit_event_id: "evt-01HTAWX5K3R8YV9NQB7C6P2DGR",
+  receipt: { execution_ref: "kh-01HTAWX5K3R8YV9NQB7C6P2DGS" },
+};
+
+const DENY: SBO3LSubmitResult = {
+  decision: "deny",
+  deny_code: "policy.budget_exceeded",
+  matched_rule_id: "daily-budget",
+  request_hash: "c0bd2fab".repeat(8),
+  policy_hash: "e044f13c".repeat(8),
+  audit_event_id: "evt-01HTAWX5K3R8YV9NQB7C6P2DGT",
+  receipt: { execution_ref: null },
+};
+
+function fakeClient(r: SBO3LSubmitResult): SBO3LClientLike {
+  return { submit: vi.fn(async () => r) };
+}
+
+describe("sbo3lFunction — descriptor", () => {
+  it("exposes name + description + parameters + call", () => {
+    const f = sbo3lFunction({ client: fakeClient(ALLOW) });
+    expect(f.name).toBe("sbo3l_payment_request");
+    expect(typeof f.description).toBe("string");
+    expect(f.parameters.type).toBe("object");
+    expect(typeof f.call).toBe("function");
+  });
+
+  it("APRP parameters declares required fields", () => {
+    const f = sbo3lFunction({ client: fakeClient(ALLOW) });
+    const required = (f.parameters.required as string[]) ?? [];
+    expect(required).toContain("agent_id");
+    expect(required).toContain("intent");
+    expect(required).toContain("risk_class");
+  });
+
+  it("custom name + description", () => {
+    const f = sbo3lFunction({ client: fakeClient(ALLOW), name: "fn", description: "d" });
+    expect(f.name).toBe("fn");
+    expect(f.description).toBe("d");
+  });
+});
+
+describe("sbo3lFunction — call", () => {
+  it("returns flat allow envelope", async () => {
+    const f = sbo3lFunction({ client: fakeClient(ALLOW) });
+    const r = await f.call(APRP);
+    expect(r.decision).toBe("allow");
+    expect(r.execution_ref).toBe("kh-01HTAWX5K3R8YV9NQB7C6P2DGS");
+  });
+
+  it("returns deny with deny_code", async () => {
+    const f = sbo3lFunction({ client: fakeClient(DENY) });
+    const r = await f.call(APRP);
+    expect(r.decision).toBe("deny");
+    expect(r.deny_code).toBe("policy.budget_exceeded");
+    expect(r.execution_ref).toBeNull();
+  });
+
+  it("forwards args to client", async () => {
+    const submit = vi.fn(async () => ALLOW);
+    const f = sbo3lFunction({ client: { submit } });
+    await f.call(APRP);
+    const [body] = submit.mock.calls[0]!;
+    expect((body as { agent_id: string }).agent_id).toBe("research-agent-01");
+  });
+
+  it("invokes idempotencyKey callback", async () => {
+    const submit = vi.fn(async () => ALLOW);
+    const f = sbo3lFunction({
+      client: { submit },
+      idempotencyKey: (args) => `${(args as { task_id: string }).task_id}-key`,
+    });
+    await f.call(APRP);
+    const [, opts] = submit.mock.calls[0]!;
+    expect((opts as { idempotencyKey?: string })?.idempotencyKey).toBe("demo-1-key");
+  });
+});
+
+describe("sbo3lFunction — errors", () => {
+  it("surfaces SBO3L code", async () => {
+    const err = Object.assign(new Error("auth"), { code: "auth.required", status: 401 });
+    const client: SBO3LClientLike = { submit: vi.fn(async () => Promise.reject(err)) };
+    const f = sbo3lFunction({ client });
+    const r = await f.call(APRP);
+    expect(r.error).toBe("auth.required");
+    expect(r.status).toBe(401);
+    expect(r.decision).toBeUndefined();
+  });
+
+  it("falls back to transport.failed", async () => {
+    const client: SBO3LClientLike = {
+      submit: vi.fn(async () => Promise.reject(new Error("ECONNREFUSED"))),
+    };
+    const f = sbo3lFunction({ client });
+    const r = await f.call(APRP);
+    expect(r.error).toBe("transport.failed");
+    expect(r.detail).toContain("ECONNREFUSED");
+  });
+});

--- a/integrations/autogen/tsconfig.json
+++ b/integrations/autogen/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "test"]
+}

--- a/integrations/autogen/vitest.config.ts
+++ b/integrations/autogen/vitest.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from "vitest/config";
+export default defineConfig({ test: { include: ["test/**/*.test.ts"], environment: "node" } });


### PR DESCRIPTION
## Summary
- Adds `integrations/autogen/` — `@sbo3l/autogen`, a TS function descriptor matching the OpenAI-style function-calling shape (name + description + JSON Schema parameters + async call).
- Drop into `ConversableAgent.register_for_llm` (or any AutoGen TS API). The function's `parameters` field is the APRP v1 JSON Schema (lite) so the LLM understands required arguments.
- Structural typing (`SBO3LClientLike` interface) — no hard import of `@sbo3l/sdk`. Listed as optional peerDep.
- 9 vitest tests passing; `tsc --noEmit` clean.

## DRAFT — depends on
- **F-9** (#90) — `@sbo3l/sdk` must merge + publish to npm.

## Test plan
- [x] `cd integrations/autogen && npm install && npm run typecheck && npm test` → 9/9 passing
- [ ] (post-F-9 publish) Heidi smoke wiring `fn.name`/`fn.parameters`/`fn.call` into a `ConversableAgent`

Closes T-1-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)