### PR TITLE
chore(release): v1.0.0 — Phase 1 closeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,94 @@
+# Changelog
+
+All notable changes to SBO3L are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] — 2026-05-01
+
+**Phase 1 closeout.** First stable release of the SBO3L agent trust layer.
+Public API (Rust crates, TypeScript SDK, Python SDK) is now committed and
+will follow semver guarantees.
+
+### Added — Rust crates (crates.io)
+- `sbo3l-core` — APRP wire format, JCS-canonical request hash, signed
+  PolicyReceipt + Ed25519 audit event types, capsule v1 + v2 schemas.
+- `sbo3l-storage` — SQLite persistence, hash-chained audit log,
+  policy + nonce + budget stores, KMS-backed signer indirection.
+- `sbo3l-policy` — YAML/JSON policy parser + evaluator with
+  deny-unknown-fields, deterministic deny precedence.
+- `sbo3l-identity` — ENS text-record resolution, ENSIP-25 CCIP-Read
+  client decoder, ERC-8004 Identity Registry calldata builders.
+- `sbo3l-execution` — sponsor `GuardedExecutor` trait, KeeperHub +
+  Uniswap adapters with `local_mock()` and `live_from_env()` peers.
+- `sbo3l-keeperhub-adapter` — standalone KeeperHub adapter crate
+  (IP-4 publishable surface).
+- `sbo3l-server` — axum-based daemon, KMS abstraction, persistent
+  budget store, idempotency atomicity (state machine).
+- `sbo3l-mcp` — MCP stdio JSON-RPC server with `sbo3l.audit_lookup` tool.
+- `sbo3l-cli` — `sbo3l` binary: `passport run/verify/explain`,
+  `audit export-bundle/verify`, `agent register/verify-ens`,
+  `policy validate`.
+
+### Added — SDKs
+- `@sbo3l/sdk` (npm) — TypeScript SDK with full type-safe APRP types,
+  fetch-based client, signing helpers.
+- `sbo3l-sdk` (PyPI) — Python SDK matching the TypeScript surface.
+
+### Added — Framework integrations
+- `@sbo3l/langchain` (npm) — LangChain JS Tool wrapping SBO3L.
+- `sbo3l-langchain` (PyPI) — LangChain Python tool.
+- `sbo3l-crewai` (PyPI) — CrewAI tool.
+- `@sbo3l/autogen` (npm) — Microsoft AutoGen function adapter.
+- `sbo3l-llamaindex` (PyPI) — LlamaIndex tool.
+
+### Added — Self-contained Passport capsule (F-6)
+- New `sbo3l.passport_capsule.v2` schema embedding `policy.policy_snapshot`
+  and `audit.audit_segment` so `sbo3l passport verify --strict` re-derives
+  every check from the capsule alone — no auxiliary inputs required.
+- 1 MiB cap on `audit.audit_segment` to bound verifier memory.
+- `--audit-bundle <path>` opt-in override that takes precedence over the
+  embedded segment (codex P1 fix on PR #118).
+
+### Added — ENS as agent trust DNS
+- Mainnet apex `sbo3lagent.eth` with 5 `sbo3l:*` text records published.
+- ENSIP-25 / EIP-3668 CCIP-Read gateway scaffold (`apps/ccip-gateway/`)
+  deployable to Vercel.
+- `sbo3l agent register` CLI (dry-run path) for Durin subname issuance
+  under `sbo3lagent.eth`.
+
+### Added — Sponsor integrations
+- KeeperHub: live workflow execution (workflow `m4t4cnpmhv8qquce3bv3c`
+  verified end-to-end on 2026-04-30).
+- Uniswap: direct `quoteExactInputSingle()` against Sepolia QuoterV2.
+
+### Added — Infrastructure
+- `docker-compose.yml` with `sbo3l-mcp` profile + compose CI smoke.
+- Vercel deployment for marketing site (`apps/marketing/`) with
+  CSP + cache + security headers.
+- GitHub Actions: per-tag publish workflows for crates.io, npm,
+  and PyPI; per-commit Rust + JSON-schema + Docker checks.
+
+### Changed
+- Rebrand: project renamed Mandate → SBO3L (PR #58, 2026-04-29). All
+  crate names, schema ids (`mandate.* → sbo3l.*`), and the CLI binary
+  (`mandate → sbo3l`) updated. Tagline preserved: *"Don't give your
+  agent a wallet. Give it a mandate."* (lowercase "mandate" = the noun;
+  SBO3L = the brand).
+- GitHub repo renamed `mandate-ethglobal-openagents-2026 →
+  SBO3L-ethglobal-openagents-2026` (old slug 301-redirects).
+
+### Security
+- `serde(deny_unknown_fields)` end-to-end on all wire types — no
+  silent acceptance of malformed APRP envelopes.
+- Hash-chained audit log: every event linked by `prev_event_hash`;
+  flip one byte and the strict verifier rejects.
+- Agent boundary: zero `SigningKey` references in `demo-agents/` —
+  signing happens only inside SBO3L. Demo gate 12 grep-asserts this.
+
+### Test counts at v1.0.0
+- 440+ Rust workspace tests
+- 13 demo gates (all green on production-shaped runner)
+- 26 real / 0 mock / 1 skipped on the production-shaped mock runner
+
+[1.0.0]: https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/releases/tag/v1.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,7 +1740,7 @@ dependencies = [
 
 [[package]]
 name = "research-agent"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1919,7 +1919,7 @@ checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
 
 [[package]]
 name = "sbo3l-cli"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1947,7 +1947,7 @@ dependencies = [
 
 [[package]]
 name = "sbo3l-core"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "sbo3l-execution"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "chrono",
  "hex",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "sbo3l-identity"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "hex",
  "reqwest",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "sbo3l-keeperhub-adapter"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "chrono",
  "hex",
@@ -2012,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "sbo3l-mcp"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "sbo3l-policy"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "chrono",
  "hex",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "sbo3l-server"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "sbo3l-storage"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "chrono",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 license = "MIT"
 authors = ["Daniel Babjak <babjak_daniel@hotmail.com>"]
@@ -76,15 +76,15 @@ url = "2"
 # survives). The IP-4 standalone adapter
 # (`crates/sbo3l-keeperhub-adapter`) needs `sbo3l-core` to be
 # publishable, which means the version must be declared here.
-sbo3l-core = { path = "crates/sbo3l-core", version = "0.1.0" }
-sbo3l-policy = { path = "crates/sbo3l-policy", version = "0.1.0" }
-sbo3l-storage = { path = "crates/sbo3l-storage", version = "0.1.0" }
-sbo3l-identity = { path = "crates/sbo3l-identity", version = "0.1.0" }
-sbo3l-execution = { path = "crates/sbo3l-execution", version = "0.1.0" }
-sbo3l-keeperhub-adapter = { path = "crates/sbo3l-keeperhub-adapter", version = "0.1.0" }
-sbo3l-mcp = { path = "crates/sbo3l-mcp", version = "0.1.0" }
-sbo3l-cli = { path = "crates/sbo3l-cli", version = "0.1.0" }
-sbo3l-server = { path = "crates/sbo3l-server", version = "0.1.0" }
+sbo3l-core = { path = "crates/sbo3l-core", version = "1.0.0" }
+sbo3l-policy = { path = "crates/sbo3l-policy", version = "1.0.0" }
+sbo3l-storage = { path = "crates/sbo3l-storage", version = "1.0.0" }
+sbo3l-identity = { path = "crates/sbo3l-identity", version = "1.0.0" }
+sbo3l-execution = { path = "crates/sbo3l-execution", version = "1.0.0" }
+sbo3l-keeperhub-adapter = { path = "crates/sbo3l-keeperhub-adapter", version = "1.0.0" }
+sbo3l-mcp = { path = "crates/sbo3l-mcp", version = "1.0.0" }
+sbo3l-cli = { path = "crates/sbo3l-cli", version = "1.0.0" }
+sbo3l-server = { path = "crates/sbo3l-server", version = "1.0.0" }
 
 [profile.release]
 lto = "thin"

--- a/crates/sbo3l-keeperhub-adapter/Cargo.toml
+++ b/crates/sbo3l-keeperhub-adapter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbo3l-keeperhub-adapter"
-version = "0.1.0"
+version = "1.0.0"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/integrations/autogen/package.json
+++ b/integrations/autogen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sbo3l/autogen",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Microsoft AutoGen function adapter wrapping SBO3L — gate every agent payment intent through SBO3L's policy boundary.",
   "license": "MIT",
   "author": "Daniel Babjak <babjak_daniel@hotmail.com>",
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@sbo3l/sdk": "^0.1.0"
+    "@sbo3l/sdk": "^1.0.0"
   },
   "peerDependenciesMeta": {
     "@sbo3l/sdk": { "optional": true }

--- a/integrations/crewai/pyproject.toml
+++ b/integrations/crewai/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sbo3l-crewai"
-version = "0.1.0"
+version = "1.0.0"
 description = "CrewAI tool wrapping SBO3L — gate every Crew action through SBO3L's policy boundary."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -16,7 +16,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-sdk = ["sbo3l-sdk>=0.1.0,<1"]
+sdk = ["sbo3l-sdk>=1.0.0,<2"]
 crewai = ["crewai-tools>=0.4,<1"]
 dev = [
     "pytest>=8.0,<9",

--- a/integrations/langchain-python/pyproject.toml
+++ b/integrations/langchain-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sbo3l-langchain"
-version = "0.1.0"
+version = "1.0.0"
 description = "LangChain Python tool wrapping SBO3L — gate every agent payment intent through SBO3L's policy boundary."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -26,7 +26,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-sdk = ["sbo3l-sdk>=0.1.0,<1"]
+sdk = ["sbo3l-sdk>=1.0.0,<2"]
 langchain = ["langchain-core>=0.2,<1"]
 dev = [
     "pytest>=8.0,<9",

--- a/integrations/langchain-typescript/package.json
+++ b/integrations/langchain-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sbo3l/langchain",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "LangChain JS Tool wrapping SBO3L — gate every agent payment intent through SBO3L's policy boundary.",
   "license": "MIT",
   "author": "Daniel Babjak <babjak_daniel@hotmail.com>",
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@sbo3l/sdk": "^0.1.0"
+    "@sbo3l/sdk": "^1.0.0"
   },
   "peerDependenciesMeta": {
     "@sbo3l/sdk": {

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sbo3l-llamaindex"
-version = "0.1.0"
+version = "1.0.0"
 description = "LlamaIndex tool wrapping SBO3L — gate every agent payment intent through SBO3L's policy boundary."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -16,7 +16,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-sdk = ["sbo3l-sdk>=0.1.0,<1"]
+sdk = ["sbo3l-sdk>=1.0.0,<2"]
 llamaindex = ["llama-index-core>=0.10,<1"]
 dev = [
     "pytest>=8.0,<9",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sbo3l-sdk"
-version = "0.1.0"
+version = "1.0.0"
 description = "Official Python SDK for SBO3L — the cryptographically verifiable trust layer for autonomous AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sbo3l/sdk",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Official TypeScript SDK for SBO3L — the cryptographically verifiable trust layer for autonomous AI agents.",
   "license": "MIT",
   "author": "Daniel Babjak <babjak_daniel@hotmail.com>",


### PR DESCRIPTION
## Summary

Bumps every publishable artefact to **1.0.0** and adds `CHANGELOG.md` with the full Phase 1 closeout.

**Rust crates (workspace.package.version):**
sbo3l-core, -storage, -policy, -identity, -execution, -keeperhub-adapter (explicit), -server, -mcp, -cli

**SDKs:**
@sbo3l/sdk (npm), sbo3l-sdk (PyPI)

**Framework integrations:**
@sbo3l/langchain, @sbo3l/autogen, sbo3l-langchain, sbo3l-crewai, sbo3l-llamaindex

(@sbo3l/elizaos #115 still in cascade — will follow as 1.0.1.)

## After this lands — release flow

1. Push 3 tags:
   ```bash
   git tag -a v1.0.0 -m "SBO3L v1.0.0 — Phase 1 closeout"
   git tag -a sdk-ts-v1.0.0 -m "@sbo3l/sdk v1.0.0"
   git tag -a sdk-py-v1.0.0 -m "sbo3l-sdk (PyPI) v1.0.0"
   git push origin v1.0.0 sdk-ts-v1.0.0 sdk-py-v1.0.0
   ```

2. Each tag triggers its respective publish workflow:
   - `v1.0.0` → `crates-publish.yml` (9 crates → crates.io, sequential w/ 30s sleep)
   - `sdk-ts-v1.0.0` → `sdk-typescript.yml` (publish to npm)
   - `sdk-py-v1.0.0` → `sdk-python.yml` (publish to PyPI)

3. **GitHub Release page** auto-generated from tag.

## Required secrets / publisher config (Daniel's task)

> **MUST be in place BEFORE pushing tags.** Otherwise tags push fine but the publish workflows fail.

- [ ] **`CARGO_REGISTRY_TOKEN`** — repo Settings → Secrets and variables → Actions. Generated at https://crates.io/me (Account Settings → API Tokens).
- [ ] **npm trusted publishing** — npm package settings → Publishing access. Add this repo + `.github/workflows/sdk-typescript.yml` as a trusted publisher. (Uses OIDC, no NPM_TOKEN required.)
- [ ] **PyPI trusted publishing** — https://pypi.org/manage/project/sbo3l-sdk/settings/publishing/ → Add a new publisher. Owner: B2JK-Industry, repo: SBO3L-ethglobal-openagents-2026, workflow: `sdk-python.yml`, environment: `pypi`.

## Test plan
- [x] cargo fmt --all --check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo build --workspace
- [ ] CI green (Rust check + Build + size + smoke + Validate JSON schemas / OpenAPI + docker-compose smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)