### PR TITLE
feat(hosted-app): /agents /audit /capsules + mock SSE feed (CTI-3-4 main slice 1)

### DIFF
--- a/apps/hosted-app/app/agents/page.tsx
+++ b/apps/hosted-app/app/agents/page.tsx
@@ -1,0 +1,43 @@
+import { auth } from "@/auth";
+import { mockAgents } from "@/lib/mock-data";
+
+export default async function AgentsPage() {
+  const session = await auth();
+  const agents = mockAgents; // CTI-3-4 main slice 2: scope to session.user
+
+  return (
+    <main>
+      <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1.5em" }}>
+        <h1>Agents</h1>
+        <button disabled title="ENS subname issuance via Durin lands once Ivan ships ENS-AGENT-A2">+ New agent</button>
+      </header>
+      <p style={{ color: "var(--muted)", marginBottom: "2em" }}>
+        Hi @{session?.user?.githubLogin ?? session?.user?.name ?? "developer"}. Each agent gets an ENS subname under{" "}
+        <code>sbo3lagent.eth</code> (issuance gated on Ivan's ENS path).
+      </p>
+      <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <thead>
+          <tr style={{ borderBottom: "1px solid var(--border)", textAlign: "left", color: "var(--muted)" }}>
+            <th style={{ padding: "0.5em 0.8em" }}>Agent ID</th>
+            <th style={{ padding: "0.5em 0.8em" }}>ENS</th>
+            <th style={{ padding: "0.5em 0.8em" }}>Pubkey</th>
+            <th style={{ padding: "0.5em 0.8em" }}>Created</th>
+          </tr>
+        </thead>
+        <tbody>
+          {agents.map((a) => (
+            <tr key={a.agentId} style={{ borderBottom: "1px solid var(--border)" }}>
+              <td style={{ padding: "0.6em 0.8em" }}><code>{a.agentId}</code></td>
+              <td style={{ padding: "0.6em 0.8em", color: "var(--muted)" }}>{a.ensName}</td>
+              <td style={{ padding: "0.6em 0.8em", color: "var(--muted)" }}><code>{a.pubkeyPrefix}</code></td>
+              <td style={{ padding: "0.6em 0.8em", color: "var(--muted)" }}>{new Date(a.createdAt).toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p style={{ color: "var(--muted)", marginTop: "2em", fontSize: "0.9em" }}>
+        Mock data. Real per-tenant agent list (Grace's daemon-side path layout) lands in CTI-3-4 main slice 2.
+      </p>
+    </main>
+  );
+}

--- a/apps/hosted-app/app/audit/page.tsx
+++ b/apps/hosted-app/app/audit/page.tsx
@@ -1,0 +1,59 @@
+import { mockAuditEvents } from "@/lib/mock-data";
+
+export default function AuditPage() {
+  const events = mockAuditEvents; // CTI-3-4 main slice 2: paginated, filterable, daemon-backed
+
+  return (
+    <main>
+      <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1.5em" }}>
+        <h1>Audit log</h1>
+        <button title="Run strict-hash verifier against the local chain">Verify (strict)</button>
+      </header>
+      <p style={{ color: "var(--muted)", marginBottom: "2em" }}>
+        Hash-chained, Ed25519-signed event log. Strict-hash verifier runs all 6 capsule checks (see{" "}
+        <a href="https://sbo3l-docs.vercel.app/concepts/audit-log">/concepts/audit-log</a>).
+      </p>
+      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.92em" }}>
+        <thead>
+          <tr style={{ borderBottom: "1px solid var(--border)", textAlign: "left", color: "var(--muted)" }}>
+            <th style={{ padding: "0.5em 0.8em" }}>Time</th>
+            <th style={{ padding: "0.5em 0.8em" }}>Type</th>
+            <th style={{ padding: "0.5em 0.8em" }}>Agent</th>
+            <th style={{ padding: "0.5em 0.8em" }}>Outcome</th>
+            <th style={{ padding: "0.5em 0.8em" }}>Request hash</th>
+          </tr>
+        </thead>
+        <tbody>
+          {events.map((e) => (
+            <tr key={e.eventId} style={{ borderBottom: "1px solid var(--border)" }}>
+              <td style={{ padding: "0.5em 0.8em", color: "var(--muted)", fontFamily: "var(--font-mono)" }}>
+                {new Date(e.tsUnixMs).toLocaleTimeString()}
+              </td>
+              <td style={{ padding: "0.5em 0.8em", color: "var(--muted)" }}>
+                <code>{e.eventType}</code>
+              </td>
+              <td style={{ padding: "0.5em 0.8em" }}>
+                <code>{e.agentId}</code>
+              </td>
+              <td style={{ padding: "0.5em 0.8em" }}>
+                {e.decision === "allow" && <span style={{ color: "var(--accent)" }}>✓ allow</span>}
+                {e.decision === "deny" && (
+                  <span style={{ color: "#ff6b6b" }}>
+                    ✗ deny <code style={{ marginLeft: "0.4em", fontSize: "0.85em" }}>{e.denyCode}</code>
+                  </span>
+                )}
+                {!e.decision && <span style={{ color: "var(--muted)" }}>checkpoint</span>}
+              </td>
+              <td style={{ padding: "0.5em 0.8em", color: "var(--muted)", fontFamily: "var(--font-mono)" }}>
+                {e.requestHashPrefix}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p style={{ color: "var(--muted)", marginTop: "2em", fontSize: "0.9em" }}>
+        Mock data. Real strict-hash verifier integration lands in CTI-3-4 main slice 2.
+      </p>
+    </main>
+  );
+}

--- a/apps/hosted-app/app/capsules/page.tsx
+++ b/apps/hosted-app/app/capsules/page.tsx
@@ -1,0 +1,59 @@
+import { mockCapsules } from "@/lib/mock-data";
+
+export default function CapsulesPage() {
+  const capsules = mockCapsules;
+
+  return (
+    <main>
+      <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1.5em" }}>
+        <h1>Capsule library</h1>
+        <a
+          href="https://sbo3l-marketing.vercel.app/proof"
+          style={{ color: "var(--accent)" }}
+        >
+          Verify in browser →
+        </a>
+      </header>
+      <p style={{ color: "var(--muted)", marginBottom: "2em" }}>
+        Self-contained Passport capsules. Each is offline-verifiable against the agent's published Ed25519 pubkey alone
+        (see <a href="https://sbo3l-docs.vercel.app/concepts/capsule">/concepts/capsule</a>).
+      </p>
+      <ul style={{ listStyle: "none", padding: 0, display: "grid", gap: "0.8em" }}>
+        {capsules.map((c) => (
+          <li
+            key={c.capsuleId}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr auto auto auto",
+              gap: "1em",
+              alignItems: "center",
+              padding: "1em",
+              border: "1px solid var(--border)",
+              borderRadius: "var(--r-md)",
+              background: "var(--code-bg)",
+            }}
+          >
+            <div>
+              <code style={{ fontSize: "0.85em" }}>{c.capsuleId}</code>
+              <div style={{ color: "var(--muted)", fontSize: "0.85em", marginTop: "0.3em" }}>
+                <code>{c.agentId}</code> · {new Date(c.emittedAt).toLocaleString()}
+              </div>
+            </div>
+            <span style={{ color: c.decision === "allow" ? "var(--accent)" : "#ff6b6b", fontWeight: 600 }}>
+              {c.decision}
+            </span>
+            <span style={{ color: "var(--muted)", fontSize: "0.85em" }}>
+              {(c.sizeBytes / 1024).toFixed(1)} KB
+            </span>
+            <button className="ghost" disabled title="Real download lands in CTI-3-4 main slice 2">
+              Download
+            </button>
+          </li>
+        ))}
+      </ul>
+      <p style={{ color: "var(--muted)", marginTop: "2em", fontSize: "0.9em" }}>
+        Mock data. Real capsule library + download via daemon adapter lands in CTI-3-4 main slice 2.
+      </p>
+    </main>
+  );
+}

--- a/apps/hosted-app/app/dashboard/RecentDecisionsLive.tsx
+++ b/apps/hosted-app/app/dashboard/RecentDecisionsLive.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface DecisionRow {
+  ts: number;
+  agentId: string;
+  intent: string;
+  decision: "allow" | "deny";
+  denyCode?: string;
+}
+
+const AGENTS = ["research-01", "trader-02", "auditor-03"];
+const INTENTS = ["swap WETH→USDC", "pay vendor", "quote check", "audit checkpoint"];
+
+// Mock SSE — emits a fake decision every ~3 seconds. Replaced in slice 2
+// by `new EventSource("/api/feed")` consuming Dev 1's ws_events endpoint
+// proxied through the daemon. Same row-shape contract.
+export function RecentDecisionsLive(): JSX.Element {
+  const [rows, setRows] = useState<DecisionRow[]>([]);
+
+  useEffect(() => {
+    const tick = (): void => {
+      const i = Math.floor(Math.random() * AGENTS.length);
+      const agentId = AGENTS[i] ?? "research-01";
+      const intent = INTENTS[Math.floor(Math.random() * INTENTS.length)] ?? "swap";
+      const allow = Math.random() > 0.15;
+      const row: DecisionRow = {
+        ts: Date.now(),
+        agentId,
+        intent,
+        decision: allow ? "allow" : "deny",
+        denyCode: allow ? undefined : "policy.budget_exceeded",
+      };
+      setRows((prev) => [row, ...prev].slice(0, 20));
+    };
+    tick();
+    const id = window.setInterval(tick, 3000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  return (
+    <section style={{ marginTop: "2em" }}>
+      <h2 style={{ marginBottom: "1em", fontSize: "1.1em" }}>Recent decisions (live)</h2>
+      <div style={{ border: "1px solid var(--border)", borderRadius: "var(--r-md)", background: "var(--code-bg)", overflow: "hidden" }}>
+        {rows.length === 0 && <p style={{ padding: "1em", color: "var(--muted)" }}>Waiting for first event…</p>}
+        {rows.map((r, idx) => (
+          <div
+            key={`${r.ts}-${idx}`}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "auto 1fr 1fr auto",
+              gap: "1em",
+              padding: "0.6em 1em",
+              borderTop: idx === 0 ? "none" : "1px solid var(--border)",
+              fontSize: "0.9em",
+            }}
+          >
+            <code style={{ color: "var(--muted)" }}>{new Date(r.ts).toLocaleTimeString()}</code>
+            <code>{r.agentId}</code>
+            <span style={{ color: "var(--muted)" }}>{r.intent}</span>
+            <span style={{ color: r.decision === "allow" ? "var(--accent)" : "#ff6b6b", fontWeight: 600 }}>
+              {r.decision === "allow" ? "✓ allow" : `✗ deny ${r.denyCode ?? ""}`}
+            </span>
+          </div>
+        ))}
+      </div>
+      <p style={{ color: "var(--muted)", fontSize: "0.85em", marginTop: "0.8em" }}>
+        Mock SSE feed — replaced by daemon EventSource in CTI-3-4 main slice 2.
+      </p>
+    </section>
+  );
+}

--- a/apps/hosted-app/app/dashboard/page.tsx
+++ b/apps/hosted-app/app/dashboard/page.tsx
@@ -1,35 +1,40 @@
+import Link from "next/link";
 import { auth, signOut } from "@/auth";
+import { mockAuditEvents, mockCapsules } from "@/lib/mock-data";
+import { RecentDecisionsLive } from "./RecentDecisionsLive";
 
 export default async function DashboardPage() {
   const session = await auth();
-  // middleware.ts guarantees session exists for /dashboard/*; the
-  // optional-chain below is for type-narrowing only.
   const handle = session?.user?.githubLogin ?? session?.user?.name ?? "developer";
+
+  const decisionsTotal = mockAuditEvents.filter((e) => e.eventType === "policy.decision").length;
+  const allowCount = mockAuditEvents.filter((e) => e.decision === "allow").length;
+  const denyCount = mockAuditEvents.filter((e) => e.decision === "deny").length;
 
   return (
     <main>
       <header style={{ display: "flex", justifyContent: "space-between", marginBottom: "2em" }}>
         <h1>Dashboard</h1>
-        <form
-          action={async () => {
-            "use server";
-            await signOut({ redirectTo: "/" });
-          }}
-        >
+        <form action={async () => { "use server"; await signOut({ redirectTo: "/" }); }}>
           <button type="submit" className="ghost">Sign out</button>
         </form>
       </header>
-      <p style={{ color: "var(--muted)", marginBottom: "2em" }}>Hi, @{handle}.</p>
+      <p style={{ color: "var(--muted)", marginBottom: "1.5em" }}>Hi, @{handle}.</p>
+
+      <nav style={{ display: "flex", gap: "1em", marginBottom: "2em", flexWrap: "wrap" }}>
+        <Link href="/agents">Agents</Link>
+        <Link href="/audit">Audit log</Link>
+        <Link href="/capsules">Capsule library</Link>
+        <Link href="/trust-dns">Trust DNS</Link>
+      </nav>
 
       <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: "1em" }}>
-        <Card title="Decisions today" value="—" hint="awaits daemon link" />
-        <Card title="Audit chain" value="—" hint="length + integrity" />
-        <Card title="Quota used" value="0%" hint="of 1k/day free tier" />
+        <Card title="Decisions today" value={`${decisionsTotal}`} hint={`allow ${allowCount} · deny ${denyCount}`} />
+        <Card title="Audit chain" value={`${mockAuditEvents.length}`} hint="length · ✓ verified" />
+        <Card title="Capsules emitted" value={`${mockCapsules.length}`} hint="downloadable + offline-verifiable" />
       </section>
 
-      <p style={{ color: "var(--muted)", marginTop: "2em", fontSize: "0.9em" }}>
-        Live SSE feed + recent-decisions table + capsule downloads land in CTI-3-4 main.
-      </p>
+      <RecentDecisionsLive />
     </main>
   );
 }

--- a/apps/hosted-app/lib/mock-data.ts
+++ b/apps/hosted-app/lib/mock-data.ts
@@ -1,0 +1,48 @@
+// Mock fixtures for the prep slice. Replaced by real daemon calls in
+// CTI-3-4 main slice 2 (consumes Dev 1's WS/SSE endpoint + adds DB
+// adapter once Grace's Postgres lands).
+
+export interface Agent {
+  agentId: string;
+  ensName: string;
+  pubkeyPrefix: string;
+  createdAt: string;
+}
+
+export interface AuditEvent {
+  eventId: string;
+  tsUnixMs: number;
+  eventType: "policy.decision" | "audit.checkpoint";
+  agentId: string;
+  decision?: "allow" | "deny";
+  denyCode?: string;
+  requestHashPrefix: string;
+}
+
+export interface Capsule {
+  capsuleId: string;
+  agentId: string;
+  decision: "allow" | "deny";
+  emittedAt: string;
+  sizeBytes: number;
+}
+
+export const mockAgents: Agent[] = [
+  { agentId: "research-01", ensName: "research-01.sbo3lagent.eth", pubkeyPrefix: "ed25519:9aF3..", createdAt: "2026-04-15T10:23:00Z" },
+  { agentId: "trader-02",   ensName: "trader-02.sbo3lagent.eth",   pubkeyPrefix: "ed25519:7bC8..", createdAt: "2026-04-22T14:01:00Z" },
+  { agentId: "auditor-03",  ensName: "auditor-03.sbo3lagent.eth",  pubkeyPrefix: "ed25519:2dE1..", createdAt: "2026-04-29T09:15:00Z" },
+];
+
+export const mockAuditEvents: AuditEvent[] = [
+  { eventId: "01HZ...A1", tsUnixMs: 1714564961000, eventType: "policy.decision", agentId: "research-01", decision: "allow", requestHashPrefix: "0xe044f1.." },
+  { eventId: "01HZ...A2", tsUnixMs: 1714564838000, eventType: "policy.decision", agentId: "research-01", decision: "deny",  denyCode: "policy.budget_exceeded", requestHashPrefix: "0x12ab34.." },
+  { eventId: "01HZ...A3", tsUnixMs: 1714564613000, eventType: "policy.decision", agentId: "trader-02",   decision: "allow", requestHashPrefix: "0x9bc7de.." },
+  { eventId: "01HZ...A4", tsUnixMs: 1714564401000, eventType: "audit.checkpoint", agentId: "research-01", requestHashPrefix: "0x4f10ee.." },
+  { eventId: "01HZ...A5", tsUnixMs: 1714564102000, eventType: "policy.decision", agentId: "auditor-03",  decision: "deny",  denyCode: "policy.deny_unknown_provider", requestHashPrefix: "0xab12cd.." },
+];
+
+export const mockCapsules: Capsule[] = [
+  { capsuleId: "cap-01HZ...A1", agentId: "research-01", decision: "allow", emittedAt: "2026-05-01T08:42:41Z", sizeBytes: 11_240 },
+  { capsuleId: "cap-01HZ...A3", agentId: "trader-02",   decision: "allow", emittedAt: "2026-05-01T08:36:53Z", sizeBytes: 10_802 },
+  { capsuleId: "cap-01HZ...A5", agentId: "auditor-03",  decision: "deny",  emittedAt: "2026-05-01T08:28:22Z", sizeBytes: 9_614  },
+];


### PR DESCRIPTION
## Summary

- New auth-protected routes: `/agents` (list), `/audit` (event log), `/capsules` (library).
- Dashboard gets a header nav, populated card values, and a live mock-SSE decision feed (`RecentDecisionsLive` client component).
- Shared mock fixtures in `lib/mock-data.ts` so all four pages share consistent agent IDs / hashes / capsule IDs.

## Why

First content slice of CTI-3-4 main. Stacks on prep PR #106 (auto-merge enabled). LoC: 302 insertions / 15 deletions, under the 500-LoC cap.

GitHub will auto-retarget this PR's base from `agent/dev3/CTI-3-4-prep` → `main` once #106 merges.

## Test plan

```bash
cd apps/hosted-app
cp .env.example .env.local   # AUTH_SECRET / AUTH_URL / AUTH_GITHUB_ID / AUTH_GITHUB_SECRET
npm install
npm run typecheck
npm run build

npm run dev                  # http://localhost:3000
# - Sign in via GitHub OAuth → /dashboard
# - Card values populate from mock fixtures (3 decisions, 5 audit events, 3 capsules)
# - "Recent decisions (live)" emits a new row every ~3s; rows scroll
# - Click "Agents" → table of 3 agents with ENS subnames
# - Click "Audit log" → 5-row event table with allow/deny coloured outcomes
# - Click "Capsule library" → 3-card capsule list with sizes
# - Sign out from any route → returns home
# - Direct /agents /audit /capsules while signed-out → middleware redirects to /login
```

## Out of scope (CTI-3-4 main slice 2)

- Real `EventSource` against Dev 1's WS endpoint — swap a single line in `RecentDecisionsLive.tsx`.
- Daemon-backed agent / audit / capsule lookups (server actions calling the daemon over HTTPS with session JWT).
- Per-tenant SQLite isolation by JWT `sub` (Grace's daemon-side path layout).
- DB adapter for NextAuth sessions (currently JWT-only).
- ENS subname issuance via Durin (depends on Ivan's ENS-AGENT-A2).
- Strict-hash verifier action on `/audit` (calls daemon).
- Real capsule download (server action streams from daemon).
- Nonce-based CSP migration (drops `'unsafe-inline'` from `script-src`).

## Dependencies

- Stacked on #106 (CTI-3-4 prep — auth + middleware + landing + login + dashboard skeleton).
- All work in this slice is mock-backed; no external dep on Dev 1 / Ivan / Grace yet. Slice 2 is when those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)