### PR TITLE
docs+infra: ENS parent pivot to sbo3lagent.eth + 3 codex fixes

### DIFF
--- a/apps/marketing/src/pages/features.astro
+++ b/apps/marketing/src/pages/features.astro
@@ -13,7 +13,7 @@ const pillars = [
       "JCS-canonical SHA-256 request hash",
       "serde(deny_unknown_fields)",
     ],
-    ref: "crates/sbo3l-server/src/aprp.rs",
+    ref: "crates/sbo3l-core/src/aprp.rs",
   },
   {
     title: "Hash-chained Ed25519 audit",
@@ -23,7 +23,7 @@ const pillars = [
       "Strict verifier: linkage + signatures + content hashes",
       "Tamper-evident by construction, no oracle required",
     ],
-    ref: "crates/sbo3l-storage/src/audit.rs",
+    ref: "crates/sbo3l-core/src/audit.rs",
   },
   {
     title: "Self-contained Passport capsule",
@@ -43,7 +43,7 @@ const pillars = [
       "Mock = CI-safe default; live = production switch",
       "Per-sponsor evidence schema in execution.executor_evidence",
     ],
-    ref: "crates/sbo3l-execution/src/adapter.rs",
+    ref: "crates/sbo3l-core/src/execution.rs",
   },
   {
     title: "ENS as agent trust DNS",
@@ -53,7 +53,7 @@ const pillars = [
       "Phase 2: ENSIP-25 CCIP-Read for off-chain records",
       "Cross-agent verification via signed attestations",
     ],
-    ref: "docs/spec/ens-text-records.md",
+    ref: "crates/sbo3l-identity/src/ens.rs",
   },
   {
     title: "No-key agent boundary",

--- a/docs/win-backlog/06-phase-2.md
+++ b/docs/win-backlog/06-phase-2.md
@@ -75,13 +75,13 @@
 **What:**
 Implement Durin per-agent subname issuance. CLI:
 ```bash
-sbo3l agent register --name research-agent --parent sbo3l.eth --records '{"sbo3l:agent_id":"research-agent-01",...}'
+sbo3l agent register --name research-agent --parent sbo3lagent.eth --records '{"sbo3l:agent_id":"research-agent-01",...}'
 ```
 
-Issues `research-agent.sbo3l.eth` via Durin contract on Sepolia (free testnet) or mainnet. Sets full record set in one tx (multicall).
+Issues `research-agent.sbo3lagent.eth` via Durin contract on Sepolia (free testnet) or mainnet. Sets full record set in one tx (multicall).
 
 **Acceptance criteria:**
-- [ ] `sbo3l agent register --name foo --parent sbo3l.eth --records ...` issues subname on Sepolia
+- [ ] `sbo3l agent register --name foo --parent sbo3lagent.eth --records ...` issues subname on Sepolia
 - [ ] Multicall sets all 7 sbo3l:* records in one tx (gas-efficient)
 - [ ] Dry-run flag `--dry-run` shows tx data without sending
 - [ ] Records readable via `LiveEnsResolver` after issuance
@@ -92,7 +92,7 @@ Issues `research-agent.sbo3l.eth` via Durin contract on Sepolia (free testnet) o
 # 1. Dry run
 cargo run -p sbo3l-cli -- agent register \
   --name test-agent \
-  --parent sbo3l.eth \
+  --parent sbo3lagent.eth \
   --network sepolia \
   --records '{"sbo3l:agent_id":"test-agent-01","sbo3l:endpoint":"http://127.0.0.1:8730/v1"}' \
   --dry-run
@@ -102,21 +102,21 @@ cargo run -p sbo3l-cli -- agent register \
 SBO3L_SEPOLIA_PRIVATE_KEY=$(cat /tmp/sepolia-key) \
 cargo run -p sbo3l-cli -- agent register \
   --name test-agent \
-  --parent sbo3l.eth \
+  --parent sbo3lagent.eth \
   --network sepolia \
   --records '{"sbo3l:agent_id":"test-agent-01"}'
 # expect: prints tx hash, exit 0
 
 # 3. Verify resolution
 SBO3L_ENS_RPC_URL=https://ethereum-sepolia-rpc.publicnode.com \
-SBO3L_ENS_NAME=test-agent.sbo3l.eth \
+SBO3L_ENS_NAME=test-agent.sbo3lagent.eth \
 cargo run -p sbo3l-identity --example ens_live_smoke
 # expect: returns sbo3l:agent_id = "test-agent-01"
 ```
 
 **[D] Daniel review:**
 - [ ] Daniel funds Sepolia wallet (~0.5 ETH = ~$150)
-- [ ] Daniel registers `sbo3l.eth` apex on Sepolia (parent for subnames)
+- [ ] Daniel registers `sbo3lagent.eth` apex on Sepolia (parent for subnames)
 - [ ] Gas costs documented in ticket
 
 ---
@@ -134,7 +134,7 @@ cargo run -p sbo3l-identity --example ens_live_smoke
 **What:**
 Pure ENS-records-only lookup CLI: `sbo3l passport resolve <ens-name> [--rpc-url <url>] [--check-policy <hash>]`. Output:
 ```
-agent identity:    research-agent-01 (ens: research-agent.sbo3l.eth)
+agent identity:    research-agent-01 (ens: research-agent.sbo3lagent.eth)
 policy hash:       e044f13c5acb… ✓ matches expected
 endpoint:          http://127.0.0.1:8730/v1
 audit root:        0x0000…0000
@@ -177,18 +177,18 @@ cargo test --test test_passport_resolve
 
 **What:**
 Register 5 named agents on Sepolia:
-- `research-agent.sbo3l.eth`
-- `trading-agent.sbo3l.eth`
-- `swap-agent.sbo3l.eth`
-- `audit-agent.sbo3l.eth`
-- `coordinator-agent.sbo3l.eth`
+- `research-agent.sbo3lagent.eth`
+- `trading-agent.sbo3lagent.eth`
+- `swap-agent.sbo3lagent.eth`
+- `audit-agent.sbo3lagent.eth`
+- `coordinator-agent.sbo3lagent.eth`
 
 Each gets full sbo3l:* record set: `agent_id`, `endpoint`, `policy_hash`, `audit_root`, `proof_uri`, `capability` (NEW), `reputation` (NEW, starts at `100/100`).
 
 **Acceptance criteria:**
 - [ ] 5 agents registered + indexed on Sepolia
 - [ ] 7 records per agent
-- [ ] `cargo run -p sbo3l-cli -- passport resolve <name>.sbo3l.eth` returns all 7 records
+- [ ] `cargo run -p sbo3l-cli -- passport resolve <name>.sbo3lagent.eth` returns all 7 records
 - [ ] `demo-fixtures/sepolia-agent-fleet.json` lists all 5 + records (for offline reproduction)
 - [ ] Total cost < 0.1 ETH on Sepolia (free testnet)
 
@@ -196,7 +196,7 @@ Each gets full sbo3l:* record set: `agent_id`, `endpoint`, `policy_hash`, `audit
 ```bash
 for name in research-agent trading-agent swap-agent audit-agent coordinator-agent; do
   SBO3L_ENS_RPC_URL=https://ethereum-sepolia-rpc.publicnode.com \
-  cargo run -p sbo3l-cli -- passport resolve ${name}.sbo3l.eth
+  cargo run -p sbo3l-cli -- passport resolve ${name}.sbo3lagent.eth
   echo "expected 7 records for ${name}"
 done
 ```
@@ -230,9 +230,9 @@ Schema:
 {
   "type": "sbo3l.cross_agent_attestation.v1",
   "from_agent_id": "research-agent-01",
-  "from_ens": "research-agent.sbo3l.eth",
+  "from_ens": "research-agent.sbo3lagent.eth",
   "to_agent_id": "trading-agent-01",
-  "to_ens": "trading-agent.sbo3l.eth",
+  "to_ens": "trading-agent.sbo3lagent.eth",
   "delegation_intent": "delegate_swap",
   "target_policy_hash": "abc123...",
   "expires_at": "2026-05-15T10:00:00Z",
@@ -246,7 +246,7 @@ Schema:
 
 **Acceptance criteria:**
 - [ ] Schema published, validates
-- [ ] CLI `sbo3l cross-agent attest --from research-agent.sbo3l.eth --to trading-agent.sbo3l.eth --intent delegate_swap` works against real Sepolia
+- [ ] CLI `sbo3l cross-agent attest --from research-agent.sbo3lagent.eth --to trading-agent.sbo3lagent.eth --intent delegate_swap` works against real Sepolia
 - [ ] Attestation flows through APRP → policy receipt → audit chain
 - [ ] Tampered attestation rejected with `cross_agent.attestation_invalid`
 - [ ] Expired attestation rejected with `cross_agent.attestation_expired`
@@ -256,8 +256,8 @@ Schema:
 ```bash
 # Attest
 ATT=$(cargo run -p sbo3l-cli -- cross-agent attest \
-  --from research-agent.sbo3l.eth \
-  --to trading-agent.sbo3l.eth \
+  --from research-agent.sbo3lagent.eth \
+  --to trading-agent.sbo3lagent.eth \
   --intent delegate_swap \
   --signer-key /tmp/research-agent-key.pem \
   --expires-in 1h)
@@ -381,7 +381,7 @@ Implement ENSIP-25 (CCIP-Read) for off-chain sbo3l:* records. Agent has minimal 
 **Acceptance criteria:**
 - [ ] CCIP-Read gateway running at `ccip.sbo3l.dev` (or similar)
 - [ ] Compatible with `ethers.js` + `viem` resolver flow (judges can resolve via standard tooling)
-- [ ] Test: `viem.getEnsText({name: 'research-agent.sbo3l.eth', key: 'sbo3l:reputation'})` returns expected
+- [ ] Test: `viem.getEnsText({name: 'research-agent.sbo3lagent.eth', key: 'sbo3l:reputation'})` returns expected
 - [ ] Doc explains the resolver setup
 
 **QA Test Plan:**
@@ -393,7 +393,7 @@ node -e "
 import { createPublicClient, http } from 'viem';
 import { mainnet } from 'viem/chains';
 const c = createPublicClient({ chain: mainnet, transport: http('https://ethereum-rpc.publicnode.com') });
-const r = await c.getEnsText({ name: 'research-agent.sbo3l.eth', key: 'sbo3l:reputation' });
+const r = await c.getEnsText({ name: 'research-agent.sbo3lagent.eth', key: 'sbo3l:reputation' });
 console.log(r);
 "
 # expect: numeric reputation

--- a/docs/win-backlog/10-first-tier-amplifiers.md
+++ b/docs/win-backlog/10-first-tier-amplifiers.md
@@ -340,7 +340,7 @@ Formal ENSIP submission proposing standardization of `sbo3l:` namespace for agen
 
 ### ENS AI Agents — push 30% → 80%
 
-#### [ENS-AGENT-A1] Mainnet `sbo3l.eth` apex + 50+ production subname agents
+#### [ENS-AGENT-A1] Mainnet `sbo3lagent.eth` apex + 50+ production subname agents
 
 **Owner:** Daniel (wallet) + ⛓️ Ivan | **Effort:** 40h + ~$200 mainnet | **Depends:** T-3-1 (Durin issuance flow)
 
@@ -349,13 +349,13 @@ Formal ENSIP submission proposing standardization of `sbo3l:` namespace for agen
 - `demo-fixtures/mainnet-agent-fleet.json`
 
 **What:**
-- Daniel registers `sbo3l.eth` apex on mainnet (~$30-200 depending on rarity)
-- Issue 50 named agent subnames via Durin: `agent-001.sbo3l.eth` through `agent-050.sbo3l.eth`
+- Daniel registers `sbo3lagent.eth` apex on mainnet (~$30-200 depending on rarity)
+- Issue 50 named agent subnames via Durin: `agent-001.sbo3lagent.eth` through `agent-050.sbo3lagent.eth`
 - Each gets full sbo3l:* record set
-- 10 named "specialist" agents: `research.sbo3l.eth`, `trading.sbo3l.eth`, ..., (10 categories)
+- 10 named "specialist" agents: `research.sbo3lagent.eth`, `trading.sbo3lagent.eth`, ..., (10 categories)
 
 **Acceptance criteria:**
-- [ ] `sbo3l.eth` owned on mainnet
+- [ ] `sbo3lagent.eth` owned on mainnet
 - [ ] 50 generic + 10 specialist subnames registered
 - [ ] All 60 agents resolve via `LiveEnsResolver` with full record set
 - [ ] Total mainnet cost ≤ $200 (using cheap mainnet windows + batched txs)
@@ -565,7 +565,7 @@ gh pr view <ensip-pr-url> --json state | jq -r .state  # "OPEN" or "MERGED"
 ```bash
 # ENS-AGENT-A1: 60 mainnet agents
 SBO3L_ENS_RPC_URL=https://ethereum-rpc.publicnode.com \
-  cargo run -p sbo3l-cli -- passport resolve agent-001.sbo3l.eth | grep -q "policy hash:"
+  cargo run -p sbo3l-cli -- passport resolve agent-001.sbo3lagent.eth | grep -q "policy hash:"
 
 # Confirm 60 total
 COUNT=$(jq '.agents | length' demo-fixtures/mainnet-agent-fleet.json)
@@ -608,7 +608,7 @@ gh pr view <uniswap-pr-url> --json state | jq -r .state  # "OPEN" or "MERGED"
 
 | Item | Cost |
 |---|---|
-| `sbo3l.eth` mainnet apex | ~$30-200 |
+| `sbo3lagent.eth` mainnet apex | ~$30-200 |
 | 60 subname mainnet registrations (batched) | ~$50 |
 | ERC-8004 mainnet registrations | ~$50 |
 | Uniswap mainnet swap (small safe amount + gas) | ~$50-100 |

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -1,2 +1,5 @@
-export { tokens, darkTokens, lightTokens } from './tokens';
-export type { Tokens } from './tokens';
+// ESM-compatible re-exports — TypeScript preserves the `.js` literal in
+// compiled output. Without `.js`, ESM resolution fails post-build with
+// ERR_MODULE_NOT_FOUND. (Codex P2 on PR #98.)
+export { tokens, darkTokens, lightTokens } from './tokens.js';
+export type { Tokens } from './tokens.js';

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,34 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": null,
-  "installCommand": null,
-  "outputDirectory": "apps/marketing"
+  "buildCommand": "cd apps/marketing && npm install && npm run build",
+  "outputDirectory": "apps/marketing/dist",
+  "installCommand": "echo 'install handled in buildCommand for monorepo subpath'",
+  "framework": null,
+  "cleanUrls": true,
+  "trailingSlash": false,
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'" }
+      ]
+    },
+    {
+      "source": "/(.*)\\.(css|js|svg|png|jpg|jpeg|woff|woff2)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    }
+  ],
+  "redirects": [
+    {
+      "source": "/proof",
+      "destination": "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/",
+      "permanent": false
+    }
+  ]
 }


### PR DESCRIPTION
Two parts:

1. **Docs sweep** — 32 `sbo3l.eth` → `sbo3lagent.eth` replacements across docs/win-backlog/06-phase-2.md (23 refs) + 10-first-tier-amplifiers.md (9 refs). Daniel pivoted Phase 2 ENS parent from new sbo3l.eth registration to existing mainnet-owned sbo3lagent.eth on 2026-05-01 ~03:15 CEST. Functionally identical (Durin issuance still used; parent flag default changes).

2. **3 Codex fixes** from QA review pass:
   - **PR #86 P1** — root vercel.json missing security headers (CSP, X-Frame-Options, Referrer-Policy, Permissions-Policy, /proof redirect, cache rules) + stale outputDirectory (Astro builds to dist/, not apps/marketing/). Fixed defensively.
   - **PR #98 P2** — packages/design-tokens/src/index.ts ESM .js extension missing on re-exports. Fixed.
   - **PR #103 P2** — apps/marketing/src/pages/features.astro 4 of 6 file:line refs pointed at non-existent files. Remapped to actual paths (sbo3l-server/aprp.rs → sbo3l-core/aprp.rs etc.). All 6 verified existent.

## Test plan
- [x] cargo test --workspace --all-targets: 439/439 (no regression)
- [x] python3 demo-fixtures/test_fixtures.py: PASS
- [x] python3 trust-badge/test_build.py: PASS
- [x] All 6 features.astro refs verified pointing to existing files

5 files, +69/-38 LoC.