### PR TITLE
docs(submission): enrich with memory-pinned live evidence

### DIFF
--- a/docs/submission/ETHGlobal-form-content.md
+++ b/docs/submission/ETHGlobal-form-content.md
@@ -40,9 +40,13 @@ The form fields below are derived from typical ETHGlobal submission forms. If th
 
 > Every action that flows through SBO3L's `KeeperHubExecutor` is gated by an APRP policy decision before any KeeperHub workflow webhook is called. Allowed actions arrive at KH with a signed `sbo3l_*` envelope (request_hash, policy_hash, receipt_signature, audit_event_id, optional passport_uri) — five optional fields KH can echo back to make every execution row cryptographically linked to the upstream authorisation.
 >
-> SBO3L ships a standalone `sbo3l-keeperhub-adapter` crate on crates.io implementing IP-1..IP-5 from the integration paths doc. The adapter has both `local_mock()` (CI-safe default) and `live_from_env()` (real `wfb_…` token + workflow id) constructors. Live submissions to KeeperHub were exercised end-to-end as part of the demo gate — execution id `kh-<ULID>` is captured into the Passport capsule for offline verification.
+> SBO3L ships a standalone `sbo3l-keeperhub-adapter` crate on crates.io implementing IP-1..IP-5 from the integration paths doc. The adapter has both `local_mock()` (CI-safe default) and `live_from_env()` (real `wfb_…` token + workflow id) constructors. Live submissions to KeeperHub were exercised end-to-end on submission day against workflow `m4t4cnpmhv8qquce3bv3c`; the IP-1 envelope POST returned a real `executionId` of the form `kh-172o77rxov7mhwvpssc3x` (KH-format, *not* a ULID — that's KeeperHub's own identifier scheme), captured into the Passport capsule's `execution.live_evidence` for offline verification.
 
-**Live integration evidence:** [`demo-scripts/sponsors/keeperhub-real-execution.sh`](../../demo-scripts/sponsors/keeperhub-real-execution.sh) + [`crates/sbo3l-keeperhub-adapter/`](../../crates/sbo3l-keeperhub-adapter/)
+**Live integration evidence:**
+- Webhook URL: `https://app.keeperhub.com/api/workflows/m4t4cnpmhv8qquce3bv3c/webhook`
+- Live arm: [`crates/sbo3l-keeperhub-adapter/`](../../../crates/sbo3l-keeperhub-adapter/) — `submit_live_to`
+- Demo gate: [`demo-scripts/sponsors/keeperhub-real-execution.sh`](../../../demo-scripts/sponsors/keeperhub-real-execution.sh)
+- Real execution captured: `kh-172o77rxov7mhwvpssc3x` (re-run sweep produces a fresh one)
 
 **5+ specific KH improvement issues filed:** _populate from `FEEDBACK.md` after T-2-1 lands_
 
@@ -54,18 +58,21 @@ The form fields below are derived from typical ETHGlobal submission forms. If th
 
 **How does your project use ENS?**
 
-> SBO3L turns ENS into *the agent trust DNS*. Every named agent gets a subname under `sbo3lagent.eth` (mainnet apex) with seven `sbo3l:*` text records: `agent_id`, `endpoint`, `policy_hash`, `audit_root`, `proof_uri`, `capability` (new in Phase 2), `reputation` (new in Phase 2, computed from the audit chain).
+> SBO3L turns ENS into *the agent trust DNS*. Every named agent gets a subname under `sbo3lagent.eth` (mainnet apex Daniel owns) with `sbo3l:*` text records. v1.0.1 ships **5 records on chain** (`agent_id`, `endpoint`, `policy_hash`, `audit_root`, `proof_uri`); Phase 2 adds two more (`capability`, `reputation`) for the full 7-record profile. Subname registration uses **direct ENS Registry `setSubnodeRecord`** (Daniel is the parent owner) + PublicResolver `setText` per record — no third-party registrar abstraction needed (we evaluated Durin and dropped it 2026-05-01: direct registry is fewer moving parts, more verifiable on Etherscan, and zero new contracts to deploy).
 >
 > An agent resolves another agent by ENS name and gets back a complete trust profile — *without trusting any single party*. Cross-agent attestations are signed Ed25519 envelopes that pin the recipient's expected `policy_hash` and an `expires_at`; the receiving SBO3L instance verifies the chain (sender's pubkey → recipient's published policy → recipient's actual decision) before allowing the delegated action.
 >
