### PR TITLE
feat(contracts): AnchorRegistry — on-chain anchor for SBO3L audit roots (P6)

### DIFF
--- a/crates/sbo3l-identity/contracts/AnchorRegistry.sol
+++ b/crates/sbo3l-identity/contracts/AnchorRegistry.sol
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title  AnchorRegistry — on-chain anchor for SBO3L audit roots
+/// @author SBO3L (Phase 3 P6)
+/// @notice Stores per-tenant `audit_root` commitments timestamped to
+///         the block they were anchored at. The registry is the
+///         on-chain counterpart of `sbo3l-storage::audit_chain_prefix_through`
+///         — a third party reading both can prove "the daemon's audit
+///         chain at block N had this digest" without trusting SBO3L.
+///
+/// @dev    Design constraints we explicitly want to preserve:
+///
+///         1. **Append-only.** A tenant can publish a *new* anchor
+///            whenever they want, but the contract never overwrites
+///            an existing entry — every (tenant, sequence) pair maps
+///            to exactly one (root, block, timestamp) triple. This
+///            makes the registry an immutable evidence trail.
+///
+///         2. **Multi-tenant.** Tenants are identified by a
+///            `bytes32` tenant_id (typically `keccak256(ENS-name)`
+///            so `sbo3lagent.eth` and `partner-org.eth` map to
+///            distinct namespaces with no central allocator).
+///
+///         3. **No value transfers.** The contract handles no funds.
+///            A `payable` constructor would be a footgun; the
+///            contract has no `receive()` / `fallback()` so accidental
+///            ETH sends revert.
+///
+///         4. **No mutable owner.** Same trust-model decision as the
+///            OffchainResolver: making the owner mutable expands the
+///            single-point-of-compromise surface. Anchors are
+///            *evidence* — there is no protocol-level reason for any
+///            party to be able to redact them.
+///
+///         5. **Per-call gas independent of N.** Each anchor write
+///            is O(1) regardless of how many anchors a tenant has
+///            already published. The sequence counter increments
+///            per tenant; reads are direct mapping lookups.
+///
+///         6. **Cross-chain replication-friendly.** The same payload
+///            (tenant_id, audit_root, attestation) is anchored on
+///            each chain the tenant operates on; an off-chain
+///            verifier reads from N chains and asserts they all
+///            agree. (Per-call replication via a `payable
+///            multi-chain` mechanism is out of scope for this PR —
+///            covered as a follow-up note below.)
+///
+/// @custom:security  No funds, no admin, no rotation. Compromising
+///                   any single tenant's signing key allows them to
+///                   anchor whatever digest they choose — but cannot
+///                   tamper with previously-anchored entries (they
+///                   are immutable on chain) and cannot affect any
+///                   other tenant's namespace.
+
+/// @dev Emitted on every successful anchor write. Indexed fields
+///      let off-chain consumers filter cheaply by tenant or
+///      sequence.
+event AnchorPublished(
+    bytes32 indexed tenantId,
+    uint256 indexed sequence,
+    bytes32 auditRoot,
+    uint64 chainHeadBlock,
+    uint64 publishedAt
+);
+
+error AnchorAlreadyExists(bytes32 tenantId, uint256 sequence);
+error InvalidTenantId();
+error InvalidAuditRoot();
+error CallerNotTenantOwner(address caller, address expected);
+error TenantAlreadyClaimed(bytes32 tenantId, address existingOwner);
+error TenantNotClaimed(bytes32 tenantId);
+
+contract AnchorRegistry {
+    /// @notice One anchor record. Stored verbatim in `_anchors[tenantId][sequence]`.
+    struct Anchor {
+        /// @dev keccak256-shaped digest of the daemon's audit chain
+        ///      at `chainHeadBlock`. Opaque to the contract; the
+        ///      operator computes it off-chain.
+        bytes32 auditRoot;
+        /// @dev `block.number` at which the audit chain was sampled.
+        ///      Useful for off-chain re-derivation: a verifier reads
+        ///      the chain log at this block and confirms the digest.
+        uint64 chainHeadBlock;
+        /// @dev `block.timestamp` at which the anchor was written.
+        ///      Distinct from `chainHeadBlock` because the operator
+        ///      may sample at block N then publish at block N+k.
+        uint64 publishedAt;
+    }
+
+    /// @notice Per-tenant ownership. Exactly one address can publish
+    ///         anchors under a tenant_id; the first call to
+    ///         `claimTenant` pins the owner permanently. Tenants
+    ///         that want multi-sig governance should claim under a
+    ///         multi-sig address.
+    mapping(bytes32 => address) public tenantOwner;
+
+    /// @notice Per-tenant next-sequence counter. Reads return the
+    ///         sequence of the *next* anchor write (so the first
+    ///         write goes to sequence 0).
+    mapping(bytes32 => uint256) public nextSequence;
+
+    /// @notice Anchor storage. `_anchors[tenantId][sequence]` is
+    ///         the (root, chainHeadBlock, publishedAt) triple
+    ///         written at sequence position `sequence`.
+    mapping(bytes32 => mapping(uint256 => Anchor)) internal _anchors;
+
+    /// @notice Claim a tenant_id. The first caller becomes the
+    ///         permanent owner; subsequent calls revert with
+    ///         `TenantAlreadyClaimed`. Tenants are identified by
+    ///         a 32-byte id (typically `keccak256(ENS-name)`); the
+    ///         caller's address is recorded as the owner that may
+    ///         publish anchors.
+    /// @param  tenantId  Caller's tenant identifier.
+    function claimTenant(bytes32 tenantId) external {
+        if (tenantId == bytes32(0)) revert InvalidTenantId();
+        address existing = tenantOwner[tenantId];
+        if (existing != address(0)) revert TenantAlreadyClaimed(tenantId, existing);
+        tenantOwner[tenantId] = msg.sender;
+    }
+
+    /// @notice Publish an anchor under a claimed tenant. Caller MUST
+    ///         be the tenant owner. The sequence is automatically
+    ///         the current `nextSequence[tenantId]`; the function
+    ///         returns it so the caller can pin it in their off-
+    ///         chain receipt.
+    /// @param  tenantId        Tenant to publish under (must be claimed).
+    /// @param  auditRoot       Off-chain audit chain digest.
+    /// @param  chainHeadBlock  Block at which `auditRoot` was sampled.
+    /// @return sequence        The sequence position this anchor was written at.
+    function publishAnchor(
+        bytes32 tenantId,
+        bytes32 auditRoot,
+        uint64 chainHeadBlock
+    ) external returns (uint256 sequence) {
+        address owner = tenantOwner[tenantId];
+        if (owner == address(0)) revert TenantNotClaimed(tenantId);
+        if (msg.sender != owner) revert CallerNotTenantOwner(msg.sender, owner);
+        if (auditRoot == bytes32(0)) revert InvalidAuditRoot();
+
+        sequence = nextSequence[tenantId];
+        // Defense-in-depth: check the slot is empty before write.
+        // The sequence counter alone guarantees this, but a future
+        // refactor that ever resets the counter would silently
+        // overwrite without this check.
+        Anchor storage existing = _anchors[tenantId][sequence];
+        if (existing.publishedAt != 0) {
+            revert AnchorAlreadyExists(tenantId, sequence);
+        }
+
+        _anchors[tenantId][sequence] = Anchor({
+            auditRoot: auditRoot,
+            chainHeadBlock: chainHeadBlock,
+            publishedAt: uint64(block.timestamp)
+        });
+        nextSequence[tenantId] = sequence + 1;
+
+        emit AnchorPublished(tenantId, sequence, auditRoot, chainHeadBlock, uint64(block.timestamp));
+    }
+
+    /// @notice Read a single anchor by (tenant, sequence). Returns
+    ///         the zero-anchor `(0, 0, 0)` if no such anchor exists
+    ///         — callers should compare `publishedAt != 0` to
+    ///         distinguish "unset" from "anchored at block 0", which
+    ///         is impossible in practice but worth noting.
+    /// @param  tenantId  Tenant id to read under.
+    /// @param  sequence  Sequence position to read.
+    /// @return anchor    The anchor record (or zero-anchor if unset).
+    function anchorAt(bytes32 tenantId, uint256 sequence)
+        external
+        view
+        returns (Anchor memory anchor)
+    {
+        anchor = _anchors[tenantId][sequence];
+    }
+
+    /// @notice Number of anchors a tenant has published. Equivalent
+    ///         to `nextSequence[tenantId]` (the next-write position
+    ///         is also the count of past writes since sequences are
+    ///         contiguous and append-only).
+    /// @param  tenantId  Tenant id to count under.
+    /// @return count     Number of anchors published.
+    function anchorCount(bytes32 tenantId) external view returns (uint256 count) {
+        count = nextSequence[tenantId];
+    }
+
+    /// @notice Read the most-recently-published anchor for a tenant.
+    ///         Reverts if the tenant has no anchors yet (no implicit
+    ///         zero-anchor surface).
+    /// @param  tenantId  Tenant id to read under.
+    /// @return anchor    The latest anchor record.
+    function latestAnchor(bytes32 tenantId) external view returns (Anchor memory anchor) {
+        uint256 count = nextSequence[tenantId];
+        if (count == 0) revert TenantNotClaimed(tenantId);
+        anchor = _anchors[tenantId][count - 1];
+    }
+
+    /// @notice ERC-165 interface advertisement. Currently advertises
+    ///         only the `IERC165` interface id; specific anchor-
+    ///         registry interface id is reserved for a future ENSIP
+    ///         that standardises the shape.
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == 0x01ffc9a7; // IERC165
+    }
+}

