### PR TITLE
docs(release): v1.2.0 recovery runbook for 5 failed publishes

### DIFF
--- a/docs/release/v1.2.0-recovery-runbook.md
+++ b/docs/release/v1.2.0-recovery-runbook.md
@@ -1,0 +1,191 @@
+# v1.2.0 release — recovery runbook
+
+**Status as of 2026-05-02 06:55 UTC:**
+
+| Package | Tag | Status |
+|---|---|---|
+| `sbo3l-langchain` | `langchain-py-v1.2.0` | ✅ live on PyPI |
+| `sbo3l-crewai` | `crewai-py-v1.2.0` | ✅ live on PyPI |
+| `sbo3l-llamaindex` | `llamaindex-py-v1.2.0` | ✅ live on PyPI |
+| `sbo3l-langgraph` | `langgraph-py-v1.2.0` | ❌ trusted-publisher missing |
+| `@sbo3l/langchain` | `langchain-ts-v1.2.0` | ❌ NPM_TOKEN missing |
+| `@sbo3l/autogen` | `autogen-v1.2.0` | ❌ NPM_TOKEN missing |
+| `@sbo3l/elizaos` | `elizaos-v1.2.0` | ❌ NPM_TOKEN missing |
+| `@sbo3l/vercel-ai` | `vercel-ai-v1.2.0` | ❌ NPM_TOKEN missing |
+
+This runbook documents the full recovery path for the 5 failed publishes. Estimated total time: **15 minutes** (10 for token provisioning, 5 for re-fires + verification).
+
+---
+
+## Step 1 — Provision `NPM_TOKEN` repo secret (4 min, fixes 4 failures)
+
+The 4 npm publishes all fail with `npm error code ENEEDAUTH` because the workflow's `Publish (provenance)` step calls `npm publish` without an authenticated session. The fix is a single repo-level `NPM_TOKEN` secret.
+
+### 1a. Create the token
+
+On the machine that owns the `@sbo3l` npm scope (Daniel's account):
+
+```bash
+npm whoami                                # confirm correct account
+npm token create --type=publish           # generates an automation token
+# Copy the printed token — it's shown only once.
+```
+
+Use **automation** type (not legacy `read-and-publish`) so npm provenance + 2FA bypass for CI both work.
+
+### 1b. Add as a GitHub repo secret
+
+```bash
+gh secret set NPM_TOKEN \
+  --repo B2JK-Industry/SBO3L-ethglobal-openagents-2026
+# Paste the token when prompted.
+```
+
+Or via the UI: **Settings → Secrets and variables → Actions → New repository secret** → name `NPM_TOKEN`, value the token from step 1a.
+
+### 1c. Verify the secret is visible
+
+```bash
+gh secret list --repo B2JK-Industry/SBO3L-ethglobal-openagents-2026 \
+  | grep NPM_TOKEN
+```
+
+Should print one line. The value is never readable back — verification is presence-only.
+
+---
+
+## Step 2 — Provision the `pypi-langgraph-py` PyPI Trusted Publisher (3 min, fixes 1 failure)
+
+The `sbo3l-langgraph` publish fails with `Token request failed: the server refused the request for the following reason: Trusted publisher claims do not match`. The 3 sister PyPI publishers (`pypi-langchain-py`, `pypi-crewai-py`, `pypi-llamaindex-py`) were configured earlier; the 4th was deferred.
+
+### 2a. Add the trusted publisher
+
+1. Sign in to https://pypi.org as the `sbo3l-langgraph` package owner.
+2. If the package doesn't yet exist on PyPI: register it via the trusted-publisher flow in **Account → Publishing → Add a new pending publisher**. Otherwise: open the package page → **Manage → Publishing → Add a trusted publisher**.
+3. Fill the form **exactly**:
+
+| Field | Value |
+|---|---|
+| PyPI Project Name | `sbo3l-langgraph` |
+| Owner | `B2JK-Industry` |
+| Repository name | `SBO3L-ethglobal-openagents-2026` |
+| Workflow name | `integrations-publish.yml` |
+| Environment name | `pypi-langgraph-py` |
+
+The workflow's job binds to environment `pypi-langgraph-py` (see `.github/workflows/integrations-publish.yml`'s `environment.name: pypi-${{ matrix.id }}`).
+
+### 2b. (Optional) Add the GitHub environment
+
+If the GitHub repo doesn't have a `pypi-langgraph-py` environment yet (the 3 working ones do):
+
+```bash
+gh api -X PUT \
+  repos/B2JK-Industry/SBO3L-ethglobal-openagents-2026/environments/pypi-langgraph-py \
+  -F wait_timer=0
+```
+
+No protection rules needed — the workflow's `if: startsWith(github.ref, 'refs/tags/langgraph-py-v')` already gates execution.
+
+---
+
+## Step 3 — Re-fire the 5 failed publishes via `workflow_dispatch` (2 min)
+
+The `workflow_dispatch` trigger lands via PR #225. After it merges, you can re-fire any failed publish job against the existing tag without deleting + re-creating tags.
+
+```bash
+# After Step 1 (NPM_TOKEN):
+gh workflow run integrations-publish.yml --ref langchain-ts-v1.2.0
+gh workflow run integrations-publish.yml --ref autogen-v1.2.0
+gh workflow run integrations-publish.yml --ref elizaos-v1.2.0
+gh workflow run integrations-publish.yml --ref vercel-ai-v1.2.0
+
+# After Step 2 (PyPI trusted publisher):
+gh workflow run integrations-publish.yml --ref langgraph-py-v1.2.0
+```
+
+Each picks up the workflow file from the **tag's** snapshot. The build-test jobs re-run too (cheap, ~25 s each); the publish jobs gate on `startsWith(github.ref_name, '<prefix>')` so only the matching one fires.
+
+### Watch them complete
+
+```bash
+# Tail the most recent run:
+gh run watch $(gh run list --workflow=integrations-publish.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+
+# Or show the full matrix at a glance:
+gh run list --workflow=integrations-publish.yml --limit 8 \
+  --json databaseId,headBranch,status,conclusion \
+  --jq '.[] | "\(.databaseId) \(.headBranch) \(.status) \(.conclusion // "—")"'
+```
+
+---
+
+## Step 4 — Verify each package is live (5 min)
+
+After all 5 re-runs report `success`:
+
+```bash
+# npm (should print "1.2.0" as the latest):
+npm view @sbo3l/langchain version
+npm view @sbo3l/autogen version
+npm view @sbo3l/elizaos version
+npm view @sbo3l/vercel-ai version
+
+# PyPI (should list 1.2.0 as the latest):
+pip index versions sbo3l-langgraph
+pip index versions sbo3l-langchain
+pip index versions sbo3l-crewai
+pip index versions sbo3l-llamaindex
+
+# Provenance check (npm) — should print the GitHub Actions OIDC attestation URL:
+npm view @sbo3l/langchain --json | jq -r '.["dist"]["attestations"]["url"]'
+```
+
+End state: **8 packages live at `1.2.0`** on their respective registries.
+
+---
+
+## Troubleshoot
+
+### `npm error code E403 — You cannot publish over the previously published versions`
+
+You re-fired against a tag that was already published. The publish job is idempotent for npm (re-publishing the same version is rejected). This is **success disguised as failure** — verify with `npm view @sbo3l/<pkg> version`.
+
+### `npm error code ENEEDAUTH` after Step 1
+
+The `NPM_TOKEN` secret name is case-sensitive. The workflow reads `NPM_TOKEN` (all caps). Re-check `gh secret list` shows `NPM_TOKEN`, not `npm_token` or `Npm_Token`.
+
+### `Trusted publisher claims do not match` after Step 2
+
+One of the 5 fields in Step 2a doesn't match. Most common: workflow file name typo (must be `integrations-publish.yml`, no path prefix), or environment name typo (must be `pypi-langgraph-py`, with the dash, not underscore).
+
+### `gh workflow run` says `could not resolve to a Workflow`
+
+The `workflow_dispatch` trigger only lands when **PR #225** merges. Check `gh pr view 225 --json state`. If still OPEN, the canonical fallback is:
+
+```bash
+git tag -d langchain-ts-v1.2.0
+git push origin :refs/tags/langchain-ts-v1.2.0
+git tag langchain-ts-v1.2.0
+git push origin langchain-ts-v1.2.0
+```
+
+…repeated per failed tag. The first push fires no workflow (race with workflow file landing on main); the second push (after delete) does fire it. This was the workaround used during the initial v1.2.0 release.
+
+### One PyPI publisher works but others don't
+
+The 3 working PyPI publishers (`pypi-langchain-py`, `pypi-crewai-py`, `pypi-llamaindex-py`) are independently configured; their success doesn't transfer. Each package needs its own trusted-publisher entry on PyPI.
+
+---
+
+## Why these failures happened (post-mortem, 1 paragraph)
+
+The `v1.2.0` release pushed all 8 tags simultaneously immediately after PR #145 (the publish workflow itself) merged. Two pre-existing infrastructure gaps surfaced at once: (a) `NPM_TOKEN` was never provisioned because no prior cohort release had needed it (PyPI's OIDC trusted publishing avoids the equivalent gap for the 3 working PyPI packages); (b) the 4th PyPI package (`sbo3l-langgraph`) was queued but its trusted publisher hadn't been configured yet because the package was authored later than the original 3. Both gaps are 1-time setup steps; once done, future releases (`v1.3.0`, etc.) re-fire automatically on tag push without manual intervention.
+
+## Future-proofing
+
+After Step 4 lands, future releases shrink to:
+1. Bump versions in 8 `package.json` / `pyproject.toml` files.
+2. Land that as one PR.
+3. `git push origin <8 tags>` — all 8 publish workflows fire green.
+
+A `scripts/release-bump.sh` that automates step 1 is a **fast-follow** in the v1.3.0 release prep.


