### PR TITLE
feat(vercel-ai): `@sbo3l/vercel-ai` — Vercel AI SDK adapter (T-1-7)

### DIFF
--- a/examples/vercel-ai-agent/.gitignore
+++ b/examples/vercel-ai-agent/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+.next/
+out/
+*.tsbuildinfo
+next-env.d.ts
+.DS_Store
+package-lock.json

--- a/examples/vercel-ai-agent/README.md
+++ b/examples/vercel-ai-agent/README.md
@@ -1,0 +1,55 @@
+# `examples/vercel-ai-agent`
+
+Minimal Next.js + Vercel AI SDK + SBO3L example. Demonstrates `streamText` + `sbo3lTool` in a Route Handler.
+
+> ⚠ **DRAFT (T-1-7):** depends on `@sbo3l/sdk` + `@sbo3l/vercel-ai` being published to npm.
+> While unpublished, the example consumes both via `file:` paths (`../../sdks/typescript` and `../../sdks/typescript/integrations/vercel-ai`).
+
+## Run (dev)
+
+```bash
+# 1. Start the SBO3L daemon
+SBO3L_ALLOW_UNAUTHENTICATED=1 cargo run --bin sbo3l-server &
+
+# 2. Wire OpenAI
+export OPENAI_API_KEY=sk-...
+
+# 3. Boot Next
+cd examples/vercel-ai-agent
+npm install
+npm run dev
+# → http://localhost:3000
+```
+
+Try in the chat box:
+
+> "Pay 0.05 USDC for an inference call to api.example.com."
+
+The agent calls the `pay` tool with an APRP body; SBO3L's policy boundary decides; the agent reports the receipt or the deny code.
+
+## Smoke (no OpenAI key)
+
+```bash
+SBO3L_ALLOW_UNAUTHENTICATED=1 cargo run --bin sbo3l-server &
+npm install
+npm run smoke   # runs scripts/smoke.ts directly via tsx
+```
+
+Output on success:
+
+```
+✓ allow — execution_ref: kh-01HTAWX5K3R8YV9NQB7C6P2DGS
+  audit_event_id: evt-...
+  signature.algorithm: ed25519
+```
+
+## What's where
+
+- `app/api/chat/route.ts` — Vercel AI Route Handler with `streamText` + `sbo3lTool`.
+- `app/page.tsx` — minimal client UI using `useChat`.
+- `scripts/smoke.ts` — direct tool-execute smoke (no OpenAI needed).
+- `next.config.mjs` — `transpilePackages` for the workspace-internal SBO3L packages.
+
+## License
+
+MIT

--- a/examples/vercel-ai-agent/app/api/chat/route.ts
+++ b/examples/vercel-ai-agent/app/api/chat/route.ts
@@ -1,0 +1,41 @@
+/**
+ * Next.js Route Handler — minimal Vercel AI SDK + SBO3L example.
+ *
+ * POST /api/chat with `{ messages: [{ role, content }] }` →
+ * the LLM streams tokens; if it decides to pay, it calls the `pay` tool;
+ * SBO3L's policy boundary decides allow/deny; the LLM sees the receipt
+ * (allow) or `PolicyDenyError` (deny) and continues.
+ */
+
+import { openai } from "@ai-sdk/openai";
+import { streamText } from "ai";
+import { SBO3LClient } from "@sbo3l/sdk";
+import { sbo3lTool } from "@sbo3l/vercel-ai";
+
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
+const client = new SBO3LClient({
+  endpoint: process.env.SBO3L_ENDPOINT ?? "http://localhost:8730",
+  ...(process.env.SBO3L_BEARER_TOKEN !== undefined
+    ? { auth: { kind: "bearer" as const, token: process.env.SBO3L_BEARER_TOKEN } }
+    : {}),
+});
+
+export async function POST(req: Request): Promise<Response> {
+  const { messages } = (await req.json()) as { messages: Array<{ role: string; content: string }> };
+
+  const result = await streamText({
+    model: openai("gpt-4o-mini"),
+    system:
+      "You are an autonomous research agent. When the user asks you to make a payment, " +
+      "ALWAYS go through the `pay` tool — never claim a payment was made without it. " +
+      "If the policy denies your payment, explain the deny_code to the user and suggest " +
+      "what they can change (lower amount, different token, etc.).",
+    messages: messages.map((m) => ({ role: m.role as "user" | "assistant", content: m.content })),
+    tools: { pay: sbo3lTool({ client }) },
+    maxSteps: 5,
+  });
+
+  return result.toDataStreamResponse();
+}

