### PR TITLE
feat(marketing): /submission landing — judges-tailored entry (P3)

### DIFF
--- a/apps/marketing/src/pages/submission.astro
+++ b/apps/marketing/src/pages/submission.astro
@@ -1,0 +1,187 @@
+---
+import BaseLayout from "~/layouts/BaseLayout.astro";
+
+const githubRepoUrl = "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026";
+
+const cards = [
+  {
+    track: "ENS · Most Creative",
+    title: "Trust DNS for autonomous agents",
+    body: "Every agent registers under <code>sbo3lagent.eth</code>; CCIP-Read keeps records writable at agent speeds; the audit chain functions as the DNS query log. ENS isn't a checkbox — it's the protocol's identity layer.",
+    cta: { text: "Read the Trust DNS essay", href: "https://sbo3l-docs.vercel.app/concepts/trust-dns" },
+  },
+  {
+    track: "KeeperHub · Best Use",
+    title: "Production-shaped sponsor adapter",
+    body: "<code>sbo3l-keeperhub-adapter</code> ships with mock + live constructors as first-class peers. Live workflow <code>m4t4cnpmhv8qquce3bv3c</code> ran end-to-end during the submission window; KH-issued <code>execution_ref</code> is in the published audit chain.",
+    cta: { text: "See the live evidence", href: "/#live-integration-evidence-2026-04-30" },
+  },
+  {
+    track: "Multi-framework · all 8 sponsor tracks",
+    title: "Eight integrations, one signed envelope",
+    body: "Adapters for LangChain (TS + Py), CrewAI, AutoGen, ElizaOS, LlamaIndex, Vercel AI SDK. Every integration uses the same APRP wire format; same Ed25519-signed receipts; same offline-verifiable Passport capsules. Switch frameworks without re-doing trust.",
+    cta: { text: "Browse SDK references", href: "https://sbo3l-docs.vercel.app/reference/sdk-typescript" },
+  },
+];
+
+const urls = [
+  { label: "Marketing", href: "https://sbo3l-marketing.vercel.app", note: "Landing + features + /proof + /demo + this page" },
+  { label: "Docs", href: "https://sbo3l-docs.vercel.app", note: "Astro Starlight; concept guides + CLI ref + API ref + auto-gen SDK refs" },
+  { label: "Hosted preview", href: "https://sbo3l-app.vercel.app", note: "Free-tier dashboard with GitHub OAuth; live decision feed" },
+  { label: "Trust DNS viz", href: "https://sbo3l-trust-dns-viz.vercel.app", note: "Force-directed graph + bench harness; embeds in /demo" },
+  { label: "CCIP gateway", href: "https://sbo3l-ccip.vercel.app", note: "ENSIP-25 off-chain text-record gateway (T-4-1)" },
+  { label: "GitHub", href: "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026", note: "Source, issues, releases (v1.0.1 latest)" },
+  { label: "crates.io", href: "https://crates.io/teams/github:b2jk-industry:owners", note: "9 publishable sbo3l-* Rust crates" },
+  { label: "npm", href: "https://www.npmjs.com/org/sbo3l", note: "@sbo3l/sdk, @sbo3l/langchain, @sbo3l/autogen, @sbo3l/vercel-ai" },
+  { label: "PyPI", href: "https://pypi.org/user/sbo3l/", note: "sbo3l-sdk, sbo3l-langchain, sbo3l-crewai, sbo3l-llamaindex" },
+  { label: "Mainnet ENS", href: "https://app.ens.domains/sbo3lagent.eth", note: "Demo agent — 5 sbo3l:* records published" },
+];
+---
+<BaseLayout
+  title="SBO3L — ETHGlobal Open Agents 2026 submission"
+  description="30-second pitch + live URLs + judges-ready demo. SBO3L is the cryptographically verifiable trust layer for autonomous AI agents."
+  ogTitle="SBO3L — Submission for ETHGlobal Open Agents 2026"
+>
+  <section class="pitch">
+    <p class="eyebrow">ETHGlobal Open Agents 2026 · Submission</p>
+    <h1>The cryptographically verifiable trust layer for autonomous AI agents.</h1>
+    <p class="lede">
+      Every action your agent takes — pay, swap, store, compute, coordinate — passes through SBO3L's policy boundary
+      first: schema validation, deterministic policy, multi-scope budget, hash-chained audit, Ed25519-signed receipt,
+      sponsor adapter routing. Output: a self-contained Passport capsule anyone can verify offline against the
+      agent's published Ed25519 pubkey alone — no daemon, no network, no RPC.
+    </p>
+    <p class="lede">
+      <strong>Don't give your agent a wallet. Give it a mandate.</strong>
+    </p>
+    <div class="cta">
+      <a class="btn primary" href="/demo">Walk the demo →</a>
+      <a class="btn ghost" href="/proof">Verify a capsule yourself</a>
+      <a class="btn ghost" href={githubRepoUrl}>View source</a>
+    </div>
+  </section>
+
+  <section class="numbers" aria-label="Key submission metrics">
+    <div class="number"><strong>8/8</strong><span>sponsor tracks shipped</span></div>
+    <div class="number"><strong>4 + 4</strong><span>npm + PyPI packages live (v1.0.1)</span></div>
+    <div class="number"><strong>5</strong><span>concrete adapters: KH · Uniswap · ENS · CCIP · CrewAI</span></div>
+    <div class="number"><strong>11</strong><span>adversarial inputs fail-closed</span></div>
+  </section>
+
+  <section class="cards">
+    {cards.map((c) => (
+      <article class="card">
+        <p class="track">{c.track}</p>
+        <h2>{c.title}</h2>
+        <p class="body" set:html={c.body}></p>
+        <a class="cta-link" href={c.cta.href}>{c.cta.text} →</a>
+      </article>
+    ))}
+  </section>
+
+  <section class="trailer">
+    <h2>The 90-second walkthrough</h2>
+    <p>
+      Click into the demo for four self-contained steps: meet the agents, watch a decision land, verify a capsule in your browser, explore the trust graph. Each step under 30 seconds; mobile-friendly.
+    </p>
+    <div class="trailer-grid">
+      <a class="trailer-card" href="/demo/1-meet-the-agents">
+        <span class="num">1</span><span class="label">Meet the agents</span>
+      </a>
+      <a class="trailer-card" href="/demo/2-watch-a-decision">
+        <span class="num">2</span><span class="label">Watch a decision</span>
+      </a>
+      <a class="trailer-card" href="/demo/3-verify-yourself">
+        <span class="num">3</span><span class="label">Verify yourself</span>
+      </a>
+      <a class="trailer-card" href="/demo/4-explore-the-trust-graph">
+        <span class="num">4</span><span class="label">Explore the graph</span>
+      </a>
+    </div>
+  </section>
+
+  <section class="urls">
+    <h2>Live URL inventory</h2>
+    <p>Everything below is live and reachable now. Click through; nothing's a screenshot.</p>
+    <ul>
+      {urls.map((u) => (
+        <li>
+          <a href={u.href}>{u.label}</a>
+          <span class="href"><code>{u.href}</code></span>
+          <span class="note">{u.note}</span>
+        </li>
+      ))}
+    </ul>
+  </section>
+
+  <section class="verify">
+    <h2>The judge-test</h2>
+    <p>
+      Don't take our word for any claim above. Drop a capsule onto <a href="/proof"><code>/proof</code></a>. The
+      WebAssembly verifier — same Rust code that runs inside the daemon, compiled to wasm32 — runs all 6 strict
+      checks in your browser. No upload, no API call, no daemon. Six green checks or a specific reject reason.
+    </p>
+    <div class="cta">
+      <a class="btn primary" href="/proof">Verify yourself →</a>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  section { max-width: var(--max); margin: 3em auto; padding: 0 1.5em; }
+
+  .pitch .eyebrow { color: var(--accent); font-family: var(--font-mono); font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 1em; }
+  .pitch h1 { font-size: var(--fs-4); line-height: 1.2; font-weight: 700; margin-bottom: 0.7em; }
+  .pitch .lede { font-size: var(--fs-2); color: var(--muted); max-width: 760px; margin-bottom: 1em; }
+  .pitch .lede strong { color: var(--fg); }
+  .pitch .cta { display: flex; gap: 1em; flex-wrap: wrap; margin-top: 1.5em; }
+
+  .numbers { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1.5em; padding: 1.5em; border: 1px solid var(--border); border-radius: var(--r-lg); }
+  .number { text-align: center; color: var(--muted); }
+  .number strong { display: block; font-size: 1.6em; color: var(--accent); font-weight: 700; margin-bottom: 0.2em; }
+  .number span { font-size: 0.95em; }
+
+  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1em; }
+  .card { padding: 1.4em; border: 1px solid var(--border); border-radius: var(--r-lg); background: var(--code-bg); }
+  .card .track { color: var(--accent); font-family: var(--font-mono); font-size: 0.78em; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.5em; }
+  .card h2 { font-size: 1.2em; font-weight: 700; margin-bottom: 0.6em; }
+  .card .body { color: var(--muted); font-size: 0.95em; margin-bottom: 1em; }
+  .card .body code { font-size: 0.9em; }
+  .card .cta-link { color: var(--accent); font-weight: 600; }
+
+  .trailer h2 { font-size: var(--fs-3); margin-bottom: 0.5em; }
+  .trailer p { color: var(--muted); margin-bottom: 1.5em; max-width: 760px; }
+  .trailer-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.8em; }
+  .trailer-card {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.8em;
+    align-items: center;
+    padding: 1em 1.2em;
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    background: var(--code-bg);
+    color: var(--fg);
+    text-decoration: none;
+    transition: border-color 0.15s;
+  }
+  .trailer-card:hover { border-color: var(--accent); text-decoration: none; }
+  .trailer-card .num { font-size: 1.4em; font-weight: 700; color: var(--accent); }
+
+  .urls h2 { font-size: var(--fs-3); margin-bottom: 0.5em; }
+  .urls > p { color: var(--muted); margin-bottom: 1.5em; }
+  .urls ul { list-style: none; padding: 0; display: grid; gap: 0.6em; }
+  .urls li { display: grid; grid-template-columns: 9em 1fr 1fr; gap: 1em; align-items: center; padding: 0.7em 1em; border: 1px solid var(--border); border-radius: var(--r-md); background: var(--code-bg); }
+  .urls li a { color: var(--accent); font-weight: 600; }
+  .urls li .href { font-size: 0.85em; color: var(--muted); }
+  .urls li .note { color: var(--muted); font-size: 0.9em; }
+
+  .verify h2 { font-size: var(--fs-3); margin-bottom: 0.5em; }
+  .verify p { color: var(--muted); margin-bottom: 1em; max-width: 760px; }
+  .verify .cta { display: flex; gap: 1em; }
+
+  @media (max-width: 640px) {
+    .urls li { grid-template-columns: 1fr; gap: 0.3em; }
+    .urls li .href, .urls li .note { font-size: 0.8em; }
+  }
+</style>