--- a/crates/sbo3l-identity/contracts/test/AnchorRegistry.t.sol
+++ b/crates/sbo3l-identity/contracts/test/AnchorRegistry.t.sol
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {
+    AnchorRegistry,
+    AnchorAlreadyExists,
+    InvalidTenantId,
+    InvalidAuditRoot,
+    CallerNotTenantOwner,
+    TenantAlreadyClaimed,
+    TenantNotClaimed,
+    AnchorPublished
+} from "../AnchorRegistry.sol";
+
+contract AnchorRegistryTest is Test {
+    AnchorRegistry internal registry;
+
+    address internal alice;
+    address internal bob;
+    bytes32 internal tenantA;
+    bytes32 internal tenantB;
+
+    function setUp() public {
+        registry = new AnchorRegistry();
+        alice = vm.addr(uint256(keccak256("alice")));
+        bob = vm.addr(uint256(keccak256("bob")));
+        tenantA = keccak256("sbo3lagent.eth");
+        tenantB = keccak256("partner-org.eth");
+    }
+
+    // ============================================================
+    // Tenant claim
+    // ============================================================
+
+    function test_claimTenant_assignsCallerAsOwner() public {
+        vm.prank(alice);
+        registry.claimTenant(tenantA);
+        assertEq(registry.tenantOwner(tenantA), alice);
+    }
+
+    function test_claimTenant_rejectsZeroId() public {
+        vm.prank(alice);
+        vm.expectRevert(InvalidTenantId.selector);
+        registry.claimTenant(bytes32(0));
+    }
+
+    function test_claimTenant_rejectsDoubleClaim() public {
+        vm.prank(alice);
+        registry.claimTenant(tenantA);
+
+        vm.prank(bob);
+        vm.expectRevert(abi.encodeWithSelector(TenantAlreadyClaimed.selector, tenantA, alice));
+        registry.claimTenant(tenantA);
+    }
+
+    function test_claimTenant_distinctTenantsCoexist() public {
+        vm.prank(alice);
+        registry.claimTenant(tenantA);
+        vm.prank(bob);
+        registry.claimTenant(tenantB);
+        assertEq(registry.tenantOwner(tenantA), alice);
+        assertEq(registry.tenantOwner(tenantB), bob);
+    }
+
+    // ============================================================
+    // Anchor publish — happy path
+    // ============================================================
+
+    function test_publishAnchor_writesToSequenceZeroFirst() public {
+        vm.prank(alice);
+        registry.claimTenant(tenantA);
+
+        vm.prank(alice);
+        uint256 seq = registry.publishAnchor(tenantA, bytes32(uint256(0xdead)), 100);
+        assertEq(seq, 0);
+        assertEq(registry.nextSequence(tenantA), 1);
+        assertEq(registry.anchorCount(tenantA), 1);
+
+        AnchorRegistry.Anchor memory a = registry.anchorAt(tenantA, 0);
+        assertEq(a.auditRoot, bytes32(uint256(0xdead)));
+        assertEq(a.chainHeadBlock, 100);
+        assertEq(a.publishedAt, uint64(block.timestamp));
+    }
+
+    function test_publishAnchor_appendsToSequence() public {
+        vm.prank(alice);
+        registry.claimTenant(tenantA);
+
+        vm.startPrank(alice);
+        registry.publishAnchor(tenantA, bytes32(uint256(0x01)), 100);
+        registry.publishAnchor(tenantA, bytes32(uint256(0x02)), 101);
+        registry.publishAnchor(tenantA, bytes32(uint256(0x03)), 102);
+        vm.stopPrank();
+
+        assertEq(registry.anchorCount(tenantA), 3);
+        assertEq(registry.anchorAt(tenantA, 0).auditRoot, bytes32(uint256(0x01)));
+        assertEq(registry.anchorAt(tenantA, 1).auditRoot, bytes32(uint256(0x02)));
+        assertEq(registry.anchorAt(tenantA, 2).auditRoot, bytes32(uint256(0x03)));
+    }
+
+    function test_publishAnchor_emitsEvent() public {
+        vm.prank(alice);
+        registry.claimTenant(tenantA);
+
+        vm.expectEmit(true, true, false, true);
+        emit AnchorPublished(tenantA, 0, bytes32(uint256(0xdead)), 100, uint64(block.timestamp));
+
+        vm.prank(alice);
+        registry.publishAnchor(tenantA, bytes32(uint256(0xdead)), 100);
+    }
+
+    // ============================================================
+    // Anchor publish — failure modes
+    // ============================================================
+
+    function test_publishAnchor_rejectsUnclaimedTenant() public {
+        vm.expectRevert(abi.encodeWithSelector(TenantNotClaimed.selector, tenantA));
+        registry.publishAnchor(tenantA, bytes32(uint256(0xdead)), 100);
+    }
+
+    function test_publishAnchor_rejectsNonOwner() public {
+        vm.prank(alice);
+        registry.claimTenant(tenantA);
+
+        vm.prank(bob);
+        vm.expectRevert(abi.encodeWithSelector(CallerNotTenantOwner.selector, bob, alice));
+        registry.publishAnchor(tenantA, bytes32(uint256(0xdead)), 100);
+    }
+
+    function test_publishAnchor_rejectsZeroAuditRoot() public {
+        vm.prank(alice);
+        registry.claimTenant(tenantA);
+
+        vm.prank(alice);
+        vm.expectRevert(InvalidAuditRoot.selector);
+        registry.publishAnchor(tenantA, bytes32(0), 100);
+    }
+
+    // ============================================================
+    // Latest anchor reader
+    // ============================================================
+
+    function test_latestAnchor_revertsWhenEmpty() public {
+        vm.expectRevert(abi.encodeWithSelector(TenantNotClaimed.selector, tenantA));
+        registry.latestAnchor(tenantA);
+    }
+
+    function test_latestAnchor_returnsMostRecent() public {
+        vm.prank(alice);
+        registry.claimTenant(tenantA);
+        vm.startPrank(alice);
+        registry.publishAnchor(tenantA, bytes32(uint256(0x01)), 100);
+        registry.publishAnchor(tenantA, bytes32(uint256(0x02)), 101);
+        registry.publishAnchor(tenantA, bytes32(uint256(0x03)), 102);
+        vm.stopPrank();
+
+        AnchorRegistry.Anchor memory latest = registry.latestAnchor(tenantA);
+        assertEq(latest.auditRoot, bytes32(uint256(0x03)));
+        assertEq(latest.chainHeadBlock, 102);
+    }
+
+    // ============================================================
+    // Cross-tenant isolation
+    // ============================================================
+
+    function test_publishAnchor_tenantsAreIsolated() public {
+        vm.prank(alice);
+        registry.claimTenant(tenantA);
+        vm.prank(bob);
+        registry.claimTenant(tenantB);
+
+        vm.prank(alice);
+        registry.publishAnchor(tenantA, bytes32(uint256(0xa)), 100);
+        vm.prank(bob);
+        registry.publishAnchor(tenantB, bytes32(uint256(0xb)), 101);
+
+        // Alice can't write into Bob's namespace.
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(CallerNotTenantOwner.selector, alice, bob));
+        registry.publishAnchor(tenantB, bytes32(uint256(0xc)), 102);
+
+        // And the data is genuinely separate.
+        assertEq(registry.anchorAt(tenantA, 0).auditRoot, bytes32(uint256(0xa)));
+        assertEq(registry.anchorAt(tenantB, 0).auditRoot, bytes32(uint256(0xb)));
+    }
+
+    // ============================================================
+    // Empty-slot read semantics
+    // ============================================================
+
+    function test_anchorAt_unsetSlotReturnsZeroAnchor() public {
+        // No claim, no publish — reading any slot returns the zero anchor.
+        AnchorRegistry.Anchor memory a = registry.anchorAt(tenantA, 42);
+        assertEq(a.auditRoot, bytes32(0));
+        assertEq(a.chainHeadBlock, 0);
+        assertEq(a.publishedAt, 0);
+    }
+
+    // ============================================================
+    // ERC-165
+    // ============================================================
+
+    function test_supportsInterface_advertisesIERC165Only() public view {
+        assertTrue(registry.supportsInterface(0x01ffc9a7)); // IERC165
+        assertFalse(registry.supportsInterface(0xdeadbeef));
+    }
+}
+
+/// @title  Fuzz suite for AnchorRegistry
+/// @notice Production-hardening fuzz suite for the on-chain anchor
+///         registry. Properties that must hold under random inputs:
+///
+///         * append-only — nothing overwrites a published anchor
+///         * tenant isolation — distinct tenant_ids never collide
+///         * sequence monotonicity — counter only increases by 1 per publish
+///         * value preservation — store input == read output
+contract AnchorRegistryFuzzTest is Test {
+    AnchorRegistry internal registry;
+    address internal owner;
+
+    function setUp() public {
+        registry = new AnchorRegistry();
+        owner = vm.addr(uint256(keccak256("fuzz-owner")));
+    }
+
+    function testFuzz_publishedAnchorIsImmutableOnRead(
+        bytes32 tenantId,
+        bytes32 auditRoot,
+        uint64 chainHeadBlock
+    ) public {
+        vm.assume(tenantId != bytes32(0));
+        vm.assume(auditRoot != bytes32(0));
+
+        vm.prank(owner);
+        registry.claimTenant(tenantId);
+        vm.prank(owner);
+        uint256 seq = registry.publishAnchor(tenantId, auditRoot, chainHeadBlock);
+
+        AnchorRegistry.Anchor memory a = registry.anchorAt(tenantId, seq);
+        assertEq(a.auditRoot, auditRoot);
+        assertEq(a.chainHeadBlock, chainHeadBlock);
+        assertEq(a.publishedAt, uint64(block.timestamp));
+
+        // Read again — same answer.
+        AnchorRegistry.Anchor memory b = registry.anchorAt(tenantId, seq);
+        assertEq(b.auditRoot, auditRoot);
+        assertEq(b.chainHeadBlock, chainHeadBlock);
+        assertEq(b.publishedAt, uint64(block.timestamp));
+    }
+
+    function testFuzz_sequenceIncrementsByOne(
+        bytes32 tenantId,
+        bytes32 root1,
+        bytes32 root2,
+        bytes32 root3
+    ) public {
+        vm.assume(tenantId != bytes32(0));
+        vm.assume(root1 != bytes32(0) && root2 != bytes32(0) && root3 != bytes32(0));
+
+        vm.prank(owner);
+        registry.claimTenant(tenantId);
+        vm.startPrank(owner);
+        uint256 s1 = registry.publishAnchor(tenantId, root1, 1);
+        uint256 s2 = registry.publishAnchor(tenantId, root2, 2);
+        uint256 s3 = registry.publishAnchor(tenantId, root3, 3);
+        vm.stopPrank();
+
+        assertEq(s1, 0);
+        assertEq(s2, 1);
+        assertEq(s3, 2);
+        assertEq(registry.anchorCount(tenantId), 3);
+    }
+
+    function testFuzz_distinctTenantsNeverCollide(
+        bytes32 tenantA,
+        bytes32 tenantB,
+        bytes32 rootA,
+        bytes32 rootB
+    ) public {
+        vm.assume(tenantA != bytes32(0) && tenantB != bytes32(0) && tenantA != tenantB);
+        vm.assume(rootA != bytes32(0) && rootB != bytes32(0));
+
+        address ownerA = vm.addr(uint256(keccak256(abi.encode("a", tenantA))));
+        address ownerB = vm.addr(uint256(keccak256(abi.encode("b", tenantB))));
+
+        vm.prank(ownerA);
+        registry.claimTenant(tenantA);
+        vm.prank(ownerB);
+        registry.claimTenant(tenantB);
+
+        vm.prank(ownerA);
+        registry.publishAnchor(tenantA, rootA, 1);
+        vm.prank(ownerB);
+        registry.publishAnchor(tenantB, rootB, 2);
+
+        // Each tenant sees only its own data.
+        assertEq(registry.anchorAt(tenantA, 0).auditRoot, rootA);
+        assertEq(registry.anchorAt(tenantB, 0).auditRoot, rootB);
+        assertEq(registry.tenantOwner(tenantA), ownerA);
+        assertEq(registry.tenantOwner(tenantB), ownerB);
+    }
+
+    function testFuzz_zeroAuditRootAlwaysRejects(bytes32 tenantId, uint64 chainHeadBlock) public {
+        vm.assume(tenantId != bytes32(0));
+
+        vm.prank(owner);
+        registry.claimTenant(tenantId);
+
+        vm.prank(owner);
+        vm.expectRevert(InvalidAuditRoot.selector);
+        registry.publishAnchor(tenantId, bytes32(0), chainHeadBlock);
+    }
+
+    function testFuzz_nonOwnerAlwaysRejected(
+        bytes32 tenantId,
+        address attacker,
+        bytes32 auditRoot,
+        uint64 chainHeadBlock
+    ) public {
+        vm.assume(tenantId != bytes32(0));
+        vm.assume(auditRoot != bytes32(0));
+        vm.assume(attacker != owner);
+        vm.assume(attacker != address(0));
+
+        vm.prank(owner);
+        registry.claimTenant(tenantId);
+
+        vm.prank(attacker);
+        vm.expectRevert(abi.encodeWithSelector(CallerNotTenantOwner.selector, attacker, owner));
+        registry.publishAnchor(tenantId, auditRoot, chainHeadBlock);
+    }
+}

