### PR TITLE
ci(integrations-publish): add workflow_dispatch for manual re-runs

### DIFF
--- a/.github/workflows/integrations-publish.yml
+++ b/.github/workflows/integrations-publish.yml
@@ -36,6 +36,13 @@ on:
       - "sdks/typescript/integrations/**"
       - "sdks/python/integrations/**"
       - ".github/workflows/integrations-publish.yml"
+  # Manual trigger — used to re-fire publish jobs against an existing
+  # tag when the workflow file changes after the tag was pushed (the
+  # tag's snapshot of the workflow file controls what runs, so we need
+  # workflow_dispatch to escape that lock-in). Each publish job's
+  # internal `if:` gate also accepts `github.ref_name` from a manual
+  # dispatch with the tag selected.
+  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Add `workflow_dispatch: {}` to `integrations-publish.yml` so Daniel can manually re-fire publish jobs without re-creating tags.

## Why this is needed RIGHT NOW
Today's v1.2.0 release pushed 8 tags. Result:

| Outcome | Packages |
|---|---|
| ✅ Live on PyPI | `sbo3l-langchain`, `sbo3l-crewai`, `sbo3l-llamaindex` |
| ❌ Failed (NPM_TOKEN missing) | `@sbo3l/langchain`, `@sbo3l/autogen`, `@sbo3l/elizaos`, `@sbo3l/vercel-ai` |
| ❌ Failed (PyPI trusted publisher not yet configured) | `sbo3l-langgraph` |

After provisioning the missing tokens/publishers, the canonical re-fire path today would be `git tag -d <tag> && git push :refs/tags/<tag> && git tag <tag> && git push origin <tag>`. With `workflow_dispatch` you can instead:

```bash
gh workflow run integrations-publish.yml --ref langchain-ts-v1.2.0
gh workflow run integrations-publish.yml --ref autogen-v1.2.0
gh workflow run integrations-publish.yml --ref elizaos-v1.2.0
gh workflow run integrations-publish.yml --ref vercel-ai-v1.2.0
gh workflow run integrations-publish.yml --ref langgraph-py-v1.2.0
```

…each picks the tag's snapshot of code (correct version, correct contents).

## Why `{}` and not inputs
Each publish job already gates on `startsWith(github.ref, '<prefix>')`. `github.ref` resolves to the dispatched ref, so no new inputs are needed. Keeps the dispatch UI minimal.

## Diff
+7 lines, no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)