### PR TITLE
docs(submission): live-url-inventory — bump 9 crates 1.0.1 → 1.2.0 (Heidi verify)

### DIFF
--- a/docs/submission/live-url-inventory.md
+++ b/docs/submission/live-url-inventory.md
@@ -12,15 +12,15 @@ Web pages on `crates.io` and `npmjs.com` are JS-rendered SPAs that return 404/40
 
 | Surface | URL | Status | Verify (machine API) |
 |---|---|---|---|
-| crates.io — sbo3l-core | https://crates.io/crates/sbo3l-core | 🟢 1.0.1 | `curl -sf https://crates.io/api/v1/crates/sbo3l-core \| jq -r .crate.max_version` |
-| crates.io — sbo3l-storage | https://crates.io/crates/sbo3l-storage | 🟢 1.0.1 | same pattern |
-| crates.io — sbo3l-policy | https://crates.io/crates/sbo3l-policy | 🟢 1.0.1 | |
-| crates.io — sbo3l-identity | https://crates.io/crates/sbo3l-identity | 🟢 1.0.1 | |
-| crates.io — sbo3l-execution | https://crates.io/crates/sbo3l-execution | 🟢 1.0.1 | |
-| crates.io — sbo3l-keeperhub-adapter | https://crates.io/crates/sbo3l-keeperhub-adapter | 🟢 1.0.1 | |
-| crates.io — sbo3l-server | https://crates.io/crates/sbo3l-server | 🟢 1.0.1 | |
-| crates.io — sbo3l-mcp | https://crates.io/crates/sbo3l-mcp | 🟢 1.0.1 | |
-| crates.io — sbo3l-cli | https://crates.io/crates/sbo3l-cli | 🟢 1.0.1 | `cargo install sbo3l-cli --version 1.0.1 && sbo3l --version` → `sbo3l 1.0.1` |
+| crates.io — sbo3l-core | https://crates.io/crates/sbo3l-core | 🟢 1.2.0 | `curl -sf https://crates.io/api/v1/crates/sbo3l-core \| jq -r .crate.max_version` |
+| crates.io — sbo3l-storage | https://crates.io/crates/sbo3l-storage | 🟢 1.2.0 | same pattern |
+| crates.io — sbo3l-policy | https://crates.io/crates/sbo3l-policy | 🟢 1.2.0 | |
+| crates.io — sbo3l-identity | https://crates.io/crates/sbo3l-identity | 🟢 1.2.0 | |
+| crates.io — sbo3l-execution | https://crates.io/crates/sbo3l-execution | 🟢 1.2.0 | |
+| crates.io — sbo3l-keeperhub-adapter | https://crates.io/crates/sbo3l-keeperhub-adapter | 🟢 1.2.0 | |
+| crates.io — sbo3l-server | https://crates.io/crates/sbo3l-server | 🟢 1.2.0 | |
+| crates.io — sbo3l-mcp | https://crates.io/crates/sbo3l-mcp | 🟢 1.2.0 | |
+| crates.io — sbo3l-cli | https://crates.io/crates/sbo3l-cli | 🟢 1.2.0 | `cargo install sbo3l-cli --version 1.2.0 && sbo3l --version` → `sbo3l 1.2.0` |
 | npm — @sbo3l/sdk | https://www.npmjs.com/package/@sbo3l/sdk | 🟢 1.0.0 | `npm view @sbo3l/sdk version` |
 | npm — @sbo3l/langchain | https://www.npmjs.com/package/@sbo3l/langchain | 🟢 | `npm view @sbo3l/langchain version` |
 | npm — @sbo3l/autogen | https://www.npmjs.com/package/@sbo3l/autogen | 🟢 | `npm view @sbo3l/autogen version` |


### PR DESCRIPTION
## Summary

\`crates-publish.yml\` v1.2.0 (run 25249048095) → SUCCESS at ~10:30 CEST. All 9 crates verified live on crates.io @ 1.2.0 via machine API. CLI smoke (\`cargo install sbo3l-cli --version 1.2.0 && sbo3l --version\`) returns \`sbo3l 1.2.0\`.

Inventory's crate-row + CLI install command both bumped to 1.2.0.

SDK publishes (\`sdk-ts-v1.2.0\`, \`sdk-py-v1.2.0\`) still queued — follow-up bump once those land.

## Test plan

- [x] All 9 crates return \`max_version: 1.2.0\` via crates.io API
- [x] Fresh \`cargo install sbo3l-cli --version 1.2.0\` succeeds; \`sbo3l --version\` → \`sbo3l 1.2.0\`
- [x] \`sbo3l --help\` works

Co-Authored-By: Heidi (QA + Release agent) <heidi@sbo3l.dev>