### PR TITLE
feat(marketing): #101 in-browser Passport verifier (PassportVerifier.astro + /proof + /proof-test)

### DIFF
--- a/apps/marketing/src/components/PassportVerifier.astro
+++ b/apps/marketing/src/components/PassportVerifier.astro
@@ -1,0 +1,253 @@
+---
+// PassportVerifier — in-browser SBO3L Passport capsule verifier (#101).
+//
+// Loads the WASM verifier built by `scripts/build-wasm-verifier.sh`
+// (output at /wasm/sbo3l_core.js + /wasm/sbo3l_core_bg.wasm) lazily
+// on first click; the wasm module is cached after first load so
+// subsequent verifications are sync. The wasm bundle is not on the
+// FCP path — `import("/wasm/sbo3l_core.js")` only fires when the user
+// clicks Verify.
+//
+// Calls `verify_capsule_strict_json(capsuleJsonString)` and renders
+// the 6-check report with PASSED / SKIPPED / FAILED pills + the
+// per-check detail string on hover.
+
+interface Props {
+  /// Optional initial capsule JSON pre-filled into the textarea (used
+  /// by /proof-test.astro to auto-run against a known-good fixture).
+  initialCapsule?: string;
+  /// When true, fire the verify action on mount. Used by /proof-test.
+  autorun?: boolean;
+  /// CSS id to expose for the smoke-test page to query the result.
+  reportId?: string;
+}
+
+const {
+  initialCapsule = "",
+  autorun = false,
+  reportId = "passport-verifier-report",
+} = Astro.props;
+---
+
+<section class="verifier" data-autorun={autorun ? "1" : "0"}>
+  <h2>Verify a SBO3L Passport capsule</h2>
+  <p class="lede">
+    Paste a capsule JSON and click Verify. The verifier runs entirely
+    in your browser via the <a href="https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/tree/main/crates/sbo3l-core">sbo3l-core</a>
+    Rust crate compiled to WebAssembly — no daemon, no network call.
+    v2 capsules with embedded <code>policy_snapshot</code> and
+    <code>audit_segment</code> verify all 6 cryptographic checks
+    self-contained; v1 capsules pass the structural and request-hash
+    checks and honestly report the others as <em>SKIPPED</em>.
+  </p>
+
+  <label for="capsule-input" class="lbl">Capsule JSON</label>
+  <textarea
+    id="capsule-input"
+    spellcheck="false"
+    placeholder='{"schema":"sbo3l.passport_capsule.v2", ...}'
+    rows="10">{initialCapsule}</textarea>
+
+  <div class="actions">
+    <button id="verify-btn" type="button">Verify</button>
+    <span id="verifier-status" class="status">idle</span>
+  </div>
+
+  <output id={reportId} class="report" data-state="idle"></output>
+</section>
+
+<style>
+  .verifier {
+    max-width: var(--max);
+    margin: 2em auto;
+    padding: 1.5em;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+  }
+  .verifier h2 { margin-top: 0; }
+  .lede { color: var(--muted); margin-bottom: 1.2em; }
+  .lbl { display: block; font-weight: 600; margin-bottom: 0.4em; }
+  textarea {
+    width: 100%;
+    box-sizing: border-box;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.85em;
+    padding: 0.6em;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg-soft, #f9fafb);
+    resize: vertical;
+  }
+  .actions {
+    display: flex;
+    align-items: center;
+    gap: 1em;
+    margin: 1em 0;
+  }
+  button {
+    padding: 0.5em 1.2em;
+    font-size: 1em;
+    border: none;
+    border-radius: 6px;
+    background: var(--accent, #1f6feb);
+    color: white;
+    cursor: pointer;
+  }
+  button:disabled { opacity: 0.6; cursor: progress; }
+  .status { color: var(--muted); font-size: 0.9em; font-family: ui-monospace, monospace; }
+  .report {
+    display: block;
+    margin-top: 1em;
+    padding: 0;
+    min-height: 1.5em;
+  }
+  .report[data-state="idle"] { display: none; }
+  .report ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.4em;
+  }
+  .report li {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 0.8em;
+    align-items: baseline;
+    padding: 0.5em 0.8em;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg-soft, #f9fafb);
+  }
+  .pill {
+    display: inline-block;
+    padding: 0.1em 0.6em;
+    border-radius: 999px;
+    font-size: 0.75em;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+  }
+  .pill.passed { background: #d1f4dd; color: #056635; }
+  .pill.skipped { background: #fff4ce; color: #6b5300; }
+  .pill.failed { background: #ffd6d6; color: #8b0000; }
+  .label { font-family: ui-monospace, monospace; font-size: 0.9em; }
+  .detail { color: var(--muted); font-size: 0.8em; max-width: 60ch; }
+  .summary {
+    margin-top: 0.8em;
+    padding: 0.5em 0.8em;
+    border-radius: 6px;
+    font-weight: 600;
+  }
+  .summary.fully-ok { background: #d1f4dd; color: #056635; }
+  .summary.with-skips { background: #fff4ce; color: #6b5300; }
+  .summary.failed { background: #ffd6d6; color: #8b0000; }
+  .err {
+    color: #8b0000;
+    background: #ffd6d6;
+    padding: 0.6em 0.8em;
+    border-radius: 6px;
+    font-family: ui-monospace, monospace;
+    font-size: 0.85em;
+    white-space: pre-wrap;
+  }
+</style>
+
+<script is:inline define:vars={{ reportId }}>
+  // Lazy WASM module init — kicked off on first verify click. The
+  // module is cached for subsequent calls so re-verifications are
+  // synchronous after the first load.
+  let wasmReady = null;
+  async function loadWasm() {
+    if (wasmReady) return wasmReady;
+    wasmReady = (async () => {
+      const mod = await import("/wasm/sbo3l_core.js");
+      await mod.default();
+      return mod;
+    })();
+    return wasmReady;
+  }
+
+  function pill(outcome) {
+    const cls =
+      outcome === "PASSED"
+        ? "passed"
+        : outcome === "FAILED"
+        ? "failed"
+        : "skipped";
+    return `<span class="pill ${cls}">${outcome}</span>`;
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, (c) =>
+      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c] || c)
+    );
+  }
+
+  function renderReport(report) {
+    const out = document.getElementById(reportId);
+    out.dataset.state = "ready";
+    const items = report.checks.map((c) => {
+      const detail = c.detail
+        ? `<span class="detail">${escapeHtml(c.detail)}</span>`
+        : "<span></span>";
+      return `<li><span class="label">${escapeHtml(c.label)}</span>${detail}${pill(c.outcome)}</li>`;
+    });
+    let summary, summaryClass;
+    if (report.ok) {
+      summary = "PASSED — all 6 cryptographic checks succeeded";
+      summaryClass = "fully-ok";
+    } else if (!report.any_failed) {
+      summary = "PASSED with skips — capsule needs aux input for full crypto coverage";
+      summaryClass = "with-skips";
+    } else {
+      summary = "FAILED — at least one cryptographic check rejected the capsule";
+      summaryClass = "failed";
+    }
+    out.innerHTML =
+      `<ul>${items.join("")}</ul>` +
+      `<div class="summary ${summaryClass}">${summary}</div>`;
+  }
+
+  function renderError(msg) {
+    const out = document.getElementById(reportId);
+    out.dataset.state = "error";
+    out.innerHTML = `<div class="err">${escapeHtml(msg)}</div>`;
+  }
+
+  async function verify() {
+    const status = document.getElementById("verifier-status");
+    const btn = document.getElementById("verify-btn");
+    const input = document.getElementById("capsule-input");
+    const json = input.value.trim();
+    if (!json) {
+      renderError("Paste a capsule JSON first.");
+      return;
+    }
+    btn.disabled = true;
+    status.textContent = "loading wasm…";
+    try {
+      const mod = await loadWasm();
+      status.textContent = `verifying (sbo3l-core v${mod.sbo3l_core_version()})…`;
+      const report = mod.verify_capsule_strict_json(json);
+      renderReport(report);
+      status.textContent = report.ok ? "ok" : "see report";
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      renderError(msg);
+      status.textContent = "error";
+    } finally {
+      btn.disabled = false;
+    }
+  }
+
+  document.getElementById("verify-btn").addEventListener("click", () => {
+    void verify();
+  });
+
+  // /proof-test.astro sets data-autorun="1" on the section so the
+  // smoke-test page exercises the full verify path on mount without
+  // user interaction.
+  if (document.querySelector(".verifier")?.dataset.autorun === "1") {
+    void verify();
+  }
+</script>

--- a/apps/marketing/src/pages/proof-test.astro
+++ b/apps/marketing/src/pages/proof-test.astro
@@ -1,0 +1,75 @@
+---
+// Smoke-test page for the WASM verifier (#101 closure). Mounts
+// PassportVerifier with `autorun=true` and the v2 golden fixture
+// pre-filled — every page load exercises the full
+// fetch-wasm → instantiate → verify flow against a known-good
+// capsule. The expected outcome is 6 PASSED checks; if the page
+// shows anything else, the wasm pipeline regressed.
+//
+// Not linked from the main nav — discoverable via /proof-test for
+// CI smoke + manual operator checks. Production traffic uses /proof
+// (the user-facing page) instead.
+
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import PassportVerifier from "~/components/PassportVerifier.astro";
+import fs from "node:fs";
+import path from "node:path";
+
+// Load the canonical v2 golden fixture at build time so the
+// verifier auto-runs against it on page mount. The fixture is the
+// same one F-6's test plan exercises.
+const fixturePath = path.resolve(
+  process.cwd(),
+  "../../test-corpus/passport/v2_golden_001_minimal.json"
+);
+const goldenCapsule = fs.readFileSync(fixturePath, "utf8");
+---
+<BaseLayout
+  title="SBO3L — WASM verifier smoke test"
+  description="Auto-runs the WASM passport verifier against test-corpus/passport/v2_golden_001_minimal.json. Expected outcome: 6 PASSED."
+>
+  <section class="hero">
+    <h1>WASM verifier smoke test</h1>
+    <p class="lede">
+      This page auto-runs the WebAssembly verifier against
+      <code>test-corpus/passport/v2_golden_001_minimal.json</code> on
+      load. Expected outcome: <strong>6 PASSED checks</strong> with
+      the green summary. Anything else means the WASM pipeline
+      regressed or the bundled fixture drifted from the verifier's
+      expectations.
+    </p>
+    <p class="lede">
+      Operators: bookmark this URL. CI: visit it post-deploy and
+      assert <code>document.querySelector('output[data-state=ready]')</code>
+      contains "PASSED — all 6".
+    </p>
+  </section>
+
+  <PassportVerifier
+    initialCapsule={goldenCapsule}
+    autorun={true}
+    reportId="passport-verifier-smoke"
+  />
+
+  <section class="docs">
+    <h2>Why a separate page</h2>
+    <p>
+      <a href="/proof">/proof</a> is the user-facing surface — empty
+      textarea, "Verify" button, no auto-run. <code>/proof-test</code>
+      loads identical code paths but auto-fires the verifier so a
+      single page-load proves the wasm bundle, the JS glue, the JSON
+      schema, the policy snapshot, the audit segment, and the
+      Ed25519 signature path all line up. If this page is green, the
+      user-facing verifier is healthy.
+    </p>
+  </section>
+
+  <style>
+    .hero { max-width: var(--max); margin: 2em auto 1em; padding: 0 1.5em; }
+    .hero h1 { margin: 0 0 0.4em; }
+    .lede { color: var(--muted); margin: 0 0 0.8em; }
+    .docs { max-width: var(--max); margin: 2em auto; padding: 0 1.5em; color: var(--muted); }
+    .docs h2 { color: var(--ink); margin-bottom: 0.4em; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.85em; }
+  </style>
+</BaseLayout>

--- a/apps/marketing/src/pages/proof.astro
+++ b/apps/marketing/src/pages/proof.astro
@@ -1,0 +1,69 @@
+---
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import PassportVerifier from "~/components/PassportVerifier.astro";
+
+const githubRepoUrl = "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026";
+---
+<BaseLayout
+  title="SBO3L — Verify a Passport capsule in your browser"
+  description="In-browser SBO3L Passport verifier. Paste a capsule JSON and run all 6 cryptographic checks via WebAssembly — no daemon, no network."
+>
+  <section class="hero">
+    <h1>Verify a Passport capsule</h1>
+    <p class="lede">
+      Every SBO3L decision is wrapped in a Passport capsule — a
+      self-contained, offline-verifiable proof artifact. This page
+      runs the same Rust verifier the CLI ships, compiled to
+      WebAssembly. You don't trust this server; you trust the bytes
+      of <code>sbo3l_core_bg.wasm</code> we serve, and you can verify
+      that bytes match the published <a href="https://crates.io/crates/sbo3l-core">sbo3l-core</a>
+      crate yourself.
+    </p>
+  </section>
+
+  <PassportVerifier />
+
+  <section class="docs">
+    <h2>What gets checked</h2>
+    <p>
+      A v2 self-contained capsule embeds <code>policy.policy_snapshot</code>
+      and <code>audit.audit_segment</code>; the verifier runs all 6 checks
+      with no aux input:
+    </p>
+    <ol>
+      <li><strong>structural</strong> — schema + cross-field invariants (deny ⇒ no execution, live mode ⇒ evidence, hash agreement, etc.)</li>
+      <li><strong>request_hash_recompute</strong> — JCS+SHA-256 of the embedded APRP equals the claimed <code>request_hash</code></li>
+      <li><strong>policy_hash_recompute</strong> — JCS+SHA-256 of the embedded policy equals the claimed <code>policy_hash</code></li>
+      <li><strong>receipt_signature</strong> — Ed25519 signature on the embedded receipt verifies against the embedded receipt-signer pubkey</li>
+      <li><strong>audit_chain</strong> — the embedded audit-bundle's chain segment verifies (signatures + prev-hash linkage)</li>
+      <li><strong>audit_event_link</strong> — the bundle's <code>summary.audit_event_id</code> matches the capsule's <code>audit.audit_event_id</code> and is present in the chain segment</li>
+    </ol>
+    <p>
+      v1 capsules pass the structural and request-hash checks; the
+      remaining four show as <em>SKIPPED</em> because the capsule
+      doesn't carry the embedded crypto material. That's an honest
+      report — never a fake-OK.
+    </p>
+    <p>
+      Source: <a href={`${githubRepoUrl}/blob/main/crates/sbo3l-core/src/passport.rs`}>crates/sbo3l-core/src/passport.rs</a>
+      (<a href={`${githubRepoUrl}/blob/main/crates/sbo3l-core/src/wasm.rs`}>wasm.rs</a> for the JS bridge,
+      <a href={`${githubRepoUrl}/blob/main/scripts/build-wasm-verifier.sh`}>scripts/build-wasm-verifier.sh</a> for the build pipeline).
+    </p>
+  </section>
+
+  <style>
+    .hero { max-width: var(--max); margin: 2em auto 1em; padding: 0 1.5em; }
+    .hero h1 { margin: 0 0 0.4em; }
+    .lede { color: var(--muted); margin: 0; }
+    .docs {
+      max-width: var(--max);
+      margin: 2em auto;
+      padding: 0 1.5em;
+      color: var(--muted);
+    }
+    .docs h2 { color: var(--ink); margin-bottom: 0.4em; }
+    .docs ol { padding-left: 1.4em; }
+    .docs ol li { margin-bottom: 0.4em; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.85em; }
+  </style>
+</BaseLayout>


### PR DESCRIPTION
## Summary

Closes the **#110 → #101** chain on the marketing-site side: the WASM artifact built by **#134** now has a UI that mounts it, calls `verify_capsule_strict_json`, and renders the 6-check pass/fail report in the browser.

- **`apps/marketing/src/components/PassportVerifier.astro`** — vanilla Astro component (no React island). Lazy-loads `/wasm/sbo3l_core.js` on first verify click via dynamic `import()` so the wasm bundle is **off the FCP path**. Caches the module promise for re-runs. Renders `PASSED` / `SKIPPED` / `FAILED` pills + a per-check detail line, plus a summary banner. Accepts `initialCapsule` + `autorun` props.
- **`apps/marketing/src/pages/proof.astro`** — user-facing surface. Empty textarea, click-to-verify, with a docs section explaining each of the 6 checks (`structural`, `request_hash_recompute`, `policy_hash_recompute`, `receipt_signature`, `audit_chain`, `audit_event_link`) and how v1 capsules honestly skip the four crypto checks they can't prove self-contained.
- **`apps/marketing/src/pages/proof-test.astro`** — CI / operator smoke test. Build-time-reads `test-corpus/passport/v2_golden_001_minimal.json`, mounts `PassportVerifier` with `autorun=true`, expected outcome **6 PASSED**. `data-state="ready"` on the report output exposes a stable selector for headless CI.

## Why these design choices

- **Lazy wasm load** — the wasm bundle is ~120KB gzipped; pulling it on every page hit would tank Lighthouse. Dynamic `import("/wasm/sbo3l_core.js")` only fires on user click (or `autorun` on `/proof-test`).
- **Separate component file** — keeps the verifier portable. Same component embeddable on `/proof`, `/proof-test`, future demo-replay pages, partner-deck microsites without copy-paste.
- **`fs.readFileSync` in frontmatter** (vs vite `?raw` suffix) — Astro static-build runs Node, so frontmatter `fs` is the simplest path that doesn't introduce a vite raw-loader dep.

## Dependencies

- **Depends on #134** (wasm-verifier-slice) for the `/wasm/sbo3l_core.js + sbo3l_core_bg.wasm` artifacts. Once #134 lands, the build script publishes them to `apps/marketing/public/wasm/`.
- **Unblocks Dev 3 (#101)** — public proof URL ready to share in partner DMs (KeeperHub, Uniswap, ENS, 0G).

## Test plan

- [x] `npm run build` clean — 5 pages generated (index, features, proof, proof-test, trust-dns-story)
- [x] `proof-test.html` contains the v2 golden capsule inlined (`grep "research-agent-01"` → 11 hits)
- [x] both `/proof` + `/proof-test` reference `loadWasm` + `verify_capsule_strict_json` via dynamic import
- [ ] post-merge: visit deployed `/proof-test` → confirm 6 green PASSED pills
- [ ] post-merge: visit `/proof`, paste a v1 capsule → 2 PASSED + 4 SKIPPED (no fake-OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)