### PR TITLE
feat(hosted-app): /admin/keys KMS status UI (P4)

### DIFF
--- a/apps/hosted-app/app/admin/keys/KmsStatusCard.tsx
+++ b/apps/hosted-app/app/admin/keys/KmsStatusCard.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import { runKmsHealthCheck, type KmsStatus, type KmsStatusResult } from "./actions";
+
+interface Props {
+  initial: KmsStatusResult;
+}
+
+const BACKEND_LABEL: Record<KmsStatus["backend"], string> = {
+  "in-memory": "In-memory (dev only)",
+  "file":      "File-backed",
+  "kms-aws":   "AWS KMS",
+  "kms-gcp":   "Google Cloud KMS",
+  "vault":     "HashiCorp Vault",
+  "unknown":   "Unknown",
+};
+
+const BACKEND_HINT: Record<KmsStatus["backend"], string> = {
+  "in-memory": "Loses signing key on daemon restart. Acceptable for local dev only.",
+  "file":      "Persists across restarts. Acceptable for local production where the file lives on encrypted storage.",
+  "kms-aws":   "Production-recommended. Private key never leaves AWS KMS.",
+  "kms-gcp":   "Production-recommended. Private key never leaves GCP KMS.",
+  "vault":     "Production-recommended. Private key never leaves Vault.",
+  "unknown":   "Daemon reported a backend kind this UI doesn't recognise yet.",
+};
+
+export function KmsStatusCard({ initial }: Props): JSX.Element {
+  const [data, setData] = useState<KmsStatusResult>(initial);
+  const [busy, setBusy] = useState(false);
+
+  const onHealthCheck = async (): Promise<void> => {
+    setBusy(true);
+    const next = await runKmsHealthCheck();
+    setData(next);
+    setBusy(false);
+  };
+
+  if (!data.ok && data.pending) {
+    return (
+      <aside
+        role="status"
+        style={{
+          background: "var(--code-bg)",
+          border: "1px solid var(--border)",
+          borderLeft: "3px solid var(--accent)",
+          borderRadius: "var(--r-md)",
+          padding: "1.2em 1.4em",
+          color: "var(--muted)",
+        }}
+      >
+        <strong style={{ color: "var(--accent)" }}>Endpoint pending.</strong>{" "}
+        <span style={{ display: "block", marginTop: "0.4em" }}>{data.error}</span>
+        <span style={{ display: "block", marginTop: "0.6em", fontSize: "0.85em" }}>
+          When Dev 1 ships <code>/v1/admin/kms/status</code> + <code>/v1/admin/kms/health</code>, this page will activate automatically — no UI changes needed.
+        </span>
+      </aside>
+    );
+  }
+
+  if (!data.ok) {
+    return (
+      <aside
+        role="alert"
+        style={{
+          background: "var(--code-bg)",
+          border: "1px solid var(--border)",
+          borderLeft: "3px solid #ff6b6b",
+          borderRadius: "var(--r-md)",
+          padding: "1.2em 1.4em",
+          color: "var(--muted)",
+        }}
+      >
+        <strong style={{ color: "#ff6b6b" }}>Daemon unreachable.</strong>
+        <span style={{ display: "block", marginTop: "0.4em" }}>{data.error}</span>
+      </aside>
+    );
+  }
+
+  const s = data.status!;
+
+  return (
+    <div style={{ display: "grid", gap: "1em" }}>
+      <article style={{ padding: "1.4em", border: "1px solid var(--border)", borderRadius: "var(--r-lg)", background: "var(--code-bg)" }}>
+        <header style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: "0.8em" }}>
+          <h2 style={{ fontSize: "1.1em" }}>Backend</h2>
+          <span style={{ color: s.configured ? "var(--accent)" : "#ff6b6b", fontFamily: "var(--font-mono)", fontSize: "0.85em" }}>
+            ● {s.configured ? "configured" : "not configured"}
+          </span>
+        </header>
+        <p style={{ fontSize: "1.1em", color: "var(--fg)", marginBottom: "0.4em" }}>
+          {BACKEND_LABEL[s.backend]}
+        </p>
+        <p style={{ color: "var(--muted)", fontSize: "0.9em", marginBottom: "0.8em" }}>{BACKEND_HINT[s.backend]}</p>
+
+        <dl style={{ display: "grid", gridTemplateColumns: "10em 1fr", gap: "0.4em 1em", margin: 0, fontSize: "0.9em" }}>
+          {s.pubkey_b58 && <><dt style={{ color: "var(--muted)" }}>Public key</dt><dd><code>{s.pubkey_b58.slice(0, 24)}…</code></dd></>}
+          {s.key_id && <><dt style={{ color: "var(--muted)" }}>Key ID</dt><dd><code>{s.key_id}</code></dd></>}
+          {s.region && <><dt style={{ color: "var(--muted)" }}>Region</dt><dd><code>{s.region}</code></dd></>}
+          <dt style={{ color: "var(--muted)" }}>Last signed</dt>
+          <dd>{s.last_signed_at ? new Date(s.last_signed_at).toLocaleString() : <em style={{ color: "var(--muted)" }}>never</em>}</dd>
+          {s.last_signed_by_request_hash && (
+            <>
+              <dt style={{ color: "var(--muted)" }}>Last request_hash</dt>
+              <dd><code>{s.last_signed_by_request_hash.slice(0, 18)}…</code></dd>
+            </>
+          )}
+        </dl>
+      </article>
+
+      <article style={{ padding: "1.4em", border: "1px solid var(--border)", borderRadius: "var(--r-lg)", background: "var(--code-bg)" }}>
+        <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "0.8em" }}>
+          <h2 style={{ fontSize: "1.1em" }}>Health check</h2>
+          <button onClick={onHealthCheck} disabled={busy} className="ghost">
+            {busy ? "Checking…" : "Run check"}
+          </button>
+        </header>
+        {!s.health && <p style={{ color: "var(--muted)" }}>Click "Run check" to issue a no-op sign request and confirm the signer is reachable.</p>}
+        {s.health?.ok === true && (
+          <p style={{ color: "var(--accent)" }}>
+            ✓ healthy{s.health.rtt_ms !== undefined && ` · ${s.health.rtt_ms} ms RTT`}
+            {s.health.checked_at && <span style={{ color: "var(--muted)", marginLeft: "0.6em" }}>at {new Date(s.health.checked_at).toLocaleTimeString()}</span>}
+          </p>
+        )}
+        {s.health?.ok === false && (
+          <p style={{ color: "#ff6b6b" }}>
+            ✗ unhealthy{s.health.detail && ` — ${s.health.detail}`}
+          </p>
+        )}
+      </article>
+    </div>
+  );
+}