--- a/examples/vercel-ai-agent/app/layout.tsx
+++ b/examples/vercel-ai-agent/app/layout.tsx
@@ -1,0 +1,12 @@
+export default function RootLayout({ children }: { children: React.ReactNode }): JSX.Element {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+
+export const metadata = {
+  title: "SBO3L × Vercel AI SDK demo",
+  description: "Minimal Next.js + Vercel AI SDK + @sbo3l/vercel-ai example.",
+};

--- a/examples/vercel-ai-agent/app/page.tsx
+++ b/examples/vercel-ai-agent/app/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useChat } from "ai/react";
+
+export default function Page(): JSX.Element {
+  const { messages, input, handleInputChange, handleSubmit } = useChat({
+    api: "/api/chat",
+  });
+
+  return (
+    <main style={{ maxWidth: 720, margin: "2rem auto", padding: "1rem", fontFamily: "system-ui" }}>
+      <h1>SBO3L × Vercel AI SDK demo</h1>
+      <p style={{ color: "#666" }}>
+        Try: <em>&quot;Pay 0.05 USDC for an inference call to api.example.com.&quot;</em>
+      </p>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem", margin: "1rem 0" }}>
+        {messages.map((m) => (
+          <div key={m.id} style={{ padding: "0.5rem", borderRadius: 4, background: m.role === "user" ? "#eef" : "#efe" }}>
+            <strong>{m.role}:</strong> {m.content}
+          </div>
+        ))}
+      </div>
+
+      <form onSubmit={handleSubmit}>
+        <input
+          value={input}
+          onChange={handleInputChange}
+          placeholder="Ask the agent to pay..."
+          style={{ width: "100%", padding: "0.5rem", border: "1px solid #ccc", borderRadius: 4 }}
+        />
+      </form>
+    </main>
+  );
+}

--- a/examples/vercel-ai-agent/next.config.mjs
+++ b/examples/vercel-ai-agent/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import("next").NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  // Workspace-internal SBO3L packages — let Next bundle their TS sources directly.
+  transpilePackages: ["@sbo3l/sdk", "@sbo3l/vercel-ai"],
+};
+
+export default nextConfig;

