### PR TITLE
feat(infra): ccip-gateway Vercel project + GitHub Actions deploy + uptime probe

### DIFF
--- a/.github/workflows/ccip-gateway-uptime.yml
+++ b/.github/workflows/ccip-gateway-uptime.yml
@@ -1,0 +1,60 @@
+name: ccip-gateway uptime
+
+# Lightweight uptime probe. Runs every 30 min against
+# https://sbo3l-ccip.vercel.app and posts a `::warning::` annotation
+# (caught by Heidi's daily regression sweep) if anything is wrong.
+#
+# This is NOT alerting / paging — it's a low-cost public-facing
+# health signal. Real production alerting would route through a
+# proper monitoring service; for the hackathon submission window
+# this gets us "is the gateway up at submission time?" coverage.
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"   # every 30 minutes
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: HTTP probe
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: GET landing page
+        run: |
+          set -euo pipefail
+          STATUS=$(curl -sS -o /tmp/landing.html -w "%{http_code}" \
+                  https://sbo3l-ccip.vercel.app/)
+          echo "landing http=$STATUS"
+          if [ "$STATUS" != "200" ]; then
+            echo "::warning::ccip-gateway landing returned $STATUS"
+            head -50 /tmp/landing.html || true
+            exit 1
+          fi
+
+      - name: GET API stub (expect 501 not_implemented)
+        run: |
+          set -euo pipefail
+          # The current pre-T-4-1 implementation returns 501; once T-4-1
+          # ships, this should switch to either 200 (valid record) or 404
+          # (unknown sender/record). When that happens, this step needs
+          # updating; the failure here on transition is intentional —
+          # the workflow flips green only after this assertion is
+          # corrected.
+          BODY=$(curl -sS -o /tmp/api.json -w "%{http_code}" \
+                  https://sbo3l-ccip.vercel.app/api/0x0000000000000000000000000000000000000000/0x00.json)
+          STATUS=$BODY
+          echo "api http=$STATUS"
+          if [ "$STATUS" = "501" ]; then
+            grep -q "not_implemented" /tmp/api.json
+            exit 0
+          fi
+          # Once T-4-1 ships, switch the assertion above to:
+          # if [ "$STATUS" = "404" ]; then exit 0; fi
+          echo "::warning::api returned unexpected status $STATUS"
+          cat /tmp/api.json
+          exit 1

--- a/.github/workflows/ccip-gateway.yml
+++ b/.github/workflows/ccip-gateway.yml
@@ -1,0 +1,165 @@
+name: ccip-gateway
+
+# Vercel deploy for `apps/ccip-gateway/` (the SBO3L CCIP-Read gateway,
+# T-4-1 deploy target). Deploys to https://sbo3l-ccip.vercel.app on
+# push to main; preview deploys on PR.
+#
+# Required GitHub repo secrets:
+#   VERCEL_TOKEN      — Vercel API token (Account → Settings → Tokens)
+#   VERCEL_ORG_ID     — `vercel link` output, in apps/ccip-gateway/.vercel/project.json
+#   VERCEL_PROJECT_ID — same source as above
+#   GATEWAY_PRIVATE_KEY — secp256k1 hex (set in Vercel project env, NOT
+#                        in GitHub secrets — this workflow does not need
+#                        the key, only Vercel runtime does. Listed here
+#                        as a reminder during initial project setup.)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/ccip-gateway/**"
+      - ".github/workflows/ccip-gateway.yml"
+  pull_request:
+    paths:
+      - "apps/ccip-gateway/**"
+      - ".github/workflows/ccip-gateway.yml"
+
+permissions:
+  contents: read
+  deployments: write       # so the workflow can post a deployment status
+  pull-requests: write     # so preview-deploy comments can land on PRs
+
+concurrency:
+  # Serialize per-branch so two pushes don't race the same Vercel project.
+  group: ccip-gateway-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  typecheck:
+    name: Typecheck (Next.js)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: apps/ccip-gateway
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: apps/ccip-gateway/package-lock.json
+
+      - name: Install
+        run: npm install --no-audit --no-fund
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+        env:
+          # The route uses GATEWAY_PRIVATE_KEY at runtime, but the build
+          # itself doesn't need it (Next App Router). Provide a dummy
+          # value so any startup-time validation doesn't fail in CI.
+          GATEWAY_PRIVATE_KEY: 0x0000000000000000000000000000000000000000000000000000000000000001
+
+  deploy-preview:
+    name: Vercel preview deploy
+    if: github.event_name == 'pull_request'
+    needs: typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: apps/ccip-gateway
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel project settings (preview)
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Build (preview)
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy (preview)
+        id: deploy
+        run: |
+          set -euo pipefail
+          URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          echo "preview_url=$URL" >> "$GITHUB_OUTPUT"
+          echo "Preview: $URL"
+
+      - name: Comment preview URL on PR
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}
+        with:
+          script: |
+            const url = process.env.PREVIEW_URL || "(deploy failed; see job logs)";
+            const body = [
+              "**ccip-gateway preview deploy**",
+              "",
+              `Preview URL: ${url}`,
+              "",
+              "Smoke test:",
+              "```bash",
+              `curl -sS ${url}/api/0x0000000000000000000000000000000000000000/0x00.json | jq`,
+              "```",
+              "(Stub returns 501 until T-4-1 main PR ships the record-source impl.)",
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+
+  deploy-production:
+    name: Vercel production deploy
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: ccip-gateway-production
+      url: https://sbo3l-ccip.vercel.app
+    defaults:
+      run:
+        working-directory: apps/ccip-gateway
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel project settings (production)
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Build (production)
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy (production)
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/apps/ccip-gateway/.env.example
+++ b/apps/ccip-gateway/.env.example
@@ -1,0 +1,12 @@
+# Copy to .env.local for local development; set the real value in
+# Vercel's project settings for production.
+#
+# 0x-prefixed 64-hex-char private key (32 bytes). Used to sign gateway
+# responses. Compromise = wrong record served, no fund loss; rotation =
+# redeploy OffchainResolver with the new address.
+#
+# Generate with:
+#     node -e "console.log('0x' + require('crypto').randomBytes(32).toString('hex'))"
+# or:
+#     openssl rand -hex 32 | sed 's/^/0x/'
+GATEWAY_PRIVATE_KEY=0x0000000000000000000000000000000000000000000000000000000000000000

--- a/apps/ccip-gateway/.gitignore
+++ b/apps/ccip-gateway/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+out
+.env*
+!.env.example
+.vercel
+*.log

--- a/apps/ccip-gateway/DEPLOY.md
+++ b/apps/ccip-gateway/DEPLOY.md
@@ -1,0 +1,169 @@
+# Deploying `@sbo3l/ccip-gateway` to Vercel
+
+**Audience:** Daniel (or any operator authorised to run Vercel + GitHub
+admin operations).
+
+**Outcome:** in 15 minutes the gateway is live at
+`https://sbo3l-ccip.vercel.app` and any push to `main` that touches
+`apps/ccip-gateway/**` auto-deploys.
+
+## One-time project setup
+
+### 1. Create the Vercel project
+
+```bash
+cd apps/ccip-gateway
+npx vercel link
+# answer:
+#   - Set up and link?         Y
+#   - Which scope?             B2JK-Industry (or personal)
+#   - Link to existing project? N
+#   - Project name?            sbo3l-ccip
+#   - Directory?               ./
+#   - Framework auto-detected: Next.js
+```
+
+After this, `apps/ccip-gateway/.vercel/project.json` exists with
+`projectId` and `orgId` — note these for step 3.
+
+`apps/ccip-gateway/.vercel/` is already in the workspace `.gitignore`
+(repo root), so the local link is ephemeral.
+
+### 2. Set the runtime env var on Vercel
+
+```bash
+# Generate a fresh secp256k1 key (never reused with any wallet that
+# holds funds — this is a *signing* key for read-side gateway responses):
+node -e "console.log('0x' + require('crypto').randomBytes(32).toString('hex'))" \
+  | tr -d '\n' | pbcopy   # copy to clipboard
+
+vercel env add GATEWAY_PRIVATE_KEY production
+# paste from clipboard
+vercel env add GATEWAY_PRIVATE_KEY preview
+# paste the SAME value (preview env mirrors prod for E2E parity)
+vercel env add GATEWAY_PRIVATE_KEY development
+# paste the SAME value (or a separate dev key — your call)
+```
+
+The address corresponding to this key is what gets baked into the
+on-chain OffchainResolver's `signer` storage when T-4-1 deploys.
+
+### 3. Add GitHub Actions secrets
+
+Repository → Settings → Secrets and variables → Actions → "New
+repository secret":
+
+| Secret               | Value                                                           |
+|----------------------|-----------------------------------------------------------------|
+| `VERCEL_TOKEN`       | from `https://vercel.com/account/tokens` (scope: full account, no expiry preferred) |
+| `VERCEL_ORG_ID`      | from `apps/ccip-gateway/.vercel/project.json` `orgId`           |
+| `VERCEL_PROJECT_ID`  | from `apps/ccip-gateway/.vercel/project.json` `projectId`       |
+
+`GATEWAY_PRIVATE_KEY` does **not** go in GitHub secrets — only Vercel.
+The deploy workflow does not need to read the key; only the running
+runtime does.
+
+### 4. Trigger the first deploy
+
+```bash
+git commit --allow-empty -m "ci: bootstrap ccip-gateway deploy"
+git push origin main
+```
+
+Watch the workflow at `https://github.com/B2JK-Industry/SBO3L-…/actions/workflows/ccip-gateway.yml`.
+
+When it goes green, smoke:
+
+```bash
+curl -sS https://sbo3l-ccip.vercel.app/ | head -5
+# expect: <!DOCTYPE html>... (the landing page from src/app/page.tsx)
+
+curl -sS -o /dev/null -w "%{http_code}\n" \
+  https://sbo3l-ccip.vercel.app/api/0x0000000000000000000000000000000000000000/0x00.json
+# expect: 501 (pre-T-4-1 stub)
+```
+
+## CI workflows
+
+### `.github/workflows/ccip-gateway.yml`
+
+- `typecheck` job: `npm run typecheck` + `npm run build` on every PR
+  and main push. Catches TS errors before deploy.
+- `deploy-preview` job: on PR — Vercel preview URL, comment posted on
+  the PR with the URL + smoke command.
+- `deploy-production` job: on push to `main` — Vercel production
+  deploy. Promotes to `https://sbo3l-ccip.vercel.app`.
+
+### `.github/workflows/ccip-gateway-uptime.yml`
+
+- Runs every 30 minutes against the production URL.
+- GETs landing page (expect 200), GETs the stub API endpoint
+  (currently expects 501; flip to 404 once T-4-1 ships record
+  lookup).
+- Posts a `::warning::` annotation on any non-2xx/3xx response so
+  Heidi's daily regression sweep catches outages.
+
+## Custom domain (post-`sbo3l.dev` unfreeze)
+
+Once Daniel acquires `sbo3l.dev`, attach `ccip.sbo3l.dev` to this
+project:
+
+```bash
+vercel domains add ccip.sbo3l.dev sbo3l-ccip
+```
+
+Then update T-4-1's OffchainResolver `urls` array to the custom
+domain. The Vercel project keeps responding on both URLs during the
+transition.
+
+## Rotating the gateway signing key
+
+```bash
+# 1. Generate a new key
+NEW=$(node -e "console.log('0x' + require('crypto').randomBytes(32).toString('hex'))")
+# 2. Update Vercel env (overwrites)
+vercel env rm GATEWAY_PRIVATE_KEY production -y
+vercel env add GATEWAY_PRIVATE_KEY production
+# paste NEW
+# 3. Trigger redeploy
+vercel --prod
+# 4. Update OffchainResolver on-chain with the new address
+sbo3l agent update-resolver-signer \
+  --network mainnet \
+  --new-signer 0x<address derived from NEW>
+# (sbo3l agent update-resolver-signer ships in a follow-up; for now,
+#  call the contract's setSigner method directly via cast/foundry.)
+```
+
+## Cost budget
+
+| Resource                     | Cost              |
+|------------------------------|-------------------|
+| Vercel Hobby plan            | free              |
+| Function invocations         | free up to 100k/mo (uptime probe + judges' resolution traffic ≪ this) |
+| Bandwidth                    | free up to 100 GB/mo |
+| Custom domain                | free (DNS only)   |
+| `GATEWAY_PRIVATE_KEY`        | $0 (no funds held)|
+
+Total recurring: **$0** while we stay within Vercel Hobby limits.
+Upgrade to Pro ($20/mo) only if function invocations exceed 100k/mo —
+unlikely during the hackathon submission window.
+
+## Troubleshooting
+
+- **Build fails with "Cannot find module 'next'"** — `npm install`
+  was skipped. The workflow caches by `package-lock.json`; if the
+  lockfile is missing, the cache key breaks. Run `npm install` once
+  locally and commit `package-lock.json`.
+- **Deploy succeeds but landing page 404s** — Vercel's "Output
+  Directory" setting is wrong. Verify the project root is
+  `apps/ccip-gateway`, not the repo root, in the Vercel project's
+  Build & Deployment settings.
+- **`vercel pull` fails with "project not found"** — `VERCEL_ORG_ID`
+  / `VERCEL_PROJECT_ID` mismatch. Re-fetch from
+  `apps/ccip-gateway/.vercel/project.json` after a fresh `vercel
+  link`.
+- **Uptime workflow alerts on 200 instead of 501** — T-4-1 has shipped
+  and the stub is gone. Update the assertion in
+  `.github/workflows/ccip-gateway-uptime.yml` to expect 404 for
+  unknown records.

--- a/apps/ccip-gateway/README.md
+++ b/apps/ccip-gateway/README.md
@@ -1,0 +1,117 @@
+# `@sbo3l/ccip-gateway`
+
+ENSIP-25 / EIP-3668 CCIP-Read gateway for off-chain SBO3L `sbo3l:*` ENS
+text records.
+
+**Status:** pre-scaffold for T-4-1. Endpoint shape, error envelopes,
+CORS headers and Vercel project layout are pinned. The actual record
+lookup + signing logic ship in the T-4-1 main PR.
+
+**Live:** [`https://sbo3l-ccip.vercel.app`](https://sbo3l-ccip.vercel.app)
+(once Daniel deploys; not yet live).
+
+## What it does
+
+When a client (viem, ethers.js, or any ENSIP-10-aware library) resolves
+an SBO3L agent name whose resolver is the OffchainResolver contract,
+the resolver reverts with `OffchainLookup(...)`. The client picks a URL
+from the revert payload and `GET`s this gateway. The gateway returns
+the requested record, signed by `GATEWAY_PRIVATE_KEY`, and the
+OffchainResolver's callback verifies the signature on-chain.
+
+```
+                     viem.getEnsText({name, key})
+                              │
+                              ▼
+                      (resolver contract reverts)
+                              │
+                              ▼
+              GET https://sbo3l-ccip.vercel.app/api/{sender}/{data}.json
+                              │
+                              ▼
+                     {"data":"0x...","ttl":60}
+                              │
+                              ▼
+                  resolver.callback(data) verifies sig
+                              │
+                              ▼
+                       returns "87"
+```
+
+## Endpoint
+
+```
+GET /api/{sender}/{data}.json
+```
+
+| Param      | Format                                   |
+|------------|------------------------------------------|
+| `{sender}` | `0x` + 40-hex-char OffchainResolver addr |
+| `{data}`   | `0x` + ABI-encoded calldata + `.json`    |
+
+### Response (200)
+
+```json
+{
+  "data": "0x...",
+  "ttl": 60
+}
+```
+
+`data` is the ABI-encoded `(bytes value, uint64 expires, bytes
+signature)` tuple. `ttl` is a hint for clients/proxies.
+
+### Errors
+
+| HTTP | `error` field    | Cause                                          |
+|------|------------------|------------------------------------------------|
+| 400  | `bad_request`    | malformed `{sender}` or `{data}`               |
+| 404  | `not_found`      | sender not whitelisted, or record absent       |
+| 500  | `signing_failed` | `GATEWAY_PRIVATE_KEY` missing / signer error   |
+| 501  | `not_implemented`| pre-scaffold stub (current state)              |
+
+## Local development
+
+```bash
+cd apps/ccip-gateway
+cp .env.example .env.local
+# generate a fresh dev key:
+node -e "console.log('0x' + require('crypto').randomBytes(32).toString('hex'))"
+# paste into .env.local as GATEWAY_PRIVATE_KEY
+npm install
+npm run dev
+# open http://localhost:3000
+# api: GET http://localhost:3000/api/0x.../0x....json
+```
+
+## Deploy (Vercel)
+
+This directory is its own Vercel project rooted at `apps/ccip-gateway`.
+Deploy:
+
+1. Vercel project root: `apps/ccip-gateway`
+2. Framework preset: Next.js (auto-detected via `vercel.json`)
+3. Project env: set `GATEWAY_PRIVATE_KEY` to a fresh secp256k1 key
+   (never reused with any wallet that holds funds).
+4. The OffchainResolver contract on-chain MUST point at this gateway's
+   public URL in its `urls` array.
+
+## Security notes
+
+1. `GATEWAY_PRIVATE_KEY` is a **read-side signing key**. Compromise =
+   wrong record served, no fund loss. Rotation = redeploy
+   OffchainResolver pointing at the new address.
+2. CORS is wide open (`Access-Control-Allow-Origin: *`) — judges can
+   evaluate from a browser console.
+3. Cache headers are short (10s + 30s SWR) to keep records fresh.
+   Reputation in particular is expected to update per checkpoint.
+4. The endpoint never reflects user input verbatim back into HTML;
+   only into ABI-encoded bytes that are signed and verified
+   on-chain.
+
+## References
+
+- [EIP-3668 CCIP-Read](https://eips.ethereum.org/EIPS/eip-3668)
+- [ENSIP-10](https://docs.ens.domains/ensip/10)
+- [ENS Labs offchain-resolver reference](https://github.com/ensdomains/offchain-resolver)
+- [T-4-1 design doc](../../docs/design/T-4-1-ccip-read-prep.md)

--- a/apps/ccip-gateway/next.config.mjs
+++ b/apps/ccip-gateway/next.config.mjs
@@ -1,0 +1,18 @@
+// CCIP-Read gateway is API-only. No client-side React, no images, no
+// CSS — just route handlers under app/api/. Server output deploys
+// straight to Vercel functions.
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  // Belt-and-suspenders: lock the workspace root so Next doesn't
+  // accidentally resolve files from sibling apps when monorepo
+  // tooling expands.
+  outputFileTracingRoot: new URL("./", import.meta.url).pathname,
+  // No image optimization needed — gateway has no UI.
+  images: {
+    unoptimized: true,
+  },
+};
+
+export default nextConfig;

--- a/apps/ccip-gateway/package.json
+++ b/apps/ccip-gateway/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@sbo3l/ccip-gateway",
+  "version": "0.0.0",
+  "private": true,
+  "description": "SBO3L CCIP-Read gateway (ENSIP-25 / EIP-3668). Returns sbo3l:* off-chain ENS text records signed by GATEWAY_PRIVATE_KEY for verification by the OffchainResolver. Deploys to sbo3l-ccip.vercel.app.",
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "viem": "^2.21.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "typescript": "^5.5.0"
+  },
+  "engines": {
+    "node": ">=18.17.0"
+  }
+}

--- a/apps/ccip-gateway/src/app/api/[sender]/[data]/route.ts
+++ b/apps/ccip-gateway/src/app/api/[sender]/[data]/route.ts
@@ -1,0 +1,86 @@
+/**
+ * SBO3L CCIP-Read gateway endpoint (ENSIP-25 / EIP-3668).
+ *
+ * URL shape per the spec:
+ *
+ *     GET /api/{sender}/{data}.json
+ *
+ * - {sender} = 0x-prefixed 40-hex-char OffchainResolver contract
+ *              address (lowercased).
+ * - {data}   = 0x-prefixed ABI-encoded calldata of the original
+ *              query (e.g. text(node, key), addr(node)).
+ *
+ * Response (200) per the convention:
+ *
+ *     {
+ *       "data": "0x...",   // ABI-encoded (bytes value, uint64 expires, bytes signature)
+ *       "ttl":  60         // gateway hint for clients/proxies
+ *     }
+ *
+ * STATUS: pre-scaffold stub. Returns 501 Not Implemented until the
+ * T-4-1 main PR ships the record source + signing logic. The route's
+ * shape, error envelope, and CORS headers are pinned now so deployers
+ * can wire the OffchainResolver against the eventual production URL
+ * without surprises.
+ *
+ * Design doc: docs/design/T-4-1-ccip-read-prep.md
+ * Ticket:     T-4-1 in docs/win-backlog/06-phase-2.md
+ */
+
+import { NextResponse } from "next/server";
+
+interface RouteParams {
+  params: Promise<{ sender: string; data: string }>;
+}
+
+const HEX_ADDR_RE = /^0x[0-9a-fA-F]{40}$/;
+const HEX_DATA_RE = /^0x[0-9a-fA-F]+\.json$/;
+
+export async function GET(_req: Request, { params }: RouteParams) {
+  const { sender, data } = await params;
+
+  if (!HEX_ADDR_RE.test(sender)) {
+    return NextResponse.json(
+      { error: "bad_request", reason: "sender must be 0x-prefixed 40-hex-char address" },
+      { status: 400 },
+    );
+  }
+
+  if (!HEX_DATA_RE.test(data)) {
+    return NextResponse.json(
+      { error: "bad_request", reason: "data must be 0x-prefixed ABI-encoded calldata with .json suffix" },
+      { status: 400 },
+    );
+  }
+
+  // T-4-1 main PR fills in:
+  //   1. Decode the calldata to extract (node, key) for text()
+  //      or node for addr().
+  //   2. Look up the value in the record source (static JSON in
+  //      apps/ccip-gateway/data/records.json initially).
+  //   3. ABI-encode (value, expires, signature) where signature is
+  //      EthSigner over keccak256(value || expires || extraData)
+  //      using GATEWAY_PRIVATE_KEY (Vercel env).
+  //   4. Return { data: "0x...", ttl: 60 }.
+  return NextResponse.json(
+    {
+      error: "not_implemented",
+      reason:
+        "CCIP-Read gateway is pre-scaffold. T-4-1 main PR will land the record lookup + signing logic.",
+      design_doc:
+        "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/docs/design/T-4-1-ccip-read-prep.md",
+    },
+    { status: 501 },
+  );
+}
+
+export async function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Max-Age": "86400",
+    },
+  });
+}

