### PR TITLE
feat(elizaos): `@sbo3l/elizaos` — ElizaOS plugin wrapping SBO3L (T-1-5)

### DIFF
--- a/integrations/elizaos/.gitignore
+++ b/integrations/elizaos/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+coverage/
+*.tsbuildinfo
+.DS_Store
+package-lock.json

--- a/integrations/elizaos/README.md
+++ b/integrations/elizaos/README.md
@@ -1,0 +1,58 @@
+# `@sbo3l/elizaos`
+
+ElizaOS plugin wrapping SBO3L. Drop into your character's plugin list to gate every payment intent through SBO3L.
+
+> ⚠ **DRAFT (T-1-5):** depends on F-9 (`@sbo3l/sdk`).
+
+## Install
+
+```bash
+npm install @sbo3l/elizaos @sbo3l/sdk
+```
+
+## Usage
+
+```ts
+import { SBO3LClient } from "@sbo3l/sdk";
+import { sbo3lPlugin } from "@sbo3l/elizaos";
+
+const client = new SBO3LClient({ endpoint: "http://localhost:8730" });
+const plugin = sbo3lPlugin({ client });
+
+// Pass `plugin` into your character's `plugins: [...]`. The plugin
+// registers an Action `SBO3L_PAYMENT_REQUEST` (similes: PAY, PURCHASE,
+// SUBMIT_PAYMENT, REQUEST_PAYMENT) that fires when the agent's message
+// contains an APRP (in `message.content.aprp` as a JSON object, or in
+// `message.content.text` as a JSON-stringified APRP).
+```
+
+## What it does
+
+The agent emits a payment intent as either a structured `aprp` object on
+the message content or a JSON-stringified APRP in the text. The Action
+forwards to `SBO3LClient.submit()` and replies with:
+
+```json
+{
+  "decision": "allow",
+  "execution_ref": "kh-...",
+  "audit_event_id": "evt-...",
+  ...
+}
+```
+
+On `deny`, the envelope contains `deny_code` (e.g. `policy.budget_exceeded`)
+so the agent can self-correct.
+
+## Custom APRP extraction
+
+```ts
+sbo3lPlugin({
+  client,
+  extractAprp: (message) => myCharacter.parseIntoAprp(message),
+});
+```
+
+## License
+
+MIT

--- a/integrations/elizaos/package.json
+++ b/integrations/elizaos/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@sbo3l/elizaos",
+  "version": "0.1.0",
+  "description": "ElizaOS plugin wrapping SBO3L — gate every agent payment intent through SBO3L's policy boundary.",
+  "license": "MIT",
+  "author": "Daniel Babjak <babjak_daniel@hotmail.com>",
+  "homepage": "https://sbo3l.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026.git",
+    "directory": "integrations/elizaos"
+  },
+  "keywords": ["sbo3l", "elizaos", "eliza", "agent", "policy", "plugin"],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": ["dist", "README.md"],
+  "sideEffects": false,
+  "engines": { "node": ">=18" },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --clean",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@sbo3l/sdk": "^0.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@sbo3l/sdk": { "optional": true }
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.5",
+    "tsup": "^8.0.2",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "publishConfig": { "access": "public" }
+}

