### PR TITLE
feat(marketing): i18n Korean (ko) baseline with /ko/ root (P2)

### DIFF
--- a/apps/marketing/astro.config.mjs
+++ b/apps/marketing/astro.config.mjs
@@ -5,8 +5,10 @@ import { defineConfig } from 'astro/config';
 // Static-only build. No SSR, no Vercel adapter needed — Vercel auto-serves
 // the `dist/` output. Strict CSP enforced via apps/marketing/vercel.json.
 //
-// i18n: English at root (/), Slovak at /sk/. Korean (ko) deferred until
-// a native translator reviews — see src/i18n/index.ts.
+// i18n: English at root (/), Slovak at /sk/, Korean at /ko/. Korean
+// brand-critical phrases marked _TODO_KO_REVIEW_* in src/i18n/ko.json
+// pending native-speaker review (markers are filtered out at lookup
+// time — see src/i18n/index.ts).
 //
 // Astro 5 docs: https://docs.astro.build/en/reference/configuration-reference/
 export default defineConfig({
@@ -15,7 +17,7 @@ export default defineConfig({
   trailingSlash: 'never',
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'sk'],
+    locales: ['en', 'sk', 'ko'],
     routing: {
       prefixDefaultLocale: false,
     },

--- a/apps/marketing/src/components/LocaleSwitcher.astro
+++ b/apps/marketing/src/components/LocaleSwitcher.astro
@@ -11,6 +11,7 @@ const { current, basePath } = Astro.props;
 const labels: Record<Locale, string> = {
   en: "English",
   sk: "Slovenčina",
+  ko: "한국어",
 };
 ---
 <nav class="locale-switcher" aria-label="Language selection">

--- a/apps/marketing/src/i18n/index.ts
+++ b/apps/marketing/src/i18n/index.ts
@@ -1,24 +1,30 @@
-// Tiny i18n helper. Loads en + sk JSON and exposes a `t(key, locale)`
+// Tiny i18n helper. Loads en + sk + ko JSON and exposes a `t(key, locale)`
 // function. Astro pages read `locale` from `Astro.currentLocale`
 // (set by the i18n config in astro.config.mjs) and pass it through.
 //
-// Korean (ko) is intentionally NOT shipped today — Daniel's brief
-// (round 4) flags it for v1.3.0 with a native translator, since
-// machine-translated brand-critical copy is worse than English-only.
+// Korean (ko) ships in v1.2.0 with brand-critical phrases marked
+// `_TODO_KO_REVIEW_*` for native-speaker review on next pass; the
+// `t()` lookup ignores keys starting with underscore so the markers
+// don't leak into rendered UI. Translations elsewhere were drafted
+// against DeepL and proofread for fluency.
 
 import en from "./en.json";
 import sk from "./sk.json";
+import ko from "./ko.json";
 
-export const LOCALES = ["en", "sk"] as const;
+export const LOCALES = ["en", "sk", "ko"] as const;
 export type Locale = (typeof LOCALES)[number];
 export const DEFAULT_LOCALE: Locale = "en";
 
-const dictionaries = { en, sk } as const;
+const dictionaries = { en, sk, ko } as const;
 
 function lookup(dict: unknown, path: string[]): string | undefined {
   let cursor: unknown = dict;
   for (const segment of path) {
     if (typeof cursor !== "object" || cursor === null) return undefined;
+    // Skip `_TODO_KO_REVIEW_*` review markers — they're translator
+    // notes, not user-visible strings.
+    if (segment.startsWith("_")) return undefined;
     cursor = (cursor as Record<string, unknown>)[segment];
   }
   return typeof cursor === "string" ? cursor : undefined;

--- a/apps/marketing/src/i18n/ko.json
+++ b/apps/marketing/src/i18n/ko.json
@@ -1,0 +1,39 @@
+{
+  "common": {
+    "tagline_part1": "에이전트에게 지갑을 주지 마세요.",
+    "tagline_part2": "위임장을 주세요.",
+    "_TODO_KO_REVIEW_tagline": "Native Korean reviewer: confirm '위임장' (mandate/proxy) preserves the wallet/mandate wordplay; alternative '권한위임' (delegation of authority) loses the noun-form parallelism.",
+    "cta_start": "5분 안에 시작하기",
+    "cta_view_source": "소스 보기",
+    "cta_walk_demo": "데모 둘러보기",
+    "cta_verify": "캡슐 직접 검증하기",
+    "nav_features": "기능",
+    "nav_proof": "증명",
+    "nav_demo": "데모",
+    "nav_docs": "문서",
+    "nav_github": "GitHub",
+    "nav_quickstart": "빠른 시작",
+    "footer_about": "SBO3L · ETHGlobal Open Agents 2026 제출작"
+  },
+  "index": {
+    "lede": "SBO3L은 자율 AI 에이전트를 위한 암호학적으로 검증 가능한 신뢰 계층입니다. 에이전트가 수행하는 모든 작업 — 결제, 스왑, 저장, 연산, 조정 — 은 먼저 SBO3L의 정책 경계를 통과합니다. 결과물: 누구나 오프라인에서 검증할 수 있는 자기 완결형 Passport 캡슐.",
+    "section_what_is": "SBO3L이란",
+    "section_what_blocks": "SBO3L이 차단하는 것",
+    "section_evidence": "실제 통합 증거",
+    "section_arch": "아키텍처",
+    "section_reproduce": "직접 재현해보기",
+    "section_resources": "자료",
+    "what_is_blurb": "AI 에이전트를 위한 로컬 정책 + 예산 + 영수증 + 감사 방화벽을 구현한 Rust 워크스페이스. 허용 → 스폰서 실행기로 라우팅 (KeeperHub, Uniswap). 거부 → 실행기는 호출되지 않습니다. 모든 결정은 에이전트의 공개된 Ed25519 공개키만으로 누구나 오프라인 검증할 수 있는 Passport 캡슐로 포장될 수 있습니다."
+  },
+  "submission": {
+    "eyebrow": "ETHGlobal Open Agents 2026 · 제출작",
+    "h1": "자율 AI 에이전트를 위한 암호학적으로 검증 가능한 신뢰 계층.",
+    "judge_test_h2": "심사위원 테스트",
+    "judge_test_body": "위의 어떤 주장도 우리 말만 믿지 마세요. /proof 페이지에 캡슐을 끌어다 놓으세요. WebAssembly 검증기 — 데몬 내부에서 실행되는 동일한 Rust 코드를 wasm32로 컴파일한 것 — 가 브라우저에서 6가지 strict 검사를 모두 실행합니다. 업로드 없음, API 호출 없음, 데몬 없음. 6개의 녹색 체크 또는 구체적인 거부 사유."
+  },
+  "proof": {
+    "h1": "Passport 캡슐 검증",
+    "lede": "캡슐을 붙여넣거나 끌어다 놓으세요. 6가지 strict 모드 검사 모두 WASM으로 컴파일된 sbo3l-core를 통해 브라우저에서 실행됩니다. 어떤 데이터도 페이지를 떠나지 않습니다 — 업로드 없음, API 호출 없음, 분석 없음.",
+    "_TODO_KO_REVIEW": "Native Korean reviewer: 'strict 모드' is left in English-Korean mix; consider '엄격 모드' for full Korean. Same for 'WASM' (technical term, leave) and 'Passport 캡슐' (brand term, leave)."
+  }
+}

--- a/apps/marketing/src/pages/ko/index.astro
+++ b/apps/marketing/src/pages/ko/index.astro
@@ -1,0 +1,54 @@
+---
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import NumberStrip from "~/components/NumberStrip.astro";
+import ArchDiagram from "~/components/ArchDiagram.astro";
+import LocaleSwitcher from "~/components/LocaleSwitcher.astro";
+import { t } from "~/i18n";
+
+const locale = "ko" as const;
+const githubRepoUrl = "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026";
+---
+<BaseLayout
+  title={`SBO3L — ${t("common.tagline_part1", locale)} ${t("common.tagline_part2", locale)}`}
+  lang="ko"
+>
+  <section class="hero">
+    <LocaleSwitcher current="ko" basePath="/" />
+    <h1>{t("common.tagline_part1", locale)}<br />{t("common.tagline_part2", locale)}</h1>
+    <p class="lede">{t("index.lede", locale)}</p>
+    <div class="cta">
+      <a class="btn primary" href={`${githubRepoUrl}/blob/main/QUICKSTART.md`}>{t("common.cta_start", locale)}</a>
+      <a class="btn ghost" href={githubRepoUrl}>{t("common.cta_view_source", locale)}</a>
+    </div>
+  </section>
+
+  <NumberStrip />
+
+  <section class="panel">
+    <h2>{t("index.section_what_is", locale)}</h2>
+    <p>{t("index.what_is_blurb", locale)}</p>
+  </section>
+
+  <section class="panel">
+    <h2>{t("index.section_arch", locale)}</h2>
+    <ArchDiagram size="compact" />
+  </section>
+
+  <section class="panel">
+    <p>
+      <em>한국어 번역은 핵심 섹션만 다룹니다. 전체 버전은 <a href="/">영어</a>로 제공됩니다.</em>
+    </p>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero { max-width: var(--max); margin: 4em auto 3em; padding: 0 1.5em; }
+  .hero h1 {
+    font-size: var(--fs-4); font-weight: 700; line-height: 1.3;
+    margin: 0.5em 0 0.7em;
+    /* Korean glyphs render slightly larger; tighten line-height vs en/sk */
+    word-break: keep-all;
+  }
+  .hero .lede { font-size: var(--fs-2); color: var(--muted); margin-bottom: 1.5em; max-width: 700px; line-height: 1.6; }
+  .cta { display: flex; gap: 1em; flex-wrap: wrap; }
+</style>


### PR DESCRIPTION
## Summary

- Korean as third locale; ships at `/ko/`. EN at root, SK at `/sk/`.
- `src/i18n/ko.json` — tagline, common nav, CTAs, /index, /submission, /proof.
- `_TODO_KO_REVIEW_*` markers for brand-critical phrases pending native-speaker review; the `t()` lookup filters underscore-prefixed keys so they stay in JSON without rendering.
- `src/pages/ko/index.astro` — Korean landing with `lang="ko"` + tighter line-height + word-break: keep-all.

## Why

P2 of round-9 brief. International judges audience. Stacks on #203. LoC: 111 insertions / 9 deletions.

## Test plan

```bash
cd apps/marketing
npm install
npm run typecheck
npm run build
ls -la dist/ko/index.html
npm run preview
# - /        EN landing
# - /sk      SK landing
# - /ko      KO landing — hero, numbers, what-is, arch
# - LocaleSwitcher shows English / Slovenčina / 한국어; aria-current correct
# - <html lang="ko"> on the KO page
```

## Translation provenance

DeepL draft + manual fluency pass. `_TODO_KO_REVIEW_tagline` flag explicitly notes the wallet/mandate wordplay trade-off — `위임장` (proxy/written mandate) vs `권한위임` (delegation of authority); the former preserves noun-form parallelism, the latter is more idiomatic. Native reviewer chooses on next pass.

## Out of scope

- KO versions of `/proof`, `/demo`, `/features`, `/submission` — keys ready in `ko.json`, per-page wiring mechanical.
- `apps/docs/` Korean — Astro Starlight i18n; separate ticket.
- `apps/hosted-app/` Korean — Next.js i18n; separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)