### PR TITLE
feat(t-4-7): sbo3l agent reputation-publish --broadcast

### DIFF
--- a/crates/sbo3l-cli/src/agent_reputation.rs
+++ b/crates/sbo3l-cli/src/agent_reputation.rs
@@ -1,15 +1,25 @@
 //! `sbo3l agent reputation-publish` — compute v2 score + emit a
-//! `setText("sbo3l:reputation_score", "<n>")` envelope (T-4-6).
+//! `setText("sbo3l:reputation_score", "<n>")` envelope (T-4-6 / T-4-7).
+//!
+//! Two paths from the same command:
+//!
+//! * **Dry-run (default)** — build the envelope (calldata, namehash,
+//!   resolver, score) and print as JSON. No network calls, no signing.
+//!   The envelope is publishable on its own — same input always
+//!   re-derives the same calldata, so an external auditor can replay
+//!   the publisher and confirm without trusting SBO3L's reporting.
+//! * **`--broadcast`** (T-4-7, requires `--features eth_broadcast`) —
+//!   sign + send `setText` over JSON-RPC via the same alloy harness
+//!   T-3-1 broadcast uses (`agent_broadcast.rs`). Mainnet path
+//!   additionally requires `SBO3L_ALLOW_MAINNET_TX=1` plus an
+//!   explicit `--network mainnet` — same double-gate the rest of
+//!   SBO3L's chain ops use.
 //!
 //! Inputs: events JSON file (array of `ReputationEventInput`), FQDN,
-//! network, optional resolver override. Output: a
+//! network, optional resolver override. Output for dry-run: a
 //! [`sbo3l_identity::ReputationPublishEnvelope`] printed to stdout
-//! and (optionally) written to `--out`.
-//!
-//! Dry-run only in this build. Broadcast wires through F-5
-//! EthSigner once that lands. The dry-run envelope is publishable
-//! on its own — same input always re-derives the same calldata,
-//! so an external auditor can replay the publisher and confirm.
+//! and (optionally) written to `--out`. Output for broadcast: the
+//! tx hash + Etherscan link printed to stdout once the tx confirms.
 
 use std::fs;
 use std::path::PathBuf;