--- a/integrations/elizaos/src/index.ts
+++ b/integrations/elizaos/src/index.ts
@@ -1,0 +1,186 @@
+/**
+ * `@sbo3l/elizaos` — ElizaOS plugin wrapping SBO3L.
+ *
+ * ElizaOS plugins export a `Plugin` object with `name`, `description`,
+ * and `actions[]`. Each `Action` has a `name`, `validate(runtime, message)`,
+ * and `handler(runtime, message, state, options, callback)`. This package
+ * exposes one such Action: `SBO3L_PAYMENT_REQUEST`. Drop the plugin into
+ * your character's plugin list to gate every payment intent through SBO3L.
+ *
+ * Structural typing — no hard import of `@elizaos/core` (its API is in
+ * flux). Consumers can wrap `sbo3lPlugin(...)` into their preferred
+ * Eliza Plugin shape, or use the exported types as-is if they match.
+ */
+
+export interface SBO3LClientLike {
+  submit(
+    request: Record<string, unknown>,
+    options?: { idempotencyKey?: string },
+  ): Promise<SBO3LSubmitResult>;
+}
+
+export interface SBO3LSubmitResult {
+  decision: "allow" | "deny" | "requires_human";
+  deny_code: string | null;
+  matched_rule_id: string | null;
+  request_hash: string;
+  policy_hash: string;
+  audit_event_id: string;
+  receipt: { execution_ref: string | null; [k: string]: unknown };
+}
+
+/**
+ * Minimal Eliza-shaped Action. Mirrors `@elizaos/core`'s `Action` interface
+ * (name + similes + description + validate + handler) without importing it.
+ *
+ * Eliza's runtime / message / state types are deliberately `unknown` here —
+ * consumers cast at the boundary. Returning a string from the handler is
+ * the convention (forwarded back to the LLM).
+ */
+export interface ElizaAction {
+  name: string;
+  similes: string[];
+  description: string;
+  examples: ElizaExample[];
+  validate: (runtime: unknown, message: unknown) => Promise<boolean>;
+  handler: (
+    runtime: unknown,
+    message: unknown,
+    state?: unknown,
+    options?: unknown,
+    callback?: ElizaCallback,
+  ) => Promise<string>;
+}
+
+export type ElizaCallback = (response: { text: string }, files?: unknown[]) => void;
+
+export interface ElizaExample {
+  user: string;
+  content: { text: string; action?: string };
+}
+
+export interface ElizaPlugin {
+  name: string;
+  description: string;
+  actions: ElizaAction[];
+  evaluators: unknown[];
+  providers: unknown[];
+}
+
+export interface SBO3LPluginOptions {
+  client: SBO3LClientLike;
+  /** Override the default action name. */
+  actionName?: string;
+  /** Optional callback to derive an idempotency key per call. */
+  idempotencyKey?: (aprp: Record<string, unknown>) => string;
+  /**
+   * How to extract the APRP body from an Eliza `message`. Defaults to
+   * looking for `message.content.aprp` (a JSON object) or
+   * `message.content.text` (a JSON-stringified APRP).
+   */
+  extractAprp?: (message: unknown) => Record<string, unknown> | null;
+}
+
+const DEFAULT_ACTION_NAME = "SBO3L_PAYMENT_REQUEST";
+const DEFAULT_DESCRIPTION =
+  "Submit an Agent Payment Request Protocol (APRP) to SBO3L for policy decision. " +
+  "Returns the decision (allow|deny|requires_human), execution_ref (when allowed), " +
+  "and audit_event_id. On deny, branch on deny_code to self-correct or escalate.";
+
+function defaultExtractAprp(message: unknown): Record<string, unknown> | null {
+  if (typeof message !== "object" || message === null) return null;
+  const m = message as { content?: unknown };
+  if (typeof m.content !== "object" || m.content === null) return null;
+  const c = m.content as { aprp?: unknown; text?: unknown };
+  if (typeof c.aprp === "object" && c.aprp !== null && !Array.isArray(c.aprp)) {
+    return c.aprp as Record<string, unknown>;
+  }
+  if (typeof c.text === "string") {
+    try {
+      const parsed: unknown = JSON.parse(c.text);
+      if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Build the SBO3L Eliza plugin. Pass into your character's `plugins: [...]`
+ * (or a Plugin loader that accepts `ElizaPlugin`-shaped objects).
+ */
+export function sbo3lPlugin(options: SBO3LPluginOptions): ElizaPlugin {
+  const { client } = options;
+  const actionName = options.actionName ?? DEFAULT_ACTION_NAME;
+  const extract = options.extractAprp ?? defaultExtractAprp;
+
+  const action: ElizaAction = {
+    name: actionName,
+    similes: ["PAY", "PURCHASE", "SUBMIT_PAYMENT", "REQUEST_PAYMENT"],
+    description: DEFAULT_DESCRIPTION,
+    examples: [
+      {
+        user: "agent",
+        content: {
+          text: "I need to pay 0.05 USDC for an inference call.",
+          action: actionName,
+        },
+      },
+    ],
+    validate: async (_runtime, message) => extract(message) !== null,
+    handler: async (_runtime, message, _state, _options, callback) => {
+      const aprp = extract(message);
+      if (aprp === null) {
+        const text = JSON.stringify({
+          error: "input.no_aprp_in_message",
+          detail: "could not extract an APRP object from message.content.aprp or .text",
+        });
+        callback?.({ text });
+        return text;
+      }
+
+      const submitOpts =
+        options.idempotencyKey !== undefined
+          ? { idempotencyKey: options.idempotencyKey(aprp) }
+          : {};
+
+      let envelope: Record<string, unknown>;
+      try {
+        const r = await client.submit(aprp, submitOpts);
+        envelope = {
+          decision: r.decision,
+          deny_code: r.deny_code,
+          matched_rule_id: r.matched_rule_id,
+          execution_ref: r.receipt.execution_ref,
+          audit_event_id: r.audit_event_id,
+          request_hash: r.request_hash,
+          policy_hash: r.policy_hash,
+        };
+      } catch (e) {
+        const code = (e as { code?: unknown })?.code;
+        const status = (e as { status?: unknown })?.status;
+        envelope = {
+          error: typeof code === "string" ? code : "transport.failed",
+          status: typeof status === "number" ? status : null,
+          detail: e instanceof Error ? e.message : String(e),
+        };
+      }
+
+      const text = JSON.stringify(envelope);
+      callback?.({ text });
+      return text;
+    },
+  };
+
+  return {
+    name: "@sbo3l/elizaos",
+    description:
+      "SBO3L payment-request gate for ElizaOS — every payment intent passes through SBO3L's policy boundary.",
+    actions: [action],
+    evaluators: [],
+    providers: [],
+  };
+}

--- a/integrations/elizaos/test/index.test.ts
+++ b/integrations/elizaos/test/index.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  sbo3lPlugin,
+  type SBO3LClientLike,
+  type SBO3LSubmitResult,
+} from "../src/index.js";
+
+const APRP = {
+  agent_id: "research-agent-01",
+  task_id: "demo-1",
+  intent: "purchase_api_call",
+};
+
+const ALLOW: SBO3LSubmitResult = {
+  decision: "allow",
+  deny_code: null,
+  matched_rule_id: "allow-low-risk-x402",
+  request_hash: "c0bd2fab".repeat(8),
+  policy_hash: "e044f13c".repeat(8),
+  audit_event_id: "evt-01HTAWX5K3R8YV9NQB7C6P2DGR",
+  receipt: { execution_ref: "kh-01HTAWX5K3R8YV9NQB7C6P2DGS" },
+};
+
+const DENY: SBO3LSubmitResult = {
+  decision: "deny",
+  deny_code: "policy.budget_exceeded",
+  matched_rule_id: "daily-budget",
+  request_hash: "c0bd2fab".repeat(8),
+  policy_hash: "e044f13c".repeat(8),
+  audit_event_id: "evt-01HTAWX5K3R8YV9NQB7C6P2DGT",
+  receipt: { execution_ref: null },
+};
+
+function fakeClient(r: SBO3LSubmitResult): SBO3LClientLike {
+  return { submit: vi.fn(async () => r) };
+}
+
+describe("sbo3lPlugin — shape", () => {
+  it("exports name + description + actions", () => {
+    const p = sbo3lPlugin({ client: fakeClient(ALLOW) });
+    expect(p.name).toBe("@sbo3l/elizaos");
+    expect(p.actions).toHaveLength(1);
+    expect(p.actions[0]?.name).toBe("SBO3L_PAYMENT_REQUEST");
+    expect(p.evaluators).toEqual([]);
+    expect(p.providers).toEqual([]);
+  });
+
+  it("similes include PAY-like aliases", () => {
+    const p = sbo3lPlugin({ client: fakeClient(ALLOW) });
+    expect(p.actions[0]?.similes).toContain("PAY");
+    expect(p.actions[0]?.similes).toContain("PURCHASE");
+  });
+
+  it("custom action name", () => {
+    const p = sbo3lPlugin({ client: fakeClient(ALLOW), actionName: "MY_PAY" });
+    expect(p.actions[0]?.name).toBe("MY_PAY");
+  });
+});
+
+describe("sbo3lPlugin — validate", () => {
+  it("returns true when message.content.aprp is present", async () => {
+    const p = sbo3lPlugin({ client: fakeClient(ALLOW) });
+    const r = await p.actions[0]!.validate({}, { content: { aprp: APRP } });
+    expect(r).toBe(true);
+  });
+
+  it("returns true when message.content.text is JSON APRP", async () => {
+    const p = sbo3lPlugin({ client: fakeClient(ALLOW) });
+    const r = await p.actions[0]!.validate({}, { content: { text: JSON.stringify(APRP) } });
+    expect(r).toBe(true);
+  });
+
+  it("returns false when no APRP can be extracted", async () => {
+    const p = sbo3lPlugin({ client: fakeClient(ALLOW) });
+    const r = await p.actions[0]!.validate({}, { content: { text: "hello" } });
+    expect(r).toBe(false);
+  });
+});
+
+describe("sbo3lPlugin — handler happy path", () => {
+  it("returns allow envelope (object aprp)", async () => {
+    const p = sbo3lPlugin({ client: fakeClient(ALLOW) });
+    const out = await p.actions[0]!.handler(
+      {},
+      { content: { aprp: APRP } },
+    );
+    const env = JSON.parse(out);
+    expect(env.decision).toBe("allow");
+    expect(env.execution_ref).toBe("kh-01HTAWX5K3R8YV9NQB7C6P2DGS");
+  });
+
+  it("returns deny envelope (text-encoded aprp)", async () => {
+    const p = sbo3lPlugin({ client: fakeClient(DENY) });
+    const out = await p.actions[0]!.handler(
+      {},
+      { content: { text: JSON.stringify(APRP) } },
+    );
+    const env = JSON.parse(out);
+    expect(env.decision).toBe("deny");
+    expect(env.deny_code).toBe("policy.budget_exceeded");
+  });
+
+  it("invokes callback with the envelope text", async () => {
+    const p = sbo3lPlugin({ client: fakeClient(ALLOW) });
+    const callback = vi.fn();
+    await p.actions[0]!.handler(
+      {},
+      { content: { aprp: APRP } },
+      undefined,
+      undefined,
+      callback,
+    );
+    expect(callback).toHaveBeenCalledOnce();
+    const env = JSON.parse(callback.mock.calls[0]![0].text);
+    expect(env.decision).toBe("allow");
+  });
+});
+
+describe("sbo3lPlugin — handler error paths", () => {
+  it("emits no-aprp error when extraction fails", async () => {
+    const p = sbo3lPlugin({ client: fakeClient(ALLOW) });
+    const out = await p.actions[0]!.handler({}, { content: { text: "no APRP here" } });
+    const env = JSON.parse(out);
+    expect(env.error).toBe("input.no_aprp_in_message");
+  });
+
+  it("surfaces SBO3LError code", async () => {
+    const err = Object.assign(new Error("auth"), { code: "auth.required", status: 401 });
+    const client: SBO3LClientLike = { submit: vi.fn(async () => Promise.reject(err)) };
+    const p = sbo3lPlugin({ client });
+    const out = await p.actions[0]!.handler({}, { content: { aprp: APRP } });
+    const env = JSON.parse(out);
+    expect(env.error).toBe("auth.required");
+    expect(env.status).toBe(401);
+  });
+
+  it("falls back to transport.failed", async () => {
+    const client: SBO3LClientLike = {
+      submit: vi.fn(async () => Promise.reject(new Error("ECONNREFUSED"))),
+    };
+    const p = sbo3lPlugin({ client });
+    const out = await p.actions[0]!.handler({}, { content: { aprp: APRP } });
+    const env = JSON.parse(out);
+    expect(env.error).toBe("transport.failed");
+  });
+});
+
+describe("sbo3lPlugin — idempotency + custom extractor", () => {
+  it("invokes idempotencyKey callback", async () => {
+    const submit = vi.fn(async () => ALLOW);
+    const p = sbo3lPlugin({
+      client: { submit },
+      idempotencyKey: (a) => `${(a as { task_id: string }).task_id}-key`,
+    });
+    await p.actions[0]!.handler({}, { content: { aprp: APRP } });
+    const [, opts] = submit.mock.calls[0]!;
+    expect((opts as { idempotencyKey?: string })?.idempotencyKey).toBe("demo-1-key");
+  });
+
+  it("custom extractAprp wins over default", async () => {
+    const submit = vi.fn(async () => ALLOW);
+    const p = sbo3lPlugin({
+      client: { submit },
+      extractAprp: () => ({ agent_id: "custom-extracted", task_id: "x" }),
+    });
+    await p.actions[0]!.handler({}, { content: { text: "ignored" } });
+    const [body] = submit.mock.calls[0]!;
+    expect((body as { agent_id: string }).agent_id).toBe("custom-extracted");
+  });
+});

--- a/integrations/elizaos/tsconfig.json
+++ b/integrations/elizaos/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "test"]
+}