--- a/apps/ccip-gateway/src/app/layout.tsx
+++ b/apps/ccip-gateway/src/app/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "SBO3L CCIP-Read gateway",
+  description:
+    "ENSIP-25 / EIP-3668 gateway for off-chain SBO3L text records.",
+  robots: {
+    // Robots can index the landing page, but the API endpoints aren't
+    // useful to crawl.
+    index: true,
+    follow: true,
+  },
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0, background: "#fff", color: "#222" }}>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/apps/ccip-gateway/src/app/page.tsx
+++ b/apps/ccip-gateway/src/app/page.tsx
@@ -1,0 +1,61 @@
+/**
+ * Landing page for the CCIP-Read gateway. Tells operators what they
+ * landed on (since some judge will inevitably visit the root URL),
+ * points at the API endpoint and the design doc. No styling beyond
+ * inline minimal — this is an API host, not a marketing surface.
+ */
+export default function Home() {
+  return (
+    <main
+      style={{
+        fontFamily: "system-ui, sans-serif",
+        maxWidth: "42rem",
+        margin: "4rem auto",
+        padding: "0 1rem",
+        lineHeight: 1.5,
+      }}
+    >
+      <h1 style={{ fontSize: "1.5rem" }}>SBO3L CCIP-Read gateway</h1>
+      <p>
+        ENSIP-25 / EIP-3668 gateway for off-chain SBO3L text records.
+        Resolves <code>sbo3l:*</code> records published by SBO3L agents
+        whose ENS names point at an OffchainResolver contract.
+      </p>
+      <p>
+        This URL is consumed automatically by{" "}
+        <code>viem.getEnsText</code>, <code>ethers.js</code>, and any
+        ENSIP-10-aware client. No SBO3L-specific code on the client side.
+      </p>
+      <h2 style={{ fontSize: "1.1rem", marginTop: "2rem" }}>API</h2>
+      <pre
+        style={{
+          background: "#f5f5f5",
+          padding: "0.75rem",
+          overflowX: "auto",
+          fontSize: "0.85rem",
+        }}
+      >
+        GET /api/{"{sender}"}/{"{data}"}.json
+      </pre>
+      <h2 style={{ fontSize: "1.1rem", marginTop: "2rem" }}>Status</h2>
+      <p>
+        Pre-scaffold. Returns <code>501 Not Implemented</code> until
+        the T-4-1 main PR ships the record source + signing logic.
+      </p>
+      <h2 style={{ fontSize: "1.1rem", marginTop: "2rem" }}>References</h2>
+      <ul>
+        <li>
+          <a href="https://eips.ethereum.org/EIPS/eip-3668">EIP-3668 (CCIP-Read)</a>
+        </li>
+        <li>
+          <a href="https://docs.ens.domains/ensip/10">ENSIP-10</a>
+        </li>
+        <li>
+          <a href="https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/docs/design/T-4-1-ccip-read-prep.md">
+            T-4-1 design doc
+          </a>
+        </li>
+      </ul>
+    </main>
+  );
+}