@@ -33,13 +43,102 @@ pub struct ReputationPublishArgs {
     pub network: String,
     pub resolver: Option<String>,
     pub out: Option<PathBuf>,
+    /// Sign + send the `setText` tx instead of just printing the
+    /// envelope. Requires the `eth_broadcast` Cargo feature; without
+    /// it the dispatch falls through to a clear "rebuild with
+    /// --features eth_broadcast" error (exit code 3, matching
+    /// T-3-1 broadcast's stub behaviour).
+    pub broadcast: bool,
+    /// JSON-RPC URL override. If unset, the broadcast path reads
+    /// `SBO3L_RPC_URL`. Validated http/https.
+    pub rpc_url: Option<String>,
+    /// Override the env var that holds the 32-byte hex private key
+    /// (default `SBO3L_SIGNER_KEY`). Same pattern T-3-1 broadcast uses.
+    pub private_key_env_var: Option<String>,
 }
 
 pub fn cmd_agent_reputation_publish(args: ReputationPublishArgs) -> ExitCode {
+    if args.broadcast {
+        return broadcast_dispatch(args);
+    }
     match run(args) {
         Ok(()) => ExitCode::SUCCESS,
         Err(code) => code,
     }
+}
+
+/// `--broadcast` dispatch — selects between the live `eth_broadcast`
+/// implementation (compiled with `--features eth_broadcast`) and the
+/// honest "rebuild with the feature" stub. Exit code 3 matches the
+/// T-3-1 broadcast contract for the stub branch.
+fn broadcast_dispatch(args: ReputationPublishArgs) -> ExitCode {
+    #[cfg(feature = "eth_broadcast")]
+    {
+        let network = match args.network.as_str() {
+            "mainnet" => sbo3l_identity::ens_anchor::EnsNetwork::Mainnet,
+            "sepolia" => sbo3l_identity::ens_anchor::EnsNetwork::Sepolia,
+            other => {
+                eprintln!(
+                    "sbo3l agent reputation-publish --broadcast: unsupported network '{other}'. \
+                     Expected 'mainnet' or 'sepolia'."
+                );
+                return ExitCode::from(2);
+            }
+        };
+        // Mainnet double-gate: requires SBO3L_ALLOW_MAINNET_TX=1.
+        if matches!(network, sbo3l_identity::ens_anchor::EnsNetwork::Mainnet)
+            && std::env::var("SBO3L_ALLOW_MAINNET_TX").as_deref() != Ok("1")
+        {
+            eprintln!(
+                "sbo3l agent reputation-publish --broadcast --network mainnet: \
+                 refusing without SBO3L_ALLOW_MAINNET_TX=1. Mainnet broadcast \
+                 costs gas (~$3-5 per tx at 50 gwei). Set the env var to \
+                 acknowledge before re-running."
+            );
+            return ExitCode::from(2);
+        }
+        let rt = match tokio::runtime::Runtime::new() {
+            Ok(rt) => rt,
+            Err(e) => {
+                eprintln!(
+                    "sbo3l agent reputation-publish --broadcast: tokio runtime init failed: {e}"
+                );
+                return ExitCode::from(1);
+            }
+        };
+        rt.block_on(crate::agent_reputation_broadcast::cmd_broadcast(
+            args, network,
+        ))
+    }
+    #[cfg(not(feature = "eth_broadcast"))]
+    {
+        broadcast_not_available(&args)
+    }
+}
+
+#[cfg(not(feature = "eth_broadcast"))]
+fn broadcast_not_available(args: &ReputationPublishArgs) -> ExitCode {
+    eprintln!(
+        "sbo3l agent reputation-publish: --broadcast was accepted but this build \
+         was compiled without `--features eth_broadcast`. The dry-run \
+         output (drop --broadcast) is the complete envelope; pipe its \
+         calldata to `cast send`, or rebuild with \
+         `cargo install sbo3l-cli --features eth_broadcast` (pulls the \
+         alloy stack)."
+    );
+    if args.rpc_url.is_some() || args.private_key_env_var.is_some() {
+        eprintln!(
+            "  --rpc-url / --private-key-env-var were accepted but ignored \
+             (broadcast feature not enabled in this build)."
+        );
+    }
+    if args.network == "mainnet" {
+        eprintln!(
+            "  Mainnet path will additionally require SBO3L_ALLOW_MAINNET_TX=1 \
+             and an explicit --network mainnet at broadcast time."
+        );
+    }
+    ExitCode::from(3)
 }
 
 fn run(args: ReputationPublishArgs) -> Result<(), ExitCode> {
@@ -144,6 +243,9 @@ mod tests {
             network: "mainnet".to_string(),
             resolver: None,
             out: None,
+            broadcast: false,
+            rpc_url: None,
+            private_key_env_var: None,
         });
         assert!(res.is_ok());
     }
@@ -157,6 +259,9 @@ mod tests {
             network: "polygon".to_string(),
             resolver: None,
             out: None,
+            broadcast: false,
+            rpc_url: None,
+            private_key_env_var: None,
         });
         assert!(res.is_err());
     }
@@ -170,6 +275,9 @@ mod tests {
             network: "mainnet".to_string(),
             resolver: None,
             out: None,
+            broadcast: false,
+            rpc_url: None,
+            private_key_env_var: None,
         });
         assert!(res.is_err());
     }
@@ -185,10 +293,39 @@ mod tests {
             network: "mainnet".to_string(),
             resolver: None,
             out: Some(out.path().to_path_buf()),
+            broadcast: false,
+            rpc_url: None,
+            private_key_env_var: None,
         });
         assert!(res.is_ok());
         let written = std::fs::read_to_string(out.path()).unwrap();
         assert!(written.contains("\"text_record_key\": \"sbo3l:reputation_score\""));
         assert!(written.contains("\"score\":"));