### PR DESCRIPTION
## Summary
Step-by-step recovery guide for the 5 publish failures from today's `v1.2.0` cohort release. Estimated total time: **15 minutes** of Daniel-side work.

## Status as of 2026-05-02 06:55 UTC
| Package | Tag | Status |
|---|---|---|
| `sbo3l-langchain` | `langchain-py-v1.2.0` | ✅ live on PyPI |
| `sbo3l-crewai` | `crewai-py-v1.2.0` | ✅ live on PyPI |
| `sbo3l-llamaindex` | `llamaindex-py-v1.2.0` | ✅ live on PyPI |
| `sbo3l-langgraph` | `langgraph-py-v1.2.0` | ❌ trusted-publisher missing |
| `@sbo3l/langchain` | `langchain-ts-v1.2.0` | ❌ NPM_TOKEN missing |
| `@sbo3l/autogen` | `autogen-v1.2.0` | ❌ NPM_TOKEN missing |
| `@sbo3l/elizaos` | `elizaos-v1.2.0` | ❌ NPM_TOKEN missing |
| `@sbo3l/vercel-ai` | `vercel-ai-v1.2.0` | ❌ NPM_TOKEN missing |

## Runbook contents (`docs/release/v1.2.0-recovery-runbook.md`, 191 lines)
1. **NPM_TOKEN provisioning** — `npm token create --type=publish` + `gh secret set NPM_TOKEN`
2. **PyPI Trusted Publisher for sbo3l-langgraph** — exact 5 field values to enter on PyPI's UI; companion `gh api -X PUT environments/pypi-langgraph-py` if the GitHub environment is missing too
3. **Re-fire 5 failed publishes** — `gh workflow run integrations-publish.yml --ref <tag>` per package (depends on #225 `workflow_dispatch` landing; canonical fallback for re-tag also documented)
4. **Verification** — `npm view <pkg> version`, `pip index versions <pkg>`, npm provenance OIDC URL check

Plus 5 troubleshoot scenarios:
- E403 idempotency (re-publishing same version)
- ENEEDAUTH after provisioning (case-sensitivity check)
- Trusted Publisher claim mismatch (5 exact field values)
- workflow_dispatch not yet on main (canonical fallback)
- per-package PyPI publisher independence (success doesn't transfer)

Plus 1-paragraph post-mortem on why both gaps surfaced today and a 3-line future-proofing note for v1.3.0+.

## Companion PRs (already in flight)
- #225 — adds `workflow_dispatch` so Step 3 doesn't require re-tag dance
- #220 — `@sbo3l/anthropic-computer-use` (unrelated to recovery; mentioned for context)
- #224 — quickstart guides (unrelated to recovery)

## Out of scope
- Automated bumping script (`scripts/release-bump.sh`) — flagged as fast-follow in the runbook
- v1.3.0 release prep — separate track once v1.2.0 fully lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)