### PR TITLE
feat(t-3-3): ENS fleet-of-5 infra — script + YAML + schema + manifest + docs

### DIFF
--- a/crates/sbo3l-cli/src/main.rs
+++ b/crates/sbo3l-cli/src/main.rs
@@ -177,6 +177,15 @@ enum AgentCmd {
         #[arg(long, default_value_t = false)]
         broadcast: bool,
 
+        /// Explicitly request dry-run (no broadcast). Dry-run is
+        /// already the default, but passing `--dry-run` surfaces
+        /// intent — automation scripts pass it as defense-in-depth so
+        /// a future flip of the CLI default to broadcast won't
+        /// silently turn an envelope-build invocation into a real tx.
+        /// Mutually exclusive with `--broadcast`.
+        #[arg(long, default_value_t = false, conflicts_with = "broadcast")]
+        dry_run: bool,
+
         #[arg(long)]
         rpc_url: Option<String>,
 
@@ -766,6 +775,14 @@ fn main() -> ExitCode {
                     owner,
                     resolver,
                     broadcast,
+                    // `--dry-run` is acknowledged but doesn't change
+                    // behaviour: dry-run is the default, broadcast
+                    // is opt-in via `--broadcast`. Clap's
+                    // conflicts_with already enforces the mutex; we
+                    // accept the flag here so scripts that pass it
+                    // for defense-in-depth aren't rejected as
+                    // "unknown argument".
+                    dry_run: _,
                     rpc_url,
                     private_key_env_var,
                     out,

--- a/docs/cli/ens-fleet.md
+++ b/docs/cli/ens-fleet.md
@@ -125,7 +125,7 @@ The script refuses without both the env var AND the explicit
 ## Step 4 — Verify
 
 ```bash
-./scripts/resolve-fleet.sh docs/proof/ens-fleet-2026-05-01.json
+./scripts/resolve-fleet.sh docs/proof/ens-fleet-agents-5-2026-05-01.json
 ```
 
 Output:
@@ -152,7 +152,7 @@ If any agent fails to resolve:
 ## Step 5 — Commit the manifest
 
 ```bash
-git add docs/proof/ens-fleet-2026-05-01.json
+git add docs/proof/ens-fleet-agents-5-2026-05-01.json
 git commit -m "chore(proof): T-3-3 mainnet fleet manifest (5 agents)"
 ```
 
@@ -173,63 +173,6 @@ without re-reading this doc.
 | Records empty after broadcast | `multicall` tx reverted | Check Etherscan for the register tx; if it succeeded but multicall reverted, the resolver isn't pointing at PublicResolver yet. Run `cast send <ENS Registry> "setResolver(...)"` per the T-4-1 deploy runbook. |
 | Subname exists but viem can't resolve | OffchainResolver pointer not flipped | Subnames inherit the parent's resolver; until step 4 of T-4-1's deploy runbook lands, only direct PublicResolver `text(...)` calls work. |
 | Pubkey mismatch with another operator | Wrong `seed_doc` or `label` | Re-run `derive-fleet-keys.py --print-secrets` against the canonical YAML; pubkeys are SHA-256 deterministic. |
-
-## T-3-4 — 60-agent ENS-AGENT-A1 amplifier
-
-Same infra, scaled to 60 agents in 6 capability classes:
-
-| Range            | Class         | Capabilities                  |
-|------------------|---------------|-------------------------------|
-| `agent-001..010` | research      | `x402-purchase`               |
-| `agent-011..020` | trading       | `uniswap-swap, x402-purchase` |
-| `agent-021..030` | swap          | `uniswap-swap`                |
-| `agent-031..040` | audit         | `audit-export, audit-verify`  |
-| `agent-041..050` | coordinator   | `delegate, attest`            |
-| `agent-051..060` | oracle        | `price-feed, attest`          |
-
-```bash
-# Derive the 60 pubkeys (committed at scripts/fleet-config/agents-60.pubkeys.json):
-python3 scripts/derive-fleet-keys.py \
-  --config scripts/fleet-config/agents-60.yaml \
-  --output-pubkeys scripts/fleet-config/agents-60.pubkeys.json
-
-# Broadcast — same script, different YAML:
-./scripts/register-fleet.sh scripts/fleet-config/agents-60.yaml
-
-# Resolve — <30s for 60 agents against PublicNode:
-./scripts/resolve-fleet.sh docs/proof/ens-fleet-agents-60-2026-05-01.json
-```
-
-**Cost (60 agents):**
-
-| Network  | Total gas      | Approx cost            |
-|----------|----------------|------------------------|
-| Sepolia  | ~0.7 SEP-ETH   | ~$2.40 (free testnet)  |
-| Mainnet  | ~0.7 ETH @ 50 gwei | ~$3 600 (Daniel approves) |
-
-### Trust-DNS viz hand-off
-
-The 60-agent fleet is the headliner of the trust-DNS visualization
-narrative. To wire `apps/trust-dns-viz/bench.html?source=mainnet-fleet`
-into the manifest, Dev 3 (the viz owner) needs to:
-
-1. Fetch `docs/proof/ens-fleet-60-events.json` (a viz-friendly
-   conversion of the manifest into an array of `agent.discovered`
-   events, committed alongside the manifest).
-2. In `apps/trust-dns-viz/src/source.ts`, add a `mainnetFleetSource()`
-   branch alongside the existing `realWebSocketSource` /
-   `mockSource`. It should fetch the events.json (relative URL or
-   GitHub Pages URL), iterate, and dispatch each as a synthetic
-   `agent.discovered` event with light pacing (e.g. 50ms apart so
-   the constellation animates in over ~3s).
-3. In `apps/trust-dns-viz/src/main.ts`, route `?source=mainnet-fleet`
-   to the new branch.
-
-The events JSON file matches the existing `VizEvent` discriminator
-shape (`kind: "agent.discovered"`) — no parser change needed in the
-viz's events.ts. **The conversion itself is in this PR**
-(`docs/proof/ens-fleet-60-events.json`); only the Vite-side fetch
-wiring is Dev 3's work.
 
 ## See also
 

--- a/docs/proof/ens-fleet-agents-5-2026-05-01.json
+++ b/docs/proof/ens-fleet-agents-5-2026-05-01.json
@@ -1,0 +1,98 @@
+{
+  "agents": [
+    {
+      "agent_id": "research-agent-01",
+      "capabilities": [
+        "x402-purchase"
+      ],
+      "endpoint": "https://app.sbo3l.dev/v1",
+      "error": null,
+      "etherscan": null,
+      "fqdn": "research-agent.sbo3lagent.eth",
+      "label": "research-agent",
+      "multicall_tx_hash": null,
+      "policy_url": "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/policies/research-agent-01.json",
+      "pubkey_ed25519": "3c754c3aad07da711d90ef16665f46c53ad050c9b3764a68d444551ca3d22003",
+      "register_tx_hash": null,
+      "status": "pending"
+    },
+    {
+      "agent_id": "trading-agent-01",
+      "capabilities": [
+        "uniswap-swap",
+        "x402-purchase"
+      ],
+      "endpoint": "https://app.sbo3l.dev/v1",
+      "error": null,
+      "etherscan": null,
+      "fqdn": "trading-agent.sbo3lagent.eth",
+      "label": "trading-agent",
+      "multicall_tx_hash": null,
+      "policy_url": "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/policies/trading-agent-01.json",
+      "pubkey_ed25519": "133a21dae2d13849c7756e1ee858319c419b8907c46a8e5917658264567713b1",
+      "register_tx_hash": null,
+      "status": "pending"
+    },
+    {
+      "agent_id": "swap-agent-01",
+      "capabilities": [
+        "uniswap-swap"
+      ],
+      "endpoint": "https://app.sbo3l.dev/v1",
+      "error": null,
+      "etherscan": null,
+      "fqdn": "swap-agent.sbo3lagent.eth",
+      "label": "swap-agent",
+      "multicall_tx_hash": null,
+      "policy_url": "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/policies/swap-agent-01.json",
+      "pubkey_ed25519": "0f5c0bd2e3b4243ad14440015765fb7a9785e6fe4d567116a81d7b7832c041cc",
+      "register_tx_hash": null,
+      "status": "pending"
+    },
+    {
+      "agent_id": "audit-agent-01",
+      "capabilities": [
+        "audit-export",
+        "audit-verify"
+      ],
+      "endpoint": "https://app.sbo3l.dev/v1",
+      "error": null,
+      "etherscan": null,
+      "fqdn": "audit-agent.sbo3lagent.eth",
+      "label": "audit-agent",
+      "multicall_tx_hash": null,
+      "policy_url": "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/policies/audit-agent-01.json",
+      "pubkey_ed25519": "c150336c92fd2e4812ef8e778df11ab99264bd017a0f540827378b7fea13df01",
+      "register_tx_hash": null,
+      "status": "pending"
+    },
+    {
+      "agent_id": "coordinator-agent-01",
+      "capabilities": [
+        "delegate",
+        "attest"
+      ],
+      "endpoint": "https://app.sbo3l.dev/v1",
+      "error": null,
+      "etherscan": null,
+      "fqdn": "coordinator-agent.sbo3lagent.eth",
+      "label": "coordinator-agent",
+      "multicall_tx_hash": null,
+      "policy_url": "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/policies/coordinator-agent-01.json",
+      "pubkey_ed25519": "3508179c76640b71b97e0bee1679b21b80b3c015ea153e1e55d47496e8d54f48",
+      "register_tx_hash": null,
+      "status": "pending"
+    }
+  ],
+  "generated_at_utc": "2026-05-01T11:00:00Z",
+  "network": "sepolia",
+  "parent": "sbo3lagent.eth",
+  "schema": "sbo3l.ens_fleet_manifest.v1",
+  "seed_doc": "sbo3l-ens-fleet-2026-05-01",
+  "totals": {
+    "agent_count": 5,
+    "failed": 0,
+    "gas_used_total": null,
+    "succeeded": 0
+  }
+}

--- a/docs/proof/ens-narrative.md
+++ b/docs/proof/ens-narrative.md
@@ -101,7 +101,7 @@ SBO3L agents need ZERO out-of-band setup to authenticate each other.**
 The protocol is one thing; the constellation is another. Phase 2
 ships two manifests under `sbo3lagent.eth`:
 
-- **`docs/proof/ens-fleet-2026-05-01.json`** — five named-role agents
+- **`docs/proof/ens-fleet-agents-5-2026-05-01.json`** — five named-role agents
   (`research`, `trading`, `swap`, `audit`, `coordinator`) each
   carrying the canonical seven `sbo3l:*` records. Reviewers re-derive
   every agent's Ed25519 pubkey byte-for-byte from the public seed
@@ -208,7 +208,7 @@ who kept a receipt.
 |--------------------------------------------------|----------------------------------------------------------------------------------------------|
 | `sbo3lagent.eth` resolves the canonical 5 records | `cast text sbo3lagent.eth sbo3l:policy_hash --rpc-url https://ethereum-rpc.publicnode.com`  |
 | The owner of `sbo3lagent.eth` is Daniel's wallet | https://app.ens.domains/sbo3lagent.eth                                                       |
-| Five named-role agents under the apex             | `./scripts/resolve-fleet.sh docs/proof/ens-fleet-2026-05-01.json` (post-broadcast)            |
+| Five named-role agents under the apex             | `./scripts/resolve-fleet.sh docs/proof/ens-fleet-agents-5-2026-05-01.json` (post-broadcast)            |
 | Sixty-agent constellation                         | `./scripts/resolve-fleet.sh docs/proof/ens-fleet-agents-60-2026-05-01.json` (post-broadcast)         |
 | Cross-agent verification ships                    | `cargo test -p sbo3l-identity --lib cross_agent::` (13 tests, including the pair-swap test)  |
 | CCIP-Read gateway is real                         | https://sbo3l-ccip.vercel.app/api/{sender}/{data}.json                                       |
@@ -273,7 +273,7 @@ Status as of `<RUNTIME>`: tx hashes filled in by
 | `audit-agent.sbo3lagent.eth`              | TBD (post-broadcast)                | TBD       |
 | `coordinator-agent.sbo3lagent.eth`        | TBD (post-broadcast)                | TBD       |
 
-Source of truth: `docs/proof/ens-fleet-2026-05-01.json`. Reviewers
+Source of truth: `docs/proof/ens-fleet-agents-5-2026-05-01.json`. Reviewers
 re-derive every pubkey via
 `python3 scripts/derive-fleet-keys.py --config scripts/fleet-config/agents-5.yaml`.
 
@@ -367,7 +367,7 @@ cast call 0xF29100983E058B709F3D539b0c765937B804AC15 \
 - OffchainResolver Solidity:
   `crates/sbo3l-identity/contracts/OffchainResolver.sol`
 - Manifests:
-  `docs/proof/ens-fleet-2026-05-01.json`,
+  `docs/proof/ens-fleet-agents-5-2026-05-01.json`,
   `docs/proof/ens-fleet-agents-60-2026-05-01.json`
 
 ## Honest scope statement

--- a/scripts/fleet-config/agents-5.yaml
+++ b/scripts/fleet-config/agents-5.yaml
@@ -13,7 +13,7 @@
 #
 # Daniel runs scripts/register-fleet.sh against this file once Dev 1's
 # T-3-1 broadcast slice lands. Output manifest at
-# docs/proof/ens-fleet-2026-05-01.json.
+# docs/proof/ens-fleet-agents-5-2026-05-01.json.
 
 seed_doc: "sbo3l-ens-fleet-2026-05-01"
 parent: "sbo3lagent.eth"

--- a/scripts/register-fleet.sh
+++ b/scripts/register-fleet.sh
@@ -118,8 +118,15 @@ python3 scripts/derive-fleet-keys.py \
 
 # ---- Per-agent registration loop -----------------------------------
 
+# Manifest filename = ens-fleet-${CONFIG_BASE}-${DATE}.json so two
+# fleets registered on the same day (e.g. agents-5.yaml and
+# agents-60.yaml) don't collide on a single output path. The
+# CONFIG_BASE comes from the YAML basename (`agents-5`, `agents-60`,
+# whatever the operator named it) — keeps the path self-describing
+# without requiring an extra flag. (codex P1 fix on #138 + #173.)
 DATE_TAG=$(date -u +%Y-%m-%d)
-MANIFEST_PATH="docs/proof/ens-fleet-${DATE_TAG}.json"
+CONFIG_BASE=$(basename "$CONFIG_PATH" .yaml)
+MANIFEST_PATH="docs/proof/ens-fleet-${CONFIG_BASE}-${DATE_TAG}.json"
 mkdir -p "$(dirname "$MANIFEST_PATH")"
 
 # Build the manifest skeleton with python (richer JSON than bash heredoc).
@@ -207,12 +214,18 @@ print(json.dumps({
     echo "    pubkey (Ed25519): $PUBKEY"
 
     DRY_RUN_OUT=$(mktemp)
+    # Defense-in-depth: pass --dry-run explicitly even though it's
+    # the CLI default. clap's conflicts_with rejects --broadcast in
+    # the same call, so a future flip of the CLI default cannot
+    # silently turn this envelope-build invocation into a real tx.
+    # (codex P1 fix on #138.)
     if ! "$SBO3L_BIN" agent register \
             --name "$LABEL" \
             --parent "$PARENT" \
             --network "$NETWORK" \
             --records "$RECORDS_JSON" \
             --owner "$OWNER" \
+            --dry-run \
             --out "$DRY_RUN_OUT" >/dev/null 2>&1; then
         echo "    ERROR: dry-run failed for $LABEL" >&2
         python3 -c "

--- a/scripts/resolve-fleet.sh
+++ b/scripts/resolve-fleet.sh
@@ -5,7 +5,7 @@
 # manifest. <5s end-to-end against PublicNode (no API key needed).
 #
 # Usage:
-#   ./scripts/resolve-fleet.sh docs/proof/ens-fleet-2026-05-01.json
+#   ./scripts/resolve-fleet.sh docs/proof/ens-fleet-agents-5-2026-05-01.json
 #
 # Env (optional):
 #   SBO3L_RESOLVE_RPC_URL  — JSON-RPC endpoint to resolve against.


### PR DESCRIPTION
## Summary
Phase 2 ENS amplifier infrastructure for issuing 5 named agents under `sbo3lagent.eth`. Each agent carries the canonical 5 `sbo3l:*` text records (`agent_id`, `endpoint`, `pubkey_ed25519`, `policy_url`, `capabilities`).

Fleet:
- `research-agent.sbo3lagent.eth` (x402-purchase)
- `trading-agent.sbo3lagent.eth` (uniswap-swap, x402-purchase)
- `swap-agent.sbo3lagent.eth` (uniswap-swap)
- `audit-agent.sbo3lagent.eth` (audit-export, audit-verify)
- `coordinator-agent.sbo3lagent.eth` (delegate, attest)

## What ships
- `scripts/derive-fleet-keys.py` — deterministic Ed25519 keypair derivation. Pubkeys = SHA-256(`seed_doc:label`). Secret seeds **never** hit disk unless `--print-secrets` opts in for the broadcast loop.
- `scripts/fleet-config/agents-5.yaml` + committed `agents-5.pubkeys.json` — public, reviewer-rederivable.
- `scripts/register-fleet.sh` — orchestration. Per agent: derive seed → `sbo3l agent register --dry-run` → `cast send` × 2 → manifest entry. Mainnet path requires `SBO3L_ALLOW_MAINNET_TX=1` + `network: mainnet` in YAML (T-3-1's double-gate).
- `scripts/resolve-fleet.sh` — demo. `cast text` against PublicNode for every FQDN. <5s for 5 agents. Exit code 3 on any mismatch.
- `schemas/sbo3l.ens_fleet_manifest.v1.json` — JSON Schema draft 2020-12 for the manifest.
- `docs/proof/ens-fleet-2026-05-01.json` — pre-broadcast manifest, all 5 agents in `pending`. Validates against the schema.
- `docs/cli/ens-fleet.md` — operator runbook. 6 steps, mainnet double-gate documented, troubleshooting matrix.

## Why
Closes **T-3-3** infrastructure. The hackathon submission narrative needs 5+ live ENS subnames as proof of the trust-DNS claim; this PR ships everything that doesn't require Daniel's wallet to broadcast. The `cast send` fallback works without Dev 1's T-3-1 broadcast slice — the script structure stays the same when that slice ships, just swap to `sbo3l agent register --broadcast`.

## Verification
- [x] `python3 scripts/derive-fleet-keys.py` → 5 deterministic pubkeys, committed to `scripts/fleet-config/agents-5.pubkeys.json`.
- [x] `bash -n scripts/register-fleet.sh` + `bash -n scripts/resolve-fleet.sh` syntax clean.
- [x] `jsonschema` validates `docs/proof/ens-fleet-2026-05-01.json` against the new schema.
- [ ] **After Daniel runs the broadcast loop:** `./scripts/resolve-fleet.sh docs/proof/ens-fleet-2026-05-01.json` returns `5 resolved | 0 failed | <5s`.

## Cost estimates (per the runbook)
| Network | Total gas | Approx cost |
|---|---|---|
| Sepolia | ~0.06 SEP-ETH | ~$0.20 (free testnet) |
| Mainnet | ~0.06 ETH at 50 gwei | ~$300 (Daniel decides) |

## Out of scope (chain ops)
- **Daniel runs `./scripts/register-fleet.sh`** with the appropriate RPC + key once #116 lands and the parent is configured. The output manifest gets committed back to this branch (or a follow-up) with the real tx hashes.
- **OffchainResolver pointer flip on `sbo3lagent.eth`** — needed for `viem.getEnsText` round-trip per T-4-1 deploy runbook step 4. Without it, only direct PublicResolver `text(...)` calls work; the `resolve-fleet.sh` smoke uses direct PublicResolver so it works regardless.
- **T-3-4 60-agent fleet** — separate PR (`agent/dev4/T-3-4`). Same infra, scaled YAML.
- **`scripts/derive-fleet-keys.py` integration into the workspace via `sbo3l-cli`** — cleaner long-term, but a Python helper is faster to ship and the deterministic algorithm is dead-simple to audit.

Refs T-3-3.

Co-Authored-By: Dev 4 (Infra + On-chain + Distributed) <dev4@sbo3l.dev>