### PR TITLE
feat(hosted-app): /admin/audit live timeline view (P3)

### DIFF
--- a/apps/hosted-app/app/admin/audit/AuditTimeline.tsx
+++ b/apps/hosted-app/app/admin/audit/AuditTimeline.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+// Mirrors apps/trust-dns-viz/src/events.ts. Server emits the same
+// shape on /v1/events. Keep the union narrow + extend as Dev 1 ships
+// new event kinds.
+export type TimelineEvent =
+  | { kind: "agent.discovered";    agent_id: string; ens_name: string; pubkey_b58: string; ts_ms: number }
+  | { kind: "attestation.signed";  from: string; to: string; attestation_id: string; ts_ms: number }
+  | { kind: "decision.made";       agent_id: string; decision: "allow" | "deny"; deny_code?: string; ts_ms: number; intent?: string }
+  | { kind: "audit.checkpoint";    agent_id: string; chain_length: number; root_hash: string; ts_ms: number }
+  | { kind: "execution.confirmed"; agent_id: string; execution_ref: string; sponsor: string; ts_ms: number }
+  | { kind: "flag.changed";        flag_name: string; enabled: boolean; changed_by: string; ts_ms: number };
+
+interface Props {
+  wsUrl: string;
+}
+
+const MAX_EVENTS = 200;
+const KIND_LABEL: Record<TimelineEvent["kind"], string> = {
+  "agent.discovered":    "agent.discovered",
+  "attestation.signed":  "attestation.signed",
+  "decision.made":       "decision.made",
+  "audit.checkpoint":    "audit.checkpoint",
+  "execution.confirmed": "execution.confirmed",
+  "flag.changed":        "flag.changed",
+};
+
+type ConnState = "connecting" | "live" | "offline";
+
+export function AuditTimeline({ wsUrl }: Props): JSX.Element {
+  const [events, setEvents] = useState<TimelineEvent[]>([]);
+  const [state, setState] = useState<ConnState>("connecting");
+  const [agentFilter, setAgentFilter] = useState("");
+  const [kindFilter, setKindFilter] = useState<TimelineEvent["kind"] | "">("");
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimer = useRef<number | null>(null);
+
+  useEffect(() => {
+    const connect = (): void => {
+      setState("connecting");
+      let ws: WebSocket;
+      try {
+        ws = new WebSocket(wsUrl);
+      } catch {
+        setState("offline");
+        reconnectTimer.current = window.setTimeout(connect, 3000);
+        return;
+      }
+      wsRef.current = ws;
+
+      ws.addEventListener("open", () => setState("live"));
+      ws.addEventListener("message", (msg) => {
+        try {
+          const ev = JSON.parse(msg.data as string) as TimelineEvent;
+          if (!isTimelineEvent(ev)) return;
+          setEvents((prev) => [ev, ...prev].slice(0, MAX_EVENTS));
+        } catch {
+          /* ignore malformed payload */
+        }
+      });
+      ws.addEventListener("close", () => {
+        setState("offline");
+        reconnectTimer.current = window.setTimeout(connect, 3000);
+      });
+      ws.addEventListener("error", () => {
+        setState("offline");
+      });
+    };
+
+    connect();
+    return () => {
+      if (reconnectTimer.current !== null) window.clearTimeout(reconnectTimer.current);
+      wsRef.current?.close();
+    };
+  }, [wsUrl]);
+
+  const filtered = useMemo(
+    () => events.filter((e) => matchesFilter(e, agentFilter, kindFilter)),
+    [events, agentFilter, kindFilter],
+  );
+
+  const onExport = (): void => {
+    const lines = events.map((e) => JSON.stringify(e)).join("\n");
+    const blob = new Blob([lines + "\n"], { type: "application/x-jsonlines" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `sbo3l-audit-${new Date().toISOString().replace(/[:.]/g, "-")}.jsonl`;
+    document.body.append(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div>
+      <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1em", flexWrap: "wrap", gap: "0.6em" }}>
+        <span style={{ color: "var(--muted)", fontSize: "0.85em", fontFamily: "var(--font-mono)" }}>
+          {state === "live" && <span style={{ color: "var(--accent)" }}>● live · {events.length}/{MAX_EVENTS} events buffered</span>}
+          {state === "connecting" && <span>● connecting…</span>}
+          {state === "offline" && <span style={{ color: "#ff6b6b" }}>● offline · auto-reconnecting</span>}
+        </span>
+        <button onClick={onExport} disabled={events.length === 0} className="ghost">
+          Export {events.length} events as JSONL
+        </button>
+      </header>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "0.6em", marginBottom: "1em" }}>
+        <input
+          type="text"
+          placeholder="Filter by agent_id (substring)"
+          value={agentFilter}
+          onChange={(ev) => setAgentFilter(ev.target.value)}
+          aria-label="Filter by agent ID"
+          style={{ background: "var(--code-bg)", color: "var(--fg)", border: "1px solid var(--border)", borderRadius: "var(--r-sm)", padding: "0.5em 0.7em", fontFamily: "var(--font-mono)" }}
+        />
+        <select
+          value={kindFilter}
+          onChange={(ev) => setKindFilter(ev.target.value as TimelineEvent["kind"] | "")}
+          aria-label="Filter by event kind"
+          style={{ background: "var(--code-bg)", color: "var(--fg)", border: "1px solid var(--border)", borderRadius: "var(--r-sm)", padding: "0.5em 0.7em", fontFamily: "var(--font-mono)" }}
+        >
+          <option value="">all event kinds</option>
+          {Object.values(KIND_LABEL).map((k) => (
+            <option key={k} value={k}>{k}</option>
+          ))}
+        </select>
+      </div>
+
+      <ol style={{ listStyle: "none", padding: 0, margin: 0, display: "grid", gap: "0.4em" }}>
+        {filtered.length === 0 && (
+          <li style={{ color: "var(--muted)", textAlign: "center", padding: "2em 0" }}>
+            {state === "live" ? "Waiting for events that match your filter." : "No events yet — daemon not connected."}
+          </li>
+        )}
+        {filtered.map((e, idx) => (
+          <li
+            key={`${e.ts_ms}-${idx}`}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "8em 9em 1fr",
+              gap: "0.8em",
+              padding: "0.55em 0.9em",
+              border: "1px solid var(--border)",
+              borderRadius: "var(--r-sm)",
+              background: "var(--code-bg)",
+              fontSize: "0.88em",
+              fontFamily: "var(--font-mono)",
+            }}
+          >
+            <code style={{ color: "var(--muted)" }}>{new Date(e.ts_ms).toLocaleTimeString()}</code>
+            <code style={{ color: kindColor(e.kind) }}>{e.kind}</code>
+            <span>{describe(e)}</span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+function isTimelineEvent(value: unknown): value is TimelineEvent {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as { kind?: unknown };
+  return typeof v.kind === "string" && v.kind in KIND_LABEL;
+}
+
+function matchesFilter(e: TimelineEvent, agentFilter: string, kindFilter: TimelineEvent["kind"] | ""): boolean {
+  if (kindFilter && e.kind !== kindFilter) return false;
+  if (!agentFilter) return true;
+  const f = agentFilter.toLowerCase();
+  if ("agent_id" in e && e.agent_id.toLowerCase().includes(f)) return true;
+  if (e.kind === "attestation.signed" && (e.from.toLowerCase().includes(f) || e.to.toLowerCase().includes(f))) return true;
+  return false;
+}
+
+function describe(e: TimelineEvent): string {
+  switch (e.kind) {
+    case "agent.discovered":    return `${e.agent_id} (${e.ens_name})`;
+    case "attestation.signed":  return `${e.from} → ${e.to}  ${e.attestation_id}`;
+    case "decision.made":       return `${e.agent_id}  ${e.decision}${e.deny_code ? ` (${e.deny_code})` : ""}${e.intent ? ` · ${e.intent}` : ""}`;
+    case "audit.checkpoint":    return `${e.agent_id}  chain_length=${e.chain_length}  root=${e.root_hash.slice(0, 14)}…`;
+    case "execution.confirmed": return `${e.agent_id} → ${e.sponsor}  ref=${e.execution_ref}`;
+    case "flag.changed":        return `${e.flag_name} → ${e.enabled ? "on" : "off"} (by ${e.changed_by})`;
+  }
+}
+
+function kindColor(kind: TimelineEvent["kind"]): string {
+  switch (kind) {
+    case "decision.made":       return "var(--accent)";
+    case "execution.confirmed": return "var(--accent)";
+    case "flag.changed":        return "#ffce5c";
+    case "audit.checkpoint":    return "var(--muted)";
+    default:                    return "var(--fg)";
+  }
+}

--- a/apps/hosted-app/app/admin/audit/page.tsx
+++ b/apps/hosted-app/app/admin/audit/page.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+import { eventsWebSocketUrl } from "@/lib/sbo3l-client";
+import { AuditTimeline } from "./AuditTimeline";
+
+export const dynamic = "force-dynamic";
+
+export default function AdminAuditPage() {
+  const wsUrl = eventsWebSocketUrl();
+
+  return (
+    <main>
+      <header style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: "1em" }}>
+        <h1>Audit timeline</h1>
+        <nav style={{ fontSize: "0.85em", display: "flex", gap: "1em" }}>
+          <Link href="/admin/users">Users</Link>
+          <Link href="/admin/flags">Flags</Link>
+          <Link href="/admin/keys">Keys</Link>
+        </nav>
+      </header>
+      <p style={{ color: "var(--muted)", marginBottom: "1.5em", maxWidth: 760 }}>
+        Live tail of the daemon's <code>/v1/events</code> WebSocket bus.
+        Every <code>policy.decision</code>, <code>execution.confirmed</code>,
+        <code>flag.changed</code>, and <code>audit.checkpoint</code> appears here in
+        real time. Filter inline; export the buffered window as JSONL for
+        post-hoc analysis. Buffered window holds the last 200 events; older
+        events scroll off (full chain remains in the daemon's audit DB).
+      </p>
+
+      <AuditTimeline wsUrl={wsUrl} />
+
+      <aside style={{ marginTop: "2em", padding: "1em 1.2em", background: "var(--code-bg)", border: "1px solid var(--border)", borderLeft: "3px solid var(--accent)", borderRadius: "var(--r-md)", color: "var(--muted)", fontSize: "0.9em" }}>
+        <strong style={{ color: "var(--fg)" }}>Tenant scope:</strong> per-tenant
+        filtering happens at the daemon (Grace's slice). Until that ships,
+        admins see every tenant's events; non-admins are blocked by the role
+        gate on this route. The agent-id filter above is client-side and
+        applies to the buffered window only.
+      </aside>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

- New `/admin/audit` admin-only page with live WebSocket tail of `/v1/events`.
- 200-event buffer; inline filters (agent_id substring + kind enum); per-kind colour coding.
- JSONL export of the buffered window via client-side Blob download.
- Auto-reconnecting WebSocket; status pill shows live/connecting/offline.

## Why

P3 of round-8 brief. Gives admins a real-time window into the daemon's audit chain — judges-facing live demo material.

LoC: 237 insertions across 2 files.

## Test plan

```bash
cd apps/hosted-app
npm install && npm run typecheck && npm run build
npm run dev          # http://localhost:3000

# Boot daemon with /v1/events reachable (cargo run --release -p sbo3l-server)
# Drive a few events: bash demo-scripts/run-openagents-final.sh

# - Sign in as admin → /admin/audit
# - Status pill: "● live · N/200 events buffered"
# - Events stream in as the demo runs; kind labels colour-coded
# - Type "research" in agent filter → only research-* events show
# - Pick "decision.made" in kind filter → only decisions show
# - Click "Export N events as JSONL" → file downloads with one event per line
# - Stop the daemon → status pill flips to "● offline · auto-reconnecting"
# - Restart daemon → reconnects within ~3s
# - Sign out as admin / sign in as operator → /admin/audit redirects to /403
```

## Event kinds covered

| Kind | Source |
|---|---|
| `agent.discovered` | Trust DNS registry |
| `attestation.signed` | cross-agent attestations |
| `decision.made` | policy allow/deny |
| `audit.checkpoint` | chain advance |
| `execution.confirmed` | sponsor callbacks (#200) |
| `flag.changed` | feature flags (#213) |

## Out of scope

- Pause/resume the live tail — own follow-up.
- Click-to-expand event detail panel — own follow-up.
- Server-side replay of historical events on connect — daemon slice.
- Per-tenant filtering at the WS subscription layer (Grace's slice).

## Dependencies

- Dev 1's WS bus (`/v1/events`) ✅ on main.
- Dev 1 #200 (`execution.confirmed` event) ✅ merged.
- Dev 1 #213 (`feature_flags` + `flag.changed` event) shipping with #217 stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)