--- a/docs/design/anchor-registry.md
+++ b/docs/design/anchor-registry.md
@@ -1,0 +1,168 @@
+# AnchorRegistry — on-chain anchor for SBO3L audit roots (P6)
+
+**Status:** Solidity contract + foundry test suite shipped (this PR).
+Deploy + L2 replication tracked as follow-ups.
+**Source:** [`crates/sbo3l-identity/contracts/AnchorRegistry.sol`](../../crates/sbo3l-identity/contracts/AnchorRegistry.sol).
+**Tests:** [`crates/sbo3l-identity/contracts/test/AnchorRegistry.t.sol`](../../crates/sbo3l-identity/contracts/test/AnchorRegistry.t.sol).
+
+## Why
+
+SBO3L's audit chain is the load-bearing artefact for "did this
+agent really decide that?". Today the chain is verifiable
+**off-chain** — a third party reads the SQLite log, verifies every
+hash linkage and every Ed25519 signature, and concludes yes-or-no.
+Phase 3's win is shrinking the trusted base further by **anchoring
+the chain root on chain**: a verifier reads one storage slot per
+anchor, knows the root is what the daemon committed to at block N,
+and re-derives the rest off chain.
+
+Anchoring on chain lets a verifier prove three things they
+otherwise can't:
+
+1. **Tamper-evidence over time.** A daemon that silently rewrites
+   the audit log changes every previously-anchored root from the
+   tampered point forward. The on-chain history makes the rewrite
+   visible.
+2. **Independent freshness.** The block timestamp + block height of
+   each anchor write are public, censorship-resistant ground truth
+   for "the daemon was at audit head X at time T."
+3. **Multi-tenant isolation.** Distinct tenants (operators,
+   organisations, individual agent owners) anchor under separate
+   `tenantId` namespaces with no central allocator and no
+   cross-tenant leakage.
+
+## Design
+
+### Append-only by construction
+
+```solidity
+mapping(bytes32 => mapping(uint256 => Anchor)) internal _anchors;
+mapping(bytes32 => uint256) public nextSequence;
+```
+
+Each anchor write goes to `_anchors[tenantId][sequence]` where
+`sequence` is the current `nextSequence[tenantId]`, then the
+counter increments. **No public method overwrites an existing
+anchor.** A future refactor that ever resets the counter would still
+be caught by an explicit `existing.publishedAt != 0` check before
+write, which reverts with `AnchorAlreadyExists`.
+
+### Multi-tenant + claim-once ownership
+
+```solidity
+mapping(bytes32 => address) public tenantOwner;
+
+function claimTenant(bytes32 tenantId) external {
+    if (tenantOwner[tenantId] != address(0)) revert TenantAlreadyClaimed(...);
+    tenantOwner[tenantId] = msg.sender;
+}
+```
+
+The first caller to claim a `tenantId` becomes its permanent owner.
+Subsequent claims revert. Tenants are typically `keccak256(ENS-name)`
+so `sbo3lagent.eth` and `partner-org.eth` get distinct namespaces
+without a central allocator. Multi-sig governance is supported via
+"claim from a multi-sig address."
+
+### What's NOT in the contract (and why)
+
+Same posture as the OffchainResolver hardening doc
+([`T-4-1-mainnet-hardening.md`](T-4-1-mainnet-hardening.md)): the
+contract is small, stateless-modulo-the-anchor-table, and built to
+do exactly one thing. Three things we deliberately omitted:
+
+- **No admin / upgrade path.** Anchors are *evidence* — there is no
+  protocol-level reason for any party to redact them. Adding an
+  admin who could nuke an anchor row is a pure trust-surface
+  expansion.
+- **No fees.** A `payable` write would let the owner gate anchors
+  behind a payment, which is operator policy not protocol policy.
+  Operators who want to charge for anchor writes can wrap this
+  contract in a paywalled facade; we don't bake the policy in.
+- **No on-chain replication primitive.** A `payable multi-chain
+  anchor` that takes ETH on chain A and emits proofs to chains B,
+  C, D is its own protocol problem (cross-chain message passing,
+  message ordering, retry semantics). Cross-chain anchor
+  consistency is achieved off-chain today: the operator publishes
+  the same `(tenantId, auditRoot)` to N AnchorRegistry deployments
+  on N chains, and a verifier reads from N chains and asserts they
+  agree. T-3-9's cross-chain-reputation aggregator is exactly this
+  shape applied to a different per-chain record; we'd reuse the
+  pattern.
+
+## Test suite
+
+15 unit tests + 5 fuzz tests at 10 000 runs each:
+
+| Test                                              | Property                                                  |
+|---------------------------------------------------|-----------------------------------------------------------|
+| `test_claimTenant_assignsCallerAsOwner`           | First claimer pinned as owner                             |
+| `test_claimTenant_rejectsZeroId`                  | `bytes32(0)` rejected                                      |
+| `test_claimTenant_rejectsDoubleClaim`             | Second claimer reverts with existing-owner error           |
+| `test_claimTenant_distinctTenantsCoexist`         | Two tenants don't collide                                  |
+| `test_publishAnchor_writesToSequenceZeroFirst`    | First write goes to sequence 0                             |
+| `test_publishAnchor_appendsToSequence`            | Subsequent writes append at next position                  |
+| `test_publishAnchor_emitsEvent`                   | `AnchorPublished` event with correct fields               |
+| `test_publishAnchor_rejectsUnclaimedTenant`       | Publish before claim reverts                               |
+| `test_publishAnchor_rejectsNonOwner`              | Non-owner publish reverts                                  |
+| `test_publishAnchor_rejectsZeroAuditRoot`         | `bytes32(0)` audit root rejected                           |
+| `test_latestAnchor_revertsWhenEmpty`              | Read with no anchors reverts cleanly                       |
+| `test_latestAnchor_returnsMostRecent`             | Latest reader returns the highest-sequence write           |
+| `test_publishAnchor_tenantsAreIsolated`           | Cross-tenant writes refused                                |
+| `test_anchorAt_unsetSlotReturnsZeroAnchor`        | Reads of unset slots return zero (not revert)              |
+| `test_supportsInterface_advertisesIERC165Only`    | ERC-165 stable                                             |
+| `testFuzz_publishedAnchorIsImmutableOnRead`       | Random anchor stored verbatim, read returns same          |
+| `testFuzz_sequenceIncrementsByOne`                | Sequence is monotonic +1 per write                         |
+| `testFuzz_distinctTenantsNeverCollide`            | Random distinct tenants never overwrite each other         |
+| `testFuzz_zeroAuditRootAlwaysRejects`             | Zero audit root rejected for any tenant / block            |
+| `testFuzz_nonOwnerAlwaysRejected`                 | Any random non-owner address rejected                      |
+
+40 tests across the contracts dir (15 + 5 here, 6 + 11 + 3 prior on
+OffchainResolver). All pass under
+`forge test --fuzz-runs 10000` in ~22 seconds wall-clock.
+
+## Deploy plan
+
+This PR ships the contract + tests. Deploy is a follow-up gated on
+operator decision:
+
+- **Sepolia first** (cheap, allows the off-chain anchor publisher
+  to be exercised end-to-end before any mainnet gas).
+- **Mainnet** + **Optimism** + **Base** + **Polygon** as the
+  multi-chain target set, matching the cross-chain-reputation
+  weights in `crates/sbo3l-policy/src/cross_chain_reputation.rs`.
+- Address(es) pinned in `crates/sbo3l-identity/src/contracts.rs`
+  (the canonical pin module from #232) once the deploys land. Each
+  network gets its own row; the registry's contract code is
+  network-independent so the address is the only network-specific
+  detail.
+
+CI gate: the new `slither` job in `.github/workflows/foundry.yml`
+(P11, #240) runs against this contract automatically. Same gate
+applies pre-mainnet-deploy.
+
+## Off-chain anchor publisher (already in the codebase)
+
+`sbo3l-identity::ens_anchor::build_envelope` produces the dry-run
+envelope for `setText("sbo3l:audit_root", value)`. The follow-up
+that wires the anchor publisher to AnchorRegistry replaces the
+ENS-resolver target with a `publishAnchor(tenantId, auditRoot,
+chainHeadBlock)` call. The dry-run shape stays the same — same
+canonical form, same JCS commitment, same audit-log row — only the
+target contract changes.
+
+## Future work
+
+- **L1 → L2 replication** (P10 round 9): write on Sepolia L1, mirror
+  to Optimism Sepolia + Base Sepolia within 1 epoch via ENSIP-19
+  cross-chain primitives. Requires an L2 deploy of this contract
+  per chain.
+- **Cross-chain consistency proof**: read the latest anchor from N
+  chains, assert all N agree on `(auditRoot, chainHeadBlock)` for
+  each tenant. Pure off-chain logic; pattern shared with T-3-9
+  cross-chain reputation aggregator.
+- **Inclusion proofs**: a tenant publishes one anchor per audit
+  *checkpoint*; an auditor verifying a *specific* audit event needs
+  the off-chain Merkle proof from the event to the checkpoint root.
+  Out of scope for the contract; the proof verifier lives in
+  `sbo3l-storage::audit_chain_prefix_through` already.


### PR DESCRIPTION
## Summary

New \`AnchorRegistry.sol\` for on-chain commitment of SBO3L audit chain roots. Append-only, multi-tenant, no admin path. Foundry test suite covers 15 unit tests + 5 fuzz tests at 10K runs each. **40/40 tests pass across the contracts dir at \`forge test --fuzz-runs 10000\`** in ~22s.

## Why

Anchoring on chain lets a verifier prove three things they otherwise can't:

1. **Tamper-evidence over time.** A daemon that silently rewrites the audit log changes every previously-anchored root from the tampered point forward. The on-chain history makes the rewrite visible.
2. **Independent freshness.** Block timestamp + height of each anchor write are public, censorship-resistant ground truth.
3. **Multi-tenant isolation.** Distinct tenants get separate \`bytes32\` namespaces with no central allocator.

## Surface

| Method | Purpose |
|---|---|
| \`claimTenant(tenantId)\` | First caller becomes permanent owner; subsequent claims revert |
| \`publishAnchor(tenantId, auditRoot, chainHeadBlock)\` | Owner-only append at the current \`nextSequence\`; returns the sequence position written |
| \`anchorAt(tenantId, sequence)\` | Direct read; returns zero-anchor for unset slots |
| \`latestAnchor(tenantId)\` | Highest-sequence anchor; reverts on empty |
| \`anchorCount(tenantId)\` | Number of anchors published |
| \`supportsInterface\` | Only IERC165 today; AnchorRegistry-specific id reserved for ENSIP |

## Design choices documented

- **Append-only** by construction (defense-in-depth check on \`existing.publishedAt != 0\` even if a future refactor reset the counter)
- **No admin / upgrade path** — anchors are evidence, not state to redact
- **No fees** — \`payable\` is operator policy, not protocol policy
- **No on-chain cross-chain replication primitive** — out of scope; consistency is done off-chain by reading from N AnchorRegistry deployments and asserting agreement (same shape as T-3-9 cross-chain reputation aggregator)
- **Multi-tenant** via \`bytes32 tenant_id\` (typically \`keccak256(ENS-name)\`)

## Test plan

- [x] \`forge test --fuzz-runs 10000\` — 40/40 pass (15 + 5 new + 6 + 11 + 3 prior on OffchainResolver)
- [x] Slither job from #240 will run against this contract on next CI cycle
- [ ] Sepolia deploy follow-up; mainnet + 3 L2s (Optimism, Base, Polygon) follow per the cross-chain-reputation weight roster

🤖 Generated with [Claude Code](https://claude.com/claude-code)