### PR TITLE
feat(server): /v1/healthz — structured daemon health endpoint

### DIFF
--- a/crates/sbo3l-server/src/lib.rs
+++ b/crates/sbo3l-server/src/lib.rs
@@ -9,6 +9,7 @@
 //! return the cached envelope without re-running any side-effecting step.
 
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
@@ -56,6 +57,12 @@ pub struct AppInner {
     pub audit_signer: DevSigner,
     pub receipt_signer: DevSigner,
     pub auth: AuthConfig,
+    /// Process start time. Surfaced via `/v1/healthz` so Dev 3's
+    /// hosted-app daemon-down detection can render a meaningful
+    /// `uptime_seconds`. Captured once at `AppState::full` time, never
+    /// reset — a daemon restart is a fresh `AppInner` with a fresh
+    /// `started_at`, which is exactly what we want.
+    pub started_at: Instant,
     /// T-3-5 backend: live event bus for `apps/trust-dns-viz/`. Built
     /// only with `--features ws_events`. The publish path inside
     /// `create_payment_request` checks `is_some()` and emits when
@@ -129,6 +136,7 @@ impl AppState {
             audit_signer,
             receipt_signer,
             auth,
+            started_at: Instant::now(),
             #[cfg(feature = "ws_events")]
             ws_events: Some(std::sync::Arc::new(ws_events::WsEventsBus::new())),
         }))