--- a/apps/ccip-gateway/tsconfig.json
+++ b/apps/ccip-gateway/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/ccip-gateway/vercel.json
+++ b/apps/ccip-gateway/vercel.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "npm run build",
+  "installCommand": "npm install",
+  "headers": [
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        },
+        {
+          "key": "Access-Control-Allow-Methods",
+          "value": "GET, OPTIONS"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=10, stale-while-revalidate=30"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- New root **`apps/ccip-gateway/`** — Next.js 15 + viem 2 + TypeScript strict scaffold for the SBO3L CCIP-Read gateway (ENSIP-25 / EIP-3668 deploy target for T-4-1). Routes `GET /api/{sender}/{data}.json` shape pinned now; current implementation returns 501 with a pointer to the design doc until T-4-1 main PR ships the record-source + signing logic. Landing page (`/`) explains the gateway.
- New **`.github/workflows/ccip-gateway.yml`** — typecheck + build on every PR, Vercel preview deploy with auto-comment posting the URL on PRs, Vercel production deploy on push to main. Cache-grouped per branch.
- New **`.github/workflows/ccip-gateway-uptime.yml`** — runs every 30 min, GETs landing page (expect 200) and stub API endpoint (expect 501 pre-T-4-1; flip to 404 once T-4-1 ships record lookup). Posts `::warning::` annotation on failure.
- New **`apps/ccip-gateway/DEPLOY.md`** — one-time Vercel project setup, three GitHub repo secrets (`VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`), `GATEWAY_PRIVATE_KEY` env handling (NOT in GitHub secrets — only Vercel runtime), custom domain attach (post `sbo3l.dev` unfreeze), key rotation procedure, $0/month Vercel Hobby cost budget, troubleshooting.

## Why
Closes the **ccip-gateway-deploy** queue item from Daniel's 2026-05-01 parallel queue. CCIP-Read is the path to a judge-evaluatable ENS resolution flow that uses standard ENSIP-10 tooling (`viem.getEnsText`) — the gateway is the deploy target for T-4-1's main implementation. Landing the deploy infrastructure first means the moment T-4-1's gateway code lands on main, it auto-deploys to `https://sbo3l-ccip.vercel.app` without any manual ops handover.

## Verification
- [ ] CI: `Docker / Build + size + smoke` and `Docker / docker-compose smoke (F-8)` unaffected (this PR adds no Rust changes).
- [ ] CI: `ccip-gateway / Typecheck (Next.js)` green on this PR (npm run typecheck + npm run build).
- [ ] CI: `ccip-gateway / Vercel preview deploy` posts a Vercel URL in a PR comment.
- [ ] After merge: `ccip-gateway / Vercel production deploy` flips `https://sbo3l-ccip.vercel.app` to live.
- [ ] After merge: `ccip-gateway uptime / HTTP probe` runs every 30 min, currently expecting 501 from API stub.

**Daniel's one-time setup before merge** (per `apps/ccip-gateway/DEPLOY.md`):

1. `cd apps/ccip-gateway && npx vercel link` — creates the Vercel project (name suggested: `sbo3l-ccip`).
2. Set `GATEWAY_PRIVATE_KEY` in Vercel project env (production + preview + development) — fresh `node -e ...` secp256k1 key, never reused with funds.
3. Add `VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` to repo Settings → Secrets and variables → Actions.

Without those secrets, the Vercel deploy steps fail at `vercel pull` — the typecheck job (the only universally-runnable gate in this PR) still passes, so the PR can merge cleanly and Daniel sets up the secrets at his leisure. The first push to main after secrets are in place flips the gateway live.

## Branch coordination note
Lives on `agent/dev4/ccip-gateway-deploy-v2` rather than the originally-planned `agent/dev4/ccip-gateway-deploy` because the original branch on origin got force-pushed by a concurrent agent's stray push during the previous cycle (Dev 2's F-12 work landed on that branch via shared-worktree race; documented in memory `worktree_pattern_for_shared_repo.md`). The `-v2` suffix is the recovered branch with my actual deploy work; the contaminated branch can be deleted at Daniel's convenience.

## Out of scope
- T-4-1's actual record-source + signing logic — separate PR (`agent/dev4/T-4-1`).
- Custom domain `ccip.sbo3l.dev` — deferred with the rest of `sbo3l.dev` per 2026-05-01 strategy update; trivial to attach later.
- Multi-region deploy — Vercel Hobby is single-region; upgrade to Pro if latency becomes a concern.
- Sentry / OpenTelemetry — uptime probe + `::warning::` annotations are the hackathon-window observability bar.

Refs **ccip-gateway-deploy** queue item.

Co-Authored-By: Dev 4 (Infra + On-chain + Distributed) <dev4@sbo3l.dev>