+    }
+
+    #[cfg(not(feature = "eth_broadcast"))]
+    #[test]
+    fn broadcast_without_feature_returns_exit3() {
+        let events = r#"[{"decision":"allow","executor_confirmed":true,"age_secs":0}]"#;
+        let f = write_events(events);
+        let code = cmd_agent_reputation_publish(ReputationPublishArgs {
+            fqdn: "research-agent.sbo3lagent.eth".to_string(),
+            events: f.path().to_path_buf(),
+            network: "sepolia".to_string(),
+            resolver: None,
+            out: None,
+            broadcast: true,
+            rpc_url: Some("https://example.invalid".to_string()),
+            private_key_env_var: None,
+        });
+        // ExitCode doesn't expose its inner u8 in stable Rust; format
+        // and inspect via Debug. The contract is "non-zero, specifically
+        // 3 to mirror T-3-1 broadcast's stub exit." Format lands as
+        // `ExitCode(unix_exit_status(3))` on Linux/macOS — pin that.
+        let formatted = format!("{code:?}");
+        assert!(
+            formatted.contains('3'),
+            "expected exit code 3 for broadcast-without-feature; got {formatted:?}"
+        );
     }
 }

--- a/crates/sbo3l-cli/src/agent_reputation_broadcast.rs
+++ b/crates/sbo3l-cli/src/agent_reputation_broadcast.rs
@@ -1,0 +1,306 @@
+//! T-4-7 reputation broadcast — `sbo3l agent reputation-publish --broadcast`
+//! real path.
+//!
+//! Compiled only with `--features eth_broadcast`. Mirrors the T-3-1
+//! broadcast harness in [`crate::agent_broadcast`] — same alloy stack,
+//! same env-var conventions (`SBO3L_RPC_URL`, `SBO3L_SIGNER_KEY`),
+//! same redacted-RPC log line, same Etherscan link emission.
+//!
+//! # Wire
+//!
+//! One transaction:
+//!
+//! 1. `Resolver.setText(node, "sbo3l:reputation_score", "<score>")`
+//!    → recipient: the resolver address (default: the network's
+//!    PublicResolver per
+//!    [`sbo3l_identity::EnsNetwork::default_public_resolver`]; can
+//!    be overridden via `--resolver`).
+//!
+//! Single-tx flow because the reputation record is just a setText —
+//! no subname issuance, no multicall. Mainnet path additionally
+//! requires `SBO3L_ALLOW_MAINNET_TX=1` (enforced upstream in the
+//! dispatch in [`crate::agent_reputation::cmd_agent_reputation_publish`]).
+//!
+//! # Inputs / outputs
+//!
+//! Same args as the dry-run path: `--fqdn`, `--events`, `--network`,
+//! optional `--resolver`. Plus the broadcast-only env vars
+//! `SBO3L_SIGNER_KEY` (32-byte hex private key) and
+//! `SBO3L_RPC_URL` (or override via `--rpc-url`).
+//!
+//! Output: stdout prints the score, the resolver address, the tx
+//! hash, the Etherscan link, the confirmed block, and the gas used.
+//! On confirmation failure the tx hash is still printed so the
+//! operator can investigate manually.
+
+use std::process::ExitCode;
+
+use alloy::network::{EthereumWallet, TransactionBuilder};
+use alloy::primitives::{Address, Bytes, FixedBytes};
+use alloy::providers::{Provider, ProviderBuilder};
+use alloy::rpc::types::TransactionRequest;
+use alloy::signers::local::PrivateKeySigner;
+use sbo3l_identity::ens_anchor::{namehash, set_text_calldata, EnsNetwork};
+use sbo3l_identity::reputation_publisher::{
+    build_publish_envelope, PublishMode, ReputationEventInput, ReputationPublishParams,
+    REPUTATION_TEXT_KEY,
+};
+
+use crate::agent_reputation::ReputationPublishArgs;
+
+const DEFAULT_SIGNER_ENV: &str = "SBO3L_SIGNER_KEY";
+const DEFAULT_RPC_ENV: &str = "SBO3L_RPC_URL";
+
+pub async fn cmd_broadcast(args: ReputationPublishArgs, network: EnsNetwork) -> ExitCode {
+    let rpc_url = match resolve_rpc_url(&args) {
+        Ok(s) => s,
+        Err(rc) => return rc,
+    };
+    let signer_env = args
+        .private_key_env_var
+        .as_deref()
+        .unwrap_or(DEFAULT_SIGNER_ENV);
+    let signer = match load_signer(signer_env) {
+        Ok(s) => s,
+        Err(rc) => return rc,
+    };
+    let signer_address = signer.address();
+
+    let resolver_str = args
+        .resolver
+        .clone()
+        .unwrap_or_else(|| network.default_public_resolver().to_string());
+    let resolver = match parse_address_str(&resolver_str, "resolver") {
+        Ok(a) => a,
+        Err(rc) => return rc,
+    };
+
+    // Read events file + compute score via the same pure-function
+    // publisher the dry-run path uses. Same input always re-derives
+    // the same score; the broadcast-side and dry-run-side outputs
+    // are byte-identical apart from the actual on-chain side
+    // effect.
+    let raw_events = match std::fs::read_to_string(&args.events) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!(
+                "sbo3l agent reputation-publish --broadcast: read events file {}: {e}",
+                args.events.display()
+            );
+            return ExitCode::from(2);
+        }
+    };
+    let events: Vec<ReputationEventInput> = match serde_json::from_str(&raw_events) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!(
+                "sbo3l agent reputation-publish --broadcast: parse events file {}: {e}",
+                args.events.display()
+            );
+            return ExitCode::from(2);
+        }
+    };
+
+    let envelope = match build_publish_envelope(
+        ReputationPublishParams {
+            network,
+            domain: &args.fqdn,
+            resolver: &resolver_str,
+            created_at: &current_rfc3339(),
+            mode: PublishMode::DryRun,
+        },
+        &events,
+    ) {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("sbo3l agent reputation-publish --broadcast: envelope build failed: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let node = match namehash(&args.fqdn) {
+        Ok(n) => n,
+        Err(e) => {
+            eprintln!("sbo3l agent reputation-publish --broadcast: bad --fqdn: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    let calldata = set_text_calldata(node, REPUTATION_TEXT_KEY, &envelope.score.to_string());
+
+    println!("sbo3l agent reputation-publish --broadcast");
+    println!("  network:        {}", network.as_str());
+    println!("  fqdn:           {}", args.fqdn);
+    println!("  score:          {} (from {} events)", envelope.score, envelope.event_count);
+    println!("  signer:         {signer_address:?}");
+    println!("  resolver:       0x{}", hex::encode(resolver));
+    println!("  text key:       {REPUTATION_TEXT_KEY}");
+    println!("  rpc:            {}", redact_rpc(&rpc_url));
+
+    let wallet = EthereumWallet::from(signer);
+    let provider = ProviderBuilder::new()
+        .with_recommended_fillers()
+        .wallet(wallet)
+        .on_http(rpc_url.parse().expect("validated above"));
+
+    let chain_id = match provider.get_chain_id().await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("sbo3l agent reputation-publish --broadcast: eth_chainId failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    println!("  chain_id:       {chain_id}");
+
+    let resolver_addr: Address = resolver.into();
+    let tx = TransactionRequest::default()
+        .with_to(resolver_addr)
+        .with_input(Bytes::from(calldata))
+        .with_chain_id(chain_id);
+
+    println!(
+        "  → tx: setText({REPUTATION_TEXT_KEY}, \"{}\") → resolver…",
+        envelope.score
+    );
+    let pending = match provider.send_transaction(tx).await {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("sbo3l agent reputation-publish --broadcast: tx send failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    let tx_hash = *pending.tx_hash();
+    println!("    tx_hash:      {tx_hash:?}");
+    println!("    explorer:     {}", explorer_url(network, &tx_hash));
+    let receipt = match pending.with_required_confirmations(1).get_receipt().await {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("sbo3l agent reputation-publish --broadcast: tx confirmation failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    if !receipt.status() {
+        eprintln!("sbo3l agent reputation-publish --broadcast: tx reverted on chain");
+        return ExitCode::from(1);
+    }
+    println!(
+        "    confirmed:    block {} gas_used={}",
+        receipt.block_number.unwrap_or(0),
+        receipt.gas_used
+    );
+
+    println!("---");
+    println!("published:     {} → {} on {}", REPUTATION_TEXT_KEY, envelope.score, network.as_str());
+    println!("verify:        sbo3l agent verify-ens {} --network {}", args.fqdn, network.as_str());
+    ExitCode::SUCCESS
+}
+
+fn resolve_rpc_url(args: &ReputationPublishArgs) -> Result<String, ExitCode> {
+    if let Some(s) = args.rpc_url.as_deref() {
+        return validate_url(s);
+    }
+    match std::env::var(DEFAULT_RPC_ENV) {
+        Ok(s) => validate_url(&s),
+        Err(_) => {
+            eprintln!(
+                "sbo3l agent reputation-publish --broadcast: pass --rpc-url <url> or set {DEFAULT_RPC_ENV} \
+                 (Sepolia Alchemy / Infura / PublicNode)."
+            );
+            Err(ExitCode::from(2))
+        }
+    }
+}
+
+fn validate_url(s: &str) -> Result<String, ExitCode> {
+    if !(s.starts_with("http://") || s.starts_with("https://")) {
+        eprintln!(
+            "sbo3l agent reputation-publish --broadcast: rpc url must be http:// or https://; got `{s}`"
+        );
+        return Err(ExitCode::from(2));
+    }
+    Ok(s.to_string())
+}
+
+fn load_signer(env: &str) -> Result<PrivateKeySigner, ExitCode> {
+    let raw = match std::env::var(env) {
+        Ok(s) => s,
+        Err(_) => {
+            eprintln!(
+                "sbo3l agent reputation-publish --broadcast: signer env var `{env}` not set. \
+                 Export 32-byte hex private key (0x-prefixed or bare)."
+            );
+            return Err(ExitCode::from(2));
+        }
+    };
+    let stripped = raw.trim().trim_start_matches("0x");
+    let bytes = match hex::decode(stripped) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("sbo3l agent reputation-publish --broadcast: signer key not valid hex: {e}");
+            return Err(ExitCode::from(2));
+        }
+    };
+    if bytes.len() != 32 {
+        eprintln!(
+            "sbo3l agent reputation-publish --broadcast: signer key must be 32 bytes; got {}",
+            bytes.len()
+        );
+        return Err(ExitCode::from(2));
+    }
+    let arr: [u8; 32] = bytes.try_into().expect("len checked");
+    PrivateKeySigner::from_bytes(&FixedBytes::from(arr)).map_err(|e| {
+        eprintln!("sbo3l agent reputation-publish --broadcast: signer construction failed: {e}");
+        ExitCode::from(2)
+    })
+}
+
+fn parse_address_str(s: &str, label: &str) -> Result<[u8; 20], ExitCode> {
+    let stripped = s.trim().trim_start_matches("0x");
+    if stripped.len() != 40 {
+        eprintln!(
+            "sbo3l agent reputation-publish --broadcast: {label} address must be 0x + 40 hex; got `{s}`"
+        );
+        return Err(ExitCode::from(2));
+    }
+    let bytes = match hex::decode(stripped) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!(
+                "sbo3l agent reputation-publish --broadcast: {label} address not hex: {e}"
+            );
+            return Err(ExitCode::from(2));
+        }
+    };
+    bytes.try_into().map_err(|_| {
+        eprintln!("sbo3l agent reputation-publish --broadcast: {label} address wrong length");
+        ExitCode::from(2)
+    })
+}
+
+fn explorer_url(network: EnsNetwork, tx_hash: &FixedBytes<32>) -> String {
+    match network {
+        EnsNetwork::Mainnet => format!("https://etherscan.io/tx/{tx_hash:?}"),
+        EnsNetwork::Sepolia => format!("https://sepolia.etherscan.io/tx/{tx_hash:?}"),
+    }
+}
+
+fn redact_rpc(url: &str) -> String {
+    let scheme_end = url.find("://").map(|i| i + 3).unwrap_or(0);
+    let after_scheme = &url[scheme_end..];
+    let host_end = after_scheme.find('/').unwrap_or(after_scheme.len());
+    format!(
+        "{}{}/<redacted>",
+        &url[..scheme_end],
+        &after_scheme[..host_end]
+    )
+}
+
+fn current_rfc3339() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    chrono::DateTime::<chrono::Utc>::from_timestamp(secs as i64, 0)
+        .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+        .unwrap_or_default()
+}

--- a/crates/sbo3l-cli/src/main.rs
+++ b/crates/sbo3l-cli/src/main.rs
@@ -10,6 +10,8 @@ use sbo3l_core::{schema, SchemaError};
 mod agent;
 #[cfg(feature = "eth_broadcast")]
 mod agent_broadcast;
+#[cfg(feature = "eth_broadcast")]
+mod agent_reputation_broadcast;
 mod agent_reputation;
 mod agent_verify;
 mod audit_anchor_ens;
@@ -263,7 +265,7 @@ enum AgentCmd {
         #[arg(long, default_value_t = false)]
         json: bool,
     },
-    /// Compute and publish an agent's reputation score (T-4-6).
+    /// Compute and publish an agent's reputation score (T-4-6 / T-4-7).
     ///
     /// Reads audit events from `--events <file.json>` (a JSON array
     /// of {decision, executor_confirmed, age_secs} objects), computes
@@ -271,8 +273,11 @@ enum AgentCmd {
     /// and emits a setText envelope publishing the score to the agent's
     /// `sbo3l:reputation_score` ENS text record.
     ///
-    /// **Dry-run only in this build.** Broadcast wires through F-5
-    /// EthSigner once that lands.
+    /// **Dry-run by default.** Pass `--broadcast` (requires
+    /// `--features eth_broadcast` at build time) to actually sign +
+    /// send the setText tx via the alloy harness shared with T-3-1
+    /// agent-register broadcast. Mainnet path additionally requires
+    /// `SBO3L_ALLOW_MAINNET_TX=1` and an explicit `--network mainnet`.
     ReputationPublish {
         /// FQDN of the agent (e.g. `research-agent.sbo3lagent.eth`).
         #[arg(long)]
@@ -296,6 +301,23 @@ enum AgentCmd {
         /// Write the envelope JSON to `<path>` in addition to printing.
         #[arg(long)]
         out: Option<PathBuf>,
+
+        /// **Sign + send the setText tx** instead of just printing
+        /// the envelope. Requires the `eth_broadcast` Cargo feature;
+        /// without it the dispatch falls through to a clear "rebuild
+        /// with --features eth_broadcast" error (exit code 3).
+        #[arg(long, default_value_t = false)]
+        broadcast: bool,
+
+        /// JSON-RPC URL for `--broadcast`. Falls back to
+        /// `SBO3L_RPC_URL` env. Validated http/https.
+        #[arg(long)]
+        rpc_url: Option<String>,
+
+        /// Override the env var that holds the 32-byte hex private
+        /// key for `--broadcast` (default `SBO3L_SIGNER_KEY`).
+        #[arg(long)]
+        private_key_env_var: Option<String>,
     },
 }
 
@@ -929,6 +951,9 @@ fn main() -> ExitCode {
                     network,
                     resolver,
                     out,
+                    broadcast,
+                    rpc_url,
+                    private_key_env_var,
                 },
         } => agent_reputation::cmd_agent_reputation_publish(
             agent_reputation::ReputationPublishArgs {
@@ -937,6 +962,9 @@ fn main() -> ExitCode {
                 network,
                 resolver,
                 out,
+                broadcast,
+                rpc_url,
+                private_key_env_var,
             },
         ),
     }

--- a/docs/cli/reputation-broadcast.md
+++ b/docs/cli/reputation-broadcast.md
@@ -1,0 +1,148 @@
+# `sbo3l agent reputation-publish --broadcast` — T-4-7
+
+**Status:** Shipped (this PR).
+**Depends on:** F-5 EthSigner (#243).
+**Companion:** [`sbo3l agent register --broadcast`](agent.md) — same
+alloy harness, same env-var conventions, same Etherscan-link
+emission shape.
+
+## What it does
+
+Computes an agent's v2 reputation score from an audit-event input
+file, builds a `setText("sbo3l:reputation_score", "<score>")` tx
+against the agent's ENS resolver, signs it via the same private-key
+env-var convention T-3-1 broadcast uses, and sends + confirms the
+tx via JSON-RPC.
+
+Single-tx flow. The reputation record is just a setText — no
+subname issuance, no multicall.
+
+## Run
+
+### Dry-run (default, no Cargo features needed)
+
+```bash
+sbo3l agent reputation-publish \
+  --fqdn research-agent.sbo3lagent.eth \
+  --events events.json \
+  --network sepolia
+```
+
+Prints the envelope JSON (calldata, namehash, score, resolver). No
+network calls, no signing.
+
+### Broadcast (Sepolia)
+
+```bash
+# Build with the feature (one-time)
+cargo install sbo3l-cli --features eth_broadcast
+
+# Then:
+export SBO3L_RPC_URL='https://eth-sepolia.g.alchemy.com/v2/<key>'
+export SBO3L_SIGNER_KEY='<32-byte hex private key>'
+
+sbo3l agent reputation-publish \
+  --fqdn research-agent.sbo3lagent.eth \
+  --events events.json \
+  --network sepolia \
+  --broadcast
+```
+
+Prints the score, sends the `setText` tx, waits one confirmation,
+prints the tx hash + Etherscan link + gas used.
+
+### Broadcast (mainnet)
+
+```bash
+export SBO3L_RPC_URL='https://eth-mainnet.g.alchemy.com/v2/<key>'
+export SBO3L_SIGNER_KEY='<32-byte hex private key>'
+export SBO3L_ALLOW_MAINNET_TX=1                # double-gate
+
+sbo3l agent reputation-publish \
+  --fqdn research-agent.sbo3lagent.eth \
+  --events events.json \
+  --network mainnet \
+  --broadcast
+```
+
+Mainnet path **additionally requires** `SBO3L_ALLOW_MAINNET_TX=1`
+plus an explicit `--network mainnet`. Without the env var, the
+command refuses with exit 2 and a "set
+`SBO3L_ALLOW_MAINNET_TX=1` to acknowledge before re-running"
+message — same double-gate the rest of SBO3L's chain ops use.
+
+Cost ceiling: ~$3-5 per tx at 50 gwei mainnet gas. Per-agent.
+
+## Env vars
+
+| Var                       | Required for          | Purpose                                                  |
+|---------------------------|-----------------------|----------------------------------------------------------|
+| `SBO3L_RPC_URL`           | `--broadcast` only    | JSON-RPC endpoint (override via `--rpc-url`)             |
+| `SBO3L_SIGNER_KEY`        | `--broadcast` only    | 32-byte hex private key (override env via `--private-key-env-var`) |
+| `SBO3L_ALLOW_MAINNET_TX`  | `--broadcast --network mainnet` | Must be set to `1`                              |
+
+## Without `eth_broadcast` feature
+
+`--broadcast` still parses, but the dispatch falls through to a
+clear "rebuild with `--features eth_broadcast`" stub returning
+exit code 3 — same contract as the T-3-1 broadcast stub. The
+dry-run output (drop `--broadcast`) is the complete envelope;
+operators can pipe its calldata to `cast send` if they prefer not
+to rebuild.
+
+## Wire format (what gets signed)
+
+```text
+1. setText(node, "sbo3l:reputation_score", "<score>")
+   selector: 0x10f13a8c
+   args: namehash(fqdn), key, value
+   recipient: --resolver (default: network's PublicResolver)
+```
+
+The score is computed from the events via
+`sbo3l_policy::reputation::compute_reputation_v2` — same v2
+4-criteria weighted scoring used by the cross-agent attestation
+refusal threshold.
+
+## Verification post-broadcast
+
+After the tx confirms, anyone can verify the record without
+SBO3L-specific tooling:
+
+```bash
+# Via SBO3L
+sbo3l agent verify-ens research-agent.sbo3lagent.eth --network sepolia
+
+# Via cast (no SBO3L dependency)
+RESOLVER=$(./target/debug/sbo3l agent reputation-publish \
+            --fqdn research-agent.sbo3lagent.eth --events events.json \
+            --network sepolia | jq -r .resolver)
+NODE=$(cast namehash research-agent.sbo3lagent.eth)
+cast call "$RESOLVER" "text(bytes32,string)(string)" "$NODE" "sbo3l:reputation_score" \
+  --rpc-url https://ethereum-sepolia-rpc.publicnode.com
+```
+
+## Coordination with T-3-1 broadcast
+
+Same alloy stack (`alloy = "0.6"`, gated on the `eth_broadcast`
+Cargo feature). Same env-var conventions
+(`SBO3L_RPC_URL`, `SBO3L_SIGNER_KEY`). Same Etherscan-link
+emission shape. The broadcast harness pattern is shared between
+[`agent_broadcast.rs`](../../crates/sbo3l-cli/src/agent_broadcast.rs)
+(T-3-1, two txs: setSubnodeRecord + multicall) and
+[`agent_reputation_broadcast.rs`](../../crates/sbo3l-cli/src/agent_reputation_broadcast.rs)
+(T-4-7, single tx: setText). The two modules deliberately share
+*pattern* not *code* for now — a unified broadcast helper is a
+follow-up once we have a third caller (likely the AnchorRegistry
+publish from P6 / round 9).
+
+## EthLocalFileSigner integration follow-up
+
+This PR uses `PrivateKeySigner::from_bytes` directly, mirroring
+T-3-1 broadcast's pattern. The `EthLocalFileSigner` from F-5
+(#243) reads the same 32-byte secret format from a *file* rather
+than an env var; the two paths converge once T-3-1 broadcast +
+T-4-7 broadcast share a unified signer-loading helper. Operators
+who prefer file-based keys today can pipe `cat key.hex |
+SBO3L_SIGNER_KEY=$(cat /dev/stdin) sbo3l ...` — the env-var path
+preserves the existing security model exactly.


### PR DESCRIPTION
## Summary

Reputation broadcast slice (P1 from round 10) — wires \`--broadcast\` on the existing \`sbo3l agent reputation-publish\` CLI through to the same alloy harness T-3-1 broadcast uses (#243).

- **Dry-run (default)** — existing behaviour, prints the envelope JSON.
- **\`--broadcast\`** (under \`--features eth_broadcast\`) — signs + sends one \`setText\` tx, waits 1 confirmation, prints tx hash + Etherscan link + gas used.
- **Without the Cargo feature** — \`--broadcast\` returns exit 3 with a clear "rebuild with --features eth_broadcast" message (same contract as T-3-1 stub).
- **Mainnet double-gate** — \`--network mainnet\` plus \`SBO3L_ALLOW_MAINNET_TX=1\` required before signing.

## Wire

Single tx: \`setText(node, "sbo3l:reputation_score", "<score>")\` against the resolver (default: network PublicResolver). Score computed via \`compute_reputation_v2\` — same path as the dry-run, so output is byte-identical apart from the side effect.

## Coordination with T-3-1 broadcast (#243)

- **Same alloy stack** (\`alloy = "0.6"\` gated on \`eth_broadcast\`).
- **Same env-var conventions** — \`SBO3L_RPC_URL\` + \`SBO3L_SIGNER_KEY\`.
- **Same Etherscan-link emission shape**, same redact-RPC behaviour.
- **Same exit-code contract** for the no-feature stub (3).

The two modules deliberately share *pattern* not *code* for now — a unified broadcast helper lands once we have a third caller (likely AnchorRegistry publish from P6).

## Branch base

This PR is based on \`agent/dev1/T-5-eth-signer\` (#243). Auto-rebases onto main when #243 merges. EthLocalFileSigner-direct integration is a follow-up once both branches land — today this PR uses \`PrivateKeySigner::from_bytes\` from env, mirroring T-3-1's pattern.

## Test plan

- [x] \`cargo build -p sbo3l-cli --bin sbo3l\` (no features) — clean
- [x] \`cargo build -p sbo3l-cli --bin sbo3l --features eth_broadcast\` — clean
- [x] \`cargo test -p sbo3l-cli --bin sbo3l agent_reputation\` — 5/5 pass (including new \`broadcast_without_feature_returns_exit3\`)
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy -p sbo3l-cli --bin sbo3l -- -D warnings\` (with + without features)
- [x] CLI smoke: dry-run prints envelope; no-feature \`--broadcast\` returns exit 3 with the correct message
- [ ] Live Sepolia broadcast (gated on Daniel's apex path choice from #215)

🤖 Generated with [Claude Code](https://claude.com/claude-code)