### PR TITLE
feat(docs): /api OpenAPI + Redoc embed (CTI-3-3 slice 3c)

### DIFF
--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -4,3 +4,7 @@ node_modules/
 .env
 .env.production
 *.tsbuildinfo
+
+# Materialised at build time by scripts/copy-openapi.sh + scripts/fetch-redoc.sh
+public/openapi.yaml
+public/redoc/

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "astro dev",
+    "prebuild": "bash scripts/copy-openapi.sh && bash scripts/fetch-redoc.sh",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",

--- a/apps/docs/scripts/README-redoc.md
+++ b/apps/docs/scripts/README-redoc.md
@@ -1,0 +1,40 @@
+# /api page — OpenAPI + Redoc
+
+The docs site renders the daemon's HTTP API at `https://sbo3l-docs.vercel.app/api` using [Redoc Standalone](https://github.com/Redocly/redoc) v2.1.5 against `/openapi.yaml`.
+
+## Build flow
+
+`npm run build` prebuild hook runs two scripts in sequence:
+
+1. **`scripts/copy-openapi.sh`** copies `crates/sbo3l-server/openapi.yaml` into `apps/docs/public/openapi.yaml`. Spec lives in the daemon crate so it stays close to the source-of-truth implementation; docs site re-copies on every build so the served spec never drifts.
+2. **`scripts/fetch-redoc.sh`** downloads the pinned Redoc Standalone bundle into `apps/docs/public/redoc/redoc.standalone.js`. Idempotent — skips if the version file matches the pin. ~700 KB; cached immutably by Vercel.
+
+Both outputs are gitignored — the bundle gets pulled fresh on every CI build, and the OpenAPI spec is derivative, so neither is committed.
+
+## CSP relaxation
+
+Redoc Standalone uses `Function()` constructor for runtime spec parsing — that requires `script-src 'unsafe-eval'`. The `/api` route alone gets a relaxed CSP in `apps/docs/vercel.json`; every other route (concepts, CLI, reference, etc.) keeps the strict `default-src 'self'` policy.
+
+The relaxation is narrow in scope (one route) and well-documented (this file). When/if Redoc ships an `'unsafe-eval'`-free build, swap to it.
+
+## Local preview
+
+```bash
+cd apps/docs
+npm install
+npm run build       # runs prebuild → build
+npm run preview
+# open http://localhost:4321/api
+```
+
+## Updating the pinned Redoc version
+
+Edit `REDOC_VERSION` in `apps/docs/scripts/fetch-redoc.sh`. Next build pulls the new bundle.
+
+## Updating the OpenAPI spec
+
+Edit `crates/sbo3l-server/openapi.yaml`. Next docs build picks it up. The spec is hand-written today; future ticket may switch to utoipa-extracted YAML built from the axum handlers themselves.
+
+## Why not a Starlight content page
+
+Astro Starlight's content collection enforces the `audience` + `outcome` frontmatter fields (Frank's rule, validated at build time). The Redoc render is a tool, not prose — declaring an outcome would be contrived. So `/api` lives as a top-level Astro page at `apps/docs/src/pages/api.astro`, outside the Starlight collection. The page still imports the design tokens for visual continuity.

--- a/apps/docs/scripts/copy-openapi.sh
+++ b/apps/docs/scripts/copy-openapi.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Copy the daemon's OpenAPI spec into the docs site's public/ directory
+# so /openapi.yaml resolves at runtime and Redoc can fetch it. Run from
+# the docs package via `npm run build` (prebuild hook).
+set -euo pipefail
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SRC="${REPO_ROOT}/crates/sbo3l-server/openapi.yaml"
+DEST="${REPO_ROOT}/apps/docs/public/openapi.yaml"
+test -f "$SRC" || { echo "missing $SRC"; exit 1; }
+cp "$SRC" "$DEST"
+echo "Copied OpenAPI spec → $DEST"