--- a/apps/hosted-app/app/admin/keys/actions.ts
+++ b/apps/hosted-app/app/admin/keys/actions.ts
@@ -1,0 +1,102 @@
+"use server";
+
+import { auth } from "@/auth";
+import { meetsRole } from "@/lib/roles";
+
+const DAEMON_URL = process.env.SBO3L_DAEMON_URL ?? "http://localhost:8080";
+const FETCH_TIMEOUT_MS = 4000;
+
+export interface KmsStatus {
+  backend: "in-memory" | "file" | "kms-aws" | "kms-gcp" | "vault" | "unknown";
+  configured: boolean;
+  pubkey_b58?: string | null;
+  key_id?: string | null;
+  last_signed_at?: string | null;
+  last_signed_by_request_hash?: string | null;
+  region?: string | null;
+  health?: {
+    ok: boolean;
+    rtt_ms?: number;
+    checked_at?: string;
+    detail?: string;
+  };
+}
+
+export interface KmsStatusResult {
+  ok: boolean;
+  status?: KmsStatus;
+  pending?: boolean;   // daemon endpoint not yet implemented
+  error?: string;
+}
+
+async function requireAdmin(): Promise<{ ok: true } | { ok: false; error: string }> {
+  const session = await auth();
+  if (!meetsRole(session?.user?.role, "admin")) {
+    return { ok: false, error: "admin role required" };
+  }
+  return { ok: true };
+}
+
+export async function fetchKmsStatus(): Promise<KmsStatusResult> {
+  const gate = await requireAdmin();
+  if (!gate.ok) return { ok: false, error: gate.error };
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${DAEMON_URL}/v1/admin/kms/status`, {
+      signal: ctrl.signal,
+      cache: "no-store",
+    });
+    if (res.status === 404) {
+      return {
+        ok: false,
+        pending: true,
+        error: "Daemon /v1/admin/kms/status endpoint not yet implemented (tracked as Dev 1 follow-up to #213). UI will activate automatically once the endpoint ships.",
+      };
+    }
+    if (!res.ok) {
+      return { ok: false, error: `daemon ${res.status} ${res.statusText}` };
+    }
+    const status = (await res.json()) as KmsStatus;
+    return { ok: true, status };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "fetch failed" };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// "Health check" sends a no-op sign request to confirm the configured
+// signer is reachable + producing valid signatures. Daemon route TBD;
+// when it lands, it should return { ok, rtt_ms, detail }.
+export async function runKmsHealthCheck(): Promise<KmsStatusResult> {
+  const gate = await requireAdmin();
+  if (!gate.ok) return { ok: false, error: gate.error };
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS * 2);
+  try {
+    const res = await fetch(`${DAEMON_URL}/v1/admin/kms/health`, {
+      method: "POST",
+      signal: ctrl.signal,
+      cache: "no-store",
+    });
+    if (res.status === 404) {
+      return {
+        ok: false,
+        pending: true,
+        error: "Daemon /v1/admin/kms/health endpoint not yet implemented.",
+      };
+    }
+    if (!res.ok) {
+      return { ok: false, error: `daemon ${res.status} ${res.statusText}` };
+    }
+    const status = (await res.json()) as KmsStatus;
+    return { ok: true, status };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "fetch failed" };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/apps/hosted-app/app/admin/keys/page.tsx
+++ b/apps/hosted-app/app/admin/keys/page.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { fetchKmsStatus } from "./actions";
+import { KmsStatusCard } from "./KmsStatusCard";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminKeysPage() {
+  const initial = await fetchKmsStatus();
+
+  return (
+    <main>
+      <header style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: "1em" }}>
+        <h1>Signing keys</h1>
+        <nav style={{ fontSize: "0.85em", display: "flex", gap: "1em" }}>
+          <Link href="/admin/users">Users</Link>
+          <Link href="/admin/flags">Flags</Link>
+          <Link href="/admin/audit">Audit</Link>
+        </nav>
+      </header>
+      <p style={{ color: "var(--muted)", marginBottom: "1.5em", maxWidth: 760 }}>
+        Visibility into the daemon's <code>Signer</code> trait
+        implementation — which backend is configured, when it last
+        produced a signature, and whether it currently responds. Read-
+        only on purpose: production key rotation goes through the KMS
+        provider's own console, not this UI.
+      </p>
+
+      <KmsStatusCard initial={initial} />
+
+      <aside style={{ marginTop: "2em", padding: "1em 1.2em", background: "var(--code-bg)", border: "1px solid var(--border)", borderLeft: "3px solid var(--accent)", borderRadius: "var(--r-md)", color: "var(--muted)", fontSize: "0.9em" }}>
+        <strong style={{ color: "var(--fg)" }}>What's signed:</strong>{" "}
+        every PolicyReceipt + every audit-event linkage hash. The agent
+        never sees the private key (identity sub-claim #2; demo gate 12
+        grep-asserts this every CI run).{" "}
+        <a href="https://sbo3l-docs.vercel.app/concepts/signing">Read the signing model →</a>
+      </aside>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

- New `/admin/keys` admin-only read-only page surfacing the daemon's `Signer` backend.
- Three render modes: pending (endpoint not shipped), error (daemon unreachable), ok (full backend metadata + health).
- Backend hint copy explains production-suitability of each variant.
- Health check button issues a no-op sign through the configured signer.

## Why

P4 of round-8 brief. Visibility into Dev 1's KMS abstraction (#213) for admins. LoC: 274 insertions across 3 files.

## Test plan

```bash
cd apps/hosted-app
npm install && npm run typecheck && npm run build
npm run dev          # http://localhost:3000

# Sign in as admin → /admin/keys

# Mode 1: daemon NOT shipped /v1/admin/kms/status yet (404)
#   → pending banner: "Daemon /v1/admin/kms/status endpoint not yet
#     implemented (tracked as Dev 1 follow-up to #213). UI will activate
#     automatically once the endpoint ships."

# Mode 2: daemon down (network error / timeout)
#   → red error banner with the daemon error message

# Mode 3: daemon up, endpoint live
#   → backend label + hint + metadata grid (pubkey/key_id/region/last_signed_at)
#   → health-check card with "Run check" button
#   → click → ✓ healthy · NN ms RTT · at HH:MM:SS

# Sign out as admin / sign in as operator → /admin/keys redirects to /403
```

## Endpoint expectations (Dev 1 follow-up)

| Path | Method | Returns |
|---|---|---|
| `/v1/admin/kms/status` | GET | `KmsStatus { backend, configured, pubkey_b58, key_id, region, last_signed_at, last_signed_by_request_hash }` |
| `/v1/admin/kms/health` | POST | `KmsStatus` with `.health: { ok, rtt_ms, checked_at, detail }` populated |

## Out of scope

- Key rotation UI — by design; out-of-band via the KMS console.
- Per-tenant key visibility — Grace's slice; today admins see the daemon-level signer only.
- Audit-event log of every prior sign — covered by #231 /admin/audit timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)