### PR TITLE
feat(t-4-6): reputation publisher CLI — sbo3l agent reputation-publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3431,6 +3431,7 @@ dependencies = [
  "hex",
  "reqwest",
  "sbo3l-core",
+ "sbo3l-policy",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/sbo3l-cli/src/agent_reputation.rs
+++ b/crates/sbo3l-cli/src/agent_reputation.rs
@@ -1,0 +1,194 @@
+//! `sbo3l agent reputation-publish` — compute v2 score + emit a
+//! `setText("sbo3l:reputation_score", "<n>")` envelope (T-4-6).
+//!
+//! Inputs: events JSON file (array of `ReputationEventInput`), FQDN,
+//! network, optional resolver override. Output: a
+//! [`sbo3l_identity::ReputationPublishEnvelope`] printed to stdout
+//! and (optionally) written to `--out`.
+//!
+//! Dry-run only in this build. Broadcast wires through F-5
+//! EthSigner once that lands. The dry-run envelope is publishable
+//! on its own — same input always re-derives the same calldata,
+//! so an external auditor can replay the publisher and confirm.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use sbo3l_identity::ens_anchor::EnsNetwork;
+use sbo3l_identity::reputation_publisher::{
+    build_publish_envelope, PublishMode, ReputationEventInput, ReputationPublishParams,
+};
+
+/// Default resolver address per network. Same well-known PublicResolver
+/// constants `sbo3l-identity::EnsNetwork::default_public_resolver` exposes.
+fn default_resolver(network: EnsNetwork) -> &'static str {
+    network.default_public_resolver()
+}
+
+#[derive(Debug, Clone)]
+pub struct ReputationPublishArgs {
+    pub fqdn: String,
+    pub events: PathBuf,
+    pub network: String,
+    pub resolver: Option<String>,
+    pub out: Option<PathBuf>,
+}
+
+pub fn cmd_agent_reputation_publish(args: ReputationPublishArgs) -> ExitCode {
+    match run(args) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(code) => code,
+    }
+}
+
+fn run(args: ReputationPublishArgs) -> Result<(), ExitCode> {
+    let network = match args.network.as_str() {
+        "mainnet" => EnsNetwork::Mainnet,
+        "sepolia" => EnsNetwork::Sepolia,
+        other => {
+            eprintln!("error: unsupported network '{other}'. Expected 'mainnet' or 'sepolia'.");
+            return Err(ExitCode::from(2));
+        }
+    };
+
+    let resolver = args
+        .resolver
+        .as_deref()
+        .unwrap_or_else(|| default_resolver(network));
+
+    let raw = fs::read_to_string(&args.events).map_err(|e| {
+        eprintln!("error: read events file {}: {e}", args.events.display());
+        ExitCode::from(2)
+    })?;
+    let events: Vec<ReputationEventInput> = serde_json::from_str(&raw).map_err(|e| {
+        eprintln!("error: parse events file {}: {e}", args.events.display());
+        ExitCode::from(2)
+    })?;
+
+    let created_at = current_rfc3339();
+    let envelope = build_publish_envelope(
+        ReputationPublishParams {
+            network,
+            domain: &args.fqdn,
+            resolver,
+            created_at: &created_at,
+            mode: PublishMode::DryRun,
+        },
+        &events,
+    )
+    .map_err(|e| {
+        eprintln!("error: build publish envelope: {e}");
+        ExitCode::from(2)
+    })?;
+
+    let json = serde_json::to_string_pretty(&envelope).map_err(|e| {
+        eprintln!("error: serialise envelope: {e}");
+        ExitCode::from(2)
+    })?;
+
+    println!("{json}");
+
+    if let Some(path) = args.out {
+        fs::write(&path, &json).map_err(|e| {
+            eprintln!("error: write {}: {e}", path.display());
+            ExitCode::from(2)
+        })?;
+        eprintln!("wrote {}", path.display());
+    }
+
+    Ok(())
+}
+
+/// Best-effort RFC-3339 of "now". Falls back to a stable empty
+/// string if the system clock is somehow unreadable — the envelope
+/// remains structurally valid (just lossy on the timestamp), and
+/// downstream consumers can re-stamp from the receipt that pins it.
+fn current_rfc3339() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    // Tiny in-tree formatter that doesn't pull chrono into the CLI
+    // for one timestamp. Delegates to the workspace's existing
+    // chrono presence via the storage crate's dep tree.
+    chrono::DateTime::<chrono::Utc>::from_timestamp(secs as i64, 0)
+        .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_events(events: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(events.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn happy_path_prints_envelope() {
+        let events = r#"[
+            {"decision":"allow","executor_confirmed":true,"age_secs":0},
+            {"decision":"deny","executor_confirmed":false,"age_secs":86400}
+        ]"#;
+        let f = write_events(events);
+        let res = run(ReputationPublishArgs {
+            fqdn: "research-agent.sbo3lagent.eth".to_string(),
+            events: f.path().to_path_buf(),
+            network: "mainnet".to_string(),
+            resolver: None,
+            out: None,
+        });
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn unsupported_network_returns_exit2() {
+        let f = write_events("[]");
+        let res = run(ReputationPublishArgs {
+            fqdn: "x.eth".to_string(),
+            events: f.path().to_path_buf(),
+            network: "polygon".to_string(),
+            resolver: None,
+            out: None,
+        });
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn malformed_events_returns_exit2() {
+        let f = write_events("not json");
+        let res = run(ReputationPublishArgs {
+            fqdn: "x.eth".to_string(),
+            events: f.path().to_path_buf(),
+            network: "mainnet".to_string(),
+            resolver: None,
+            out: None,
+        });
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn writes_out_file_when_provided() {
+        let events = r#"[{"decision":"allow","executor_confirmed":true,"age_secs":0}]"#;
+        let f = write_events(events);
+        let out = NamedTempFile::new().unwrap();
+        let res = run(ReputationPublishArgs {
+            fqdn: "research-agent.sbo3lagent.eth".to_string(),
+            events: f.path().to_path_buf(),
+            network: "mainnet".to_string(),
+            resolver: None,
+            out: Some(out.path().to_path_buf()),
+        });
+        assert!(res.is_ok());
+        let written = std::fs::read_to_string(out.path()).unwrap();
+        assert!(written.contains("\"text_record_key\": \"sbo3l:reputation_score\""));
+        assert!(written.contains("\"score\":"));
+    }
+}

--- a/crates/sbo3l-cli/src/main.rs
+++ b/crates/sbo3l-cli/src/main.rs
@@ -10,6 +10,7 @@ use sbo3l_core::{schema, SchemaError};
 mod agent;
 #[cfg(feature = "eth_broadcast")]
 mod agent_broadcast;
+mod agent_reputation;
 mod audit_anchor_ens;
 mod audit_checkpoint;
 mod doctor;
@@ -196,6 +197,41 @@ enum AgentCmd {
 
         /// Write the dry-run envelope to `<path>` as JSON in addition
         /// to printing.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
+
+    /// Compute and publish an agent's reputation score (T-4-6).
+    ///
+    /// Reads audit events from `--events <file.json>` (a JSON array
+    /// of {decision, executor_confirmed, age_secs} objects), computes
+    /// the v2 weighted score (sbo3l_policy::reputation::compute_reputation_v2),
+    /// and emits a setText envelope publishing the score to the agent's
+    /// `sbo3l:reputation_score` ENS text record.
+    ///
+    /// **Dry-run only in this build.** Broadcast wires through F-5
+    /// EthSigner once that lands.
+    ReputationPublish {
+        /// FQDN of the agent (e.g. `research-agent.sbo3lagent.eth`).
+        #[arg(long)]
+        fqdn: String,
+
+        /// Path to a JSON file: array of `ReputationEventInput`
+        /// (`{decision, executor_confirmed, age_secs}`).
+        #[arg(long)]
+        events: PathBuf,
+
+        /// `mainnet` or `sepolia`. Default `mainnet` since the
+        /// canonical reputation publishes are on `sbo3lagent.eth`.
+        #[arg(long, default_value = "mainnet")]
+        network: String,
+
+        /// Override the resolver address. Default = the network's
+        /// canonical PublicResolver.
+        #[arg(long)]
+        resolver: Option<String>,
+
+        /// Write the envelope JSON to `<path>` in addition to printing.
         #[arg(long)]
         out: Option<PathBuf>,
     },
@@ -801,6 +837,24 @@ fn main() -> ExitCode {
             private_key_env_var,
             out,
         }),
+        Command::Agent {
+            op:
+                AgentCmd::ReputationPublish {
+                    fqdn,
+                    events,
+                    network,
+                    resolver,
+                    out,
+                },
+        } => agent_reputation::cmd_agent_reputation_publish(
+            agent_reputation::ReputationPublishArgs {
+                fqdn,
+                events,
+                network,
+                resolver,
+                out,
+            },
+        ),
     }
 }
 

--- a/crates/sbo3l-identity/Cargo.toml
+++ b/crates/sbo3l-identity/Cargo.toml
@@ -14,6 +14,9 @@ categories = ["api-bindings"]
 
 [dependencies]
 sbo3l-core = { workspace = true }
+# T-4-6 reputation publisher: depends on policy::reputation::compute_reputation_v2.
+# No cycle (sbo3l-policy depends on sbo3l-core; identity also depends on core).
+sbo3l-policy = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/sbo3l-identity/src/lib.rs
+++ b/crates/sbo3l-identity/src/lib.rs
@@ -19,6 +19,7 @@ pub mod durin;
 pub mod ens;
 pub mod ens_anchor;
 pub mod ens_live;
+pub mod reputation_publisher;
 
 pub use ccip_read::{
     decode_gateway_data, decode_gateway_response_body, decode_string_result,
@@ -38,4 +39,8 @@ pub use ens_anchor::{
 pub use ens_live::{
     JsonRpcTransport, LiveEnsResolver, ReqwestTransport, RpcError, ENS_REGISTRY_ADDRESS,
     RESOLVER_SELECTOR, SBO3L_TEXT_KEYS, TEXT_SELECTOR,
+};
+pub use reputation_publisher::{
+    build_publish_envelope, PublishMode, ReputationEventInput, ReputationPublishEnvelope,
+    ReputationPublishParams, REPUTATION_ENVELOPE_SCHEMA_ID, REPUTATION_TEXT_KEY,
 };

--- a/crates/sbo3l-identity/src/reputation_publisher.rs
+++ b/crates/sbo3l-identity/src/reputation_publisher.rs
@@ -1,0 +1,359 @@
+//! Reputation publisher (T-4-6 — follow-up to T-4-3).
+//!
+//! Publishes an agent's v2 reputation score to its ENS resolver as
+//! the `sbo3l:reputation_score` text record. Pure-function: takes
+//! audit-event input + identity (fqdn, network, resolver), emits a
+//! [`ReputationPublishEnvelope`] containing the `setText` calldata
+//! ready for broadcast.
+//!
+//! The score itself is computed via
+//! [`sbo3l_policy::reputation::compute_reputation_v2`] — same
+//! 4-criteria weighted scoring used by the cross-agent attestation
+//! refusal threshold. This module does not redefine the scoring
+//! rules; it only ships the on-chain publication path.
+//!
+//! ## Wire format
+//!
+//! ENS text record key: `sbo3l:reputation_score`. Value: decimal
+//! `0..=100` (e.g. `"87"`). Reads cleanly in `viem.getEnsText` /
+//! ENS App / direct `text(node, key)` calls — no special decoding
+//! on the consumer side.
+//!
+//! ## Truthfulness
+//!
+//! Same dry-run / fixture story as the audit-anchor envelope: the
+//! envelope is publishable on its own — same audit-event input
+//! always re-derives the same score and the same calldata. Caller
+//! can pin the envelope hash in a receipt to prove "this score
+//! was computed from these events at this time".
+//!
+//! ## CLI
+//!
+//! `sbo3l agent reputation publish <fqdn>` is the operator-facing
+//! entry point. It reads events from a JSON file (decoupled from
+//! the SQLite storage layer for portability — operators commonly
+//! want to publish reputation from a CI artifact, not a live DB),
+//! calls [`build_publish_envelope`], and prints / writes the
+//! envelope. Broadcast wires through F-5 EthSigner once that lands.
+
+use serde::{Deserialize, Serialize};
+
+use crate::ens_anchor::{namehash, set_text_calldata, AnchorError, EnsNetwork};
+use sbo3l_policy::reputation::{compute_reputation_v2, Reputation, ReputationEvent};
+
+/// ENS text-record key under which the reputation score lives.
+pub const REPUTATION_TEXT_KEY: &str = "sbo3l:reputation_score";
+
+/// Envelope schema id. Bump on any breaking change to the JSON
+/// shape — pinned in the JSON output so consumers can version-gate.
+pub const REPUTATION_ENVELOPE_SCHEMA_ID: &str = "sbo3l.reputation_publish_envelope.v1";
+
+/// Wire-format input for publisher CLI / library callers. Mirrors
+/// [`ReputationEvent`] but uses `u64` seconds for `age` so the
+/// shape is JSON-friendly without pulling Duration through serde.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReputationEventInput {
+    /// `"allow"` / `"deny"` / unknown.
+    pub decision: String,
+    /// Whether the signed receipt for this decision was carried
+    /// through to a sponsor adapter and confirmed.
+    pub executor_confirmed: bool,
+    /// Age of the event at scoring time, in seconds. Recent events
+    /// weigh more (per `compute_reputation_v2`'s recency penalty).
+    pub age_secs: u64,
+}
+
+impl From<&ReputationEventInput> for ReputationEvent {
+    fn from(input: &ReputationEventInput) -> Self {
+        ReputationEvent {
+            decision: input.decision.clone(),
+            executor_confirmed: input.executor_confirmed,
+            age: std::time::Duration::from_secs(input.age_secs),
+        }
+    }
+}
+
+/// Inputs to [`build_publish_envelope`]. Validated at build time:
+/// `resolver` must be a 0x-prefixed 40-hex-char address, `domain`
+/// must be a non-empty ENS name.
+#[derive(Debug, Clone)]
+pub struct ReputationPublishParams<'a> {
+    pub network: EnsNetwork,
+    pub domain: &'a str,
+    pub resolver: &'a str,
+    /// RFC-3339 timestamp pinned in the envelope.
+    pub created_at: &'a str,
+    /// Mode tag matching the audit-anchor convention (`"dry_run"`
+    /// or `"offline_fixture"`). Stored verbatim in the envelope's
+    /// `mode` field so consumers can tell publishable artifacts
+    /// apart.
+    pub mode: PublishMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublishMode {
+    DryRun,
+    OfflineFixture,
+}
+
+impl PublishMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::DryRun => "dry_run",
+            Self::OfflineFixture => "offline_fixture",
+        }
+    }
+
+    fn explanation(self) -> &'static str {
+        match self {
+            Self::DryRun => {
+                "Dry-run reputation envelope. Computed exactly what would be \
+                             broadcast (namehash, calldata, score) but did NOT contact any \
+                             RPC and did NOT sign anything. Re-run with --broadcast in a \
+                             build that wires the broadcast path."
+            }
+            Self::OfflineFixture => {
+                "Offline reputation fixture. Identical content to dry-run, \
+                                      written to disk for demo / CI fixture use."
+            }
+        }
+    }
+}
+
+/// Output of [`build_publish_envelope`]. Carries everything a
+/// downstream consumer needs to verify the envelope independently
+/// (recompute the score from the events, recompute the calldata
+/// from the score, recompute the namehash from the domain).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReputationPublishEnvelope {
+    /// `sbo3l.reputation_publish_envelope.v1`.
+    pub schema: String,
+    pub mode: String,
+    pub explanation: String,
+    pub network: String,
+    pub domain: String,
+    pub namehash: String,
+    pub resolver: String,
+    /// Always `sbo3l:reputation_score`.
+    pub text_record_key: String,
+    pub score: u8,
+    pub event_count: u64,
+    /// Hex-encoded `setText(bytes32,string,string)` calldata, no
+    /// `0x` prefix. Same form as the audit-anchor envelope.
+    pub calldata: String,
+    pub created_at: String,
+}
+
+/// Build a publish envelope from raw audit events.
+pub fn build_publish_envelope(
+    params: ReputationPublishParams<'_>,
+    events: &[ReputationEventInput],
+) -> Result<ReputationPublishEnvelope, AnchorError> {
+    let resolver = validate_resolver(params.resolver)?;
+    let node = namehash(params.domain)?;
+
+    let policy_events = events.iter().map(ReputationEvent::from);
+    let score: Reputation = compute_reputation_v2(policy_events);
+    let value = score.to_text_record();
+
+    let calldata = set_text_calldata(node, REPUTATION_TEXT_KEY, &value);
+
+    Ok(ReputationPublishEnvelope {
+        schema: REPUTATION_ENVELOPE_SCHEMA_ID.to_string(),
+        mode: params.mode.as_str().to_string(),
+        explanation: params.mode.explanation().to_string(),
+        network: params.network.as_str().to_string(),
+        domain: params.domain.to_string(),
+        namehash: hex::encode(node),
+        resolver,
+        text_record_key: REPUTATION_TEXT_KEY.to_string(),
+        score: score.as_u8(),
+        event_count: events.len() as u64,
+        calldata: hex::encode(&calldata),
+        created_at: params.created_at.to_string(),
+    })
+}
+
+fn validate_resolver(s: &str) -> Result<String, AnchorError> {
+    let stripped = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X"));
+    let body = match stripped {
+        Some(b) => b,
+        None => return Err(AnchorError::ResolverBadFormat(s.to_string())),
+    };
+    if body.len() != 40 || !body.bytes().all(|c| c.is_ascii_hexdigit()) {
+        return Err(AnchorError::ResolverBadFormat(s.to_string()));
+    }
+    Ok(format!("0x{}", body.to_lowercase()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ens_anchor::SET_TEXT_SELECTOR;
+
+    fn ev(decision: &str, executor_confirmed: bool, age_secs: u64) -> ReputationEventInput {
+        ReputationEventInput {
+            decision: decision.to_string(),
+            executor_confirmed,
+            age_secs,
+        }
+    }
+
+    fn params() -> ReputationPublishParams<'static> {
+        ReputationPublishParams {
+            network: EnsNetwork::Mainnet,
+            domain: "research-agent.sbo3lagent.eth",
+            resolver: "0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63",
+            created_at: "2026-05-02T00:00:00Z",
+            mode: PublishMode::DryRun,
+        }
+    }
+
+    #[test]
+    fn empty_chain_publishes_max_score() {
+        let env = build_publish_envelope(params(), &[]).unwrap();
+        assert_eq!(env.score, 100);
+        assert_eq!(env.event_count, 0);
+    }
+
+    #[test]
+    fn fleet_of_clean_events_publishes_high_score() {
+        let events: Vec<_> = (0..120).map(|_| ev("allow", true, 86400)).collect();
+        let env = build_publish_envelope(params(), &events).unwrap();
+        // 120 events, all clean+confirmed → 100.
+        assert_eq!(env.score, 100);
+        assert_eq!(env.event_count, 120);
+    }
+
+    #[test]
+    fn calldata_is_set_text_with_decimal_score_value() {
+        let events: Vec<_> = (0..10).map(|_| ev("allow", true, 0)).collect();
+        let env = build_publish_envelope(params(), &events).unwrap();
+
+        // First 4 bytes of calldata = SET_TEXT_SELECTOR.
+        let bytes = hex::decode(&env.calldata).unwrap();
+        assert_eq!(&bytes[..4], &SET_TEXT_SELECTOR);
+
+        // The score string is included verbatim somewhere in the
+        // tail (it's a short ASCII value, so check substring).
+        let score_str = env.score.to_string();
+        let calldata_lower = String::from_utf8_lossy(&bytes).to_lowercase();
+        // Look for the score's hex form in the tail.
+        let score_hex = hex::encode(score_str.as_bytes());
+        assert!(
+            env.calldata.contains(&score_hex),
+            "calldata should contain hex-encoded score '{score_hex}': {calldata_lower}",
+        );
+    }
+
+    #[test]
+    fn namehash_pinned_for_known_domain() {
+        let env = build_publish_envelope(params(), &[]).unwrap();
+        assert_eq!(env.namehash.len(), 64);
+        // namehash is deterministic — re-derive and compare.
+        let recomputed = namehash("research-agent.sbo3lagent.eth").unwrap();
+        assert_eq!(env.namehash, hex::encode(recomputed));
+    }
+
+    #[test]
+    fn resolver_normalised_to_lowercase_0x_prefix() {
+        let mut p = params();
+        p.resolver = "0x231B0EE14048E9DCCD1D247744D114A4EB5E8E63";
+        let env = build_publish_envelope(p, &[]).unwrap();
+        assert_eq!(env.resolver, "0x231b0ee14048e9dccd1d247744d114a4eb5e8e63");
+    }
+
+    #[test]
+    fn malformed_resolver_rejected() {
+        let mut p = params();
+        p.resolver = "not-an-address";
+        let err = build_publish_envelope(p, &[]).unwrap_err();
+        assert!(matches!(err, AnchorError::ResolverBadFormat(_)));
+    }
+
+    #[test]
+    fn empty_domain_rejected() {
+        let mut p = params();
+        p.domain = "";
+        let err = build_publish_envelope(p, &[]).unwrap_err();
+        assert!(matches!(err, AnchorError::EmptyDomain));
+    }
+
+    #[test]
+    fn schema_id_pinned() {
+        let env = build_publish_envelope(params(), &[]).unwrap();
+        assert_eq!(env.schema, "sbo3l.reputation_publish_envelope.v1");
+        assert_eq!(env.text_record_key, "sbo3l:reputation_score");
+    }
+
+    #[test]
+    fn mode_tag_round_trips() {
+        let mut p = params();
+        p.mode = PublishMode::OfflineFixture;
+        let env = build_publish_envelope(p, &[]).unwrap();
+        assert_eq!(env.mode, "offline_fixture");
+        assert!(env.explanation.contains("Offline"));
+    }
+
+    #[test]
+    fn json_round_trip() {
+        let env = build_publish_envelope(params(), &[ev("allow", true, 0)]).unwrap();
+        let s = serde_json::to_string(&env).unwrap();
+        let back: ReputationPublishEnvelope = serde_json::from_str(&s).unwrap();
+        assert_eq!(env, back);
+    }
+
+    #[test]
+    fn input_event_round_trip_via_json() {
+        let input = ev("allow", true, 12345);
+        let s = serde_json::to_string(&input).unwrap();
+        let back: ReputationEventInput = serde_json::from_str(&s).unwrap();
+        assert_eq!(input, back);
+    }
+
+    #[test]
+    fn input_event_rejects_unknown_fields() {
+        let bad = r#"{"decision":"allow","executor_confirmed":true,"age_secs":0,"extra":"x"}"#;
+        let res: Result<ReputationEventInput, _> = serde_json::from_str(bad);
+        assert!(res.is_err());
+    }
+
+    /// Pinned: 5-agent fleet shape. Each agent has the same
+    /// 12-event allow/deny mix; same input → same score.
+    #[test]
+    fn fleet_of_5_publishes_consistent_scores() {
+        let mixed = vec![
+            ev("allow", true, 0),
+            ev("allow", true, 0),
+            ev("allow", true, 0),
+            ev("allow", true, 0),
+            ev("allow", true, 0),
+            ev("allow", true, 0),
+            ev("allow", true, 0),
+            ev("allow", true, 0),
+            ev("allow", true, 0),
+            ev("allow", false, 0),
+            ev("deny", false, 0),
+            ev("deny", false, 0),
+        ];
+        let scores: Vec<u8> = (0..5)
+            .map(|_| build_publish_envelope(params(), &mixed).unwrap().score)
+            .collect();
+        assert!(scores.iter().all(|&s| s == scores[0]));
+        // Sanity: not 100 (some denies), not 0 (mostly allows).
+        assert!(scores[0] > 50 && scores[0] < 100, "got score {}", scores[0]);
+    }
+
+    /// Building the same envelope twice produces bit-identical
+    /// output (modulo `created_at`, which is an explicit input).
+    /// Truthfulness: an operator can replay the publisher and get
+    /// the same calldata.
+    #[test]
+    fn envelope_is_deterministic() {
+        let events = vec![ev("allow", true, 0), ev("deny", false, 86400 * 7)];
+        let a = build_publish_envelope(params(), &events).unwrap();
+        let b = build_publish_envelope(params(), &events).unwrap();
+        assert_eq!(a, b);
+    }
+}


### PR DESCRIPTION
## Summary

- New \`sbo3l agent reputation-publish\` CLI: read audit events JSON → compute v2 score → emit setText envelope.
- New \`crates/sbo3l-identity/src/reputation_publisher.rs\` pure-function publisher.
- ENS text record: \`sbo3l:reputation_score\` (decimal \`0..=100\`).
- 18 new tests (14 publisher + 4 CLI). \`cargo fmt\` + \`clippy\` clean.

## Wire format

\`\`\`json
{
  \"schema\": \"sbo3l.reputation_publish_envelope.v1\",
  \"mode\": \"dry_run\",
  \"network\": \"mainnet\",
  \"domain\": \"research-agent.sbo3lagent.eth\",
  \"namehash\": \"7131b849ffa657c77803cb882a11ea7edaa6e5c2dc2f33f9a878cb1bf39435dd\",
  \"resolver\": \"0x231b0ee14048e9dccd1d247744d114a4eb5e8e63\",
  \"text_record_key\": \"sbo3l:reputation_score\",
  \"score\": 71,
  \"event_count\": 6,
  \"calldata\": \"10f13a8c...\",
  \"created_at\": \"2026-05-02T...\"
}
\`\`\`

## End-to-end smoke

\`\`\`bash
echo '[{\"decision\":\"allow\",\"executor_confirmed\":true,\"age_secs\":0}, ...]' > events.json
sbo3l agent reputation-publish \\
  --fqdn research-agent.sbo3lagent.eth \\
  --events events.json
# → prints envelope, score 71, calldata starts with 10f13a8c (setText selector)
\`\`\`

## Truthfulness

Dry-run only in this build. The envelope is publishable on its own — same input always re-derives the same calldata. An external auditor can replay the publisher and confirm. Broadcast wires through F-5 EthSigner once that lands.

## Test plan

- [x] \`cargo test -p sbo3l-identity --lib\` — 61/61 (47 prior + 14 new)
- [x] \`cargo test -p sbo3l-cli --bin sbo3l agent_reputation\` — 4/4
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy -p sbo3l-identity -p sbo3l-cli --bin sbo3l --lib -- -D warnings\`
- [x] CLI smoke: 6 mixed events → score 71, calldata + namehash + resolver verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)