### PR TITLE
feat(server): T-3-5 ws_events — /v1/events WebSocket for trust-dns viz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http",
@@ -166,8 +167,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -514,6 +517,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +697,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +727,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -2064,9 +2085,11 @@ dependencies = [
  "bcrypt",
  "chrono",
  "ed25519-dalek",
+ "futures-util",
  "hex",
  "http-body-util",
  "jsonwebtoken",
+ "reqwest",
  "sbo3l-core",
  "sbo3l-policy",
  "sbo3l-storage",
@@ -2075,6 +2098,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-tungstenite 0.21.0",
  "tower",
  "tracing",
  "tracing-subscriber",
@@ -2206,6 +2230,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2541,6 +2576,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.21.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2698,6 +2757,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2742,6 +2838,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/crates/sbo3l-server/Cargo.toml
+++ b/crates/sbo3l-server/Cargo.toml
@@ -22,9 +22,13 @@ sbo3l-storage = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
-axum = { workspace = true }
+axum = { workspace = true, features = ["ws"] }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
+# T-3-5 backend: futures combinators for the WebSocket split read/write
+# path. Pulled in unconditionally since reqwest already transitively
+# depends on futures-util; gating saves no bytes.
+futures-util = "0.3"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 chrono = { workspace = true }
@@ -40,6 +44,10 @@ http-body-util = "0.1"
 tempfile = { workspace = true }
 ed25519-dalek = { workspace = true }
 base64 = "0.22"
+# T-3-5 integration test: real WebSocket client against the in-process
+# server bound to an ephemeral port.
+tokio-tungstenite = "0.21"
+reqwest = { workspace = true }
 
 # F-5: passthrough features for sbo3l-core's KMS backends so a
 # `cargo test -p sbo3l-server --features aws_kms` route compiles the
@@ -51,3 +59,7 @@ aws_kms = ["sbo3l-core/aws_kms"]
 gcp_kms = ["sbo3l-core/gcp_kms"]
 phala_tee = ["sbo3l-core/phala_tee"]
 eth_signer = ["sbo3l-core/eth_signer"]
+# T-3-5: mounts `GET /v1/events` (WebSocket → trust-dns viz). OFF by
+# default so existing daemon runs aren't disturbed; opt in with
+# `--features ws_events` at build time.
+ws_events = []

--- a/crates/sbo3l-server/src/lib.rs
+++ b/crates/sbo3l-server/src/lib.rs
@@ -34,6 +34,9 @@ use sbo3l_storage::Storage;
 pub mod auth;
 pub use auth::AuthConfig;
 
+#[cfg(feature = "ws_events")]
+pub mod ws_events;
+
 /// `Idempotency-Key` header constraints from `docs/api/openapi.json`.
 const IDEMPOTENCY_KEY_HEADER: &str = "Idempotency-Key";
 const IDEMPOTENCY_KEY_MIN_LEN: usize = 16;
@@ -53,6 +56,13 @@ pub struct AppInner {
     pub audit_signer: DevSigner,
     pub receipt_signer: DevSigner,
     pub auth: AuthConfig,
+    /// T-3-5 backend: live event bus for `apps/trust-dns-viz/`. Built
+    /// only with `--features ws_events`. The publish path inside
+    /// `create_payment_request` checks `is_some()` and emits when
+    /// the bus is wired; existing daemon runs (without the feature)
+    /// see no behaviour change.
+    #[cfg(feature = "ws_events")]
+    pub ws_events: Option<std::sync::Arc<ws_events::WsEventsBus>>,
 }
 
 impl AppState {
@@ -119,14 +129,19 @@ impl AppState {
             audit_signer,
             receipt_signer,
             auth,
+            #[cfg(feature = "ws_events")]
+            ws_events: Some(std::sync::Arc::new(ws_events::WsEventsBus::new())),
         }))
     }
 }
 
 pub fn router(state: AppState) -> Router {
-    Router::new()
+    let r = Router::new()
         .route("/v1/health", get(health))
-        .route("/v1/payment-requests", post(create_payment_request))
+        .route("/v1/payment-requests", post(create_payment_request));
+    #[cfg(feature = "ws_events")]
+    let r = r.route("/v1/events", get(ws_events::ws_events_handler));
+    r
         .with_state(state)
 }
 
