### PR TITLE
chore(release): v1.0.1 — Phase 2 ENS integration patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to SBO3L are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] — 2026-05-01
+
+**Phase 2 ENS integration patch.** Re-publishes all 9 crates at 1.0.1 to
+include T-3-1 Durin agent registration support. The initial v1.0.0
+publish chain caught `sbo3l-cli` referencing `sbo3l_identity::durin`,
+a module added by PR #116 which landed on main between identity@1.0.0
+and cli@1.0.0 publish steps.
+
+### Added
+- `sbo3l-identity::durin` module — calldata builders for Durin
+  `register(bytes32, string, address, address)` and PublicResolver
+  `multicall(bytes[])`. Selectors recompute-pinned by unit tests
+  (`0x4b7d0927` register, `0xac9650d8` multicall).
+- `sbo3l agent register` CLI subcommand (dry-run path) — prints
+  Durin registration calldata for a given agent name + parent ENS.
+- `crates/sbo3l-server/policies/reference_low_risk.json` — vendored
+  reference policy (was at workspace-root `test-corpus/`, broke cargo
+  publish; #135 vendored it).
+
+### Fixed
+- v1.0.0 cargo publish chain was incomplete (8 of 9 crates landed,
+  cli failed). v1.0.1 re-publishes all 9 cleanly.
+
+[1.0.1]: https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/releases/tag/v1.0.1
+
 ## [1.0.0] — 2026-05-01
 
 **Phase 1 closeout.** First stable release of the SBO3L agent trust layer.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "research-agent"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1940,7 +1940,7 @@ checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
 
 [[package]]
 name = "sbo3l-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1968,7 +1968,7 @@ dependencies = [
 
 [[package]]
 name = "sbo3l-core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -1986,7 +1986,7 @@ dependencies = [
 
 [[package]]
 name = "sbo3l-execution"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "hex",
@@ -2004,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "sbo3l-identity"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "hex",
  "reqwest",
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "sbo3l-keeperhub-adapter"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "hex",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "sbo3l-mcp"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2059,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "sbo3l-policy"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "hex",
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "sbo3l-server"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "sbo3l-storage"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 license = "MIT"
 authors = ["Daniel Babjak <babjak_daniel@hotmail.com>"]
@@ -76,15 +76,15 @@ url = "2"
 # survives). The IP-4 standalone adapter
 # (`crates/sbo3l-keeperhub-adapter`) needs `sbo3l-core` to be
 # publishable, which means the version must be declared here.
-sbo3l-core = { path = "crates/sbo3l-core", version = "1.0.0" }
-sbo3l-policy = { path = "crates/sbo3l-policy", version = "1.0.0" }
-sbo3l-storage = { path = "crates/sbo3l-storage", version = "1.0.0" }
-sbo3l-identity = { path = "crates/sbo3l-identity", version = "1.0.0" }
-sbo3l-execution = { path = "crates/sbo3l-execution", version = "1.0.0" }
-sbo3l-keeperhub-adapter = { path = "crates/sbo3l-keeperhub-adapter", version = "1.0.0" }
-sbo3l-mcp = { path = "crates/sbo3l-mcp", version = "1.0.0" }
-sbo3l-cli = { path = "crates/sbo3l-cli", version = "1.0.0" }
-sbo3l-server = { path = "crates/sbo3l-server", version = "1.0.0" }
+sbo3l-core = { path = "crates/sbo3l-core", version = "1.0.1" }
+sbo3l-policy = { path = "crates/sbo3l-policy", version = "1.0.1" }
+sbo3l-storage = { path = "crates/sbo3l-storage", version = "1.0.1" }
+sbo3l-identity = { path = "crates/sbo3l-identity", version = "1.0.1" }
+sbo3l-execution = { path = "crates/sbo3l-execution", version = "1.0.1" }
+sbo3l-keeperhub-adapter = { path = "crates/sbo3l-keeperhub-adapter", version = "1.0.1" }
+sbo3l-mcp = { path = "crates/sbo3l-mcp", version = "1.0.1" }
+sbo3l-cli = { path = "crates/sbo3l-cli", version = "1.0.1" }
+sbo3l-server = { path = "crates/sbo3l-server", version = "1.0.1" }
 
 [profile.release]
 lto = "thin"

--- a/crates/sbo3l-keeperhub-adapter/Cargo.toml
+++ b/crates/sbo3l-keeperhub-adapter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbo3l-keeperhub-adapter"
-version = "1.0.0"
+version = "1.0.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary

Bumps all Rust crates 1.0.0 → 1.0.1 to ship T-3-1 Durin agent registration that landed in #116 between identity@1.0.0 and cli@1.0.0 publish steps.

The initial v1.0.0 cargo publish chain shipped 8 of 9 crates; sbo3l-cli failed at verify because it references sbo3l_identity::durin which wasn't in the 1.0.0 publish of identity.

## Changes
- workspace.package.version → 1.0.1
- sbo3l-keeperhub-adapter explicit → 1.0.1
- All workspace internal-dep version constraints → 1.0.1
- CHANGELOG.md v1.0.1 section

## After merge
1. Push v1.0.1 tag → triggers crates-publish.yml
2. All 9 crates re-publish at 1.0.1 (clean)
3. New GitHub Release page

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy --workspace --all-targets -D warnings
- [x] cargo build --workspace
- [ ] CI green
- [ ] After merge: cargo publish chain succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)