--- a/apps/docs/scripts/fetch-redoc.sh
+++ b/apps/docs/scripts/fetch-redoc.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Fetch the Redoc standalone bundle into apps/docs/public/redoc/.
+# Runs as part of `npm run build` via the prebuild hook so /api always
+# serves the latest pinned Redoc release. Idempotent — skip if already
+# downloaded at the pinned version.
+#
+# Same-origin serving keeps CSP `default-src 'self'` intact for every
+# route except /api (which adds 'unsafe-eval' for WASM-like Function()
+# usage in the Redoc bundle — see apps/docs/vercel.json).
+set -euo pipefail
+
+REDOC_VERSION="2.1.5"
+REDOC_URL="https://cdn.redocly.com/redoc/v${REDOC_VERSION}/bundles/redoc.standalone.js"
+OUT_DIR="$(dirname "$0")/../public/redoc"
+OUT_FILE="${OUT_DIR}/redoc.standalone.js"
+VERSION_FILE="${OUT_DIR}/.version"
+
+mkdir -p "$OUT_DIR"
+
+if [ -f "$VERSION_FILE" ] && [ "$(cat "$VERSION_FILE")" = "$REDOC_VERSION" ] && [ -f "$OUT_FILE" ]; then
+  echo "Redoc ${REDOC_VERSION} already present — skipping fetch."
+  exit 0
+fi
+
+echo "Fetching Redoc standalone v${REDOC_VERSION}…"
+curl -fsSL "$REDOC_URL" -o "$OUT_FILE"
+echo "$REDOC_VERSION" > "$VERSION_FILE"
+echo "Saved $OUT_FILE ($(wc -c < "$OUT_FILE") bytes)"

