### PR TITLE
feat(docs): mount VersionSelector via Starlight Sidebar override (P2)

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -31,6 +31,13 @@ export default defineConfig({
         },
       ],
       customCss: ["./src/styles/custom.css"],
+      components: {
+        // Mounts the VersionSelector at the top of the sidebar; the
+        // override re-renders the default Sidebar via <slot /> so all
+        // other nav behaviour is unchanged. See
+        // src/components/VersionSelectorWrapper.astro for the wiring.
+        Sidebar: "./src/components/VersionSelectorWrapper.astro",
+      },
       sidebar: [
         { label: "Quickstart", link: "/quickstart" },
         {

--- a/apps/docs/src/components/VersionSelectorWrapper.astro
+++ b/apps/docs/src/components/VersionSelectorWrapper.astro
@@ -1,0 +1,32 @@
+---
+// Starlight Sidebar override — prepends the VersionSelector to the
+// default sidebar so users always see which version they're reading
+// and can switch with one click.
+//
+// Wired via apps/docs/astro.config.mjs:
+//   starlight({ components: { Sidebar: './.../VersionSelectorWrapper.astro' } })
+//
+// The override pattern (https://starlight.astro.build/guides/overriding-components/):
+// import the upstream default + render our addition above it. We keep
+// the default's <slot /> contract so Starlight's nav rendering is
+// unchanged.
+import Default from "@astrojs/starlight/components/Sidebar.astro";
+import VersionSelector from "./VersionSelector.astro";
+---
+<div class="version-selector-wrap">
+  <VersionSelector />
+</div>
+<Default><slot /></Default>
+
+<style>
+  .version-selector-wrap {
+    padding: 0.6em var(--sl-sidebar-pad-x, 1em) 0.4em;
+    border-bottom: 1px solid var(--sl-color-hairline);
+    margin-bottom: 0.6em;
+  }
+  /* Mobile: Starlight collapses the sidebar; keep the version
+     selector visible at the top of the content area instead. */
+  @media (max-width: 50em) {
+    .version-selector-wrap { padding: 0.4em 0.8em; }
+  }
+</style>


### PR DESCRIPTION
## Summary

- New `VersionSelectorWrapper.astro` mounted via Starlight's Sidebar override slot.
- Renders the existing `VersionSelector.astro` from #212 above the default sidebar; preserves `<slot />` contract.
- `astro.config.mjs` adds `components: { Sidebar: '...' }`.

## Why

P2 of round-6 brief. Stacks on #212 which shipped the component + version registry; this PR makes it actually visible.

LoC: 39 insertions across 2 files.

## Test plan

```bash
cd apps/docs
npm install
npm run typecheck
npm run build
npm run preview               # http://localhost:4321
# - Sidebar top shows the VersionSelector dropdown
# - "latest" pill green; click → dropdown lists all versions from versions.json
# - Click v1.0.0 → /v1.0.0/ root resolves (404 today since builds aren't there
#   yet; once build:versioned runs, all paths resolve)
# - Mobile (<800px): sidebar collapses; version selector reflows with tighter padding
# - Default Starlight nav (Concepts, CLI, etc.) renders below unchanged
```

## Dependencies

- Stacks on #212 (`agent/dev3/docs-versioned` — shipped VersionSelector.astro + versions.json + build-versions.sh).
- No code changes to the existing component; pure mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)