@@ -138,14 +146,115 @@ impl AppState {
 pub fn router(state: AppState) -> Router {
     let r = Router::new()
         .route("/v1/health", get(health))
+        .route("/v1/healthz", get(healthz))
         .route("/v1/payment-requests", post(create_payment_request));
     #[cfg(feature = "ws_events")]
     let r = r.route("/v1/events", get(ws_events::ws_events_handler));
     r.with_state(state)
 }
 
+/// Legacy liveness probe. Returns the literal string `ok`. Kept for
+/// callers that already shipped against the original `/v1/health`
+/// contract; new integrations should prefer [`healthz`] which carries
+/// version + audit-chain head + uptime.
 async fn health() -> &'static str {
     "ok"
+}
+
+/// Structured health response served at `GET /v1/healthz`. Designed
+/// for Dev 3's hosted-app daemon-down detection — one call covers
+/// "is the daemon up", "what version", "is the audit chain alive",
+/// and "for how long". Stable wire format; additive changes only.
+#[derive(Debug, Serialize)]
+pub struct HealthzResponse {
+    /// Always `"ok"` on a 200; on a 503 the body carries
+    /// `"storage_unreachable"` so failure mode is structured, not
+    /// just an HTTP code.
+    pub status: &'static str,
+    /// `Cargo.toml` version of the `sbo3l-server` crate at compile
+    /// time. Useful for confirming a new build actually deployed.
+    pub version: &'static str,
+    /// Hex-encoded `event_hash` of the latest audit event. `null`
+    /// when the chain is empty (fresh daemon, no requests yet).
+    /// Surfacing this lets a probe assert "audit chain advanced"
+    /// across two health calls.
+    pub audit_chain_head: Option<String>,
+    /// Seq number of the chain tip; pairs with `audit_chain_head`
+    /// for a unique identity (the hash alone is monotonic but a
+    /// length lets the probe also see growth).
+    pub audit_chain_length: u64,
+    /// Wall-clock seconds since `AppInner::started_at`. Reset by
+    /// daemon restart, which is the intended semantic.
+    pub uptime_seconds: u64,
+}
+
+/// `GET /v1/healthz` — full daemon health snapshot.
+///
+/// Returns 200 with [`HealthzResponse`] when storage is reachable
+/// (audit-chain head can be queried). Returns 503 with a problem-shape
+/// body when the storage mutex is poisoned or the audit query fails;
+/// either is a hard signal that the daemon can't serve traffic.
+async fn healthz(State(state): State<AppState>) -> Response {
+    let inner = &state.0;
+    let uptime_seconds = inner.started_at.elapsed().as_secs();
+
+    let (head, length) = {
+        let storage = match inner.storage.lock() {
+            Ok(s) => s,
+            Err(_) => {
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(serde_json::json!({
+                        "status": "storage_unreachable",
+                        "reason": "storage mutex poisoned",
+                        "version": env!("CARGO_PKG_VERSION"),
+                        "uptime_seconds": uptime_seconds,
+                    })),
+                )
+                    .into_response();
+            }
+        };
+        let length = match storage.audit_count() {
+            Ok(n) => n,
+            Err(e) => {
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(serde_json::json!({
+                        "status": "storage_unreachable",
+                        "reason": format!("audit_count: {e}"),
+                        "version": env!("CARGO_PKG_VERSION"),
+                        "uptime_seconds": uptime_seconds,
+                    })),
+                )
+                    .into_response();
+            }
+        };
+        let head = match storage.audit_last() {
+            Ok(opt) => opt.map(|ev| ev.event_hash),
+            Err(e) => {
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(serde_json::json!({
+                        "status": "storage_unreachable",
+                        "reason": format!("audit_last: {e}"),
+                        "version": env!("CARGO_PKG_VERSION"),
+                        "uptime_seconds": uptime_seconds,
+                    })),
+                )
+                    .into_response();
+            }
+        };
+        (head, length)
+    };
+
+    Json(HealthzResponse {
+        status: "ok",
+        version: env!("CARGO_PKG_VERSION"),
+        audit_chain_head: head,
+        audit_chain_length: length,
+        uptime_seconds,
+    })
+    .into_response()
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/sbo3l-server/tests/healthz.rs
+++ b/crates/sbo3l-server/tests/healthz.rs
@@ -1,0 +1,121 @@
+//! `GET /v1/healthz` integration tests.
+//!
+//! Dev 3's hosted-app polls this endpoint for daemon-down detection.
+//! The wire format is contract-stable; if these tests need updating,
+//! the hosted-app probe also needs updating.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use sbo3l_server::{reference_policy, router, AppState};
+use sbo3l_storage::Storage;
+use serde_json::Value;
+use tower::ServiceExt;
+
+const APRP_GOLDEN: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../test-corpus/aprp/golden_001_minimal.json"
+));
+
+fn build() -> axum::Router {
+    let storage = Storage::open_in_memory().unwrap();
+    router(AppState::new(reference_policy(), storage))
+}
+
+async fn get_healthz(app: axum::Router) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/healthz")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    (status, json)
+}
+
+#[tokio::test]
+async fn healthz_on_fresh_daemon_returns_ok_with_null_chain_head() {
+    let app = build();
+    let (status, body) = get_healthz(app).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["status"], "ok");
+    assert!(
+        body["version"].as_str().is_some(),
+        "version must be present"
+    );
+    // Fresh storage — no audit events yet — head is null, length 0.
+    assert!(
+        body["audit_chain_head"].is_null(),
+        "fresh chain has null head, got {body}"
+    );
+    assert_eq!(body["audit_chain_length"], 0);
+    assert!(
+        body["uptime_seconds"].as_u64().is_some(),
+        "uptime_seconds must be a u64"
+    );
+}
+
+#[tokio::test]
+async fn healthz_after_request_reports_chain_advanced() {
+    let app = build();
+
+    // Fire one payment request so the audit chain has a tip.
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/payment-requests")
+        .header("content-type", "application/json")
+        .body(Body::from(APRP_GOLDEN.to_string()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let (status, body) = get_healthz(app).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["status"], "ok");
+    assert_eq!(body["audit_chain_length"], 1);
+    let head = body["audit_chain_head"].as_str().unwrap_or_default();
+    assert!(
+        !head.is_empty() && head.chars().all(|c| c.is_ascii_hexdigit()),
+        "audit_chain_head must be a non-empty hex string, got {head:?}"
+    );
+}
+
+#[tokio::test]
+async fn healthz_response_shape_is_stable() {
+    // Locks the wire contract — Dev 3's hosted-app probe parses these
+    // exact keys. Adding a key is fine (additive); removing or
+    // renaming any of these is a breaking change.
+    let app = build();
+    let (_status, body) = get_healthz(app).await;
+    for key in [
+        "status",
+        "version",
+        "audit_chain_head",
+        "audit_chain_length",
+        "uptime_seconds",
+    ] {
+        assert!(
+            body.get(key).is_some(),
+            "/v1/healthz response missing key {key}, got {body}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn legacy_health_endpoint_still_returns_ok() {
+    // /v1/health (the original liveness probe) must keep returning the
+    // literal "ok" — callers shipped against this before /v1/healthz
+    // existed, and we don't want to break them.
+    let app = build();
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/health")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(&body[..], b"ok");
+}


### PR DESCRIPTION
## Summary

Adds `GET /v1/healthz` for **Dev 3's hosted-app daemon-down detection**. The legacy `/v1/health` (literal `"ok"`) is fine for liveness but tells you nothing about whether the daemon is actually serving traffic. One call now covers *is the daemon up*, *what version*, *is the audit chain alive*, and *for how long*.

### Wire format (200)

\`\`\`json
{
  "status": "ok",
  "version": "1.0.0",
  "audit_chain_head": "8f3c…7a21",
  "audit_chain_length": 42,
  "uptime_seconds": 1834
}
\`\`\`

### Wire format (503 — storage unreachable)

\`\`\`json
{
  "status": "storage_unreachable",
  "reason": "audit_count: <error>",
  "version": "1.0.0",
  "uptime_seconds": 1834
}
\`\`\`

### Why these fields

- **`version`** — `env!(\"CARGO_PKG_VERSION\")`, confirms a deploy actually rolled. Cheap canary against caching/CDN issues.
- **`audit_chain_head` + `audit_chain_length`** — pairs let a probe assert *the chain advanced between ping N and ping N+1*. Head is `null` on a fresh daemon, never empty-string.
- **`uptime_seconds`** — monotonic since `AppInner::started_at`. Reset by daemon restart; a flapping daemon shows up as repeatedly-low uptime.

### Implementation

- `AppInner` gains `started_at: std::time::Instant` set by the single `Self::full` constructor. Every existing `AppState::new / ::with_signers / ::with_auth_config` already funnels through `full`, so the field is captured uniformly with no caller changes.
- Storage-unreachable failure mode covers (a) poisoned mutex, (b) `audit_count` error, (c) `audit_last` error — all return 503 with the same problem shape.
- **Legacy `/v1/health` preserved verbatim** — old probes continue to work; new integrations should use `/v1/healthz`.

### Test plan

- [x] `cargo test --package sbo3l-server --test healthz` → 4/4 pass
  - fresh daemon: 200, status=ok, head=null, length=0
  - after one request: head is hex-non-empty, length=1
  - response shape lock — 5 documented keys present
  - legacy `/v1/health` still returns `"ok"`
- [x] `cargo test --package sbo3l-server --features ws_events --tests` → 13/13 pass (no regression)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] post-merge: `curl localhost:8080/v1/healthz` against a running daemon → 200 with valid JSON

unblocks: Dev 3 (hosted-app daemon-down detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)