### PR TITLE
feat(infra): /demo screenshot capture CI workflow (P2)

### DIFF
--- a/.github/workflows/capture-demo-screenshots.yml
+++ b/.github/workflows/capture-demo-screenshots.yml
@@ -1,0 +1,117 @@
+name: Capture /demo screenshots
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_url:
+        description: "Marketing base URL to screenshot (defaults to deployed)"
+        type: string
+        default: "https://sbo3l-marketing.vercel.app"
+      open_pr:
+        description: "Open auto-PR with the captured PNGs + .svg→.png swap"
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  capture:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Playwright + Chromium
+        run: |
+          npm install --no-save playwright@^1.48
+          npx playwright install --with-deps chromium
+
+      - name: Capture screenshots
+        env:
+          DEMO_BASE_URL: ${{ inputs.target_url }}
+        run: node apps/marketing/scripts/capture-demo-screenshots.mjs
+
+      - name: Verify all 8 PNGs landed
+        run: |
+          missing=0
+          for n in 1 2 3 4; do
+            for variant in "" "-mobile"; do
+              f="apps/marketing/public/demo/step-${n}${variant}.png"
+              if [ ! -s "$f" ]; then
+                echo "::error::missing or empty: $f"
+                missing=$((missing + 1))
+              else
+                printf "%-55s %s bytes\n" "$f" "$(wc -c < "$f")"
+              fi
+            done
+          done
+          test "$missing" = "0"
+
+      - name: Sed swap .svg → .png in 3 demo pages
+        if: inputs.open_pr == true
+        run: |
+          sed -i 's/\.svg/\.png/g' \
+            apps/marketing/src/pages/demo/index.astro \
+            apps/marketing/src/pages/demo/1-meet-the-agents.astro \
+            apps/marketing/src/pages/demo/4-explore-the-trust-graph.astro
+
+      - name: Remove now-unused .svg placeholders
+        if: inputs.open_pr == true
+        run: |
+          rm -f apps/marketing/public/demo/step-*.svg
+          # Keep the .placeholder-step.svg artist source — useful if a
+          # future re-run regenerates with the script.
+
+      - name: Configure git + create branch
+        if: inputs.open_pr == true
+        id: branch
+        run: |
+          git config user.name "sbo3l-bot"
+          git config user.email "bot@sbo3l.dev"
+          ts=$(date -u +%Y%m%d-%H%M%S)
+          branch="bot/demo-screenshots-${ts}"
+          git checkout -b "$branch"
+          git add apps/marketing/public/demo/ apps/marketing/src/pages/demo/
+          if git diff --cached --quiet; then
+            echo "no changes — skipping commit"
+            echo "made_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git commit -m "chore(marketing): refresh /demo screenshots from ${{ inputs.target_url }}"
+          git push --set-upstream origin "$branch"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "made_changes=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open auto-PR
+        if: inputs.open_pr == true && steps.branch.outputs.made_changes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "${{ steps.branch.outputs.branch }}" \
+            --title "chore(marketing): refresh /demo screenshots" \
+            --body "Auto-captured by \`.github/workflows/capture-demo-screenshots.yml\` against \`${{ inputs.target_url }}\`.
+
+          - 8 PNGs in \`apps/marketing/public/demo/\` (step-{1,2,3,4}{,-mobile}.png)
+          - \`.svg\` placeholder references swapped to \`.png\` in 3 demo pages
+          - \`.svg\` placeholder files removed; \`.placeholder-step.svg\` (artist source) kept
+
+          Triggered by @${{ github.actor }} via \`workflow_dispatch\`.
+
+          Auto-merge enabled below."
+          pr_number=$(gh pr list --head "${{ steps.branch.outputs.branch }}" --json number -q '.[0].number')
+          gh pr merge "$pr_number" --auto --squash --delete-branch
+
+      - name: Upload screenshots as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-screenshots-${{ github.run_id }}
+          path: apps/marketing/public/demo/step-*.png
+          retention-days: 30

--- a/apps/marketing/public/demo/README.md
+++ b/apps/marketing/public/demo/README.md
@@ -24,7 +24,17 @@ The `/demo` landing page renders these as `<picture>`-element-driven cards (mobi
 
 Loading is lazy (`loading="lazy"` on every `<img>`); the screenshots are served as static PNGs from Vercel's edge cache, immutable per the `*.png` rule in `apps/marketing/vercel.json`.
 
-## Regeneration
+## Regeneration — CI (preferred)
+
+The fastest path is **GitHub Actions**:
+
+1. Open the [Capture /demo screenshots workflow](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/actions/workflows/capture-demo-screenshots.yml).
+2. Click **Run workflow** → optionally override `target_url` → leave `open_pr: true` ticked → **Run workflow**.
+3. The workflow runs Playwright against the deployed marketing site, commits 8 PNGs, swaps `.svg` → `.png` in the 3 referencing files, opens an auto-merge PR.
+
+No terminal access needed; Daniel triggers via the GitHub UI.
+
+## Regeneration — local
 
 ```bash
 cd apps/marketing


### PR DESCRIPTION
## Summary

- `.github/workflows/capture-demo-screenshots.yml` — `workflow_dispatch` runs Playwright + Chromium against the deployed marketing site, opens auto-merge PR with 8 PNGs + sed swap.
- README updated with the GitHub UI walkthrough (local path kept as alternative).

## Why

P2 of round-8 brief. Replaces the "Daniel runs Playwright manually" pattern from #174 with a click-once GitHub Actions trigger. No terminal access needed.

LoC: 128 insertions / 1 deletion across 2 files.

## How Daniel triggers

1. Open https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/actions/workflows/capture-demo-screenshots.yml
2. Click **Run workflow** → optionally override `target_url` → **Run workflow**
3. Watch the run; on success, an auto-merge PR opens with the 8 PNGs + sed-swap

## Failure modes handled

- **All 8 PNGs missing/empty** → workflow fails with a clear `::error::` annotation per missing file. No PR opened.
- **No source changes** (re-running on identical state) → "no changes — skipping commit" log, no empty PR.
- **Daniel ticks `open_pr: false`** → PNGs land in artifact only (30-day retention); repo unchanged.

## Out of scope

- Auto-trigger on /demo source-file change — would race with merges, ship stale captures.
- Per-locale captures (`/sk/demo`) — separate ticket once `/sk/demo` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)