### PR TITLE
feat(trust-dns-viz): WS exponential-backoff reconnect + stale-frame watchdog

### DIFF
--- a/apps/trust-dns-viz/src/source.ts
+++ b/apps/trust-dns-viz/src/source.ts
@@ -5,21 +5,104 @@ import { isVizEvent, type VizEvent } from "./events";
 // query param OR absence of `ws=` URL.
 
 export interface EventSource {
-  start(onEvent: (e: VizEvent) => void, onStatus: (s: "connecting" | "connected" | "disconnected") => void): void;
+  start(
+    onEvent: (e: VizEvent) => void,
+    onStatus: (s: "connecting" | "connected" | "disconnected") => void,
+  ): void;
   stop(): void;
 }
 
-export function realWebSocketSource(url: string): EventSource {
+/// Reconnect schedule for `realWebSocketSource`: exponential backoff
+/// starting at 1s, doubling up to a 30s cap. Reset to 1s on every
+/// successful `open`. The schedule is exported so callers + tests
+/// can introspect it; the actual impl multiplies the previous delay
+/// by 2 rather than indexing this array, but the values are the
+/// same.
+export const RECONNECT_SCHEDULE_MS = [1_000, 2_000, 4_000, 8_000, 16_000, 30_000] as const;
+
+/// Cap on the reconnect delay in ms. Once we hit this, the delay
+/// stays here until a successful `open` resets the schedule.
+export const RECONNECT_CAP_MS = 30_000;
+
+/// Initial reconnect delay (ms). The first close → reconnect attempt
+/// uses this; subsequent attempts double until the cap.
+export const RECONNECT_INITIAL_MS = 1_000;
+
+/// "Stale stream" threshold (ms). If the connection is open but we
+/// haven't seen any frame for this long, the source preemptively
+/// closes + reconnects. Daemons can drop a TCP connection silently
+/// (load balancer, NAT idle timeout); without this watchdog the viz
+/// would sit on a dead socket forever.
+export const STALE_FRAME_THRESHOLD_MS = 60_000;
+
+/// Optional knobs for `realWebSocketSource`. All defaults match the
+/// pinned constants above; tests override to drive the watchdog
+/// + reconnect path on a sub-second budget.
+export interface RealWebSocketOptions {
+  /// Override the WebSocket constructor — tests inject a fake.
+  /// Defaults to the global `WebSocket`.
+  webSocketCtor?: typeof WebSocket;
+  /// Initial reconnect delay (ms). Defaults to
+  /// [`RECONNECT_INITIAL_MS`].
+  initialDelayMs?: number;
+  /// Reconnect cap (ms). Defaults to [`RECONNECT_CAP_MS`].
+  capDelayMs?: number;
+  /// Stale-frame watchdog threshold (ms). Defaults to
+  /// [`STALE_FRAME_THRESHOLD_MS`]. Set to `0` to disable the
+  /// watchdog (used by the connect-then-close test where we want
+  /// to assert reconnect timing without watchdog interference).
+  staleThresholdMs?: number;
+}
+
+export function realWebSocketSource(
+  url: string,
+  opts: RealWebSocketOptions = {},
+): EventSource {
+  const WebSocketCtor: typeof WebSocket = opts.webSocketCtor ?? WebSocket;
+  const initialDelay = opts.initialDelayMs ?? RECONNECT_INITIAL_MS;
+  const capDelay = opts.capDelayMs ?? RECONNECT_CAP_MS;
+  const staleThreshold = opts.staleThresholdMs ?? STALE_FRAME_THRESHOLD_MS;
+
   let ws: WebSocket | null = null;
-  let reconnectTimer: number | null = null;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let staleTimer: ReturnType<typeof setTimeout> | null = null;
+  let nextDelay = initialDelay;
+  let stopped = false;
 
   return {
     start(onEvent, onStatus) {
+      stopped = false;
+      const armStaleWatchdog = (): void => {
+        if (staleThreshold <= 0) return;
+        if (staleTimer !== null) clearTimeout(staleTimer);
+        staleTimer = setTimeout(() => {
+          // No frame for `staleThreshold` ms while the socket
+          // believes itself open. Force a reconnect — the close
+          // handler will schedule it. Logging surfaces the event
+          // so an operator sees why the viz blipped.
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[trust-dns-viz] stale stream — no frame for ${staleThreshold}ms; reconnecting`,
+          );
+          ws?.close();
+        }, staleThreshold);
+      };
+
       const connect = (): void => {
+        if (stopped) return;
         onStatus("connecting");
-        ws = new WebSocket(url);
-        ws.addEventListener("open", () => onStatus("connected"));
-        ws.addEventListener("message", (msg) => {
+        ws = new WebSocketCtor(url);
+        ws.addEventListener("open", () => {
+          onStatus("connected");
+          // Reset backoff after a successful open. A future close
+          // schedules from `initialDelay` again.
+          nextDelay = initialDelay;
+          armStaleWatchdog();
+        });
+        ws.addEventListener("message", (msg: MessageEvent) => {
+          // Reset the stale watchdog on every frame — the connection
+          // is provably alive while the daemon is publishing.
+          armStaleWatchdog();
           try {
             const parsed: unknown = JSON.parse(msg.data as string);
             if (isVizEvent(parsed)) onEvent(parsed);
@@ -28,14 +111,41 @@ export function realWebSocketSource(url: string): EventSource {
           }
         });
         ws.addEventListener("close", () => {
+          if (staleTimer !== null) {
+            clearTimeout(staleTimer);
+            staleTimer = null;
+          }
           onStatus("disconnected");
-          reconnectTimer = window.setTimeout(connect, 2000);
+          if (stopped) return;
+          // Schedule the next reconnect with the current delay,
+          // then double for the next attempt — capped at
+          // `capDelay`. A successful open resets to `initialDelay`.
+          const delay = nextDelay;
+          nextDelay = Math.min(nextDelay * 2, capDelay);
+          reconnectTimer = setTimeout(connect, delay);
+        });
+        ws.addEventListener("error", () => {
+          // `error` events on WebSockets always also trigger a
+          // close, so the close handler does the scheduling. We
+          // only need to ensure the stale timer is canceled.
+          if (staleTimer !== null) {
+            clearTimeout(staleTimer);
+            staleTimer = null;
+          }
         });
       };
       connect();
     },
     stop() {
-      if (reconnectTimer !== null) window.clearTimeout(reconnectTimer);
+      stopped = true;
+      if (reconnectTimer !== null) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      if (staleTimer !== null) {
+        clearTimeout(staleTimer);
+        staleTimer = null;
+      }
       ws?.close();
     },
   };
@@ -54,15 +164,35 @@ export function mockSource(): EventSource {
     const now = Date.now();
     if (step < AGENTS.length) {
       const id = AGENTS[step]!;
-      onEvent({ kind: "agent.discovered", agent_id: id, ens_name: `${id}.sbo3lagent.eth`, pubkey_b58: `mock-pubkey-${step}`, ts_ms: now });
+      onEvent({
+        kind: "agent.discovered",
+        agent_id: id,
+        ens_name: `${id}.sbo3lagent.eth`,
+        pubkey_b58: `mock-pubkey-${step}`,
+        ts_ms: now,
+      });
     } else {
       const i = step % AGENTS.length;
       const a = AGENTS[i]!;
       const b = AGENTS[(i + 1 + (step % 3)) % AGENTS.length]!;
       const which = step % 3;
-      if (which === 0) onEvent({ kind: "attestation.signed", from: a, to: b, attestation_id: `att-${step}`, ts_ms: now });
+      if (which === 0)
+        onEvent({
+          kind: "attestation.signed",
+          from: a,
+          to: b,
+          attestation_id: `att-${step}`,
+          ts_ms: now,
+        });
       else if (which === 1) onEvent({ kind: "decision.made", agent_id: a, decision: "allow", ts_ms: now });
-      else onEvent({ kind: "decision.made", agent_id: a, decision: "deny", deny_code: "policy.deny_unknown_provider", ts_ms: now });
+      else
+        onEvent({
+          kind: "decision.made",
+          agent_id: a,
+          decision: "deny",
+          deny_code: "policy.deny_unknown_provider",
+          ts_ms: now,
+        });
     }
     step += 1;
   };

--- a/apps/trust-dns-viz/tests/reconnect.test.ts
+++ b/apps/trust-dns-viz/tests/reconnect.test.ts
@@ -1,0 +1,289 @@
+// Tests for `realWebSocketSource` — exponential-backoff reconnect +
+// stale-frame watchdog.
+//
+// We don't mount the graph here; this is purely about the source's
+// connect / close / reconnect behavior. The test injects a fake
+// WebSocket constructor via `RealWebSocketOptions.webSocketCtor` so
+// every connection attempt is observable + drivable from the test
+// (no real network, no jsdom WebSocket — vitest's jsdom doesn't
+// ship one anyway).
+
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import {
+  RECONNECT_CAP_MS,
+  RECONNECT_INITIAL_MS,
+  realWebSocketSource,
+} from "../src/source";
+
+type FakeListener = (ev: unknown) => void;
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  url: string;
+  listeners: Map<string, FakeListener[]> = new Map();
+  closed = false;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+  addEventListener(kind: string, fn: FakeListener): void {
+    const arr = this.listeners.get(kind) ?? [];
+    arr.push(fn);
+    this.listeners.set(kind, arr);
+  }
+  removeEventListener(): void {
+    /* not used in source.ts */
+  }
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.fire("close", { code: 1006 });
+  }
+  // Test-only helpers — drive the lifecycle.
+  open(): void {
+    this.fire("open", {});
+  }
+  message(payload: unknown): void {
+    this.fire("message", { data: JSON.stringify(payload) });
+  }
+  fire(kind: string, ev: unknown): void {
+    for (const fn of this.listeners.get(kind) ?? []) fn(ev);
+  }
+  static reset(): void {
+    FakeWebSocket.instances = [];
+  }
+  static last(): FakeWebSocket {
+    const last = FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+    if (!last) throw new Error("no FakeWebSocket instances yet");
+    return last;
+  }
+}
+
+describe("realWebSocketSource — exponential-backoff reconnect", () => {
+  beforeEach(() => {
+    FakeWebSocket.reset();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("schedules first reconnect at 1s after a clean close", () => {
+    const source = realWebSocketSource("ws://daemon/v1/events", {
+      webSocketCtor: FakeWebSocket as unknown as typeof WebSocket,
+      staleThresholdMs: 0, // disable watchdog so the test only
+      // exercises the reconnect-after-close path.
+    });
+    const events: unknown[] = [];
+    const statuses: string[] = [];
+    source.start(
+      (e) => events.push(e),
+      (s) => statuses.push(s),
+    );
+
+    expect(FakeWebSocket.instances.length).toBe(1);
+    FakeWebSocket.last().open();
+    expect(statuses).toEqual(["connecting", "connected"]);
+
+    // Drop the connection. The source should set a 1s reconnect
+    // timer; advancing 999ms should NOT yet have fired it; 1000ms
+    // should.
+    FakeWebSocket.last().close();
+    expect(statuses[statuses.length - 1]).toBe("disconnected");
+    expect(FakeWebSocket.instances.length).toBe(1);
+
+    vi.advanceTimersByTime(999);
+    expect(FakeWebSocket.instances.length).toBe(1);
+    vi.advanceTimersByTime(1);
+    expect(FakeWebSocket.instances.length).toBe(2);
+
+    source.stop();
+  });
+
+  it("doubles the delay after each subsequent close: 1s, 2s, 4s, 8s, 16s, 30s", () => {
+    const source = realWebSocketSource("ws://daemon/v1/events", {
+      webSocketCtor: FakeWebSocket as unknown as typeof WebSocket,
+      staleThresholdMs: 0,
+    });
+    source.start(
+      () => {
+        /* noop */
+      },
+      () => {
+        /* noop */
+      },
+    );
+
+    // No `open` between closes — that mimics a daemon that's
+    // straight-up unreachable. The schedule must double each time
+    // and cap at 30s.
+    const expected = [1_000, 2_000, 4_000, 8_000, 16_000, 30_000, 30_000];
+    for (let i = 0; i < expected.length; i += 1) {
+      const before = FakeWebSocket.instances.length;
+      FakeWebSocket.last().close();
+      const delay = expected[i]!;
+      // One ms before the timer should NOT have produced a new
+      // socket; advancing by 1 ms more should.
+      vi.advanceTimersByTime(delay - 1);
+      expect(FakeWebSocket.instances.length).toBe(before);
+      vi.advanceTimersByTime(1);
+      expect(FakeWebSocket.instances.length).toBe(before + 1);
+    }
+
+    source.stop();
+  });
+
+  it("resets the backoff schedule on a successful open", () => {
+    const source = realWebSocketSource("ws://daemon/v1/events", {
+      webSocketCtor: FakeWebSocket as unknown as typeof WebSocket,
+      staleThresholdMs: 0,
+    });
+    source.start(
+      () => {},
+      () => {},
+    );
+
+    // Burn through to a 4s delay…
+    FakeWebSocket.last().close();
+    vi.advanceTimersByTime(1_000);
+    FakeWebSocket.last().close();
+    vi.advanceTimersByTime(2_000);
+    // …open + close once more. The reconnect should now be back
+    // at 1s, NOT 8s.
+    FakeWebSocket.last().open();
+    FakeWebSocket.last().close();
+    const before = FakeWebSocket.instances.length;
+    vi.advanceTimersByTime(999);
+    expect(FakeWebSocket.instances.length).toBe(before);
+    vi.advanceTimersByTime(1);
+    expect(FakeWebSocket.instances.length).toBe(before + 1);
+
+    source.stop();
+  });
+});
+
+describe("realWebSocketSource — stale-frame watchdog", () => {
+  beforeEach(() => {
+    FakeWebSocket.reset();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("forces a reconnect when no frame arrives within the stale threshold", () => {
+    const source = realWebSocketSource("ws://daemon/v1/events", {
+      webSocketCtor: FakeWebSocket as unknown as typeof WebSocket,
+      staleThresholdMs: 60_000,
+      initialDelayMs: 1, // tighten reconnect so the test asserts
+      // the watchdog-then-reconnect chain quickly.
+    });
+    source.start(
+      () => {},
+      () => {},
+    );
+    FakeWebSocket.last().open();
+    expect(FakeWebSocket.instances.length).toBe(1);
+
+    // Watchdog at 60s. Advance 60s → close fires → reconnect
+    // schedules at +1ms (from initialDelayMs) → new socket.
+    vi.advanceTimersByTime(60_000);
+    expect(FakeWebSocket.last().closed).toBe(true);
+    vi.advanceTimersByTime(1);
+    expect(FakeWebSocket.instances.length).toBe(2);
+
+    source.stop();
+  });
+
+  it("a frame resets the watchdog so the connection survives past the threshold", () => {
+    const source = realWebSocketSource("ws://daemon/v1/events", {
+      webSocketCtor: FakeWebSocket as unknown as typeof WebSocket,
+      staleThresholdMs: 60_000,
+    });
+    source.start(
+      () => {},
+      () => {},
+    );
+    const ws = FakeWebSocket.last();
+    ws.open();
+
+    // Advance 30s, send a frame, advance 30s more — total 60s of
+    // wall time but the watchdog should NOT have fired because
+    // the message reset it.
+    vi.advanceTimersByTime(30_000);
+    ws.message({
+      kind: "decision.made",
+      agent_id: "a",
+      decision: "allow",
+      ts_ms: 1,
+    });
+    vi.advanceTimersByTime(30_000);
+    expect(ws.closed).toBe(false);
+    expect(FakeWebSocket.instances.length).toBe(1);
+
+    source.stop();
+  });
+});
+
+describe("realWebSocketSource — kill-and-reconnect within 5s warm-path budget", () => {
+  beforeEach(() => {
+    FakeWebSocket.reset();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // The brief's success criterion: kill server mid-stream,
+  // reconnect within 5s on warm path. Warm-path = the previous
+  // connection had a successful open, so the backoff schedule
+  // resets to 1s.
+  it("reconnects within 5 seconds of a mid-stream kill (warm path)", () => {
+    const source = realWebSocketSource("ws://daemon/v1/events", {
+      webSocketCtor: FakeWebSocket as unknown as typeof WebSocket,
+      staleThresholdMs: 0,
+    });
+    const events: unknown[] = [];
+    source.start(
+      (e) => events.push(e),
+      () => {},
+    );
+    FakeWebSocket.last().open();
+    FakeWebSocket.last().message({
+      kind: "agent.discovered",
+      agent_id: "first",
+      ens_name: "first.sbo3lagent.eth",
+      pubkey_b58: "p",
+      ts_ms: 1,
+    });
+    expect(events.length).toBe(1);
+
+    // Kill mid-stream.
+    FakeWebSocket.last().close();
+    // Within 5s budget the source must have spawned a new socket.
+    vi.advanceTimersByTime(5_000);
+    expect(FakeWebSocket.instances.length).toBeGreaterThanOrEqual(2);
+
+    // Walk-through: the new socket can immediately be opened +
+    // resume publishing, with the same handler chain.
+    FakeWebSocket.last().open();
+    FakeWebSocket.last().message({
+      kind: "agent.discovered",
+      agent_id: "second",
+      ens_name: "second.sbo3lagent.eth",
+      pubkey_b58: "p2",
+      ts_ms: 2,
+    });
+    expect(events.length).toBe(2);
+
+    source.stop();
+  });
+});
+
+describe("RECONNECT_* constants are exported and well-formed", () => {
+  it("initial < cap and cap == 30s", () => {
+    expect(RECONNECT_INITIAL_MS).toBeLessThan(RECONNECT_CAP_MS);
+    expect(RECONNECT_CAP_MS).toBe(30_000);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the fixed 2-second reconnect timer in \`realWebSocketSource\` with an **exponential-backoff schedule** and adds a **stale-frame watchdog** that catches silent connection death.

### Reconnect schedule

**1s, 2s, 4s, 8s, 16s, 30s — capped at 30s.** Resets to 1s on every successful \`open\` so a flapping daemon doesn't burn through to the cap. Previously a flaky daemon meant the viz hammered it every 2s forever; now it backs off responsibly.

### Stale-frame watchdog

If no message frame arrives within **60s** while the socket reports itself open, we force-close + reconnect. Daemons behind load balancers or NATs can drop a TCP connection silently (idle-timeout); without this watchdog the viz sits on a dead socket indefinitely. Every received frame resets the watchdog timer.

### API

\`realWebSocketSource(url, opts?)\` — back-compat. The no-opts call uses pinned defaults:
- \`RECONNECT_INITIAL_MS = 1000\`
- \`RECONNECT_CAP_MS = 30000\`
- \`STALE_FRAME_THRESHOLD_MS = 60000\`

Tests inject a fake WebSocket constructor + tighter thresholds via \`opts\` to drive the lifecycle on a sub-second budget.

## Tests (7, all green) — \`apps/trust-dns-viz/tests/reconnect.test.ts\`

- [x] schedules first reconnect at 1s after a clean close
- [x] **doubles the delay on subsequent closes**: 1s → 2s → 4s → 8s → 16s → 30s, capped at 30s
- [x] resets the backoff schedule on a successful \`open\` (a 4s-deep schedule snaps back to 1s after the next open)
- [x] **forces a reconnect when no frame arrives within the stale threshold** (watchdog fires close)
- [x] a frame resets the watchdog so a 30s+30s walk with one frame in between survives past the 60s threshold
- [x] **kill-and-reconnect within the brief's 5-second warm-path budget** (a mid-stream close → new socket within 5s + new frames flow)
- [x] exported \`RECONNECT_*\` constants are well-formed

\`npx vitest run tests/reconnect.test.ts\`: **7/7 pass**. \`npx tsc --noEmit\`: clean.

## Scope

\`source.ts\` only. The stale-frame watchdog's "request resync from chain head" semantic is implemented as a **reconnect** — the daemon re-emits \`agent.discovered\` on every fresh subscription per #129's contract, and the graph layer's existing \`pendingEdges\` buffer already handles out-of-order replay so a reconnect doesn't strand attestation edges. A future audit-cursor RPC would let us request a specific \`seq\`, but reconnect-and-replay is sufficient for the demo + production-shaped runner.

refs: T-3-5 production polish (deferred from earlier P3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)