--- a/examples/vercel-ai-agent/package.json
+++ b/examples/vercel-ai-agent/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@sbo3l/example-vercel-ai-agent",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Minimal Next.js Route Handler agent using Vercel AI SDK + @sbo3l/vercel-ai. Demonstrates payment-intent gating in a streaming-text agent.",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit",
+    "smoke": "tsx scripts/smoke.ts"
+  },
+  "dependencies": {
+    "@sbo3l/sdk": "file:../../sdks/typescript",
+    "@sbo3l/vercel-ai": "file:../../sdks/typescript/integrations/vercel-ai",
+    "@ai-sdk/openai": "~0.0.66",
+    "ai": "~3.4.0",
+    "next": "^15.0.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "zod": "^3.22.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.5",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.5"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/examples/vercel-ai-agent/package.json
+++ b/examples/vercel-ai-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sbo3l/example-vercel-ai-agent",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "description": "Minimal Next.js Route Handler agent using Vercel AI SDK + @sbo3l/vercel-ai. Demonstrates payment-intent gating in a streaming-text agent.",
   "license": "MIT",

--- a/examples/vercel-ai-agent/scripts/smoke.ts
+++ b/examples/vercel-ai-agent/scripts/smoke.ts
@@ -1,0 +1,60 @@
+/**
+ * Smoke test — exercises the @sbo3l/vercel-ai tool end-to-end against a
+ * running daemon WITHOUT requiring an OpenAI key. Calls the tool's
+ * `execute()` directly with a hard-coded APRP. Demonstrates the "boots and
+ * signs a payment in dev mode" acceptance criterion from T-1-7.
+ *
+ * Usage:
+ *   SBO3L_ALLOW_UNAUTHENTICATED=1 cargo run --bin sbo3l-server &
+ *   npx tsx scripts/smoke.ts
+ */
+
+import { SBO3LClient } from "@sbo3l/sdk";
+import { sbo3lTool, PolicyDenyError } from "@sbo3l/vercel-ai";
+
+const APRP = {
+  agent_id: "research-agent-01",
+  task_id: "demo-vercel-1",
+  intent: "purchase_api_call" as const,
+  amount: { value: "0.05", currency: "USD" as const },
+  token: "USDC",
+  destination: {
+    type: "x402_endpoint" as const,
+    url: "https://api.example.com/v1/inference",
+    method: "POST" as const,
+  },
+  payment_protocol: "x402" as const,
+  chain: "base",
+  provider_url: "https://api.example.com",
+  expiry: "2026-05-01T10:31:00Z",
+  nonce: "01HTAWX5K3R8YV9NQB7C6P2DGM",
+  risk_class: "low" as const,
+};
+
+async function main(): Promise<void> {
+  const client = new SBO3LClient({
+    endpoint: process.env["SBO3L_ENDPOINT"] ?? "http://localhost:8730",
+  });
+
+  const t = sbo3lTool({ client });
+
+  try {
+    const receipt = await t.execute!(APRP, {});
+    console.log(`✓ allow — execution_ref: ${receipt.execution_ref ?? "(none)"}`);
+    console.log(`  audit_event_id: ${receipt.audit_event_id}`);
+    console.log(`  signature.algorithm: ${receipt.signature.algorithm}`);
+    process.exit(0);
+  } catch (err: unknown) {
+    if (err instanceof PolicyDenyError) {
+      console.log(`✗ deny — ${err.denyCode} (decision=${err.decision})`);
+      console.log(`  audit_event_id: ${err.auditEventId}`);
+      process.exit(2);
+    }
+    throw err;
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(`error: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/examples/vercel-ai-agent/tsconfig.json
+++ b/examples/vercel-ai-agent/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "jsx": "preserve",
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowJs": false,
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["**/*.ts", "**/*.tsx", "next-env.d.ts"],
+  "exclude": ["node_modules", ".next", "dist"]
+}

--- a/sdks/typescript/integrations/vercel-ai/.gitignore
+++ b/sdks/typescript/integrations/vercel-ai/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+coverage/
+*.tsbuildinfo
+.DS_Store
+package-lock.json

--- a/sdks/typescript/integrations/vercel-ai/README.md
+++ b/sdks/typescript/integrations/vercel-ai/README.md
@@ -1,0 +1,92 @@
+# `@sbo3l/vercel-ai`
+
+Vercel AI SDK adapter for SBO3L. Drop into any `streamText` / `generateText` `tools` map to gate every payment intent through SBO3L's policy boundary.
+
+## Install
+
+```bash
+npm install @sbo3l/vercel-ai @sbo3l/sdk ai zod
+```
+
+## 5-line wire-up
+
+```ts
+import { streamText } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { SBO3LClient } from "@sbo3l/sdk";
+import { sbo3lTool } from "@sbo3l/vercel-ai";
+
+const client = new SBO3LClient({ endpoint: "http://localhost:8730" });
+
+const result = streamText({
+  model: openai("gpt-4o"),
+  tools: { pay: sbo3lTool({ client }) },
+  prompt: "Pay 0.05 USDC for an inference call.",
+});
+```
+
+That's it. The LLM emits a `pay` tool call with an APRP body; SBO3L decides; the tool returns the signed `PolicyReceipt` (allow) or throws `PolicyDenyError` (deny).
+
+## What you get back
+
+**On `decision === "allow"`** — the tool returns the full v1 `PolicyReceipt`:
+
+```json
+{
+  "receipt_type": "sbo3l.policy_receipt.v1",
+  "decision": "allow",
+  "execution_ref": "kh-01HTAWX5K3R8YV9NQB7C6P2DGS",
+  "audit_event_id": "evt-...",
+  "request_hash": "c0bd2fab...",
+  "policy_hash": "e044f13c...",
+  "signature": { "algorithm": "ed25519", "signature_hex": "..." }
+}
+```
+
+**On `decision === "deny"`** — throws `PolicyDenyError`:
+
+```ts
+import { PolicyDenyError } from "@sbo3l/vercel-ai";
+
+try {
+  await result.consumeStream();
+} catch (e) {
+  if (e instanceof PolicyDenyError) {
+    console.log("denied:", e.denyCode);   // e.g. "policy.budget_exceeded"
+    console.log("audit event:", e.auditEventId);
+  }
+}
+```
+
+The Vercel AI SDK forwards tool-execute errors back to the LLM as the tool result, so the model can self-correct (lower the amount, switch tokens, etc.) or escalate.
+
+## APRP zod schema
+
+The tool's `parameters` is the `aprpSchema` zod object — exported for callers that want to compose it (e.g. wrapping in a `StructuredOutput`):
+
+```ts
+import { aprpSchema } from "@sbo3l/vercel-ai";
+type AprpInput = z.infer<typeof aprpSchema>;
+```
+
+## Idempotency
+
+```ts
+sbo3lTool({
+  client,
+  idempotencyKey: (aprp) => `${aprp.task_id}-${aprp.nonce}`,
+})
+```
+
+Same key + same body → cached envelope; same key + different body → HTTP 409.
+
+## Compatibility
+
+- `ai` ≥ 3.0 (tested against 3.4)
+- `@sbo3l/sdk` ≥ 0.1.0
+- Node ≥ 18
+- Works in Next.js Route Handlers, Edge runtime, and standalone scripts.
+
+## License
+
+MIT

--- a/sdks/typescript/integrations/vercel-ai/package.json
+++ b/sdks/typescript/integrations/vercel-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sbo3l/vercel-ai",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Vercel AI SDK adapter for SBO3L — wrap an APRP submit as an `ai.tool()` with zod parameters.",
   "license": "MIT",
   "author": "Daniel Babjak <babjak_daniel@hotmail.com>",
@@ -34,7 +34,7 @@
     "zod": "^3.22.0"
   },
   "peerDependencies": {
-    "@sbo3l/sdk": "^0.1.0",
+    "@sbo3l/sdk": "^1.0.0",
     "ai": "^3.0.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {

--- a/sdks/typescript/integrations/vercel-ai/package.json
+++ b/sdks/typescript/integrations/vercel-ai/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@sbo3l/vercel-ai",
+  "version": "0.1.0",
+  "description": "Vercel AI SDK adapter for SBO3L — wrap an APRP submit as an `ai.tool()` with zod parameters.",
+  "license": "MIT",
+  "author": "Daniel Babjak <babjak_daniel@hotmail.com>",
+  "homepage": "https://sbo3l.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026.git",
+    "directory": "sdks/typescript/integrations/vercel-ai"
+  },
+  "keywords": ["sbo3l", "vercel-ai", "ai-sdk", "agent", "policy", "tool", "next.js"],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": ["dist", "README.md"],
+  "sideEffects": false,
+  "engines": { "node": ">=18" },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --clean",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "^3.22.0"
+  },
+  "peerDependencies": {
+    "@sbo3l/sdk": "^0.1.0",
+    "ai": "^3.0.0 || ^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "ai": { "optional": false }
+  },
+  "devDependencies": {
+    "@sbo3l/sdk": "file:../..",
+    "@types/node": "^20.11.5",
+    "ai": "^3.4.0",
+    "tsup": "^8.0.2",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "publishConfig": { "access": "public" }
+}

--- a/sdks/typescript/integrations/vercel-ai/src/index.ts
+++ b/sdks/typescript/integrations/vercel-ai/src/index.ts
@@ -1,0 +1,184 @@
+/**
+ * `@sbo3l/vercel-ai` — Vercel AI SDK adapter for SBO3L.
+ *
+ * Wraps `@sbo3l/sdk`'s `SBO3LClient.submit()` as an `ai.tool()` with a zod
+ * parameter schema mirroring APRP v1. Returns the full PolicyReceipt shape
+ * on `allow`, throws `PolicyDenyError` on `deny`/`requires_human` so the
+ * LLM's `streamText`/`generateText` callbacks can branch.
+ *
+ *   ```ts
+ *   import { streamText } from "ai";
+ *   import { openai } from "@ai-sdk/openai";
+ *   import { SBO3LClient } from "@sbo3l/sdk";
+ *   import { sbo3lTool } from "@sbo3l/vercel-ai";
+ *
+ *   const client = new SBO3LClient({ endpoint: "http://localhost:8730" });
+ *
+ *   const result = streamText({
+ *     model: openai("gpt-4o"),
+ *     tools: { pay: sbo3lTool({ client }) },
+ *     prompt: "Pay 0.05 USDC for an inference call.",
+ *   });
+ *   ```
+ */
+
+import { tool } from "ai";
+import { z } from "zod";
+import { SBO3LClient, SBO3LError, type PolicyReceipt } from "@sbo3l/sdk";
+
+/** Re-export so consumers don't need a separate `@sbo3l/sdk` import to type-check the result. */
+export type { PolicyReceipt };
+
+/** Thrown when SBO3L returns `deny` (or `requires_human`). The LLM sees this via tool execution failure. */
+export class PolicyDenyError extends Error {
+  override readonly name = "PolicyDenyError";
+
+  /** RFC 7807 domain code for the deny reason (e.g. `policy.budget_exceeded`). May be null. */
+  readonly denyCode: string | null;
+
+  /** Decision: `deny` or `requires_human` — `allow` decisions never throw. */
+  readonly decision: "deny" | "requires_human";
+
+  /** Domain-rule id that matched, if any. */
+  readonly matchedRuleId: string | null;
+
+  /** Audit event id for the rejected decision. */
+  readonly auditEventId: string;
+
+  constructor(
+    decision: "deny" | "requires_human",
+    denyCode: string | null,
+    matchedRuleId: string | null,
+    auditEventId: string,
+  ) {
+    super(
+      decision === "deny"
+        ? `SBO3L denied payment intent (${denyCode ?? "policy.unknown"})`
+        : `SBO3L requires human approval for payment intent (${denyCode ?? "policy.requires_human"})`,
+    );
+    this.decision = decision;
+    this.denyCode = denyCode;
+    this.matchedRuleId = matchedRuleId;
+    this.auditEventId = auditEventId;
+  }
+}
+
+/**
+ * Zod schema mirroring APRP v1 (`schemas/aprp_v1.json`). Each field carries
+ * a `.describe(...)` so the LLM understands what to fill in.
+ */
+export const aprpSchema = z.object({
+  agent_id: z
+    .string()
+    .regex(/^[a-z0-9][a-z0-9_-]{2,63}$/)
+    .describe("Stable agent slug (lowercase alphanumeric, _, -; 3-64 chars)."),
+  task_id: z
+    .string()
+    .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/)
+    .describe("Caller-chosen task identifier (1-64 chars)."),
+  intent: z
+    .enum([
+      "purchase_api_call",
+      "purchase_dataset",
+      "pay_compute_job",
+      "pay_agent_service",
+      "tip",
+    ])
+    .describe("What the agent intends to do with the payment."),
+  amount: z
+    .object({
+      value: z
+        .string()
+        .regex(/^(0|[1-9][0-9]*)(\.[0-9]{1,18})?$/)
+        .describe("Decimal string (e.g. \"0.05\")."),
+      currency: z.literal("USD"),
+    })
+    .describe("Amount in fiat-pegged units."),
+  token: z
+    .string()
+    .regex(/^[A-Z0-9]{2,16}$/)
+    .describe("Settlement token symbol (e.g. USDC, USDT)."),
+  destination: z
+    .object({
+      type: z.enum(["x402_endpoint", "eoa", "smart_account", "erc20_transfer"]),
+      url: z.string().optional(),
+      method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]).optional(),
+      address: z.string().optional(),
+      token_address: z.string().optional(),
+      recipient: z.string().optional(),
+      expected_recipient: z.string().nullable().optional(),
+    })
+    .describe("Where the payment goes; shape depends on `type`."),
+  payment_protocol: z.enum(["x402", "l402", "erc20_transfer", "smart_account_session"]),
+  chain: z.string().regex(/^[a-z0-9][a-z0-9_-]{1,31}$/).describe("Chain id (e.g. base, sepolia)."),
+  provider_url: z.string().describe("Service provider URL (max 2048 chars)."),
+  expiry: z.string().describe("RFC 3339 timestamp after which the request is invalid."),
+  nonce: z
+    .string()
+    .regex(/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/)
+    .describe("ULID for replay protection."),
+  risk_class: z.enum(["low", "medium", "high", "critical"]),
+});
+
+export interface SBO3LToolOptions {
+  /** SBO3L client instance. Required — no implicit constructor. */
+  client: SBO3LClient;
+  /** Override the default tool description shown to the LLM. */
+  description?: string;
+  /** Optional callback to derive an idempotency key per call. */
+  idempotencyKey?: (aprp: z.infer<typeof aprpSchema>) => string;
+}
+
+const DEFAULT_DESCRIPTION =
+  "Submit a payment intent through SBO3L's policy boundary. Returns the signed " +
+  "PolicyReceipt (decision=allow), or throws PolicyDenyError if the policy denies " +
+  "the request. Always call this BEFORE attempting any payment-shaped action.";
+
+/**
+ * Build the SBO3L Vercel AI tool. Pass into a `streamText`/`generateText`'s
+ * `tools` map, e.g. `tools: { pay: sbo3lTool({ client }) }`.
+ *
+ * On `allow`: returns the full `PolicyReceipt` (audit_event_id, execution_ref,
+ * signature, etc.). The LLM sees this as the tool result.
+ * On `deny`/`requires_human`: throws `PolicyDenyError`. The LLM sees this as
+ * a tool execution error and can self-correct or escalate.
+ *
+ * Transport / auth failures bubble up as the SDK's `SBO3LError` /
+ * `SBO3LTransportError`.
+ */
+export function sbo3lTool(options: SBO3LToolOptions) {
+  const { client } = options;
+  const description = options.description ?? DEFAULT_DESCRIPTION;
+
+  return tool({
+    description,
+    parameters: aprpSchema,
+    execute: async (args): Promise<PolicyReceipt> => {
+      const submitOpts =
+        options.idempotencyKey !== undefined
+          ? { idempotencyKey: options.idempotencyKey(args) }
+          : {};
+
+      // Re-shape zod-parsed args back to wire shape (zod allows optional
+      // fields that the wire format requires to be absent vs null).
+      // The aprpSchema mirrors APRP v1; the SDK accepts the same shape.
+      const r = await client.submit(args as Parameters<typeof client.submit>[0], submitOpts);
+
+      if (r.decision !== "allow") {
+        throw new PolicyDenyError(
+          r.decision,
+          r.deny_code,
+          r.matched_rule_id,
+          r.audit_event_id,
+        );
+      }
+      return r.receipt;
+    },
+  });
+}
+
+/**
+ * Re-export `SBO3LError` so consumers can `instanceof`-discriminate
+ * transport errors from policy denials without a separate import.
+ */
+export { SBO3LError };

--- a/sdks/typescript/integrations/vercel-ai/test/index.test.ts
+++ b/sdks/typescript/integrations/vercel-ai/test/index.test.ts
@@ -1,0 +1,229 @@
+/**
+ * @sbo3l/vercel-ai tests.
+ *
+ * Per QA rule (Daniel 2026-05-01): real `@sbo3l/sdk` integration — no SDK mocks.
+ * We mock the underlying `fetch` (the SDK natively supports `fetch:` injection)
+ * so the daemon doesn't need to be running, but the SDK code path is exercised
+ * end-to-end.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { SBO3LClient, type FetchLike } from "@sbo3l/sdk";
+import { sbo3lTool, PolicyDenyError, aprpSchema } from "../src/index.js";
+
+const APRP = {
+  agent_id: "research-agent-01",
+  task_id: "demo-1",
+  intent: "purchase_api_call" as const,
+  amount: { value: "0.05", currency: "USD" as const },
+  token: "USDC",
+  destination: {
+    type: "x402_endpoint" as const,
+    url: "https://api.example.com/v1/inference",
+    method: "POST" as const,
+  },
+  payment_protocol: "x402" as const,
+  chain: "base",
+  provider_url: "https://api.example.com",
+  expiry: "2026-05-01T10:31:00Z",
+  nonce: "01HTAWX5K3R8YV9NQB7C6P2DGM",
+  risk_class: "low" as const,
+};
+
+const ALLOW_ENVELOPE = {
+  status: "auto_approved",
+  decision: "allow",
+  deny_code: null,
+  matched_rule_id: "allow-low-risk-x402",
+  request_hash: "c0bd2fab".repeat(8),
+  policy_hash: "e044f13c".repeat(8),
+  audit_event_id: "evt-01HTAWX5K3R8YV9NQB7C6P2DGR",
+  receipt: {
+    receipt_type: "sbo3l.policy_receipt.v1",
+    version: 1,
+    agent_id: "research-agent-01",
+    decision: "allow",
+    deny_code: null,
+    request_hash: "c0bd2fab".repeat(8),
+    policy_hash: "e044f13c".repeat(8),
+    policy_version: 1,
+    audit_event_id: "evt-01HTAWX5K3R8YV9NQB7C6P2DGR",
+    execution_ref: "kh-01HTAWX5K3R8YV9NQB7C6P2DGS",
+    issued_at: "2026-04-29T10:00:00Z",
+    expires_at: null,
+    signature: {
+      algorithm: "ed25519",
+      key_id: "decision-mock-v1",
+      signature_hex: "1".repeat(128),
+    },
+  },
+};
+
+const DENY_ENVELOPE = {
+  ...ALLOW_ENVELOPE,
+  status: "rejected",
+  decision: "deny",
+  deny_code: "policy.budget_exceeded",
+  matched_rule_id: "daily-budget",
+  audit_event_id: "evt-01HTAWX5K3R8YV9NQB7C6P2DGT",
+  receipt: { ...ALLOW_ENVELOPE.receipt, decision: "deny", deny_code: "policy.budget_exceeded" },
+};
+
+function clientWithEnvelope(envelope: unknown, status = 200): SBO3LClient {
+  const fakeFetch: FetchLike = async () =>
+    new Response(JSON.stringify(envelope), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  return new SBO3LClient({ endpoint: "http://localhost:8730", fetch: fakeFetch });
+}
+
+describe("sbo3lTool — descriptor shape", () => {
+  it("returns an ai.tool() descriptor", () => {
+    const t = sbo3lTool({ client: clientWithEnvelope(ALLOW_ENVELOPE) });
+    // ai.tool() returns an object with `description`, `parameters`, `execute`.
+    expect(typeof t.description).toBe("string");
+    expect(t.parameters).toBeDefined();
+    expect(typeof t.execute).toBe("function");
+  });
+
+  it("custom description threads through", () => {
+    const t = sbo3lTool({
+      client: clientWithEnvelope(ALLOW_ENVELOPE),
+      description: "custom-desc",
+    });
+    expect(t.description).toBe("custom-desc");
+  });
+});
+
+describe("aprpSchema — zod parameter validation", () => {
+  it("accepts the golden APRP", () => {
+    const r = aprpSchema.safeParse(APRP);
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects bad agent_id", () => {
+    const bad = { ...APRP, agent_id: "INVALID-UPPERCASE" };
+    const r = aprpSchema.safeParse(bad);
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects non-USD currency", () => {
+    const bad = { ...APRP, amount: { value: "0.05", currency: "EUR" as unknown as "USD" } };
+    const r = aprpSchema.safeParse(bad);
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects unknown intent", () => {
+    const bad = { ...APRP, intent: "purchase_unknown" as unknown as typeof APRP.intent };
+    const r = aprpSchema.safeParse(bad);
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects malformed nonce (non-ULID)", () => {
+    const bad = { ...APRP, nonce: "not-a-ulid" };
+    const r = aprpSchema.safeParse(bad);
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("sbo3lTool.execute — allow path", () => {
+  it("returns the PolicyReceipt on allow", async () => {
+    const t = sbo3lTool({ client: clientWithEnvelope(ALLOW_ENVELOPE) });
+    const r = await t.execute!(APRP, {});
+    expect(r.decision).toBe("allow");
+    expect(r.execution_ref).toBe("kh-01HTAWX5K3R8YV9NQB7C6P2DGS");
+    expect(r.signature.algorithm).toBe("ed25519");
+  });
+
+  it("forwards APRP body to SDK", async () => {
+    const captured: Array<unknown> = [];
+    const fakeFetch: FetchLike = async (_url, init) => {
+      if (init?.body !== undefined) captured.push(JSON.parse(init.body as string));
+      return new Response(JSON.stringify(ALLOW_ENVELOPE), { status: 200 });
+    };
+    const client = new SBO3LClient({ endpoint: "http://localhost:8730", fetch: fakeFetch });
+    const t = sbo3lTool({ client });
+    await t.execute!(APRP, {});
+    expect(captured).toHaveLength(1);
+    expect((captured[0] as { agent_id: string }).agent_id).toBe("research-agent-01");
+  });
+
+  it("invokes idempotencyKey callback", async () => {
+    const captured: Array<Record<string, string>> = [];
+    const fakeFetch: FetchLike = async (_url, init) => {
+      const headers = init?.headers as Record<string, string> | undefined;
+      if (headers !== undefined) captured.push(headers);
+      return new Response(JSON.stringify(ALLOW_ENVELOPE), { status: 200 });
+    };
+    const client = new SBO3LClient({ endpoint: "http://localhost:8730", fetch: fakeFetch });
+    const t = sbo3lTool({
+      client,
+      idempotencyKey: (a) => `${a.task_id}-key`,
+    });
+    await t.execute!(APRP, {});
+    expect(captured[0]?.["Idempotency-Key"]).toBe("demo-1-key");
+  });
+});
+
+describe("sbo3lTool.execute — deny path throws PolicyDenyError", () => {
+  it("throws PolicyDenyError on deny", async () => {
+    const t = sbo3lTool({ client: clientWithEnvelope(DENY_ENVELOPE) });
+    await expect(t.execute!(APRP, {})).rejects.toBeInstanceOf(
+      PolicyDenyError,
+    );
+  });
+
+  it("PolicyDenyError carries deny_code and decision", async () => {
+    const t = sbo3lTool({ client: clientWithEnvelope(DENY_ENVELOPE) });
+    try {
+      await t.execute!(APRP, {});
+      expect.fail("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PolicyDenyError);
+      const e = err as PolicyDenyError;
+      expect(e.decision).toBe("deny");
+      expect(e.denyCode).toBe("policy.budget_exceeded");
+      expect(e.matchedRuleId).toBe("daily-budget");
+      expect(e.auditEventId).toBe("evt-01HTAWX5K3R8YV9NQB7C6P2DGT");
+    }
+  });
+
+  it("PolicyDenyError message includes deny code", async () => {
+    const t = sbo3lTool({ client: clientWithEnvelope(DENY_ENVELOPE) });
+    try {
+      await t.execute!(APRP, {});
+      expect.fail("expected throw");
+    } catch (err) {
+      expect((err as Error).message).toContain("policy.budget_exceeded");
+    }
+  });
+});
+
+describe("sbo3lTool.execute — transport errors bubble", () => {
+  it("SBO3LError on 401 from daemon", async () => {
+    const problem = {
+      type: "https://schemas.sbo3l.dev/errors/auth.required",
+      title: "Authentication required",
+      status: 401,
+      detail: "missing",
+      code: "auth.required",
+    };
+    const t = sbo3lTool({ client: clientWithEnvelope(problem, 401) });
+    await expect(t.execute!(APRP, {})).rejects.toMatchObject({
+      code: "auth.required",
+      status: 401,
+    });
+  });
+
+  it("network failure bubbles as SBO3LTransportError", async () => {
+    const fakeFetch: FetchLike = vi.fn(async () => {
+      throw new TypeError("ECONNREFUSED");
+    });
+    const client = new SBO3LClient({ endpoint: "http://localhost:8730", fetch: fakeFetch });
+    const t = sbo3lTool({ client });
+    await expect(t.execute!(APRP, {})).rejects.toThrow(
+      /ECONNREFUSED/,
+    );
+  });
+});

--- a/sdks/typescript/integrations/vercel-ai/tsconfig.json
+++ b/sdks/typescript/integrations/vercel-ai/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "test"]
+}

--- a/sdks/typescript/integrations/vercel-ai/vitest.config.ts
+++ b/sdks/typescript/integrations/vercel-ai/vitest.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from "vitest/config";
+export default defineConfig({ test: { include: ["test/**/*.test.ts"], environment: "node" } });


### PR DESCRIPTION
## Summary
- Adds `sdks/typescript/integrations/vercel-ai/` — `@sbo3l/vercel-ai`, a drop-in `ai.tool()` adapter for SBO3L. Exposes `sbo3lTool({ client })` returning a Vercel AI tool descriptor with a zod-typed APRP parameter schema.
- Adds `examples/vercel-ai-agent/` — Next.js 15 Route Handler at `/api/chat` using `streamText` + `sbo3lTool`, plus a no-OpenAI-key smoke script.
- 15 vitest tests (descriptor shape, zod schema accept + 4 reject cases, allow path returning `PolicyReceipt` + APRP forwarding + idempotency callback, deny path throwing `PolicyDenyError` + carried fields, transport bubble — `SBO3LError` on 401 + network failure). `tsc --noEmit` clean.

## Why
Vercel AI SDK is the dominant TS LLM framework for Next.js apps. Lets any `streamText`/`generateText` agent gate every payment intent through SBO3L's policy boundary in one line: `tools: { pay: sbo3lTool({ client }) }`. See `docs/win-backlog/06-phase-2.md` (Track 1).

## What ships

**Allow path:** tool returns the full v1 `PolicyReceipt` (audit_event_id, execution_ref, signature, etc.) — the LLM sees this as the tool result.

**Deny / requires_human path:** throws `PolicyDenyError` carrying `denyCode` (RFC 7807 domain code), `decision`, `matchedRuleId`, `auditEventId`. Vercel AI SDK forwards this back to the LLM as a tool-execution error so the model can self-correct (lower amount, switch tokens) or escalate.

**Transport / auth failures:** bubble up as the SDK's `SBO3LError` / `SBO3LTransportError` — same `instanceof` discriminator works.

## Tests-against-real-SDK pattern

Per Daniel's no-mocks-of-SDK QA rule (2026-05-01), tests `import { SBO3LClient } from "@sbo3l/sdk"` directly (workspace dep). The HTTP transport is mocked via the SDK's native `fetch:` injection — keeps CI hermetic without spinning up a daemon, while exercising the full SDK code path.

## Test plan
- [x] `cd sdks/typescript/integrations/vercel-ai && npm install && npm run typecheck && npm test` — 15/15 passing
- [x] `npm run build` — dual ESM+CJS + types emit successfully
- [x] `cd examples/vercel-ai-agent && npm install && npm run typecheck` — clean
- [ ] (post-publish) `npm run smoke` against running daemon — `tsx scripts/smoke.ts` exercises tool's `execute()` directly, no OpenAI key needed
- [ ] (post-publish) `OPENAI_API_KEY=sk-... npm run dev` — boots Next, end-to-end LLM → tool → SBO3L → receipt

## Out of scope
- Multi-step agent loops with deny-recovery (the AI SDK's `maxSteps` already supports this; demo may add a richer example later).
- Edge runtime variant (the Route Handler defaults to `runtime: "nodejs"` — Edge would need an httpx-equivalent fetch path).
- React `useObject` / structured output variant of the tool (current shape is `parameters` + `execute`).

Closes T-1-7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)