### PR DESCRIPTION
## Summary

- New `apps/marketing/src/pages/submission.astro` — single curated submission entry page.
- 30-second pitch + numbers strip + 3 narrative cards + 4-step demo trailer + 10-URL inventory + verify-yourself CTA.
- One file, no new dependencies, no external CDNs. Mobile-friendly grids.

## Why

P3 from Daniel's brief — judges-tailored entry that fits in a chat message, an ETHGlobal form, or a README link. LoC: 187 insertions, one file.

## Test plan

```bash
cd apps/marketing
npm install
npm run typecheck
npm run build
ls -la dist/submission/index.html

npm run preview         # http://localhost:4321/submission
# - Hero with eyebrow / h1 / lede / 3 CTAs (Walk demo / Verify capsule / View source)
# - Numbers strip with 4 metrics
# - 3 cards (ENS, KeeperHub, multi-framework) — each with track tag + body + cta link
# - "The 90-second walkthrough" 4-card grid linking into /demo/{1,2,3,4}
# - URL inventory: 10 rows (label / URL / note) clickable to live sites
# - "The judge-test" verify-yourself CTA → /proof

# Mobile (375px viewport): URL inventory rows reflow to single column
```

## Out of scope

- Embedded /demo trailer is a CARD-GRID-LINK approach (not iframe) — keeps the page lightweight and lets each demo step open in a fresh visit. Daniel's brief said "Embedded /demo trailer"; if the iframe variant is preferred, it's a 5-line swap.
- T-3-7 ENS Most Creative submission narrative (Daniel-owned) is separate; this page complements it as the public-facing 30-second entry.

## Dependencies

- /demo routes (PR #150 still in flight). Until #150 merges, the trailer-card links 404 gracefully. Both PRs land on main shortly via auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)