### PR TITLE
ci(integrations): per-package release workflow + matrix build-test (P2)

### DIFF
--- a/.github/workflows/integrations-publish.yml
+++ b/.github/workflows/integrations-publish.yml
@@ -1,0 +1,311 @@
+name: Integrations publish
+
+# Per-integration publish workflow. One matrix job per ecosystem (npm and
+# PyPI); build-test runs on every push that touches an integration dir or
+# this workflow file; publish runs only when a matching per-package tag
+# is pushed.
+#
+# Tag conventions:
+#   langchain-ts-v*  → @sbo3l/langchain        (npm)
+#   autogen-v*       → @sbo3l/autogen          (npm)
+#   elizaos-v*       → @sbo3l/elizaos          (npm)
+#   vercel-ai-v*     → @sbo3l/vercel-ai        (npm)
+#   langchain-py-v*  → sbo3l-langchain         (PyPI)
+#   crewai-py-v*     → sbo3l-crewai            (PyPI)
+#   llamaindex-py-v* → sbo3l-llamaindex        (PyPI)
+#   langgraph-py-v*  → sbo3l-langgraph         (PyPI)
+#
+# OIDC trusted publishing (PyPI) and npm provenance (npm) — same model as
+# sdk-typescript.yml + sdk-python.yml.
+
+on:
+  push:
+    branches: ["**"]
+    tags:
+      - "langchain-ts-v*"
+      - "autogen-v*"
+      - "elizaos-v*"
+      - "vercel-ai-v*"
+      - "langchain-py-v*"
+      - "crewai-py-v*"
+      - "llamaindex-py-v*"
+      - "langgraph-py-v*"
+  pull_request:
+    paths:
+      - "integrations/**"
+      - "sdks/typescript/integrations/**"
+      - "sdks/python/integrations/**"
+      - ".github/workflows/integrations-publish.yml"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  # ───────────────────────────────────────────────────────────────────
+  # TS / npm matrix — one job per TS integration
+  # ───────────────────────────────────────────────────────────────────
+  npm-build-test:
+    name: npm build+test (${{ matrix.id }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: langchain-ts
+            dir: integrations/langchain-typescript
+            pkg: "@sbo3l/langchain"
+          - id: autogen
+            dir: integrations/autogen
+            pkg: "@sbo3l/autogen"
+          - id: elizaos
+            dir: integrations/elizaos
+            pkg: "@sbo3l/elizaos"
+          - id: vercel-ai
+            dir: sdks/typescript/integrations/vercel-ai
+            pkg: "@sbo3l/vercel-ai"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install
+        working-directory: ${{ matrix.dir }}
+        run: npm install --no-audit --no-fund
+
+      - name: Typecheck
+        working-directory: ${{ matrix.dir }}
+        run: npm run typecheck
+
+      - name: Test
+        working-directory: ${{ matrix.dir }}
+        run: npm test
+
+      - name: Build
+        working-directory: ${{ matrix.dir }}
+        run: npm run build
+
+  # ───────────────────────────────────────────────────────────────────
+  # PyPI / Python matrix — one job per Python integration
+  # ───────────────────────────────────────────────────────────────────
+  pypi-build-test:
+    name: pypi build+test (${{ matrix.id }} / py${{ matrix.python }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.11", "3.12"]
+        include:
+          - id: langchain-py
+            dir: integrations/langchain-python
+            pkg: sbo3l-langchain
+            module: sbo3l_langchain
+          - id: crewai-py
+            dir: integrations/crewai
+            pkg: sbo3l-crewai
+            module: sbo3l_crewai
+          - id: llamaindex-py
+            dir: integrations/llamaindex
+            pkg: sbo3l-llamaindex
+            module: sbo3l_llamaindex
+          - id: langgraph-py
+            dir: sdks/python/integrations/langgraph
+            pkg: sbo3l-langgraph
+            module: sbo3l_langgraph
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install (workspace SDK + integration + dev extras)
+        working-directory: ${{ matrix.dir }}
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e "${{ github.workspace }}/sdks/python"
+          python -m pip install -e ".[dev]"
+
+      - name: Ruff lint
+        working-directory: ${{ matrix.dir }}
+        run: ruff check .
+
+      - name: Ruff format check
+        working-directory: ${{ matrix.dir }}
+        run: ruff format --check .
+
+      - name: Mypy --strict
+        working-directory: ${{ matrix.dir }}
+        run: mypy --strict ${{ matrix.module }}
+
+      - name: Pytest
+        working-directory: ${{ matrix.dir }}
+        run: pytest -q
+
+      - name: Build wheel + sdist
+        working-directory: ${{ matrix.dir }}
+        run: |
+          python -m pip install build
+          python -m build
+
+  # ───────────────────────────────────────────────────────────────────
+  # npm publish — fires only on `<id>-v*` tag for the matching package
+  # ───────────────────────────────────────────────────────────────────
+  npm-publish:
+    name: npm publish (${{ matrix.id }})
+    runs-on: ubuntu-latest
+    needs: npm-build-test
+    if: |
+      startsWith(github.ref, 'refs/tags/langchain-ts-v') ||
+      startsWith(github.ref, 'refs/tags/autogen-v') ||
+      startsWith(github.ref, 'refs/tags/elizaos-v') ||
+      startsWith(github.ref, 'refs/tags/vercel-ai-v')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: langchain-ts
+            tag_prefix: langchain-ts-v
+            dir: integrations/langchain-typescript
+          - id: autogen
+            tag_prefix: autogen-v
+            dir: integrations/autogen
+          - id: elizaos
+            tag_prefix: elizaos-v
+            dir: integrations/elizaos
+          - id: vercel-ai
+            tag_prefix: vercel-ai-v
+            dir: sdks/typescript/integrations/vercel-ai
+
+    steps:
+      - name: Skip non-matching tag
+        if: ${{ !startsWith(github.ref_name, matrix.tag_prefix) }}
+        run: |
+          echo "Tag ${{ github.ref_name }} does not match prefix ${{ matrix.tag_prefix }} — skipping ${{ matrix.id }}."
+          exit 0
+
+      - uses: actions/checkout@v4
+        if: ${{ startsWith(github.ref_name, matrix.tag_prefix) }}
+
+      - name: Setup Node
+        if: ${{ startsWith(github.ref_name, matrix.tag_prefix) }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install
+        if: ${{ startsWith(github.ref_name, matrix.tag_prefix) }}
+        working-directory: ${{ matrix.dir }}
+        run: npm install --no-audit --no-fund
+
+      - name: Verify tag version matches package.json
+        if: ${{ startsWith(github.ref_name, matrix.tag_prefix) }}
+        working-directory: ${{ matrix.dir }}
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#${{ matrix.tag_prefix }}}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::tag $TAG_VERSION != package.json $PKG_VERSION"
+            exit 1
+          fi
+
+      - name: Build
+        if: ${{ startsWith(github.ref_name, matrix.tag_prefix) }}
+        working-directory: ${{ matrix.dir }}
+        run: npm run build
+
+      - name: Publish (provenance)
+        if: ${{ startsWith(github.ref_name, matrix.tag_prefix) }}
+        working-directory: ${{ matrix.dir }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
+
+  # ───────────────────────────────────────────────────────────────────
+  # PyPI publish — fires only on `<id>-v*` tag for the matching package
+  # ───────────────────────────────────────────────────────────────────
+  pypi-publish:
+    name: pypi publish (${{ matrix.id }})
+    runs-on: ubuntu-latest
+    needs: pypi-build-test
+    if: |
+      startsWith(github.ref, 'refs/tags/langchain-py-v') ||
+      startsWith(github.ref, 'refs/tags/crewai-py-v') ||
+      startsWith(github.ref, 'refs/tags/llamaindex-py-v') ||
+      startsWith(github.ref, 'refs/tags/langgraph-py-v')
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: langchain-py
+            tag_prefix: langchain-py-v
+            dir: integrations/langchain-python
+            pkg: sbo3l-langchain
+          - id: crewai-py
+            tag_prefix: crewai-py-v
+            dir: integrations/crewai
+            pkg: sbo3l-crewai
+          - id: llamaindex-py
+            tag_prefix: llamaindex-py-v
+            dir: integrations/llamaindex
+            pkg: sbo3l-llamaindex
+          - id: langgraph-py
+            tag_prefix: langgraph-py-v
+            dir: sdks/python/integrations/langgraph
+            pkg: sbo3l-langgraph
+
+    environment:
+      name: pypi-${{ matrix.id }}
+      url: https://pypi.org/p/${{ matrix.pkg }}
+
+    steps:
+      - name: Skip non-matching tag
+        if: ${{ !startsWith(github.ref_name, matrix.tag_prefix) }}
+        run: |
+          echo "Tag ${{ github.ref_name }} does not match prefix ${{ matrix.tag_prefix }} — skipping ${{ matrix.id }}."
+          exit 0
+
+      - uses: actions/checkout@v4
+        if: ${{ startsWith(github.ref_name, matrix.tag_prefix) }}
+
+      - name: Setup Python
+        if: ${{ startsWith(github.ref_name, matrix.tag_prefix) }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build
+        if: ${{ startsWith(github.ref_name, matrix.tag_prefix) }}
+        run: python -m pip install --upgrade pip build
+
+      - name: Verify tag version matches pyproject.toml
+        if: ${{ startsWith(github.ref_name, matrix.tag_prefix) }}
+        working-directory: ${{ matrix.dir }}
+        run: |
+          PKG_VERSION=$(python -c "import tomllib; print(tomllib.loads(open('pyproject.toml','rb').read().decode())['project']['version'])")
+          TAG_VERSION="${GITHUB_REF_NAME#${{ matrix.tag_prefix }}}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::tag $TAG_VERSION != pyproject.toml $PKG_VERSION"
+            exit 1
+          fi
+
+      - name: Build
+        if: ${{ startsWith(github.ref_name, matrix.tag_prefix) }}
+        working-directory: ${{ matrix.dir }}
+        run: python -m build
+
+      - name: Publish to PyPI (Trusted Publishing)
+        if: ${{ startsWith(github.ref_name, matrix.tag_prefix) }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: ${{ matrix.dir }}/dist

--- a/.github/workflows/integrations-publish.yml
+++ b/.github/workflows/integrations-publish.yml
@@ -73,6 +73,20 @@ jobs:
         with:
           node-version: "20"
 
+      # Integrations under sdks/typescript/integrations/ depend on @sbo3l/sdk
+      # via `file:../..` and resolve types from the SDK's `dist/` folder.
+      # `npm install` in the integration directory will NOT trigger a build
+      # in the SDK workspace, so typecheck would fail with "Cannot find
+      # module '@sbo3l/sdk'". Build the SDK first, unconditionally — it's
+      # cheap (<10s) and the downstream integrations under
+      # `integrations/<n>/` simply ignore the prebuilt dist/ when they
+      # resolve `@sbo3l/sdk` from the npm registry.
+      - name: Build root SBO3L TS SDK (provides dist/ for file:../.. peers)
+        working-directory: sdks/typescript
+        run: |
+          npm install --no-audit --no-fund
+          npm run build
+
       - name: Install
         working-directory: ${{ matrix.dir }}
         run: npm install --no-audit --no-fund

--- a/.github/workflows/integrations-publish.yml
+++ b/.github/workflows/integrations-publish.yml
@@ -97,7 +97,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      # Use explicit `id` axis × explicit `python` axis instead of
+      # `matrix.python` + `include`. With `include` entries that don't set
+      # `python`, GitHub does NOT cross-product against the python axis —
+      # it adds each include as a single combination with python undefined,
+      # which silently drops 8 of the 12 expected combos and leaves
+      # `${{ matrix.python }}` empty (setup-python then either errors or
+      # falls back to system Python). Listing both axes explicitly keeps
+      # all 12 combos visible in the run summary.
       matrix:
+        id: [langchain-py, crewai-py, llamaindex-py, langgraph-py]
         python: ["3.10", "3.11", "3.12"]
         include:
           - id: langchain-py

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,0 +1,38 @@
+# SBO3L framework integrations
+
+Drop-in adapters that wrap `@sbo3l/sdk` (TS) or `sbo3l-sdk` (Py) for the dominant LLM frameworks. One per directory; each ships independently to npm or PyPI via `.github/workflows/integrations-publish.yml`.
+
+| Package | Path | Registry | Tag |
+|---|---|---|---|
+| `@sbo3l/langchain` | `integrations/langchain-typescript/` | npm | `langchain-ts-v*` |
+| `@sbo3l/autogen` | `integrations/autogen/` | npm | `autogen-v*` |
+| `@sbo3l/elizaos` | `integrations/elizaos/` | npm | `elizaos-v*` |
+| `@sbo3l/vercel-ai` | `sdks/typescript/integrations/vercel-ai/` | npm | `vercel-ai-v*` |
+| `sbo3l-langchain` | `integrations/langchain-python/` | PyPI | `langchain-py-v*` |
+| `sbo3l-crewai` | `integrations/crewai/` | PyPI | `crewai-py-v*` |
+| `sbo3l-llamaindex` | `integrations/llamaindex/` | PyPI | `llamaindex-py-v*` |
+| `sbo3l-langgraph` | `sdks/python/integrations/langgraph/` | PyPI | `langgraph-py-v*` |
+
+## Per-package release flow
+
+1. Bump the package's `version` field (`package.json` for npm, `pyproject.toml` for PyPI).
+2. Open + merge a PR with the bump.
+3. Tag locally and push:
+   ```bash
+   git tag langchain-ts-v1.1.0
+   git push origin langchain-ts-v1.1.0
+   ```
+4. `.github/workflows/integrations-publish.yml` fires the matching matrix entry: verifies the tag version equals the file version, builds, publishes (npm with provenance, PyPI via Trusted Publishing).
+
+Tag-version mismatch fails the workflow before publishing — the version in the file is the source of truth.
+
+## Publish credentials Daniel must provision
+
+- **npm** — `NPM_TOKEN` repo secret + `@sbo3l` scope (one-time setup).
+- **PyPI** — Trusted Publishing config in repo environment `pypi-<id>` (one per integration: `pypi-langchain-py`, `pypi-crewai-py`, `pypi-llamaindex-py`, `pypi-langgraph-py`).
+
+`@sbo3l/sdk` (npm) and `sbo3l-sdk` (PyPI) have their own publish workflows — `sdk-typescript.yml` + `sdk-python.yml`.
+
+## Build-test on every PR
+
+The `npm-build-test` and `pypi-build-test` matrix jobs run on every PR that touches an integration dir or the workflow file. Each integration's tests + lint + (build wheel|build dist) run in isolation; failures don't block sibling integrations (`fail-fast: false`).

--- a/integrations/autogen/package.json
+++ b/integrations/autogen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sbo3l/autogen",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Microsoft AutoGen function adapter wrapping SBO3L — gate every agent payment intent through SBO3L's policy boundary.",
   "license": "MIT",
   "author": "Daniel Babjak <babjak_daniel@hotmail.com>",

--- a/integrations/crewai/pyproject.toml
+++ b/integrations/crewai/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sbo3l-crewai"
-version = "1.0.0"
+version = "1.2.0"
 description = "CrewAI tool wrapping SBO3L — gate every Crew action through SBO3L's policy boundary."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/elizaos/package.json
+++ b/integrations/elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sbo3l/elizaos",
-  "version": "0.1.0",
+  "version": "1.2.0",
   "description": "ElizaOS plugin wrapping SBO3L — gate every agent payment intent through SBO3L's policy boundary.",
   "license": "MIT",
   "author": "Daniel Babjak <babjak_daniel@hotmail.com>",

--- a/integrations/langchain-python/pyproject.toml
+++ b/integrations/langchain-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sbo3l-langchain"
-version = "1.0.0"
+version = "1.2.0"
 description = "LangChain Python tool wrapping SBO3L — gate every agent payment intent through SBO3L's policy boundary."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/langchain-typescript/package.json
+++ b/integrations/langchain-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sbo3l/langchain",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "LangChain JS Tool wrapping SBO3L — gate every agent payment intent through SBO3L's policy boundary.",
   "license": "MIT",
   "author": "Daniel Babjak <babjak_daniel@hotmail.com>",

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sbo3l-llamaindex"
-version = "1.0.0"
+version = "1.2.0"
 description = "LlamaIndex tool wrapping SBO3L — gate every agent payment intent through SBO3L's policy boundary."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdks/python/integrations/langgraph/pyproject.toml
+++ b/sdks/python/integrations/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sbo3l-langgraph"
-version = "1.0.0"
+version = "1.2.0"
 description = "LangGraph adapter for SBO3L — drop a PolicyGuardNode between your plan and execute nodes to gate every action through SBO3L's policy boundary."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdks/typescript/integrations/vercel-ai/package.json
+++ b/sdks/typescript/integrations/vercel-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sbo3l/vercel-ai",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Vercel AI SDK adapter for SBO3L — wrap an APRP submit as an `ai.tool()` with zod parameters.",
   "license": "MIT",
   "author": "Daniel Babjak <babjak_daniel@hotmail.com>",


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/integrations-publish.yml` — matrix workflow covering all 8 framework integrations (4 npm + 4 PyPI). Per-package tags trigger publish; build-test runs on every PR touching an integration.
- Adds `integrations/README.md` with the full release matrix table + flow.

## Tag → package mapping

| Package | Path | Tag |
|---|---|---|
| `@sbo3l/langchain` | `integrations/langchain-typescript/` | `langchain-ts-v*` |
| `@sbo3l/autogen` | `integrations/autogen/` | `autogen-v*` |
| `@sbo3l/elizaos` | `integrations/elizaos/` | `elizaos-v*` |
| `@sbo3l/vercel-ai` | `sdks/typescript/integrations/vercel-ai/` | `vercel-ai-v*` |
| `sbo3l-langchain` | `integrations/langchain-python/` | `langchain-py-v*` |
| `sbo3l-crewai` | `integrations/crewai/` | `crewai-py-v*` |
| `sbo3l-llamaindex` | `integrations/llamaindex/` | `llamaindex-py-v*` |
| `sbo3l-langgraph` | `sdks/python/integrations/langgraph/` | `langgraph-py-v*` |

## Why
Each integration needs its own tag-driven publish path. v1.0.0 release workflow (`crates-publish.yml`) handled Rust crates + the main SDKs; this fills the per-integration gap. Re-uses the OIDC pattern from `sdk-typescript.yml` + `sdk-python.yml` (npm provenance + PyPI Trusted Publishing).

## Job structure

- `npm-build-test` — fail-fast=false matrix over 4 TS integrations; runs `npm install`, `typecheck`, `test`, `build`.
- `pypi-build-test` — fail-fast=false matrix over 4 Py integrations × 3 Python versions (3.10/3.11/3.12); runs ruff lint+format, mypy --strict, pytest, build wheel+sdist.
- `npm-publish` — gated on `<id>-v*` tag, verifies tag-vs-package.json version, builds, `npm publish --provenance --access public`.
- `pypi-publish` — gated on `<id>-v*` tag, verifies tag-vs-pyproject.toml version, builds, `pypa/gh-action-pypi-publish` (Trusted Publishing via per-integration `pypi-<id>` repo environment).

Tag-version mismatch fails before publish; file version is source of truth.

## Provisioning Daniel needs

- **npm:** `NPM_TOKEN` repo secret + `@sbo3l` scope — already required for `sdk-typescript.yml`. Same secret reused.
- **PyPI:** Trusted Publishing config in **per-integration** repo environments: `pypi-langchain-py`, `pypi-crewai-py`, `pypi-llamaindex-py`, `pypi-langgraph-py`. (Per PyPA recommendation each package gets its own environment for least-privilege scoping.)

## Test plan
- [x] YAML parses clean (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [ ] Open this PR → matrix `npm-build-test` and `pypi-build-test` jobs run for every integration in parallel; all 4 npm + 12 pypi cells should green (fail-fast off).
- [ ] (post-merge, post-publish-env-provisioning) push test tag e.g. `langchain-ts-v1.0.1` → `npm-publish` matrix entry `langchain-ts` runs, others skip via tag-prefix guard.

## Out of scope
- Rust crate publish — handled by `.github/workflows/crates-publish.yml` (F-11).
- Main SDK publish — handled by `sdk-typescript.yml` (`@sbo3l/sdk`) + `sdk-python.yml` (`sbo3l-sdk`).
- Auto-bump of dependent integration versions when `@sbo3l/sdk` ships a new major — manual for now; can be a follow-up.

Closes P2 integrations-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)