-> Five named agents on Sepolia (`research-agent`, `trading-agent`, `swap-agent`, `audit-agent`, `coordinator-agent`) discover each other in real time in the [trust-DNS visualization](https://app.sbo3l.dev/trust-dns). The visualization is the demo video centerpiece.
+> Five+ named agents on Sepolia (`research-agent`, `trading-agent`, `swap-agent`, `audit-agent`, `coordinator-agent`) discover each other in real time in the [trust-DNS visualization](https://app.sbo3l.dev/trust-dns). The visualization is the demo video centerpiece.
 
 **Live ENS evidence:**
-- Mainnet `sbo3lagent.eth` with 7 sbo3l:* records (resolve via any ENS gateway)
-- Sepolia subname issuance via Durin (PR #116 dry-run, full live in T-3-1 main)
-- Cross-agent attestation protocol (T-3-4)
-- Trust-DNS viz (T-3-5)
-- 1500-word "Trust DNS" essay at https://docs.sbo3l.dev/trust-dns (T-3-6)
+- Mainnet `sbo3lagent.eth` with 5 `sbo3l:*` records on chain. `policy_hash = e044f13c5acb792dd3109f1be3a98536168b0990e25595b3cedc131d02e666cf` — matches the offline fixture byte-for-byte (no drift)
+- ENS Registry constant: `0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e` (mainnet + Sepolia, deterministic deployment)
+- Mainnet PublicResolver: `0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63`
+- Sepolia subname issuance via direct ENS Registry (`sbo3l agent register --network sepolia`; PR #116 dry-run merged; broadcast slice in flight)
+- ENSIP-25 CCIP-Read gateway live at https://ccip.sbo3l.dev (T-4-1 ✅; PR #124 + #121 + uptime probe)
+- Cross-agent attestation protocol (T-3-4 — first-tier amplifier 60-agent fleet PR #141)
+- Trust-DNS viz (T-3-5 — canvas renderer PR #164 for ≥100 agents)
+- 1500-word "Trust DNS" essay at https://docs.sbo3l.dev/trust-dns (T-3-6 — pending)
 
 ## Sponsor track field — ENS AI Agents
 
@@ -81,7 +88,10 @@ The form fields below are derived from typical ETHGlobal submission forms. If th
 
 **Live Uniswap evidence:**
 - `crates/sbo3l-execution/src/uniswap.rs` — `live_from_env()` + Sepolia QuoterV2 quote
-- `examples/uniswap-agent/` (T-5-6) — TS + Py demo
+- Sepolia QuoterV2: `0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3`
+- Sepolia route: WETH → USDC `0x1c7D4B19…` (used in submission-day verification at HEAD `0707079`)
+- Quote evidence captured: `quote_source: uniswap-v3-quoter-sepolia-…` plus real `sqrt_price_x96_after` and a freshness timestamp embedded in the capsule
+- `examples/uniswap-agent/` (T-5-6) — TS + Py demo (gated on T-5-5 swap landing; Dev 2 in flight on PR #165 for T-5-1 swap construction)
 - Real Sepolia tx hash captured into capsule (`demo-scripts/artifacts/uniswap-real-swap-capsule.json` after T-5-5)
 
 ## Sponsor track field — 0G Track A (Storage)
@@ -100,10 +110,10 @@ _populate after T-8-* (multi-node SBO3L with AXL)_
 
 | Surface | State |
 |---|---|
-| KeeperHub | Live `wfb_…` token executes real workflows; `kh-<ULID>` captured |
-| ENS apex `sbo3lagent.eth` | Mainnet, 7 sbo3l:* records on chain |
-| ENS subnames | Sepolia, issued via Durin |
-| Uniswap | Sepolia QuoterV2 quotes live; real swap (T-5-5) Sepolia |
+| KeeperHub | Live `wfb_…` token executes real workflows against `m4t4cnpmhv8qquce3bv3c`; `kh-172o77rxov7mhwvpssc3x` shape executionId captured |
+| ENS apex `sbo3lagent.eth` | **Mainnet, 5 `sbo3l:*` records on chain today** (Phase 2 adds 2 more for 7 total) |
+| ENS subnames | Sepolia, issued via direct ENS Registry `setSubnodeRecord` (Daniel parent-owner; Durin path evaluated and dropped 2026-05-01) |
+| Uniswap | Sepolia QuoterV2 (`0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3`) quotes live; real swap (T-5-5) Sepolia |
 | 0G | Testnet (faucet flaky; see notes in `docs/0g-…`) |
 | Gensyn AXL | Testnet |
 

--- a/docs/submission/demo-video-script.md
+++ b/docs/submission/demo-video-script.md
@@ -19,28 +19,34 @@
 > **Voiceover:** "Watch a real KeeperHub workflow run, gated by SBO3L."
 > **Screen:**
 > 1. Show APRP request hitting SBO3L → `decision: allow`
-> 2. Show the `sbo3l_*` envelope POSTed to KeeperHub workflow webhook (real `wfb_…` token, real execution id `kh-<ULID>`)
+> 2. Show the `sbo3l_*` envelope POSTed to the real KH workflow webhook `https://app.keeperhub.com/api/workflows/m4t4cnpmhv8qquce3bv3c/webhook` (real `wfb_…` token; the executionId returned is KH-format, e.g. `kh-172o77rxov7mhwvpssc3x` — *not* a ULID)
 > 3. Show the executionId echoed back, plus the audit chain entry that links them
 > 4. Show denied request: `policy.deny_unknown_provider` — KH never sees the request
 > **Voiceover beat:** "Denied actions never reach the sponsor. Allowed actions arrive with a signed envelope KH can echo back into their audit row."
+>
+> *Pre-record verification (memory `submission_2026-04-30_live_verification`):* IP-1 envelope POST accepted; live arm of `KeeperHubExecutor::execute` via `submit_live_to`; same `wfb_…` token used in Daniel's submission-day verification still valid until rotation.
 
 ## Live integration #2 — Uniswap (1:00 — 1:30)
 
 > **Voiceover:** "Same shape on a real Sepolia swap."
 > **Screen:**
-> 1. APRP → SBO3L → `quoteExactInputSingle` against Sepolia QuoterV2
-> 2. Real Sepolia tx hash on Etherscan
-> 3. Capsule contains the `tx_hash` and the quote evidence — re-verify offline shows the swap was authorised, recorded, and matches the quoted price within slippage bounds
+> 1. APRP → SBO3L → `quoteExactInputSingle` against Sepolia QuoterV2 at `0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3` (route: WETH → Sepolia USDC `0x1c7D4B19…`)
+> 2. Real Sepolia tx hash on Etherscan (T-5-5 — captures `tx_hash` into `execution.live_evidence` of the capsule)
+> 3. Capsule contains the `tx_hash` and the quote evidence (`sqrt_price_x96_after`, `quote_source: uniswap-v3-quoter-sepolia-…`) — re-verify offline shows the swap was authorised, recorded, and matches the quoted price within slippage bounds
 > **Voiceover beat:** "The capsule contains the tx hash. Tomorrow, an auditor can prove this swap was bounded, authorised, and within MEV-safe slippage — without trusting our daemon being online."
+>
+> *Pre-record verification:* QuoterV2 live path verified at HEAD `0707079` (memory `submission_2026-04-30_live_verification`); rerun `bash demo-scripts/sponsors/uniswap-real-swap.sh` morning-of to capture a fresh tx hash.
 
 ## Live integration #3 — ENS Trust DNS (1:30 — 2:00)
 
 > **Voiceover:** "When five agents need to know who they're talking to, SBO3L turns ENS into the agent trust DNS."
 > **Screen:**
-> 1. Mainnet `sbo3lagent.eth` resolving 7 `sbo3l:*` text records
-> 2. Sepolia agent fleet — 5 named agents resolved via Durin
-> 3. Trust-DNS visualization: D3 force-directed graph, agents discovering each other in real time, attestation edges signing on the wire
+> 1. Mainnet `sbo3lagent.eth` resolving its `sbo3l:*` text records (5 on chain today: `agent_id`, `endpoint`, `policy_hash` = `e044f13c5acb792dd3109f1be3a98536168b0990e25595b3cedc131d02e666cf`, `audit_root`, `proof_uri`; Phase 2 adds `capability` + `reputation` for 7 total)
+> 2. Sepolia agent fleet — 5+ named agents (`research-agent.sbo3lagent.eth`, `trading-agent…`, etc.) registered via direct ENS Registry `setSubnodeRecord` (Daniel owns the parent — Durin not used; memory `durin_dropped_2026-05-01`)
+> 3. Trust-DNS visualization: force-directed graph (D3 + canvas renderer for ≥100 agents), agents discovering each other in real time, attestation edges signing on the wire
 > **Voiceover beat:** "Cross-agent attestations are signed, time-bound, and policy-hash-pinned. A tampered attestation gets `cross_agent.attestation_invalid`."
+>
+> *Pre-record verification:* Mainnet `policy_hash` matches offline fixture exactly (no drift); 5 agents on Sepolia gated on PR #138 (fleet-of-5 infra).
 
 ## The verifier (2:00 — 2:30)
 
@@ -71,10 +77,11 @@
 
 ## Storyboard checklist (Daniel pre-record)
 
-- [ ] All four sponsor `live_from_env()` paths smoke-tested same morning as record (KH wfb token, Sepolia private key, ENS RPC, mainnet)
-- [ ] Capsule for tamper demo pre-prepared (`/tmp/capsule-tamper-demo.json`)
-- [ ] Etherscan window pre-loaded with the real Sepolia swap tx
-- [ ] Trust-DNS viz pre-warmed with 5+ agents already resolved
+- [ ] All four sponsor `live_from_env()` paths smoke-tested same morning as record (KH wfb token still valid; Sepolia private key funded — `0xdc7EFA…D231` per memory `alchemy_rpc_endpoints`; ENS RPC PublicNode mainnet + Sepolia per memory `live_rpc_endpoints_known`)
+- [ ] Capsule for tamper demo pre-prepared (`/tmp/capsule-tamper-demo.json`) — generate via `sbo3l passport run … --out` then byte-flip one char in `audit_event_hash`
+- [ ] Etherscan window pre-loaded with the real Sepolia swap tx (re-run `bash demo-scripts/sponsors/uniswap-real-swap.sh` morning-of)
+- [ ] Trust-DNS viz pre-warmed with 5+ agents already resolved (PR #138 fleet must be merged + run)
+- [ ] KH workflow `m4t4cnpmhv8qquce3bv3c` pre-warmed (1 successful execution today so cached path is hot)
 - [ ] Recording at 1080p minimum, screen-share crisp, terminal font ≥ 18pt
 - [ ] Re-record any segment longer than its allotted slice; total cap = 3:00
 

--- a/docs/submission/partner-onepagers/ens.md
+++ b/docs/submission/partner-onepagers/ens.md
@@ -9,7 +9,7 @@
 ```bash
 cargo install sbo3l-cli --version 1.0.1
 
-# Resolve the mainnet apex — 7 sbo3l:* records returned
+# Resolve the mainnet apex — 5 sbo3l:* records on chain today (Phase 2 target: 7)
 sbo3l passport resolve sbo3lagent.eth
 
 # Resolve a Sepolia subname (after T-3-3 fleet lands)
@@ -19,17 +19,30 @@ sbo3l passport resolve research-agent.sbo3lagent.eth
 
 ## What we put on chain
 
-| Record | Meaning |
-|---|---|
-| `sbo3l:agent_id` | Stable agent identifier |
-| `sbo3l:endpoint` | HTTPS endpoint for the SBO3L daemon serving this agent |
-| `sbo3l:policy_hash` | Canonical hash of the agent's active policy snapshot |
-| `sbo3l:audit_root` | Latest audit-chain head (rolled forward via checkpoints) |
-| `sbo3l:proof_uri` | Stable URL where the latest Passport capsule for this agent lives |
-| `sbo3l:capability` | Comma-separated capability tags (`x402-purchase`, `uniswap-swap`, `delegation-target`) |
-| `sbo3l:reputation` | `<score>/100` computed from the audit chain (4-criteria scoring) |
+| Record | On chain at v1.0.1 | Meaning |
+|---|---|---|
+| `sbo3l:agent_id` | ✅ | Stable agent identifier |
+| `sbo3l:endpoint` | ✅ | HTTPS endpoint for the SBO3L daemon serving this agent |
+| `sbo3l:policy_hash` | ✅ | Canonical hash of the agent's active policy snapshot |
+| `sbo3l:audit_root` | ✅ | Latest audit-chain head (rolled forward via checkpoints) |
+| `sbo3l:proof_uri` | ✅ | Stable URL where the latest Passport capsule for this agent lives |
+| `sbo3l:capability` | Phase 2 | Comma-separated capability tags (`x402-purchase`, `uniswap-swap`, `delegation-target`) |
+| `sbo3l:reputation` | Phase 2 | `<score>/100` computed from the audit chain (4-criteria scoring) |
 
-Reading these seven records gives you a complete trust profile for an agent — *without trusting any single party*.
+Reading these records gives you a complete trust profile for an agent — *without trusting any single party*. Mainnet `sbo3lagent.eth` resolves a `policy_hash` (`e044f13c5acb…`) that **byte-matches** the offline fixture used in CI — no drift between published identity and shipped behaviour.
+
+## How subnames are issued — direct ENS Registry (not Durin)
+
+Daniel owns `sbo3lagent.eth` mainnet apex, so subname registration is a single transaction directly to the canonical ENS Registry (`0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e`, deterministic deployment on mainnet + Sepolia):
+
+```
+ENS Registry.setSubnodeRecord(parentNode, label, owner, resolver, ttl)   # one call
+PublicResolver.setText(subnameNode, "sbo3l:agent_id", value)             # × 5 (per record)
+```
+
+We evaluated Durin and dropped it on 2026-05-01 — direct ENS Registry has fewer moving parts, no third-party registrar contract to deploy, and is more verifiable on Etherscan ("owner of `sbo3lagent.eth`" is a single on-chain fact).
+
+PublicResolver: `0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63` (mainnet).
 
 ## Cross-agent verification
 


### PR DESCRIPTION
## Summary

Stacked on #161 (docs/submission skeleton). Three small fact-fixes the skeleton left as TODO, all sourced from memory pointers:

- **KH** — real workflow id `m4t4cnpmhv8qquce3bv3c`, real webhook URL, real executionId format `kh-172o77rxov7mhwvpssc3x` (KH-format, **not** a ULID — the skeleton wrongly templated as `kh-<ULID>`).
- **ENS** — corrected to **5 sbo3l:* records on chain today** (Phase 2 adds 2 more for 7 total — the skeleton wrongly claimed 7 already on chain). Mainnet `policy_hash = e044f13c5acb…` pinned for byte-match. Subname path switched **Durin → direct ENS Registry** per the 2026-05-01 dropping decision; ENS Registry + PublicResolver addresses inlined.
- **Uniswap** — Sepolia QuoterV2 address pinned (`0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3`), route WETH → USDC pinned, quote evidence shape (`sqrt_price_x96_after`, `quote_source`) referenced.

## Why

The submission package is what judges read first. Every claim in there has to be falsifiable; the skeleton's `<ULID>` placeholder and "7 records on chain" overstatement would have been easy targets in a sponsor review. These edits replace abstractions with the actual on-chain / on-network facts captured in memory pointers `submission_2026-04-30_live_verification`, `durin_dropped_2026-05-01`, and `live_rpc_endpoints_known`.

## Test plan

- [x] All three files render as markdown
- [x] No new claims that aren't in memory + don't have a code reference
- [x] Storyboard checklist updated with concrete pre-record verification (real RPC endpoints, real wallet `0xdc7EFA…D231`, known-good KH workflow id)

## Out of scope

- The `live-url-inventory.md` _populate from FEEDBACK.md after T-2-1 lands_ TODO is left as-is — Daniel files those KH issues; not a Heidi action.
- The `examples/uniswap-agent/` link is left pointing at the gated T-5-6 path; will go live when PR #165 lands and T-5-5 captures a real tx hash.

## Stack note

Base is `agent/qa/heidi-watch-and-submission` (#161). When #161 merges to main, this PR's base will need to be retargeted to `main` (or rebased + pushed). If #161 takes long, I can re-target to main directly and resolve the trivial conflicts.

Co-Authored-By: Heidi (QA + Release agent) <heidi@sbo3l.dev>