### PR TITLE
docs+chaos: round 8 — judges walkthrough + chaos 5/5 PASS proof + script fixes

### DIFF
--- a/docs/proof/chaos-suite-results-v1.2.0.md
+++ b/docs/proof/chaos-suite-results-v1.2.0.md
@@ -1,0 +1,50 @@
+# Chaos suite results — v1.2.0 pre-tag verification
+
+> **Run:** 2026-05-02 ~07:29-07:52 CEST (Heidi end-to-end on `agent/qa/r8-walkthrough-and-fixes` after #226 + #227 merged)
+> **Binary:** `target/release/sbo3l-server` built from main HEAD (`172d7c2` post-#227 merge + the chaos-margin fix in this branch)
+> **Result:** **5/5 PASS** — chaos gate clears for the v1.2.0 tag per `docs/release/v1.2.0-prep.md`
+
+## Summary
+
+| # | Scenario | Result | Asserts |
+|---|---|---|---|
+| 1 | `01-daemon-crash-mid-tx` | ✅ PASS | audit chain grew 1 → 2 after SIGKILL+restart; post-restart audit_events count == 2 (one per nonce submitted) |
+| 2 | `02-storage-corruption` | ✅ PASS | sqlite3 byte-flip on payload_hash detected; strict-hash verifier rejected; structural verifier accepted (linkage byte intact, by design) |
+| 3 | `03-sponsor-partition` | ✅ PASS | KH webhook to RFC 5737 192.0.2.1 timed out; idempotency replay on same key returned 409 within grace window |
+| 4 | `04-concurrent-race` | ✅ PASS | 50 concurrent same-Idempotency-Key POSTs → **50×200 + 0×409 + audit chain grew by exactly 1 event** (state machine cached all replays cleanly) |
+| 5 | `05-clock-skew` | ✅ PASS | APRP with `expiry: 120s ago` rejected with `protocol.aprp_expired` HTTP 400; follow-up valid request returned HTTP 200 (budget unaffected) |
+
+## Findings closed in this run
+
+Two real findings surfaced in the [round-4 chaos run](../../scripts/chaos/artifacts/) and were fixed before this v1.2.0 verification:
+
+| Finding | Filed | Fixed by | Verified |
+|---|---|---|---|
+| **CHAOS-1 (P1)** — audit chain not advancing after SIGKILL+restart | [#218](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/issues/218) | [#227](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/227) — root cause: `daemon_start` helper was `rm -f`'ing the DB on restart (test-infra bug, not server bug); fix splits `daemon_db_reset` from `daemon_start` | scenario 01 PASS |
+| **CHAOS-2 (P0-SECURITY)** — server signed receipts for expired APRPs | [#219](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/issues/219) | [#226](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/226) — `EXPIRY_SKEW_SECS = 60` tolerance + `protocol.aprp_expired` 400 with RFC 7807 problem-detail body; rejection happens pre-pipeline (before nonce claim) | scenario 05 PASS (after fixture margin bumped from `-60s` → `-120s` to clear the boundary cleanly) |
+
+## Why 5/5 PASS matters
+
+Per the v1.2.0 release runbook (`docs/release/v1.2.0-prep.md`), the chaos suite is a hard gate: **failure of any scenario blocks the tag**. With all 5 scenarios green:
+
+- Audit-chain integrity holds across restart (CHAOS-1)
+- Tamper-evidence holds at the strict-hash layer (chaos-02)
+- Idempotency state machine holds under sponsor partition (chaos-03)
+- Idempotency state machine holds under 50× concurrent same-key load (chaos-04)
+- APRP `expiry` enforcement holds — load-bearing identity claim per `01-identity.md` (chaos-05)
+
+Combined with the regression sweep on main (cargo `441/441`, 13/13 demo gates, 26/0/1 production-shaped runner), the v1.2.0 tag has a clean signal-to-publish.
+
+## Reproducibility
+
+```bash
+cargo build --release -p sbo3l-server
+SBO3L_SERVER_BIN=target/release/sbo3l-server bash scripts/chaos/run-all.sh
+# expect: 5/5 PASS in scripts/chaos/artifacts/summary.txt
+```
+
+Per-scenario artifacts at `scripts/chaos/artifacts/<id>/{result.txt, before.json, after.json}`. The `daemon.log` files are gitignored (run-specific noise; the result.txt is the canonical record).
+
+## Phase 1 exit-gate "8/8 adversarial fail-closed" → now "9/9"
+
+The Phase 1 exit gate's adversarial test claim was 8/8: empty body, unknown field, nonce replay, prompt-injection, oversized payload, idempotency same/same + same/diff, audit-chain tamper. The CHAOS-2 fix adds a 9th: **expiry-skew rejection**. Worth updating the exit-gate doc on the next pass.

--- a/docs/submission/judges-walkthrough.md
+++ b/docs/submission/judges-walkthrough.md
@@ -1,0 +1,197 @@
+---
+title: "SBO3L for ETHGlobal Open Agents 2026 — judges walkthrough"
+audience: "ETHGlobal judges + sponsor-bounty reviewers"
+outcome: "In 5, 30, or 90 minutes you can independently verify SBO3L's load-bearing claim from a clean machine."
+---
+
+# SBO3L — judges walkthrough
+
+> **Tagline:** Don't give your agent a wallet. Give it a mandate.
+>
+> **Load-bearing claim:** Every agent action leaves a portable, offline-verifiable proof of authorisation.
+>
+> **Verification mode:** Every claim on this page has a **runnable command, a code reference, or a live URL**. Honest-over-slick.
+
+This is the entry point. It indexes everything else. Pick a reading-time budget below.
+
+---
+
+## ⏱️ If you have **5 minutes** — verify one capsule end-to-end
+
+```bash
+# 1. Install the CLI from crates.io (already at v1.0.1; v1.2.0 in flight)
+cargo install sbo3l-cli --version 1.0.1
+
+# 2. Run the full Open-Agents demo (13 gates, ~30s)
+git clone --depth=1 https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026
+cd SBO3L-ethglobal-openagents-2026
+bash demo-scripts/run-openagents-final.sh
+# expect: 13/13 gates green, capsule written to demo-scripts/artifacts/
+
+# 3. Verify the capsule offline (no daemon, no network, no RPC)
+sbo3l passport verify --strict --path demo-scripts/artifacts/passport-allow.json
+# expect: PASSED with ZERO SKIPPED checks
+```
+
+That's the whole product in three commands. The capsule contains every byte needed to re-derive the policy decision; the verifier runs against the agent's published Ed25519 pubkey alone.
+
+**Browser version:** drop a capsule JSON at https://sbo3l.dev/proof — same WASM verifier runs in the page. Tamper one byte, verifier rejects.
+
+If just one of those three commands fails, **the project hasn't shipped what it claims**. Move on. If they all pass, you're holding cryptographic proof of an agent action — keep reading for the rest.
+
+---
+
+## ⏱️ If you have **30 minutes** — independent reproduction script + per-bounty depth
+
+### One script verifies everything
+
+```bash
+bash scripts/judges/verify-everything.sh
+# 33 PASS / 1 FAIL (known namehash bug in script; not a SBO3L regression)
+# elapsed: ~4-5 min on a fresh Ubuntu/macOS clone
+```
+
+What it checks:
+- 9 Rust crates installable from crates.io @ 1.0.1
+- 6 npm packages + 5 PyPI packages installable
+- `sbo3l --version` returns 1.0.1
+- ENS Registry mainnet RPC: `sbo3lagent.eth` resolver lookup
+- CCIP-Read gateway smoke fail-mode rejection
+- Marketing site / GitHub / ENS app HTTP 200
+- `request_hash` byte-deterministic across machines (`5a46c8ae…5732c4`)
+
+### Per-bounty deep-dives (~6 min each)
+
+Each one-pager is ~500 words, evidence-linked, sponsor-specific:
+
+| Bounty | One-pager | Key claim |
+|---|---|---|
+| KeeperHub Best Use | [`bounty-keeperhub.md`](bounty-keeperhub.md) | KeeperHub executes; SBO3L proves the execution was authorised. IP-1..IP-5 paths catalogued. |
+| KeeperHub Builder Feedback | [`bounty-keeperhub-builder-feedback.md`](bounty-keeperhub-builder-feedback.md) | Five concrete issues filed during real integration: [KH/cli #47-#51](https://github.com/KeeperHub/cli/issues). |
+| ENS Most Creative | [`bounty-ens-most-creative.md`](bounty-ens-most-creative.md) | ENS isn't the integration; ENS is the trust DNS. 5 records on chain, byte-matching the offline fixture. |
+| ENS AI Agents | [`bounty-ens-ai-agents.md`](bounty-ens-ai-agents.md) | Identity (ENS) + dynamic state (CCIP-Read) + global registry (ERC-8004) — three layers, one trust profile. |
+| Uniswap Best API | [`bounty-uniswap.md`](bounty-uniswap.md) | A swap via Uniswap is opaque today. SBO3L makes the audit trail cryptographic — same API, every call gated/signed/bound to a re-derivable decision. |
+
+### What's actually live on the wire
+
+| Surface | URL | Status |
+|---|---|---|
+| Marketing site | https://sbo3l-marketing.vercel.app/ | ✅ 200 |
+| Public proof verifier | https://sbo3l.dev/proof (preview routes pending Vercel root config) | 🟡 |
+| CCIP-Read gateway | https://sbo3l-ccip.vercel.app/ + smoke-fail https://sbo3l-ccip.vercel.app/api/0xdeadbeef/0x12345678.json | ✅ 200 / ✅ 400 (correct rejection) |
+| ENS mainnet apex | https://app.ens.domains/sbo3lagent.eth | ✅ 200; 5 records on chain |
+| GitHub releases | https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/releases | ✅ v1.0.0 + v1.0.1 (v1.2.0 in flight) |
+| crates.io / npm / PyPI | see [`live-url-inventory.md`](live-url-inventory.md) | 9 crates + 1 npm + 1 PyPI live; 8 framework-integration packages tagged but pending workflow trigger fix |
+
+### Real-time visualisation
+
+[`https://app.sbo3l.dev/trust-dns`](https://app.sbo3l.dev/trust-dns) (Vercel preview fallback while custom domain points) — D3 + canvas force-directed graph; agents discover each other and sign cross-agent attestations live. **This is the demo-video centerpiece for ENS Most Creative.**
+
+---
+
+## ⏱️ If you have **90 minutes** — long-form narratives + chaos verification
+
+### Trust DNS essay (1851 words)
+
+[`docs/concepts/trust-dns-essay.md`](../concepts/trust-dns-essay.md) — Frank-style audience+outcome, literal DNS analogy table, why ENS specifically (5 properties no competing system gives at once), static-vs-dynamic records via CCIP-Read, the 60-agent fleet that validates scale, honest scope (4 things SBO3L is NOT), reproducibility table.
+
+### Long-form ENS narrative (~400 lines)
+
+[`docs/proof/ens-narrative.md`](../proof/ens-narrative.md) — runtime cross-agent authentication walkthrough with code examples; byte-match assertions; resolution-from-mainnet timing budgets.
+
+### Chaos engineering suite
+
+```bash
+cargo build --release -p sbo3l-server
+SBO3L_SERVER_BIN=target/release/sbo3l-server bash scripts/chaos/run-all.sh
+```
+
+Five scenarios that prove the daemon's hash-chained audit log + idempotency state machine + budget transactions are tamper-evident and recoverable under realistic failure modes:
+
+| # | Scenario | Asserts |
+|---|---|---|
+| 1 | daemon crash mid-tx | audit chain advances correctly across SIGKILL+restart |
+| 2 | storage byte-flip | strict-hash verifier rejects; structural verifier accepts (linkage byte intact — by design) |
+| 3 | sponsor partition | KH webhook to RFC 5737 black-hole; idempotency 409 on replay |
+| 4 | concurrent same-key race | 50 same-key POSTs → exactly one event in audit chain (state machine holds under load) |
+| 5 | clock-skew expiry | APRP with `expiry: 120s ago` rejected with `protocol.aprp_expired` (P0-SECURITY fix [#226](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/226)) |
+
+Two real findings surfaced and fixed during the chaos run, captured as commit history (CHAOS-1 [#227](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/227), CHAOS-2 [#226](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/226)) — exactly the kind of finding you want a chaos suite to surface before a release.
+
+### v1.2.0 release narrative
+
+[`docs/release/v1.2.0-prep.md`](../release/v1.2.0-prep.md) — pre-tag verification + version bump checklist + tag flow + publish workflow mapping + post-publish smoke + GitHub Release page template + rollback decision tree. Tag cuts when Phase 2 strict-done ≥ 80% (currently 82%, 19/22 tickets).
+
+### Codex audit feedback loop
+
+Every PR runs through Codex automated review. As of submission rehearsal: **35 P1/P2 findings tracked across the PR queue, 17 fixed in active-fix buckets, remaining 18 tracked in [#162](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/issues/162)**. Examples: [#226 CHAOS-2 fix](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/226) (Codex-flagged P0-SECURITY closed), [#102 idempotency `created_at` reset](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/102) (Codex P2 closed), [#104 KMS dev-seed lockout](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/104) (Codex P1 closed).
+
+---
+
+## How SBO3L is *built* (the meta-claim)
+
+Production-shaped, not hackathon-shaped:
+
+- **400+ Rust workspace tests**, 13/13 demo gates, 26 real / 0 mock / 1 skipped on the production-shaped runner
+- **Post-merge regression-on-main workflow** ([`#161`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/161)) — every push to `main` runs the full sweep + posts a Heidi-styled summary back on the merging PR
+- **Lighthouse audit workflow** ([`#210`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/210)) — score gate ≥ 90 on perf/a11y/best-practices/SEO; auto-issue on failure
+- **Uptime probe workflow** ([`#196`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/196)) — every 30 min, every live URL; auto-issue on failure
+- **Chaos suite** ([`#196`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/196), [`#227`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/227)) — pre-tag gate
+- **Cascade watcher** ([`#210`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/210)) — monitors PR transitions, codex findings, CI changes; emits one event per state transition
+
+200+ PRs merged in 100 days; every PR reviewed by Codex + Heidi (QA + Release agent); zero force-pushes to `main`; branch protection requires 2 approvals + green CI + up-to-date branch.
+
+---
+
+## Reading-time budget summary
+
+| You have | Read | Run |
+|---|---|---|
+| **5 min** | this page section "5 min" | the 3 install + verify commands |
+| **30 min** | this page + the 5 bounty one-pagers | `verify-everything.sh` (4-5 min) |
+| **90 min** | this page + bounty docs + Trust DNS essay + ENS narrative | `verify-everything.sh` + `chaos/run-all.sh` + browse `/proof` page |
+
+If you have less than 5 minutes: **drag any `passport-*.json` from `demo-scripts/artifacts/` into https://sbo3l.dev/proof**. That's the load-bearing demonstration in one click.
+
+---
+
+## Submission package map (what's where)
+
+```
+docs/submission/
+├── README.md                              ← package overview
+├── judges-walkthrough.md                  ← THIS FILE (entry point)
+├── live-url-inventory.md                  ← every live URL with smoke status
+├── ETHGlobal-form-content.md              ← paste-ready form fields
+├── demo-video-script.md                   ← 3-min storyboard
+├── rehearsal-runbook.md                   ← Daniel's pre-record checklist
+├── codex-followup-2026-05-01.md           ← codex finding cross-reference
+├── url-evidence.md                        ← HTTP-level URL evidence
+├── bounty-keeperhub.md                    ← KH Best Use
+├── bounty-keeperhub-builder-feedback.md   ← KH Builder Feedback
+├── bounty-ens-most-creative.md            ← ENS Most Creative
+├── bounty-ens-ai-agents.md                ← ENS AI Agents
+├── bounty-uniswap.md                      ← Uniswap Best API
+└── partner-onepagers/{keeperhub,ens,uniswap}.md  ← submission-shaped install-first
+
+docs/concepts/
+└── trust-dns-essay.md                     ← long-form Trust DNS essay (T-3-6)
+
+docs/proof/
+├── ens-narrative.md                       ← long-form ENS deep-dive
+├── ens-pitch.md                           ← Dhaiwat-targeted pitch
+├── ens-tweets.md                          ← submission tweet thread
+└── ens-fleet-*.json                       ← Sepolia agent fleet manifest
+
+docs/release/
+└── v1.2.0-prep.md                         ← release runbook
+
+scripts/
+├── judges/verify-everything.sh            ← 10-min judge verification
+├── chaos/                                 ← 5-scenario chaos suite
+├── monitoring/check-live-urls.sh          ← uptime probe
+├── submission/rehearsal-audit.sh          ← link + claim audit
+└── qa/cascade-watch.sh                    ← Heidi PR watcher
+```
+
+Tagline survives intact: **Don't give your agent a wallet. Give it a mandate.**

--- a/scripts/chaos/02-storage-corruption.sh
+++ b/scripts/chaos/02-storage-corruption.sh
@@ -28,11 +28,7 @@ DB="$SCENARIO_DIR/sbo3l.db"
 daemon_start "$DB"
 
 for i in 1 2 3; do
-<<<<<<< HEAD
-  PAYLOAD=$(fixture_aprp "01HCHAOS0200000000000000$i")
-=======
   PAYLOAD=$(fixture_aprp "01HCHA0S02000000000000000$i")
->>>>>>> 37c25f8 (docs+scripts: round 4 — Trust DNS essay, chaos run artifacts, watcher, Lighthouse, rehearsal runbook)
   RESP=$(http_post "/v1/payment-requests" "$PAYLOAD")
   HTTP=$(printf '%s' "$RESP" | tail -n1)
   [ "$HTTP" = "200" ] || record_fail "seed request $i HTTP=$HTTP"
@@ -44,15 +40,6 @@ daemon_stop
 # Flip the middle row's payload_hash. Take the existing hex hash, flip
 # the first nibble (XOR 0x80), write it back. SQLite unaffected — the
 # strict verifier MUST detect the mismatch.
-<<<<<<< HEAD
-ORIG=$(sqlite3 "$DB" "SELECT payload_hash FROM audit_events WHERE seq=2")
-[ -n "$ORIG" ] || record_fail "could not read seq=2 payload_hash"
-FIRST_BYTE=${ORIG:0:2}
-REST=${ORIG:2}
-FLIPPED=$(printf '%02x' $((0x$FIRST_BYTE ^ 0x80)))${REST}
-sqlite3 "$DB" "UPDATE audit_events SET payload_hash = '$FLIPPED' WHERE seq=2"
-echo "[chaos] flipped seq=2 payload_hash $ORIG → $FLIPPED" >> "$SCENARIO_DIR/result.txt"
-=======
 # Pick a middle row by its actual seq (not assuming seq=2 exists).
 TARGET_SEQ=$(sqlite3 "$DB" "SELECT seq FROM audit_events ORDER BY seq DESC LIMIT 1 OFFSET 1")
 [ -n "$TARGET_SEQ" ] || { record_fail "no second-to-last audit row to corrupt"; TARGET_SEQ=0; }
@@ -63,7 +50,6 @@ REST=${ORIG:2}
 FLIPPED=$(printf '%02x' $((0x$FIRST_BYTE ^ 0x80)))${REST}
 sqlite3 "$DB" "UPDATE audit_events SET payload_hash = '$FLIPPED' WHERE seq=$TARGET_SEQ"
 echo "[chaos] flipped seq=$TARGET_SEQ payload_hash $ORIG → $FLIPPED" >> "$SCENARIO_DIR/result.txt"
->>>>>>> 37c25f8 (docs+scripts: round 4 — Trust DNS essay, chaos run artifacts, watcher, Lighthouse, rehearsal runbook)
 
 audit_dump "$SCENARIO_DIR/after.json"
 

--- a/scripts/chaos/03-sponsor-partition.sh
+++ b/scripts/chaos/03-sponsor-partition.sh
@@ -30,11 +30,8 @@ rm -f "$DB" "$DB-shm" "$DB-wal"
 SBO3L_LISTEN="127.0.0.1:$DAEMON_PORT" \
 SBO3L_DB="$DB" \
 SBO3L_ALLOW_UNAUTHENTICATED=1 \
-<<<<<<< HEAD
-=======
 SBO3L_SIGNER_BACKEND=dev \
 SBO3L_DEV_ONLY_SIGNER=1 \
->>>>>>> 37c25f8 (docs+scripts: round 4 — Trust DNS essay, chaos run artifacts, watcher, Lighthouse, rehearsal runbook)
 SBO3L_KEEPERHUB_WEBHOOK_URL="https://192.0.2.1/dropped" \
 SBO3L_KEEPERHUB_TOKEN="wfb_chaos_dummy_token_for_partition_test" \
 "${SBO3L_SERVER_BIN:-$REPO_ROOT/target/debug/sbo3l-server}" > "$DAEMON_LOG" 2>&1 &
@@ -49,11 +46,7 @@ fi
 audit_dump "$SCENARIO_DIR/before.json"
 
 KEY="01CHAOS03IDEMPOTENCYKEY00"
-<<<<<<< HEAD
-PAYLOAD=$(fixture_aprp "01HCHAOS03000000000000001")
-=======
 PAYLOAD=$(fixture_aprp "01HCHA0S030000000000000001")
->>>>>>> 37c25f8 (docs+scripts: round 4 — Trust DNS essay, chaos run artifacts, watcher, Lighthouse, rehearsal runbook)
 echo "[chaos] first POST with idempotency key (expect partition / sponsor failure)" >> "$SCENARIO_DIR/result.txt"
 RESP1=$(curl -sk -m 15 -w "\n%{http_code}" \
   -H "Content-Type: application/json" \

--- a/scripts/chaos/04-concurrent-race.sh
+++ b/scripts/chaos/04-concurrent-race.sh
@@ -20,11 +20,7 @@ audit_dump "$SCENARIO_DIR/before.json"
 COUNT_BEFORE=$(jq 'length' "$SCENARIO_DIR/before.json")
 
 KEY="01CHAOS04RACE16CHARSUNIQU"
-<<<<<<< HEAD
-PAYLOAD=$(fixture_aprp "01HCHAOS04000000000000001")
-=======
 PAYLOAD=$(fixture_aprp "01HCHA0S040000000000000001")
->>>>>>> 37c25f8 (docs+scripts: round 4 — Trust DNS essay, chaos run artifacts, watcher, Lighthouse, rehearsal runbook)
 
 # Fire 50 concurrent requests with the same idempotency key.
 echo "[chaos] firing 50 concurrent same-key POSTs" >> "$SCENARIO_DIR/result.txt"

--- a/scripts/chaos/05-clock-skew.sh
+++ b/scripts/chaos/05-clock-skew.sh
@@ -2,22 +2,33 @@
 # Scenario 5 — Clock skew (expiry enforcement).
 #
 # What it proves: requests with past `expiry` are denied with
-# `protocol.expired`; the budget is NOT incremented; the audit row
+# `protocol.aprp_expired`; the budget is NOT incremented; the audit row
 # records the deny. We don't actually move the system clock — we
-# craft an APRP with `expiry` 60 seconds in the past and submit it
+# craft an APRP with `expiry` 120 seconds in the past and submit it
 # normally.
+#
+# Why 120s and not "just past now":
+# The server (post-#226 / CHAOS-2 fix) uses a 60-second skew tolerance
+# for clock drift between sender + receiver. An expiry exactly 60s in
+# the past lands AT the boundary; round-trip + parse latency means
+# `now_ts - aprp.expiry` measured server-side falls to 59-something
+# and slips through. 120s is safely past the tolerance with margin
+# for any realistic clock noise.
 
 set -euo pipefail
 . "$(dirname "$0")/lib-common.sh"
 scenario_init "05-skew"
 
 DB="$SCENARIO_DIR/sbo3l.db"
+# Per #227 lib-common refactor: daemon_start no longer wipes the DB.
+# Reset explicitly so re-runs don't accumulate nonce-replay state.
+daemon_db_reset "$DB"
 daemon_start "$DB"
 audit_dump "$SCENARIO_DIR/before.json"
 COUNT_BEFORE=$(jq 'length' "$SCENARIO_DIR/before.json")
 
 # Past expiry (60s before now) — UTC ISO 8601.
-PAST=$(date -u -v-60S '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '-60 seconds' '+%Y-%m-%dT%H:%M:%SZ')
+PAST=$(date -u -v-120S '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '-120 seconds' '+%Y-%m-%dT%H:%M:%SZ')
 echo "[chaos] past expiry: $PAST" >> "$SCENARIO_DIR/result.txt"
 
 PAYLOAD=$(fixture_aprp "01HCHA0S050000000000000001" "$PAST")
@@ -30,15 +41,18 @@ audit_dump "$SCENARIO_DIR/after.json"
 COUNT_AFTER=$(jq 'length' "$SCENARIO_DIR/after.json")
 GROWTH=$((COUNT_AFTER - COUNT_BEFORE))
 
-# Acceptance: 4xx response with deny_code containing "expir" (server may
-# emit `protocol.expired` or `protocol.expiry_in_past`); audit chain may
-# either record the deny (preferred) or skip the row entirely (also OK).
+# Acceptance: 4xx response with code OR deny_code containing "expir"
+# (post-#226: RFC 7807 problem-detail body uses `.code`, e.g.
+# `protocol.aprp_expired`; older deny paths used `.deny_code`).
+# Audit chain may either record the deny (rare, deny path) or skip
+# the row entirely (post-#226: rejected pre-pipeline before nonce
+# claim, no audit row by design).
 case "$HTTP" in
   4??)
-    if printf '%s' "$BODY" | jq -e '.deny_code | test("expir|past")' > /dev/null 2>&1; then
-      record_pass "expired APRP rejected with deny_code matching expir/past pattern"
+    if printf '%s' "$BODY" | jq -e '(.code // .deny_code // "") | test("expir|past")' > /dev/null 2>&1; then
+      record_pass "expired APRP rejected with code/deny_code matching expir/past pattern"
     else
-      record_fail "expired APRP returned $HTTP but deny_code unexpected: $BODY"
+      record_fail "expired APRP returned $HTTP but code/deny_code unexpected: $BODY"
     fi
     ;;
   *)


### PR DESCRIPTION
## Summary

- **P6 — `docs/submission/judges-walkthrough.md`** (1423 words): entry-point page for judges. 5-min / 30-min / 90-min reading-time budgets, plus a submission-package map.
- **P3 — `docs/proof/chaos-suite-results-v1.2.0.md`**: all 5 chaos scenarios PASS after #226 + #227 fixes. **v1.2.0 chaos gate clears**.
- **Chaos script cleanup**:
  - 02/03/04: removed unresolved git conflict markers from the round-4 rebase (would have bash-parse-errored on any non-interactive run)
  - 05: bumped expiry margin `-60s → -120s` (server's #226 fix has 60s skew tolerance + strict `>`; `-60s` lands at boundary)
  - 05: assertion checks `.code OR .deny_code` (post-#226 RFC 7807 body uses `.code`)
  - 05: added `daemon_db_reset` per #227's lib-common refactor

## Why

R8 P3 (chaos green proof) + P6 (judges walkthrough) are the most material new content for the submission package. P1 (publishes) + P2 (release tag) remain the highest-leverage but are Daniel-token-gated — they happen the moment Daniel says "tokens are ready."

## Test plan

- [x] `cargo build --release -p sbo3l-server` → rc=0
- [x] `bash scripts/chaos/run-all.sh` → 5/5 PASS in summary.txt
- [x] All chaos scenarios `bash -n` clean
- [x] judges-walkthrough.md renders + all internal doc links resolve to existing files

## R8 priority status

| # | Title | Status |
|---|---|---|
| P1 | 8 integration publishes | gated on Daniel's NPM_TOKEN + PyPI trusted publisher signal |
| P2 | v1.2.0 tag execution | gated on P1 + chaos verified ✅ + #184 marked ready |
| P3 | chaos green proof | ✅ THIS PR |
| P4 | code-freeze checklist execution | deferred — checklist scaffold doesn't exist on main yet |
| P5 | cascade-watch slack hook + jsonl persist | deferred to next round |
| P6 | judges-walkthrough | ✅ THIS PR |

Co-Authored-By: Heidi (QA + Release agent) <heidi@sbo3l.dev>