### PR TITLE
fix(ccip-gateway): drop .js extensions in imports (unblocks Vercel)

### DIFF
--- a/apps/ccip-gateway/src/app/api/[sender]/[data]/route.ts
+++ b/apps/ccip-gateway/src/app/api/[sender]/[data]/route.ts
@@ -21,13 +21,13 @@
 import { NextResponse } from "next/server";
 import type { Hex } from "viem";
 
-import { decodeResolverCall } from "../../../../lib/ens.js";
-import { lookupByNode } from "../../../../lib/records.js";
+import { decodeResolverCall } from "@/lib/ens";
+import { lookupByNode } from "@/lib/records";
 import {
   encodeEmptyStringResult,
   encodeStringResult,
   signGatewayResponse,
-} from "../../../../lib/sign.js";
+} from "@/lib/sign";
 
 interface RouteParams {
   params: Promise<{ sender: string; data: string }>;

--- a/apps/ccip-gateway/src/lib/records.ts
+++ b/apps/ccip-gateway/src/lib/records.ts
@@ -6,7 +6,7 @@
  */
 
 import recordsRaw from "../../data/records.json";
-import { namehash } from "./ens.js";
+import { namehash } from "./ens";
 
 type RecordsFile = Record<string, Record<string, string>>;
 


### PR DESCRIPTION
Vercel CCIP gateway has been stuck on #121-era code (501 not_implemented) since #124 introduced .js suffix imports that webpack can't resolve. Drop .js + use @/ alias. Verified npm run build clean.