### PR TITLE
fix(ci): crates-publish — restrict trigger to semver tags + fix prefix strip

### DIFF
--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -24,7 +24,8 @@ name: Publish 9 SBO3L crates to crates.io
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
 
 jobs:
   publish:
@@ -40,7 +41,8 @@ jobs:
       - name: Verify the tag matches the workspace version
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF#refs/tags/v}"
+          tag="${GITHUB_REF#refs/tags/}"
+          tag="${tag#v}"
           ws_version=$(grep -E '^version = ' Cargo.toml | head -1 | cut -d'"' -f2)
           if [ "$tag" != "$ws_version" ]; then
             echo "::error::tag $tag does not match workspace.package.version $ws_version"


### PR DESCRIPTION
## Summary

Two bugs in `.github/workflows/crates-publish.yml` exposed by the `vercel-ai-v1.2.0` tag (an integrations-publish-only tag) misfiring the cargo publish workflow:

1. **Trigger pattern too greedy** — `tags: ['v*']` matches per-package tags like `vercel-ai-v1.2.0`, `sdk-py-v1.2.0`, `sdk-ts-v1.2.0` (because they happen to contain a `v`). Restricted to strict semver pattern `v[0-9]+.[0-9]+.[0-9]+` (+ optional pre-release suffix).

2. **Prefix strip uses wrong substring** — `tag="${GITHUB_REF#refs/tags/v}"` removes only `refs/tags/v`, so `refs/tags/vercel-ai-v1.2.0` became `ercel-ai-v1.2.0` in the error message. Fix: strip `refs/tags/` first, then optionally strip leading `v`.

## Test plan
- [ ] CI green (workflow file syntax valid)
- [ ] Future per-package tags (`vercel-ai-v*`, `sdk-py-v*`, `sdk-ts-v*`) don't fire the cargo workflow
- [ ] Future workspace tags (`v1.2.1`, `v1.3.0`) still fire the cargo workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)