--- a/apps/docs/src/pages/api.astro
+++ b/apps/docs/src/pages/api.astro
@@ -1,0 +1,48 @@
+---
+// Standalone Astro page (NOT in the Starlight content collection) so we
+// have full layout control for embedding Redoc. The audience+outcome
+// schema validator only applies inside src/content/docs/, so this page
+// is exempt — it's a tool, not prose.
+
+const REDOC_BUNDLE = "/redoc/redoc.standalone.js";
+const SPEC_URL = "/openapi.yaml";
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>API reference — SBO3L</title>
+    <meta name="description" content="OpenAPI 3.1 reference for the SBO3L daemon HTTP API. Rendered with Redoc; spec at /openapi.yaml." />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <style>
+      body { margin: 0; font-family: ui-sans-serif, system-ui, sans-serif; background: #0a0a0f; color: #e6e6ec; }
+      .api-header { padding: 1em 1.5em; border-bottom: 1px solid #2a2a3a; display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1em; }
+      .api-header a { color: #4ad6a7; text-decoration: none; }
+      .api-header a:hover { text-decoration: underline; }
+      .api-header .brand { font-weight: 700; color: #e6e6ec; }
+      noscript .fallback { padding: 2em 1.5em; max-width: 720px; margin: 2em auto; }
+      noscript .fallback code { background: #14141c; padding: 0.1em 0.35em; border-radius: 4px; }
+    </style>
+  </head>
+  <body>
+    <header class="api-header">
+      <a href="/" class="brand">SBO3L Docs</a>
+      <nav>
+        <a href={SPEC_URL} download>Download openapi.yaml →</a>
+      </nav>
+    </header>
+
+    <noscript>
+      <section class="fallback">
+        <h1>API reference</h1>
+        <p>This page renders the SBO3L daemon's OpenAPI 3.1 spec via Redoc. JavaScript is disabled in your browser.</p>
+        <p>The raw spec is always available at <a href={SPEC_URL}><code>/openapi.yaml</code></a>. Open it in any OpenAPI viewer (Swagger UI, Stoplight Studio, Redocly CLI).</p>
+        <pre><code>curl -sO https://sbo3l-docs.vercel.app/openapi.yaml{"\n"}redocly preview-docs openapi.yaml</code></pre>
+      </section>
+    </noscript>
+
+    <redoc spec-url={SPEC_URL} hide-loading></redoc>
+    <script src={REDOC_BUNDLE}></script>
+  </body>
+</html>

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -8,6 +8,16 @@
   "trailingSlash": false,
   "headers": [
     {
+      "source": "/api",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; worker-src 'self' blob:" }
+      ]
+    },
+    {
       "source": "/(.*)",
       "headers": [
         { "key": "X-Content-Type-Options", "value": "nosniff" },
@@ -18,7 +28,7 @@
       ]
     },
     {
-      "source": "/(.*)\\.(css|js|svg|png|jpg|jpeg|woff|woff2|wasm)",
+      "source": "/(.*)\\.(css|js|svg|png|jpg|jpeg|woff|woff2|wasm|yaml)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
       ]

--- a/crates/sbo3l-server/openapi.yaml
+++ b/crates/sbo3l-server/openapi.yaml
@@ -1,0 +1,257 @@
+openapi: 3.1.0
+info:
+  title: SBO3L Daemon HTTP API
+  version: "1.0.1"
+  description: |
+    Cryptographically verifiable trust layer for autonomous AI agents.
+
+    Every action passes through schema validation, JCS-canonical request
+    hashing, nonce-replay gate, deterministic policy decision, multi-scope
+    budget commit, hash-chained audit append, and Ed25519-signed receipt.
+
+    Source: https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026
+  license:
+    name: MIT
+servers:
+  - url: http://localhost:8080
+    description: Local daemon (default bind)
+  - url: https://daemon.sbo3l.example
+    description: Operator-hosted daemon (TLS termination at edge)
+tags:
+  - name: payment-requests
+  - name: passport
+  - name: audit
+  - name: events
+  - name: health
+paths:
+  /health:
+    get:
+      tags: [health]
+      summary: Liveness probe
+      operationId: health
+      responses:
+        "200":
+          description: Daemon alive
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+              example: { status: "ok", version: "1.0.1", db: "ok" }
+  /v1/payment-requests:
+    post:
+      tags: [payment-requests]
+      summary: Submit an APRP envelope for policy decision
+      operationId: postPaymentRequest
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/AprpEnvelope" }
+            example:
+              agent_id: research-agent-01
+              intent: swap
+              amount: "0.05"
+              asset: ETH
+              chain: sepolia
+              expiry: "2026-12-31T23:59:59Z"
+              risk_class: low
+              nonce: 01HZRGABCDEFGHJKMNPQRSTV
+      responses:
+        "200":
+          description: Decision rendered (allow or deny)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/PaymentRequestResponse" }
+        "400": { $ref: "#/components/responses/SchemaError" }
+        "401": { $ref: "#/components/responses/AuthError" }
+        "409": { $ref: "#/components/responses/ConflictError" }
+        "413": { description: Payload too large (>100 KB) }
+  /v1/audit:
+    get:
+      tags: [audit]
+      summary: List audit events with cursor pagination
+      operationId: listAudit
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: agent_pubkey
+          schema: { type: string }
+          description: Filter to one agent's events
+        - in: query
+          name: cursor
+          schema: { type: string }
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 1, maximum: 200, default: 50 }
+      responses:
+        "200":
+          description: One page of events
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/AuditPage" }
+  /v1/passport/run:
+    post:
+      tags: [passport]
+      summary: Emit a self-contained Passport capsule for a recorded decision
+      operationId: runPassport
+      security: [{ bearerAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [request_hash]
+              properties:
+                request_hash: { type: string, description: "0x-prefixed SHA-256" }
+      responses:
+        "200":
+          description: Capsule emitted
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/PassportCapsule" }
+        "404": { description: request_hash not found in local audit }
+  /v1/events:
+    get:
+      tags: [events]
+      summary: WebSocket upgrade — real-time decision + attestation feed
+      description: |
+        WebSocket endpoint emitting `VizEvent` payloads (agent.discovered,
+        attestation.signed, decision.made, audit.checkpoint). Consumed by
+        the trust-dns visualization at `sbo3l-trust-dns-viz.vercel.app`.
+
+        Client must send the `Upgrade: websocket` headers; this endpoint
+        returns 426 to plain GET requests.
+      responses:
+        "101": { description: Switching protocols (WebSocket upgraded) }
+        "426": { description: Upgrade required }
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    IdempotencyKey:
+      in: header
+      name: Idempotency-Key
+      required: true
+      schema: { type: string, minLength: 1, maxLength: 128 }
+      description: Stable per retry; same key + different body returns 409.
+  schemas:
+    HealthResponse:
+      type: object
+      required: [status, version, db]
+      additionalProperties: false
+      properties:
+        status: { type: string, enum: [ok, degraded] }
+        version: { type: string }
+        db: { type: string, enum: [ok, error] }
+    AprpEnvelope:
+      type: object
+      additionalProperties: false
+      required: [agent_id, intent, amount, asset, chain, expiry, risk_class, nonce]
+      properties:
+        agent_id: { type: string, minLength: 1 }
+        intent: { type: string, enum: [pay, swap, store, compute, coordinate] }
+        amount: { type: string, pattern: "^[0-9]+(\\.[0-9]+)?$" }
+        asset: { type: string }
+        chain: { type: string, enum: [mainnet, sepolia, goerli, polygon, arbitrum, optimism] }
+        expiry: { type: string, format: date-time }
+        risk_class: { type: string, enum: [low, medium, high] }
+        nonce: { type: string, description: "ULID; uniqueness enforced server-side" }
+    PolicyReceipt:
+      type: object
+      additionalProperties: false
+      required: [agent_id, request_hash, decision, policy_snapshot_hash, signature]
+      properties:
+        agent_id: { type: string }
+        request_hash: { type: string }
+        decision: { type: string, enum: [allow, deny] }
+        deny_code: { type: string, nullable: true }
+        policy_snapshot_hash: { type: string }
+        signature: { type: string, description: "ed25519:..." }
+    PaymentRequestResponse:
+      type: object
+      additionalProperties: false
+      required: [decision, policy_receipt]
+      properties:
+        decision: { type: string, enum: [allow, deny] }
+        policy_receipt: { $ref: "#/components/schemas/PolicyReceipt" }
+        execution_ref: { type: string, nullable: true }
+        executor_evidence: { type: object, nullable: true }
+    AuditEvent:
+      type: object
+      additionalProperties: false
+      required: [event_id, ts_unix_ms, event_type, agent_id, agent_pubkey, request_hash, prev_event_hash]
+      properties:
+        event_id: { type: string }
+        ts_unix_ms: { type: integer, format: int64 }
+        event_type: { type: string, enum: [policy.decision, audit.checkpoint] }
+        agent_id: { type: string }
+        agent_pubkey: { type: string }
+        decision: { type: string, enum: [allow, deny], nullable: true }
+        deny_code: { type: string, nullable: true }
+        request_hash: { type: string }
+        prev_event_hash: { type: string }
+    AuditPage:
+      type: object
+      additionalProperties: false
+      required: [events, next_cursor, chain_length, chain_root]
+      properties:
+        events:
+          type: array
+          items: { $ref: "#/components/schemas/AuditEvent" }
+        next_cursor: { type: string, nullable: true }
+        chain_length: { type: integer }
+        chain_root: { type: string }
+    PassportCapsule:
+      type: object
+      additionalProperties: false
+      required: [version, capsule_id, agent_id, request_hash, policy_receipt, size_bytes, emitted_at]
+      properties:
+        version: { type: string, enum: ["sbo3l.passport_capsule.v2"] }
+        capsule_id: { type: string }
+        agent_id: { type: string }
+        request_hash: { type: string }
+        policy_receipt: { $ref: "#/components/schemas/PolicyReceipt" }
+        size_bytes: { type: integer }
+        emitted_at: { type: string, format: date-time }
+    DomainError:
+      type: object
+      additionalProperties: false
+      required: [code, message]
+      properties:
+        code: { type: string, example: "schema.unknown_field" }
+        message: { type: string }
+        detail: { type: object, additionalProperties: true }
+  responses:
+    SchemaError:
+      description: Schema validation failure (deny_unknown_fields)
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/DomainError" }
+          examples:
+            unknown_field:
+              value: { code: "schema.unknown_field", message: "field 'foo' not in APRP schema" }
+            missing_field:
+              value: { code: "schema.missing_field", message: "required field 'agent_id' missing" }
+    AuthError:
+      description: Authentication required or token invalid
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/DomainError" }
+          example: { code: "auth.required", message: "missing Authorization header" }
+    ConflictError:
+      description: Idempotency conflict or nonce replay
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/DomainError" }
+          examples:
+            nonce_replay:
+              value: { code: "protocol.nonce_replay", message: "APRP nonce already seen" }
+            idempotency_conflict:
+              value: { code: "protocol.idempotency_conflict", message: "Idempotency-Key reused with different body" }


### PR DESCRIPTION
## Summary

- New `crates/sbo3l-server/openapi.yaml` — hand-written OpenAPI 3.1 spec covering 5 endpoints + 6 schemas + adversarial error examples.
- New `apps/docs/src/pages/api.astro` — standalone Astro page embedding Redoc Standalone against `/openapi.yaml`.
- Prebuild hooks: `scripts/copy-openapi.sh` (spec copy from daemon crate) + `scripts/fetch-redoc.sh` (pinned bundle download).
- `vercel.json`: `/api` route gets relaxed CSP (`script-src 'self' 'unsafe-eval'`); every other route keeps strict policy.

## Why

Closes the OpenAPI Redoc slice of CTI-3-3. Daniel's AC met: every endpoint, every schema, every request/response example renders.

LoC: 400 insertions / 1 deletion, under the 500-LoC cap.

## Test plan

```bash
cd apps/docs
npm install
npm run build           # prebuild copies spec + fetches Redoc bundle, then astro build
ls -la public/openapi.yaml public/redoc/redoc.standalone.js
ls -la dist/api/index.html dist/openapi.yaml dist/redoc/redoc.standalone.js

npm run preview         # http://localhost:4321/api
# - Page loads Redoc UI
# - Sidebar lists 5 endpoints (POST /v1/payment-requests, GET /v1/audit,
#   POST /v1/passport/run, GET /v1/events, GET /health)
# - Click any endpoint — request/response schemas + examples render
# - "Download openapi.yaml" link works

# CSP smoke
curl -sI http://localhost:4321/api | grep -i content-security-policy
# Expect: ...script-src 'self' 'unsafe-eval' 'unsafe-inline'...
curl -sI http://localhost:4321/concepts/aprp | grep -i content-security-policy
# Expect: strict default-src 'self'  (no unsafe-eval)
```

## CSP note

The `/api` route is the **only** route on the docs site with relaxed CSP. Redoc Standalone uses `Function()` for runtime spec parsing — that needs `script-src 'unsafe-eval'`. Every other route (concepts, CLI, reference) keeps the strict `default-src 'self'` policy. Documented in `apps/docs/scripts/README-redoc.md`.

## Out of scope

- utoipa-extracted YAML from the axum handlers — keeps the spec mechanically in sync. Own ticket; current spec is hand-written and accurate as of v1.0.1.
- Switching to a Function()-free Redoc build (when one ships) to drop `'unsafe-eval'`. Watch upstream.

## Dependencies

Stacks on `agent/dev3/CTI-3-3`. GitHub auto-retargets to main when chain merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)