### PR TITLE
feat(docs): 4 CLI subcommand reference pages (CTI-3-3 slice 2b)

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -55,7 +55,11 @@ export default defineConfig({
           label: "CLI reference",
           items: [
             { label: "Overview", link: "/cli" },
+            { label: "passport run", link: "/cli/passport-run" },
             { label: "passport verify", link: "/cli/passport-verify" },
+            { label: "audit export-bundle", link: "/cli/audit-export-bundle" },
+            { label: "agent register", link: "/cli/agent-register" },
+            { label: "agent verify-ens", link: "/cli/agent-verify-ens" },
           ],
         },
         { label: "API reference", link: "/api" },

--- a/apps/docs/src/content/docs/cli/agent-register.mdx
+++ b/apps/docs/src/content/docs/cli/agent-register.mdx
@@ -1,0 +1,78 @@
+---
+title: agent register
+description: Register a new agent with the daemon — generates an Ed25519 keypair, optionally publishes ENS records.
+audience: agent runtime developers, ops
+outcome: You'll know how to bootstrap an agent identity and where its keys live.
+prereqs:
+  - signing model read
+---
+
+```bash
+sbo3l agent register --agent-id <ID> [--ens <NAME>] [OPTIONS]
+```
+
+Registers a new agent and provisions its identity material on the daemon side. The agent itself never sees the private key.
+
+## Flags
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--agent-id <STRING>` | required | logical identifier; must be unique per daemon |
+| `--ens <NAME>` | none | optionally publish `sbo3l:*` text records under this ENS name |
+| `--signer <kind>` | `in-memory` | one of `in-memory`, `file`, `kms-aws`, `kms-gcp`, `vault` |
+| `--key-path <PATH>` | none | required when `--signer file`; path to chmod-600 secret |
+| `--kms-key-id <ID>` | none | required when `--signer kms-*` |
+| `--dry-run` | off | print plan, exit `rc=3` without state changes |
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | OK — agent registered, pubkey emitted on stdout |
+| `1` | IO error — daemon unreachable, ENS resolver unavailable, file path unwritable |
+| `2` | semantic — agent_id already registered, ENS name controlled by another address |
+| `3` | nothing-to-do — `--dry-run` succeeded |
+
+## Examples
+
+### Local dev (in-memory signer)
+
+```bash
+sbo3l agent register --agent-id research-01
+# stdout: agent_id=research-01 pubkey=ed25519:9aF3...
+# (signer in-memory; lost on daemon restart)
+```
+
+### Production (KMS-backed signer + ENS publish)
+
+```bash
+sbo3l agent register \
+  --agent-id research-01 \
+  --signer kms-aws \
+  --kms-key-id arn:aws:kms:eu-west-1:123:key/abcd \
+  --ens research-01.sbo3lagent.eth
+# Publishes:
+#   sbo3l:pubkey   = ed25519:9aF3...
+#   sbo3l:endpoint = http://127.0.0.1:8730/v1
+#   sbo3l:policy_hash = e044f1...
+#   sbo3l:audit_root  = 0x000000...
+#   sbo3l:proof_uri   = https://sbo3l-marketing.vercel.app/proof
+```
+
+### Dry-run — print plan, don't execute
+
+```bash
+sbo3l agent register --agent-id research-01 --ens research-01.sbo3lagent.eth --dry-run
+# rc=3, prints the plan (keys to generate, records to write) without state changes
+```
+
+## Pitfalls
+
+- **`--signer in-memory` loses signatures on restart.** Audit chain becomes unverifiable for events signed before the restart. Use `file` or `kms-*` for anything beyond ephemeral dev.
+- **ENS publish requires gas.** SBO3L does not hold a wallet; ENS records are written by the operator's wallet (out-of-band). The CLI emits the records as a transaction-payload that the operator submits.
+- **`--agent-id` is permanent in the audit chain.** Renaming requires a fresh agent registration and a chain checkpoint.
+
+## See also
+
+- [`agent verify-ens`](/cli/agent-verify-ens) — confirm published records match daemon state.
+- [Signing model](/concepts/signing) — where the private key actually lives.

--- a/apps/docs/src/content/docs/cli/agent-verify-ens.mdx
+++ b/apps/docs/src/content/docs/cli/agent-verify-ens.mdx
@@ -1,0 +1,86 @@
+---
+title: agent verify-ens
+description: Verify that an agent's published ENS records match its current daemon-side identity.
+audience: integration testers, ops, third-party verifiers
+outcome: You'll know how to detect ENS-vs-daemon drift and what each mismatch means.
+prereqs:
+  - agent register read
+---
+
+```bash
+sbo3l agent verify-ens --ens <NAME> [OPTIONS]
+```
+
+Resolves an ENS name and compares the `sbo3l:*` text records against the local daemon's view of that agent. Fails fast on drift.
+
+## Flags
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--ens <NAME>` | required | ENS name to resolve |
+| `--rpc-url <URL>` | `https://ethereum-rpc.publicnode.com` | mainnet RPC for ENS resolution |
+| `--expected-pubkey <ED25519>` | none | optionally pin the pubkey; mismatch is `rc=2` |
+| `--json` | off | structured output for CI |
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | OK — every record present and matches daemon state |
+| `1` | IO error — RPC down, daemon unreachable, ENS unresolvable |
+| `2` | semantic — at least one record missing or mismatched |
+| `3` | nothing-to-do — ENS name resolves but has zero `sbo3l:*` records |
+
+## Records checked
+
+| Key | Daemon source |
+|---|---|
+| `sbo3l:pubkey` | configured signer's pubkey |
+| `sbo3l:endpoint` | daemon's public bind address |
+| `sbo3l:policy_hash` | active `policy.json` JCS hash |
+| `sbo3l:audit_root` | current chain root |
+| `sbo3l:proof_uri` | configured proof base URL |
+
+A passing run confirms third parties resolving the ENS name see exactly what the daemon claims to be.
+
+## Examples
+
+### Mainnet smoke against the demo agent
+
+```bash
+sbo3l agent verify-ens --ens sbo3lagent.eth
+# stdout (truncated):
+# ✓ pubkey       ed25519:9aF3...   matches
+# ✓ endpoint     http://127.0.0.1:8730/v1
+# ✓ policy_hash  e044f13c5acb...
+# ✓ audit_root   0x000000...
+# ✓ proof_uri    https://sbo3l-marketing.vercel.app/proof
+# rc=0
+```
+
+### CI gate — fail build on drift
+
+```bash
+sbo3l agent verify-ens --ens prod-research-01.sbo3lagent.eth --json | tee verify.json
+test "$(jq -r .rc verify.json)" = "0"
+```
+
+### Pinned pubkey check (third-party verifier)
+
+```bash
+sbo3l agent verify-ens \
+  --ens research-01.sbo3lagent.eth \
+  --expected-pubkey ed25519:9aF3aaaa...
+# rc=2 if the published pubkey ever rotates without the verifier updating
+```
+
+## Pitfalls
+
+- **Public RPC rate limits.** `publicnode.com` is generous but enforces caps. For CI loops use a private RPC.
+- **CCIP-Read records (Phase 2 T-4-1)** — when records move off-chain via ENSIP-25, this command needs the CCIP gateway URL. `--ccip-gateway` flag is added in the T-4-1 ticket; until then, on-chain-only.
+- **ENS namehash mismatch — case sensitivity.** Ensure `--ens` is lowercase; mixed-case names hash differently.
+
+## See also
+
+- [`agent register`](/cli/agent-register) — how the records were published in the first place.
+- [Trust DNS concept](/concepts/trust-dns) — the broader story (lands in T-3-6).

--- a/apps/docs/src/content/docs/cli/audit-export-bundle.mdx
+++ b/apps/docs/src/content/docs/cli/audit-export-bundle.mdx
@@ -1,0 +1,87 @@
+---
+title: audit export-bundle
+description: Export a self-contained audit bundle (multiple events + signatures + index) for archival or batch replay.
+audience: compliance teams, archive operators
+outcome: You'll know how to export a date-ranged bundle, what it contains, and how to verify it round-trip.
+prereqs:
+  - audit log read
+---
+
+```bash
+sbo3l audit export-bundle [OPTIONS] --out <FILE>
+```
+
+Exports a contiguous slice of the audit chain into a single signed bundle (`sbo3l.audit_bundle.v2`). One bundle = many events; the verifier checks every link plus a per-bundle root signature.
+
+## Flags
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--out <FILE>` | required | path to write the bundle |
+| `--from <RFC3339>` | epoch start | export events at-or-after this timestamp |
+| `--to <RFC3339>` | now | export events at-or-before this timestamp |
+| `--agent-pubkey <ED25519>` | all | filter to one agent |
+| `--max-events <N>` | unlimited | hard cap on bundle size |
+| `--gzip` | off | gzip the output |
+
+Time filtering is **inclusive** at both ends. The bundle index records the actual `[from, to]` covered.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | OK — bundle written |
+| `1` | IO error — output path unwritable, daemon unreachable |
+| `2` | semantic — chain has gaps in the requested range; bundle would be incomplete |
+| `3` | nothing-to-do — no events in the requested range |
+
+## Bundle shape
+
+```json
+{
+  "version": "sbo3l.audit_bundle.v2",
+  "bundle_id": "01HZRG...",
+  "covers_from": "2026-04-29T00:00:00Z",
+  "covers_to":   "2026-04-30T23:59:59Z",
+  "event_count": 4219,
+  "first_event_hash": "0x...",
+  "last_event_hash": "0x...",
+  "events": [/* ... event_count entries ... */],
+  "bundle_signature": "ed25519:..."
+}
+```
+
+The bundle signature covers `bundle_id || first_event_hash || last_event_hash || event_count`, so a tampered slice fails the bundle-level check before per-event verification even runs.
+
+## Examples
+
+### Daily compliance export
+
+```bash
+sbo3l audit export-bundle \
+  --from 2026-05-01T00:00:00Z \
+  --to   2026-05-01T23:59:59Z \
+  --gzip --out bundles/2026-05-01.json.gz
+```
+
+### Per-agent slice
+
+```bash
+sbo3l audit export-bundle \
+  --agent-pubkey ed25519:9aF3... \
+  --max-events 1000 \
+  --out research-01-recent.json
+```
+
+### Round-trip verification
+
+```bash
+sbo3l audit export-bundle --out bundle.json
+sbo3l audit verify --mode strict --bundle bundle.json
+# Expected: bundle OK · 4219 events · root 0x... · rc=0
+```
+
+## See also
+
+- [`audit verify` CLI](/cli) — the matching consumer.
+- [Audit log concept](/concepts/audit-log) — what each event contains.

--- a/apps/docs/src/content/docs/cli/passport-run.mdx
+++ b/apps/docs/src/content/docs/cli/passport-run.mdx
@@ -1,0 +1,71 @@
+---
+title: passport run
+description: Emit a self-contained Passport capsule from a recorded daemon decision.
+audience: integration testers, agent runtime developers
+outcome: You'll know how to materialise a capsule for any past decision and pipe it into other tools.
+prereqs:
+  - capsule v2 read
+---
+
+```bash
+sbo3l passport run --request-hash <HASH> [OPTIONS]
+```
+
+Materialises a Passport capsule from a previously-recorded decision. The capsule embeds the policy snapshot, audit segment, and signed receipt — everything needed for offline replay.
+
+## Flags
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--request-hash <HEX>` | required | which decision to capsule |
+| `--out <FILE>` | stdout | write the capsule JSON to a file |
+| `--include-execution` | on | include `execution_ref` + `executor_evidence` if present |
+| `--pretty` | off | indent the output (4-space); off for JCS canonical |
+| `--quiet` | off | suppress info messages on stderr |
+
+The default output is **JCS-canonical** (sorted keys, no insignificant whitespace) so downstream consumers can hash for golden-file comparisons.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | OK — capsule emitted |
+| `1` | IO error — daemon unreachable, request hash missing from local audit |
+| `2` | semantic — request hash exists but decision is incomplete (no signed receipt yet) |
+| `3` | nothing-to-do — `--request-hash` matches no event; nothing to emit |
+
+## Examples
+
+### Emit and verify in one shot
+
+```bash
+sbo3l passport run --request-hash 0xe044f1... | tee capsule.json | sbo3l passport verify --strict
+```
+
+### Round-trip across machines
+
+```bash
+# Producer
+sbo3l passport run --request-hash 0xe044f1... --out capsule.json
+scp capsule.json reviewer@host:/tmp/
+
+# Reviewer
+sbo3l passport verify --strict --path /tmp/capsule.json
+```
+
+### CI golden-file diff
+
+```bash
+sbo3l passport run --request-hash 0xe044f1... > current.json
+diff <(jq -S . current.json) <(jq -S . tests/fixtures/golden-capsule.json)
+```
+
+## Pitfalls
+
+- **Stale audit DB** — if the daemon and the audit DB live on different paths and you point `passport run` at the wrong one, you'll get `rc=3` (nothing-to-do). `--config` chooses an alternate config path; default reads `~/.sbo3l/config.toml`.
+- **`--pretty` breaks hashes** — pretty-printed output is whitespace-different from JCS canonical. Don't pipe a pretty capsule into a hash function expecting it to match a JCS hash.
+
+## See also
+
+- [`passport verify`](/cli/passport-verify) — the matching consumer.
+- [Audit replay](/concepts/audit-replay) — what consumers do with the output.


### PR DESCRIPTION
## Summary

- 4 new CLI reference pages: `passport run`, `audit export-bundle`, `agent register`, `agent verify-ens`.
- Sidebar expanded in narrative order.
- Each page: flags table, exit codes (0/1/2/3 contract), 3 examples, pitfalls section.

## Why

Stacks on slice 2a (#139). Closes the CLI page subset of CTI-3-3 slice 2. LoC: 326 insertions, under the 500-LoC cap.

## Test plan

```bash
cd apps/docs
npm install
npm run typecheck
npm run build              # all 4 new pages must build; schema validator confirms audience+outcome
ls -la dist/cli/passport-run/index.html dist/cli/audit-export-bundle/index.html \
       dist/cli/agent-register/index.html dist/cli/agent-verify-ens/index.html

npm run preview
# - Each new page renders with proper title + lede
# - Cross-links to /concepts/audit-replay / /concepts/signing / /cli/passport-verify resolve
# - Pagefind search returns hits for "JCS-canonical", "bundle_signature", "kms-aws", "namehash"
```

## Out of scope (future slices)

- SDK references (TS via typedoc, Py via sphinx) — separate slice; needs auto-gen tooling.
- OpenAPI Redoc embed at `/api` — separate slice; needs YAML + Redoc CLI build.
- `/concepts/policy` and `/concepts/budget` — separate slice.
- `/reference/errors`, `/reference/schemas`, `/reference/security` — separate slice.
- T-3-6 Trust DNS essay — own ticket.

## Dependencies

- Stacks on slice 2a (#139). Both should land together. GitHub will auto-retarget to main when #122 → #139 chain merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)