### PR TITLE
fix(server): vendor reference_low_risk policy (unblocks v1.0.0 publish)

### DIFF
--- a/crates/sbo3l-server/policies/reference_low_risk.json
+++ b/crates/sbo3l-server/policies/reference_low_risk.json
@@ -1,0 +1,83 @@
+{
+  "version": 1,
+  "policy_id": "default-low-risk",
+  "description": "Reference policy for demo and CI. Allows the research agent to buy small x402 API calls from approved providers; denies unknown recipients.",
+  "default_decision": "deny",
+  "agents": [
+    {
+      "agent_id": "research-agent-01",
+      "status": "active",
+      "policy_role": "research"
+    }
+  ],
+  "budgets": [
+    {
+      "agent_id": "research-agent-01",
+      "scope": "per_tx",
+      "cap_usd": "0.50"
+    },
+    {
+      "agent_id": "research-agent-01",
+      "scope": "daily",
+      "cap_usd": "10.00"
+    },
+    {
+      "agent_id": "research-agent-01",
+      "scope": "per_provider",
+      "scope_key": "api.example.com",
+      "cap_usd": "5.00"
+    }
+  ],
+  "providers": [
+    {
+      "id": "api.example.com",
+      "url": "https://api.example.com",
+      "status": "trusted",
+      "cert_pin_sha256": null
+    }
+  ],
+  "recipients": [
+    {
+      "address": "0x1111111111111111111111111111111111111111",
+      "chain": "base",
+      "status": "allowed",
+      "label": "example-api-x402-recipient"
+    },
+    {
+      "address": "0x9999999999999999999999999999999999999999",
+      "chain": "base-sepolia",
+      "status": "denied",
+      "label": "ethprague-attacker-demo"
+    }
+  ],
+  "rules": [
+    {
+      "id": "deny-emergency-freeze",
+      "effect": "deny",
+      "deny_code": "policy.deny_emergency_frozen",
+      "when": "input.emergency.freeze_all == true"
+    },
+    {
+      "id": "deny-unknown-provider",
+      "effect": "deny",
+      "deny_code": "policy.deny_unknown_provider",
+      "when": "not input.provider.trusted"
+    },
+    {
+      "id": "deny-recipient-not-allowlisted",
+      "effect": "deny",
+      "deny_code": "policy.deny_recipient_not_allowlisted",
+      "when": "not input.recipient.allowed"
+    },
+    {
+      "id": "allow-small-x402-api-call",
+      "effect": "allow",
+      "deny_code": null,
+      "when": "input.intent == \"purchase_api_call\" and input.payment_protocol == \"x402\" and input.amount_usd <= 0.50 and input.provider.trusted and input.recipient.allowed"
+    }
+  ],
+  "emergency": {
+    "freeze_all": false,
+    "paused_agents": []
+  }
+}

--- a/crates/sbo3l-server/src/lib.rs
+++ b/crates/sbo3l-server/src/lib.rs
@@ -681,10 +681,8 @@ async fn run_pipeline(
 /// Embedded reference policy for development/demo. Production callers should
 /// load from `/etc/sbo3l/policies/...`.
 pub fn reference_policy() -> Policy {
-    Policy::parse_json(include_str!(
-        "../../../test-corpus/policy/reference_low_risk.json"
-    ))
-    .expect("invariant: bundled reference policy parses")
+    Policy::parse_json(include_str!("../policies/reference_low_risk.json"))
+        .expect("invariant: bundled reference policy parses")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

\`cargo publish -p sbo3l-server v1.0.0\` failed at the verify step:

\`\`\`
error: couldn't read \`crates/sbo3l-server/src/../../../test-corpus/policy/reference_low_risk.json\`: No such file or directory
\`\`\`

The \`include_str!\` in \`lib.rs:684\` reaches up to the workspace-root \`test-corpus/\`, which cargo publish strips from the tarball.

## Fix

Vendor \`test-corpus/policy/reference_low_risk.json\` into \`crates/sbo3l-server/policies/\` and update the path. Same pattern F-11 already uses for schemas + migrations.

## Impact

Unblocks v1.0.0 cargo publish chain (currently 6 of 9 crates published; sbo3l-server + sbo3l-mcp + sbo3l-cli pending).

## Test plan
- [x] cargo build -p sbo3l-server clean
- [x] cargo fmt clean
- [ ] CI green
- [ ] After merge: cargo publish -p sbo3l-server succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)