--- a/integrations/elizaos/vitest.config.ts
+++ b/integrations/elizaos/vitest.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from "vitest/config";
+export default defineConfig({ test: { include: ["test/**/*.test.ts"], environment: "node" } });


### PR DESCRIPTION
## Summary
- Adds `integrations/elizaos/` — `@sbo3l/elizaos`, an ElizaOS plugin exposing one Action `SBO3L_PAYMENT_REQUEST` (similes: PAY, PURCHASE, SUBMIT_PAYMENT, REQUEST_PAYMENT).
- The action's `validate()` returns true when `message.content.aprp` (object) or `message.content.text` (JSON-stringified APRP) is present. `handler()` forwards to `SBO3LClient.submit()` and replies with the decision envelope.
- Custom `extractAprp` callback supported for non-default content shapes.
- Structural typing — no hard import of `@elizaos/core` (its API is in flux). Plugin/Action types declared minimally; consumers cast at the boundary.
- 14 vitest tests passing; `tsc --noEmit` clean.

## Why
ElizaOS is the dominant TypeScript agent framework in the autonomous-agent track (matches Bleyle's competitor track-fit). See `docs/win-backlog/06-phase-2.md#T-1-5`.

## DRAFT — depends on
- **F-9** (#90) — `@sbo3l/sdk` must merge + publish to npm.

## Test plan
- [x] `cd integrations/elizaos && npm install && npm run typecheck && npm test` → 14/14 passing
- [ ] (post-F-9 publish) Heidi smoke registering the plugin in an ElizaOS character

## Out of scope
- ElizaOS Provider that exposes SBO3L's audit chain to the LLM as context — could be a follow-up if useful.
- Evaluator that grades the agent's deny-recovery behavior — follow-up.

Closes T-1-5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)