@@ -643,6 +658,29 @@ async fn run_pipeline(
                 })?
         }
     };
+
+    // T-3-5 backend: fan out the request outcome to the trust-dns viz
+    // event bus. No-op when no subscribers are connected (broadcast
+    // channel returns SendError quietly). Compiled out entirely
+    // without `--features ws_events`.
+    #[cfg(feature = "ws_events")]
+    if let Some(bus) = inner.ws_events.as_ref() {
+        let viz_decision = match receipt_decision {
+            ReceiptDecision::Allow => ws_events::DecisionKind::Allow,
+            ReceiptDecision::Deny => ws_events::DecisionKind::Deny,
+            // requires_human is rejected upstream; defensive default.
+            ReceiptDecision::RequiresHuman => ws_events::DecisionKind::Deny,
+        };
+        ws_events::publish_pipeline_run(
+            bus,
+            &aprp.agent_id,
+            None, // ENS name lookup is upstream of this handler.
+            viz_decision,
+            final_deny_code.clone(),
+            signed_event.event.seq,
+            &signed_event.event_hash,
+        );
+    }
 
     let receipt = UnsignedReceipt {
         agent_id: aprp.agent_id.clone(),

--- a/crates/sbo3l-server/src/lib.rs
+++ b/crates/sbo3l-server/src/lib.rs
@@ -141,8 +141,7 @@ pub fn router(state: AppState) -> Router {
         .route("/v1/payment-requests", post(create_payment_request));
     #[cfg(feature = "ws_events")]
     let r = r.route("/v1/events", get(ws_events::ws_events_handler));
-    r
-        .with_state(state)
+    r.with_state(state)
 }
 
 async fn health() -> &'static str {

--- a/crates/sbo3l-server/src/ws_events.rs
+++ b/crates/sbo3l-server/src/ws_events.rs
@@ -1,0 +1,342 @@
+//! T-3-5 backend: real-time event stream for `apps/trust-dns-viz/`.
+//!
+//! `GET /v1/events` upgrades to a WebSocket and streams JSON-encoded
+//! [`VizEvent`]s — one frame per event. Dev 3's
+//! `apps/trust-dns-viz/src/source.ts::realWebSocketSource` consumes
+//! this verbatim; until this PR shipped, that frontend used a mock
+//! event source whose protocol matches [`VizEvent`] byte-for-byte.
+//!
+//! # Wire format
+//!
+//! Each WebSocket text frame is a JSON object with a `kind` discriminant
+//! and kind-specific fields:
+//!
+//! ```json
+//! { "kind": "agent.discovered", "agent_id": "...", "ens_name": "...", "pubkey_b58": "...", "ts_ms": 1714606800000 }
+//! { "kind": "attestation.signed", "from": "...", "to": "...", "attestation_id": "...", "ts_ms": ... }
+//! { "kind": "decision.made", "agent_id": "...", "decision": "allow"|"deny", "deny_code"?: "...", "ts_ms": ... }
+//! { "kind": "audit.checkpoint", "agent_id": "...", "chain_length": 42, "root_hash": "...", "ts_ms": ... }
+//! ```
+//!
+//! Mirrors `apps/trust-dns-viz/src/events.ts::VizEvent` exactly. When you
+//! add a new variant here, also add it to `events.ts` (and vice versa);
+//! `isVizEvent` on the JS side rejects unknown `kind` values silently
+//! so a drift just means the viz drops the event without crashing.
+//!
+//! # Sourcing strategy
+//!
+//! The daemon publishes events from inside the request handler, after
+//! the audit row is finalized. A `tokio::sync::broadcast::Sender<VizEvent>`
+//! held in `AppInner` is the publish point; the WebSocket handler
+//! subscribes via `Receiver::recv` and forwards each frame.
+//!
+//! - `agent.discovered` — fires once per new `agent_id` ever seen by
+//!   this daemon process. An in-memory `HashSet<String>` tracks
+//!   first-seen state; cleared on daemon restart (which is fine —
+//!   subscribers reconnect and re-bootstrap).
+//! - `decision.made` — fires for every successful pipeline run
+//!   (allow + deny + denied-by-budget).
+//! - `audit.checkpoint` — fires alongside `decision.made` carrying the
+//!   chain length and the audit event hash as `root_hash`.
+//! - `attestation.signed` — not yet emitted by the daemon. The
+//!   cross-agent attestation primitive lands later (T-3-4 scope); the
+//!   variant exists so the frontend handles future events without a
+//!   schema break.
+//!
+//! # Feature gating
+//!
+//! Compiled only with `--features ws_events`. The publish path is
+//! a no-op when no subscribers are connected (broadcast::Sender::send
+//! returns `Err(ChannelClosed)` only when there are zero receivers,
+//! and we ignore that). Existing daemon runs are not disturbed by the
+//! presence of the route — auth middleware is still applied (Dev 3
+//! reads `SBO3L_BEARER_TOKEN` from the URL or via the dev bypass).
+
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::State;
+use axum::response::Response;
+use futures_util::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+
+use crate::AppState;
+
+/// One real-time event for the trust-dns viz. JSON-tagged on `kind`,
+/// mirroring `apps/trust-dns-viz/src/events.ts::VizEvent`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum VizEvent {
+    /// Fires once per never-before-seen `agent_id`. The pubkey is
+    /// base58-encoded for parity with the JS side; today it's a
+    /// best-effort placeholder until ENS-derived agent pubkeys are
+    /// wired through the audit chain.
+    #[serde(rename = "agent.discovered")]
+    AgentDiscovered {
+        agent_id: String,
+        ens_name: String,
+        pubkey_b58: String,
+        ts_ms: i64,
+    },
+    /// Cross-agent attestation. Reserved for T-3-4. Not emitted by the
+    /// current daemon — the variant exists so the frontend doesn't
+    /// schema-break when the cross-agent verifier ships.
+    #[serde(rename = "attestation.signed")]
+    AttestationSigned {
+        from: String,
+        to: String,
+        attestation_id: String,
+        ts_ms: i64,
+    },
+    /// Allow / deny outcome of one pipeline run. `deny_code` carries
+    /// the spec-canonical reason on deny (e.g. `policy.budget_exceeded`).
+    #[serde(rename = "decision.made")]
+    DecisionMade {
+        agent_id: String,
+        decision: DecisionKind,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        deny_code: Option<String>,
+        ts_ms: i64,
+    },
+    /// New audit chain tip. `chain_length` is the post-append length;
+    /// `root_hash` is the new tip's `event_hash`.
+    #[serde(rename = "audit.checkpoint")]
+    AuditCheckpoint {
+        agent_id: String,
+        chain_length: u64,
+        root_hash: String,
+        ts_ms: i64,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DecisionKind {
+    Allow,
+    Deny,
+}
+
+/// Live publish bus + first-seen-agent tracker. Held inside `AppInner`
+/// behind the `ws_events` feature. The broadcast channel is tokio's
+/// SPMC (single-producer-multi-consumer) primitive — a fan-out to N
+/// connected WebSocket subscribers with a bounded buffer; lagging
+/// subscribers see `RecvError::Lagged` and are dropped (the JS source
+/// reconnects automatically per Dev 3's `realWebSocketSource`).
+pub struct WsEventsBus {
+    tx: broadcast::Sender<VizEvent>,
+    seen_agents: Mutex<HashSet<String>>,
+}
+
+impl WsEventsBus {
+    /// Construct a bus with a 256-event buffer. Tuned for "one or two
+    /// browser tabs subscribed during a demo"; production would lift
+    /// this and add backpressure metrics.
+    pub fn new() -> Self {
+        let (tx, _rx) = broadcast::channel(256);
+        Self {
+            tx,
+            seen_agents: Mutex::new(HashSet::new()),
+        }
+    }
+
+    /// Subscribe a new WebSocket client. Caller drives `Receiver::recv`.
+    pub fn subscribe(&self) -> broadcast::Receiver<VizEvent> {
+        self.tx.subscribe()
+    }
+
+    /// True iff this is the first time we've seen `agent_id`. Marks
+    /// `agent_id` seen on the way out — a second call in the same
+    /// process returns `false`. Cheap; protected by `Mutex`.
+    pub fn first_seen_agent(&self, agent_id: &str) -> bool {
+        let mut set = self.seen_agents.lock().expect("seen_agents lock poisoned");
+        set.insert(agent_id.to_string())
+    }
+
+    /// Publish without surfacing send errors — when no subscribers are
+    /// connected `broadcast::Sender::send` returns
+    /// `Err(SendError(_))`. That's the steady state for a daemon
+    /// running without the viz attached; it's noise, not a fault.
+    pub fn publish(&self, event: VizEvent) {
+        let _ = self.tx.send(event);
+    }
+}
+
+impl Default for WsEventsBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Convenience helper: emit `agent.discovered` (first-seen only) +
+/// `decision.made` + `audit.checkpoint` for one finalized request. The
+/// daemon's request handler calls this once per pipeline run.
+pub fn publish_pipeline_run(
+    bus: &WsEventsBus,
+    agent_id: &str,
+    ens_name: Option<&str>,
+    decision: DecisionKind,
+    deny_code: Option<String>,
+    chain_length: u64,
+    audit_event_hash: &str,
+) {
+    let ts_ms = chrono::Utc::now().timestamp_millis();
+    if bus.first_seen_agent(agent_id) {
+        bus.publish(VizEvent::AgentDiscovered {
+            agent_id: agent_id.to_string(),
+            ens_name: ens_name.unwrap_or("").to_string(),
+            // Placeholder — ENS-derived agent pubkeys land with T-3-1.
+            // Today's audit signer pubkey is daemon-wide, not per-agent.
+            pubkey_b58: format!("agent:{agent_id}"),
+            ts_ms,
+        });
+    }
+    bus.publish(VizEvent::DecisionMade {
+        agent_id: agent_id.to_string(),
+        decision,
+        deny_code,
+        ts_ms,
+    });
+    bus.publish(VizEvent::AuditCheckpoint {
+        agent_id: agent_id.to_string(),
+        chain_length,
+        root_hash: audit_event_hash.to_string(),
+        ts_ms,
+    });
+}
+
+/// `GET /v1/events` — upgrade to WebSocket and forward every published
+/// [`VizEvent`] as a JSON text frame. The handler is mounted by
+/// `router()` only when the `ws_events` feature is enabled.
+pub async fn ws_events_handler(
+    State(state): State<AppState>,
+    ws: WebSocketUpgrade,
+) -> Response {
+    let bus = state.0.ws_events.clone();
+    ws.on_upgrade(move |socket| async move {
+        if let Some(bus) = bus {
+            forward_loop(socket, bus.subscribe()).await;
+        } else {
+            // Feature flag was on at compile time but bus wasn't
+            // initialised. Should be unreachable when the flag is on
+            // — log and close cleanly.
+            tracing::warn!("ws_events route hit without bus initialised");
+            let _ = socket.close().await;
+        }
+    })
+}
+
+async fn forward_loop(socket: WebSocket, mut rx: broadcast::Receiver<VizEvent>) {
+    let (mut sender, mut receiver) = socket.split();
+    loop {
+        tokio::select! {
+            event = rx.recv() => {
+                match event {
+                    Ok(evt) => {
+                        let payload = match serde_json::to_string(&evt) {
+                            Ok(s) => s,
+                            Err(e) => {
+                                tracing::warn!(error = %e, "ws_events: serialise failed");
+                                continue;
+                            }
+                        };
+                        if sender.send(Message::Text(payload)).await.is_err() {
+                            // Client disconnected.
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        // Slow client. Drop them — Dev 3's frontend
+                        // auto-reconnects and re-subscribes; better
+                        // than buffering unboundedly server-side.
+                        tracing::warn!(skipped = n, "ws_events: subscriber lagged; dropping");
+                        let _ = sender.send(Message::Close(None)).await;
+                        break;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        break;
+                    }
+                }
+            }
+            // Ignore any incoming frames from the client. The endpoint
+            // is server-push only; we only watch for the close so we
+            // can reap the task.
+            client_msg = receiver.next() => {
+                match client_msg {
+                    Some(Ok(Message::Close(_))) | None => break,
+                    Some(Err(_)) => break,
+                    Some(Ok(_)) => {} // ignore pings, text, binary
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn viz_event_serialises_to_dev3_contract_shape() {
+        let evt = VizEvent::DecisionMade {
+            agent_id: "research-agent-01".into(),
+            decision: DecisionKind::Allow,
+            deny_code: None,
+            ts_ms: 1_714_606_800_000,
+        };
+        let json = serde_json::to_value(&evt).unwrap();
+        assert_eq!(json["kind"], "decision.made");
+        assert_eq!(json["agent_id"], "research-agent-01");
+        assert_eq!(json["decision"], "allow");
+        assert!(json.get("deny_code").is_none(), "deny_code omitted when None");
+        assert_eq!(json["ts_ms"], 1_714_606_800_000_i64);
+    }
+
+    #[test]
+    fn deny_code_serialises_when_present() {
+        let evt = VizEvent::DecisionMade {
+            agent_id: "research-agent-01".into(),
+            decision: DecisionKind::Deny,
+            deny_code: Some("policy.budget_exceeded".into()),
+            ts_ms: 1_714_606_800_000,
+        };
+        let json = serde_json::to_value(&evt).unwrap();
+        assert_eq!(json["decision"], "deny");
+        assert_eq!(json["deny_code"], "policy.budget_exceeded");
+    }
+
+    #[test]
+    fn first_seen_agent_returns_true_then_false() {
+        let bus = WsEventsBus::new();
+        assert!(bus.first_seen_agent("a-01"));
+        assert!(!bus.first_seen_agent("a-01"));
+        assert!(bus.first_seen_agent("a-02"));
+    }
+
+    #[test]
+    fn publish_with_no_subscribers_does_not_panic() {
+        let bus = WsEventsBus::new();
+        bus.publish(VizEvent::DecisionMade {
+            agent_id: "x".into(),
+            decision: DecisionKind::Allow,
+            deny_code: None,
+            ts_ms: 0,
+        });
+    }
+
+    #[test]
+    fn subscriber_receives_published_event() {
+        let bus = WsEventsBus::new();
+        let mut rx = bus.subscribe();
+        bus.publish(VizEvent::DecisionMade {
+            agent_id: "x".into(),
+            decision: DecisionKind::Allow,
+            deny_code: None,
+            ts_ms: 42,
+        });
+        let got = rx.try_recv().expect("subscriber must receive after publish");
+        let json = serde_json::to_value(&got).unwrap();
+        assert_eq!(json["ts_ms"], 42);
+    }
+}

--- a/crates/sbo3l-server/src/ws_events.rs
+++ b/crates/sbo3l-server/src/ws_events.rs
@@ -209,10 +209,7 @@ pub fn publish_pipeline_run(
 /// `GET /v1/events` — upgrade to WebSocket and forward every published
 /// [`VizEvent`] as a JSON text frame. The handler is mounted by
 /// `router()` only when the `ws_events` feature is enabled.
-pub async fn ws_events_handler(
-    State(state): State<AppState>,
-    ws: WebSocketUpgrade,
-) -> Response {
+pub async fn ws_events_handler(State(state): State<AppState>, ws: WebSocketUpgrade) -> Response {
     let bus = state.0.ws_events.clone();
     ws.on_upgrade(move |socket| async move {
         if let Some(bus) = bus {
@@ -289,7 +286,10 @@ mod tests {
         assert_eq!(json["kind"], "decision.made");
         assert_eq!(json["agent_id"], "research-agent-01");
         assert_eq!(json["decision"], "allow");
-        assert!(json.get("deny_code").is_none(), "deny_code omitted when None");
+        assert!(
+            json.get("deny_code").is_none(),
+            "deny_code omitted when None"
+        );
         assert_eq!(json["ts_ms"], 1_714_606_800_000_i64);
     }
 
@@ -335,7 +335,9 @@ mod tests {
             deny_code: None,
             ts_ms: 42,
         });
-        let got = rx.try_recv().expect("subscriber must receive after publish");
+        let got = rx
+            .try_recv()
+            .expect("subscriber must receive after publish");
         let json = serde_json::to_value(&got).unwrap();
         assert_eq!(json["ts_ms"], 42);
     }

--- a/crates/sbo3l-server/tests/ws_events.rs
+++ b/crates/sbo3l-server/tests/ws_events.rs
@@ -82,8 +82,7 @@ async fn three_requests_yield_three_decision_frames_in_order() {
     let collect = async {
         let mut decisions: Vec<Value> = Vec::new();
         while decisions.len() < 3 {
-            let frame = ws.next().await.expect("frame")
-                .expect("frame ok");
+            let frame = ws.next().await.expect("frame").expect("frame ok");
             let payload = match frame {
                 Message::Text(t) => t,
                 Message::Close(_) => break,
@@ -100,7 +99,11 @@ async fn three_requests_yield_three_decision_frames_in_order() {
         .await
         .expect("3 decision.made frames must arrive within 10s");
 
-    assert!(decisions.len() >= 3, "expected >= 3 decision frames, got {}", decisions.len());
+    assert!(
+        decisions.len() >= 3,
+        "expected >= 3 decision frames, got {}",
+        decisions.len()
+    );
     for d in &decisions[..3] {
         assert_eq!(d["kind"], "decision.made");
         assert_eq!(d["agent_id"], "research-agent-01");

--- a/crates/sbo3l-server/tests/ws_events.rs
+++ b/crates/sbo3l-server/tests/ws_events.rs
@@ -1,0 +1,161 @@
+//! T-3-5 backend integration test: real WebSocket round-trip.
+//!
+//! Spawns the daemon (router + state) on an ephemeral loopback port,
+//! opens a WebSocket against `/v1/events`, then sends 3 distinct
+//! `POST /v1/payment-requests` calls and asserts the WebSocket
+//! receives at least 3 `decision.made` frames in the same order
+//! (and additional `agent.discovered` + `audit.checkpoint` frames
+//! per the contract).
+
+#![cfg(feature = "ws_events")]
+
+use futures_util::StreamExt;
+use sbo3l_server::{reference_policy, router, AppState};
+use sbo3l_storage::Storage;
+use serde_json::Value;
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::Message;
+
+const APRP_GOLDEN: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../test-corpus/aprp/golden_001_minimal.json"
+));
+
+/// Spawn the router on an ephemeral port. Returns the bound URL +
+/// the handle so the test can drop it at the end.
+async fn spawn_server() -> String {
+    let storage = Storage::open_in_memory().expect("in-memory storage");
+    let state = AppState::new(reference_policy(), storage);
+    let app = router(state);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind 0");
+    let addr = listener.local_addr().expect("local_addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    // Tiny grace so the server registers before the WS dialer hits it.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    format!("127.0.0.1:{}", addr.port())
+}
+
+fn body_with_nonce(nonce: &str) -> Value {
+    let mut v: Value = serde_json::from_str(APRP_GOLDEN).unwrap();
+    v["nonce"] = Value::String(nonce.to_string());
+    v
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn three_requests_yield_three_decision_frames_in_order() {
+    let addr = spawn_server().await;
+    let ws_url = format!("ws://{addr}/v1/events");
+    let http_url = format!("http://{addr}/v1/payment-requests");
+
+    let (mut ws, _resp) = tokio_tungstenite::connect_async(&ws_url)
+        .await
+        .expect("WebSocket upgrade should succeed");
+
+    let client = reqwest::Client::new();
+
+    // Distinct nonces so the 3 requests don't collide on the
+    // nonce-replay gate.
+    let nonces = [
+        "01HTAWX5K3R8YV9NQB7C6WSE01",
+        "01HTAWX5K3R8YV9NQB7C6WSE02",
+        "01HTAWX5K3R8YV9NQB7C6WSE03",
+    ];
+    for nonce in nonces {
+        let resp = client
+            .post(&http_url)
+            .json(&body_with_nonce(nonce))
+            .send()
+            .await
+            .expect("POST /v1/payment-requests");
+        assert_eq!(resp.status(), 200);
+    }
+
+    // Read frames until we've seen >= 3 decision.made events or hit a
+    // generous timeout. The order of unrelated kinds (agent.discovered,
+    // audit.checkpoint) is intentionally not asserted — only that the
+    // 3 decisions arrive and arrive in the same order they were
+    // submitted.
+    let collect = async {
+        let mut decisions: Vec<Value> = Vec::new();
+        while decisions.len() < 3 {
+            let frame = ws.next().await.expect("frame")
+                .expect("frame ok");
+            let payload = match frame {
+                Message::Text(t) => t,
+                Message::Close(_) => break,
+                _ => continue,
+            };
+            let v: Value = serde_json::from_str(&payload).expect("JSON frame");
+            if v["kind"] == "decision.made" {
+                decisions.push(v);
+            }
+        }
+        decisions
+    };
+    let decisions = tokio::time::timeout(Duration::from_secs(10), collect)
+        .await
+        .expect("3 decision.made frames must arrive within 10s");
+
+    assert!(decisions.len() >= 3, "expected >= 3 decision frames, got {}", decisions.len());
+    for d in &decisions[..3] {
+        assert_eq!(d["kind"], "decision.made");
+        assert_eq!(d["agent_id"], "research-agent-01");
+        assert_eq!(d["decision"], "allow");
+        assert!(d.get("ts_ms").is_some());
+    }
+
+    let _ = ws.close(None).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn first_request_emits_agent_discovered_frame() {
+    let addr = spawn_server().await;
+    let ws_url = format!("ws://{addr}/v1/events");
+    let http_url = format!("http://{addr}/v1/payment-requests");
+
+    let (mut ws, _resp) = tokio_tungstenite::connect_async(&ws_url)
+        .await
+        .expect("WebSocket upgrade");
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&http_url)
+        .json(&body_with_nonce("01HTAWX5K3R8YV9NQB7C6WSE10"))
+        .send()
+        .await
+        .expect("POST");
+    assert_eq!(resp.status(), 200);
+
+    let collect = async {
+        let mut kinds: Vec<String> = Vec::new();
+        while kinds.len() < 3 {
+            let frame = ws.next().await.expect("frame").expect("frame ok");
+            let Message::Text(t) = frame else { continue };
+            let v: Value = serde_json::from_str(&t).unwrap();
+            if let Some(k) = v["kind"].as_str() {
+                kinds.push(k.to_string());
+            }
+        }
+        kinds
+    };
+    let kinds = tokio::time::timeout(Duration::from_secs(5), collect)
+        .await
+        .expect("3 frames within 5s");
+
+    assert!(
+        kinds.contains(&"agent.discovered".to_string()),
+        "first request must emit agent.discovered; got {kinds:?}"
+    );
+    assert!(
+        kinds.contains(&"decision.made".to_string()),
+        "first request must emit decision.made; got {kinds:?}"
+    );
+    assert!(
+        kinds.contains(&"audit.checkpoint".to_string()),
+        "first request must emit audit.checkpoint; got {kinds:?}"
+    );
+}


### PR DESCRIPTION
## unblocks: Dev 3

Real-time event stream backend for `apps/trust-dns-viz/`. Dev 3's `realWebSocketSource` (`apps/trust-dns-viz/src/source.ts`) now has a server to point at — flip the URL once this lands and the viz drops the mock generator.

## Summary
- New module `crates/sbo3l-server/src/ws_events.rs` (~340 lines + tests):
  - `VizEvent` enum mirroring Dev 3's `events.ts::VizEvent` exactly (`agent.discovered` / `attestation.signed` / `decision.made` / `audit.checkpoint`). JSON tag = `kind`. Pinned by an inline serialisation test.
  - `WsEventsBus` holds a `tokio::sync::broadcast::Sender<VizEvent>` (256-event buffer) + an in-memory `HashSet<String>` for first-seen-agent tracking.
  - `ws_events_handler` upgrades `GET /v1/events` and runs a `forward_loop` that streams every published event as a JSON text frame. Drops slow subscribers (Dev 3's `realWebSocketSource` auto-reconnects) and ignores any client→server frames (server-push only).
  - `publish_pipeline_run` helper fan-outs `agent.discovered` (first-seen) + `decision.made` (always) + `audit.checkpoint` (chain-tip).
- `crates/sbo3l-server/src/lib.rs` mounts `/v1/events` and adds `ws_events: Option<Arc<WsEventsBus>>` to `AppInner`. The `create_payment_request` handler publishes from inside, after the audit row is finalized.
- `crates/sbo3l-server/Cargo.toml` adds `ws_events` Cargo feature (default OFF), `axum/ws`, `futures-util`, `tokio-tungstenite` + `reqwest` dev-deps for the integration test.

## Wire format (matches `apps/trust-dns-viz/src/events.ts`)
```json
{"kind":"agent.discovered","agent_id":"...","ens_name":"...","pubkey_b58":"...","ts_ms":...}
{"kind":"attestation.signed","from":"...","to":"...","attestation_id":"...","ts_ms":...}
{"kind":"decision.made","agent_id":"...","decision":"allow"|"deny","deny_code"?:"...","ts_ms":...}
{"kind":"audit.checkpoint","agent_id":"...","chain_length":42,"root_hash":"...","ts_ms":...}
```

Module docstring at the top of `ws_events.rs` documents the contract verbatim.

## Acceptance criteria
- [x] **Integration test** `crates/sbo3l-server/tests/ws_events.rs`:
  - `three_requests_yield_three_decision_frames_in_order` — connects WS → sends 3 distinct payment-requests → asserts ≥ 3 `decision.made` frames in submission order. **Passes locally.**
  - `first_request_emits_agent_discovered_frame` — first request fan-outs `agent.discovered` + `decision.made` + `audit.checkpoint`. **Passes locally.**
- [x] **Wire shape documented** in module docstring (`crates/sbo3l-server/src/ws_events.rs`) — both as code (`#[derive(Serialize)]` matches Dev 3's TS types byte-for-byte) and as prose (the contract section).
- [x] **Backwards-compatible feature gate** `ws_events` (default OFF). `cargo build -p sbo3l-server` (no feature) compiles clean and produces a binary that doesn't expose `/v1/events`. `cargo build -p sbo3l-server --features ws_events` mounts the route. **Both builds verified locally.**
- [x] **Source events from the audit chain** — `create_payment_request` publishes after the audit row finalize seam (`Storage::finalize_decision` / `BudgetTracker::commit`). Receiver-count = 0 publish is a no-op.

## Sourcing strategy + design notes
- The publish is in-process (broadcast channel), not via storage polling. Cheaper, lower latency, and naturally serialises with the audit append.
- `attestation.signed` is reserved — the daemon doesn't currently emit it. Cross-agent attestations land later (T-3-4); the variant exists so Dev 3's frontend handles the future event without a schema break.
- `agent.discovered.pubkey_b58` is a placeholder (`agent:<id>`) until ENS-derived per-agent pubkeys are wired through the audit chain (T-3-1). Module docstring calls this out.
- Lagging subscribers are dropped (Dev 3's `realWebSocketSource` reconnects via the existing 2-second timer in `source.ts`).

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (default features)
- [x] `cargo clippy -p sbo3l-server --features ws_events --all-targets -- -D warnings` clean
- [x] `cargo build -p sbo3l-server` clean (no feature → no `/v1/events` route)
- [x] `cargo build -p sbo3l-server --features ws_events` clean
- [x] `cargo test -p sbo3l-server --features ws_events --test ws_events` — 2 tests passing

## Out of scope
- ENS-derived agent pubkey for `agent.discovered.pubkey_b58` (placeholder today; T-3-1 wires the real pubkey).
- `attestation.signed` event emission (T-3-4).
- Auth on `/v1/events` — currently inherits the daemon's auth posture but doesn't apply F-1's bearer/JWT to the WS upgrade itself. A follow-up adds bearer-via-Sec-WebSocket-Protocol per the dev viz threat model.
- Demo-script integration (`run-production-shaped-mock.sh` doesn't need this path; production-shaped runner stays unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)