### PR TITLE
feat(marketplace-cli): sbo3l-marketplace bin — adopt + verify + publish (P3)

### DIFF
--- a/sdks/typescript/marketplace/README.md
+++ b/sdks/typescript/marketplace/README.md
@@ -3,8 +3,30 @@
 Content-addressed, signed policy registry SDK for SBO3L. Operators publish vetted policy bundles + consumers fetch + verify them offline.
 
 ```bash
-npm i @sbo3l/marketplace
+npm i @sbo3l/marketplace                        # SDK
+npm i -g @sbo3l/marketplace                     # SDK + sbo3l-marketplace CLI binary
 ```
+
+## CLI quick reference
+
+```bash
+# Adopt a registry-hosted policy locally:
+sbo3l-marketplace adopt --from sha256-<hex> \
+  --registry https://marketplace.sbo3l.dev \
+  --as my-policy
+# → writes verified policy to .sbo3l/policies/my-policy.json
+
+# Verify a bundle file you already have:
+sbo3l-marketplace verify --file ./bundle.json
+
+# Publish a pre-signed bundle to a registry:
+sbo3l-marketplace publish --file ./bundle.json \
+  --registry https://marketplace.sbo3l.dev
+```
+
+`adopt` does TWO checks: (a) the registry-returned bytes hash to the requested `policy_id` (catches a misbehaving CDN), and (b) the bundle's signature verifies under a trusted issuer. Either failure aborts the write and exits non-zero.
+
+Trusted issuers are loaded from (in precedence order): `--issuers <path>` flag → `$XDG_CONFIG_HOME/sbo3l/trusted-issuers.json` → `~/.sbo3l/trusted-issuers.json` → fallback (SBO3L official only, with placeholder pubkey — every verify fails until you wire a real config).
 
 ## What it solves
 

--- a/sdks/typescript/marketplace/package-lock.json
+++ b/sdks/typescript/marketplace/package-lock.json
@@ -12,6 +12,9 @@
         "@noble/ed25519": "^2.1.0",
         "@noble/hashes": "^1.4.0"
       },
+      "bin": {
+        "sbo3l-marketplace": "dist/cli.js"
+      },
       "devDependencies": {
         "@types/node": "^20.11.5",
         "tsup": "^8.0.2",

--- a/sdks/typescript/marketplace/package.json
+++ b/sdks/typescript/marketplace/package.json
@@ -23,6 +23,9 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "sbo3l-marketplace": "./dist/cli.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -33,13 +36,18 @@
       "types": "./dist/policies.d.ts",
       "import": "./dist/policies.js",
       "require": "./dist/policies.cjs"
+    },
+    "./cli": {
+      "types": "./dist/cli.d.ts",
+      "import": "./dist/cli.js",
+      "require": "./dist/cli.cjs"
     }
   },
   "files": ["dist", "policies", "README.md", "CHANGELOG.md"],
   "sideEffects": false,
   "engines": { "node": ">=18" },
   "scripts": {
-    "build": "tsup src/index.ts src/policies.ts --format esm,cjs --dts --clean",
+    "build": "tsup src/index.ts src/policies.ts src/cli.ts --format esm,cjs --dts --clean && chmod +x dist/cli.js dist/cli.cjs",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/sdks/typescript/marketplace/src/cli.ts
+++ b/sdks/typescript/marketplace/src/cli.ts
@@ -1,0 +1,310 @@
+/**
+ * `sbo3l-marketplace` — minimal CLI binary for the marketplace SDK.
+ *
+ * Subcommands:
+ *
+ *   sbo3l-marketplace adopt --from <policy_id> [--registry <url>] [--as <name>]
+ *     - Fetches the signed bundle from the registry.
+ *     - Verifies the signature against the trusted-issuer registry
+ *       (loaded from `~/.sbo3l/trusted-issuers.json` or `--issuers`).
+ *     - Writes the unwrapped policy JSON to `.sbo3l/policies/<name>.json`
+ *       (default name = `policy_id` slug).
+ *     - Re-checks `policy_id == sha256(canonical_json(policy))` after
+ *       fetch, refusing to write if they disagree (registry tampering
+ *       check, independent of signature).
+ *
+ *   sbo3l-marketplace verify --file <path>
+ *     - Reads a `SignedPolicyBundle` from `<path>`.
+ *     - Verifies all 5 invariants (metadata, content hash, signature,
+ *       issuer trusted, pubkey match).
+ *     - Exits 0 on ok, 1 on verify fail; prints the failure code.
+ *
+ *   sbo3l-marketplace publish --file <path> [--registry <url>]
+ *     - PUTs an already-signed bundle to a registry.
+ *
+ * Out of scope: signing happens in the producer's own tooling (key
+ * material doesn't belong in a public CLI flag). Use `signBundle` from
+ * the SDK for that.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, resolve } from "node:path";
+
+import {
+  HttpTransport,
+  IssuerRegistry,
+  type SignedPolicyBundle,
+  bootstrapOfficialRegistry,
+  computePolicyId,
+  fetchPolicy,
+  publishPolicy,
+  verifyBundle,
+} from "./index.js";
+
+interface ParsedArgs {
+  command: string | undefined;
+  flags: Record<string, string>;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const command = argv[0];
+  const flags: Record<string, string> = {};
+  for (let i = 1; i < argv.length; i++) {
+    const tok = argv[i];
+    if (tok === undefined) continue;
+    if (tok.startsWith("--")) {
+      const key = tok.slice(2);
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith("--")) {
+        flags[key] = next;
+        i++;
+      } else {
+        flags[key] = "true";
+      }
+    }
+  }
+  return { command, flags };
+}
+
+const HELP = `sbo3l-marketplace — adopt + verify + publish signed policy bundles
+
+USAGE:
+  sbo3l-marketplace adopt   --from <policy_id> [--registry <url>] [--as <name>] [--issuers <path>]
+  sbo3l-marketplace verify  --file <path> [--issuers <path>]
+  sbo3l-marketplace publish --file <path> [--registry <url>]
+  sbo3l-marketplace help
+
+FLAGS:
+  --from       Content-addressed policy id to fetch (sha256-<hex>)
+  --registry   HTTP marketplace registry base URL (default: $SBO3L_MARKETPLACE)
+  --as         Local name for the adopted policy (default: derived from policy_id)
+  --file       Path to a SignedPolicyBundle JSON file
+  --issuers    Path to trusted issuers JSON (default: \\$XDG_CONFIG_HOME/sbo3l/trusted-issuers.json)
+
+EXIT CODES:
+  0  ok
+  1  verify failed / fetch failed / file write failed
+  2  bad arguments
+`;
+
+/** Public entry point — exported for testing without a real process.exit. */
+export async function run(argv: string[]): Promise<number> {
+  const { command, flags } = parseArgs(argv);
+
+  if (command === undefined || command === "help" || flags.help === "true") {
+    process.stdout.write(HELP);
+    return command === undefined ? 2 : 0;
+  }
+
+  switch (command) {
+    case "adopt":
+      return cmdAdopt(flags);
+    case "verify":
+      return cmdVerify(flags);
+    case "publish":
+      return cmdPublish(flags);
+    default:
+      process.stderr.write(`unknown command: ${command}\n${HELP}`);
+      return 2;
+  }
+}
+
+/**
+ * Load the trusted-issuer registry. Precedence:
+ *   1. `--issuers <path>` flag
+ *   2. `$XDG_CONFIG_HOME/sbo3l/trusted-issuers.json` (Linux)
+ *   3. `~/.sbo3l/trusted-issuers.json`
+ *   4. fallback: SBO3L official issuer only (no pubkey configured →
+ *      every verify will return `issuer_pubkey_mismatch` until the
+ *      operator wires real keys; clear failure mode > silent trust)
+ */
+async function loadIssuerRegistry(flag: string | undefined): Promise<IssuerRegistry> {
+  const candidates: string[] = [];
+  if (flag !== undefined) candidates.push(flag);
+  if (process.env["XDG_CONFIG_HOME"] !== undefined) {
+    candidates.push(`${process.env["XDG_CONFIG_HOME"]}/sbo3l/trusted-issuers.json`);
+  }
+  candidates.push(`${homedir()}/.sbo3l/trusted-issuers.json`);
+
+  for (const path of candidates) {
+    try {
+      const raw = await readFile(path, "utf-8");
+      const parsed = JSON.parse(raw) as Record<string, string>;
+      const r = new IssuerRegistry();
+      for (const [issuer_id, pubkey_hex] of Object.entries(parsed)) {
+        r.trust(issuer_id, pubkey_hex);
+      }
+      return r;
+    } catch {
+      // try the next candidate
+    }
+  }
+  // No issuers file → bootstrap with the official issuer + a placeholder
+  // pubkey. Verify will fail with issuer_pubkey_mismatch until the
+  // operator drops a real trusted-issuers.json in place. Surfacing this
+  // as a clear deny is preferable to silently trusting nothing or
+  // (worse) trusting everything.
+  return bootstrapOfficialRegistry("00".repeat(32));
+}
+
+/** Slugify a policy_id into a filesystem-safe local name. */
+function defaultLocalName(policyId: string): string {
+  // sha256-abcdef... → policy-abcdef-12-chars
+  const stripped = policyId.replace(/^sha256-/, "");
+  return `policy-${stripped.slice(0, 12)}`;
+}
+
+async function cmdAdopt(flags: Record<string, string>): Promise<number> {
+  const policyId = flags["from"];
+  const registry = flags["registry"] ?? process.env["SBO3L_MARKETPLACE"];
+  const localName = flags["as"] ?? (policyId !== undefined ? defaultLocalName(policyId) : undefined);
+  // `--out-dir` defaults to `.sbo3l/policies/` (relative to cwd), the
+  // canonical location the daemon's policy loader scans. Tests override
+  // it to a tmpdir to avoid mutating the cwd.
+  const outDir = flags["out-dir"] ?? ".sbo3l/policies";
+
+  if (policyId === undefined) {
+    process.stderr.write("adopt: --from <policy_id> is required\n");
+    return 2;
+  }
+  if (registry === undefined) {
+    process.stderr.write(
+      "adopt: --registry <url> required (or set SBO3L_MARKETPLACE env var)\n",
+    );
+    return 2;
+  }
+  if (localName === undefined) {
+    process.stderr.write("adopt: --as <name> is required\n");
+    return 2;
+  }
+
+  const transport = new HttpTransport(registry);
+  const bundle = await fetchPolicy(transport, policyId);
+  if (bundle === undefined) {
+    process.stderr.write(`adopt: registry has no bundle for ${policyId}\n`);
+    return 1;
+  }
+
+  // Tamper check independent of signature: did the registry hand us
+  // bytes that hash to the requested id? Catches a registry that
+  // silently returns the wrong bundle (e.g. on a misconfigured CDN).
+  const actualId = computePolicyId(bundle.policy);
+  if (actualId !== policyId) {
+    process.stderr.write(
+      `adopt: registry returned ${actualId} instead of ${policyId} (content tampering?)\n`,
+    );
+    return 1;
+  }
+
+  const registryIss = await loadIssuerRegistry(flags["issuers"]);
+  const result = await verifyBundle(bundle, registryIss);
+  if (!result.ok) {
+    process.stderr.write(`adopt: verify failed (${result.code}): ${result.detail}\n`);
+    return 1;
+  }
+
+  const dest = resolve(`${outDir}/${localName}.json`);
+  await mkdir(dirname(dest), { recursive: true });
+  await writeFile(dest, JSON.stringify(bundle.policy, null, 2) + "\n", "utf-8");
+
+  process.stdout.write(
+    [
+      `✓ adopted ${policyId}`,
+      `  issuer:  ${result.issuer_id}`,
+      `  label:   ${result.metadata.label}`,
+      `  risk:    ${result.metadata.risk_class}`,
+      `  written: ${dest}`,
+      "",
+    ].join("\n"),
+  );
+  return 0;
+}
+
+async function cmdVerify(flags: Record<string, string>): Promise<number> {
+  const file = flags["file"];
+  if (file === undefined) {
+    process.stderr.write("verify: --file <path> is required\n");
+    return 2;
+  }
+
+  let raw: string;
+  try {
+    raw = await readFile(file, "utf-8");
+  } catch (e) {
+    process.stderr.write(`verify: cannot read ${file}: ${e instanceof Error ? e.message : String(e)}\n`);
+    return 1;
+  }
+
+  let bundle: SignedPolicyBundle;
+  try {
+    bundle = JSON.parse(raw) as SignedPolicyBundle;
+  } catch (e) {
+    process.stderr.write(`verify: ${file} is not valid JSON: ${e instanceof Error ? e.message : String(e)}\n`);
+    return 1;
+  }
+
+  const registry = await loadIssuerRegistry(flags["issuers"]);
+  const result = await verifyBundle(bundle, registry);
+  if (!result.ok) {
+    process.stderr.write(`verify: failed (${result.code}): ${result.detail}\n`);
+    return 1;
+  }
+  process.stdout.write(
+    [
+      `✓ verified ${result.policy_id}`,
+      `  issuer:  ${result.issuer_id}`,
+      `  label:   ${result.metadata.label}`,
+      `  risk:    ${result.metadata.risk_class}`,
+      "",
+    ].join("\n"),
+  );
+  return 0;
+}
+
+async function cmdPublish(flags: Record<string, string>): Promise<number> {
+  const file = flags["file"];
+  const registry = flags["registry"] ?? process.env["SBO3L_MARKETPLACE"];
+  if (file === undefined) {
+    process.stderr.write("publish: --file <path> is required\n");
+    return 2;
+  }
+  if (registry === undefined) {
+    process.stderr.write("publish: --registry <url> required\n");
+    return 2;
+  }
+
+  let bundle: SignedPolicyBundle;
+  try {
+    const raw = await readFile(file, "utf-8");
+    bundle = JSON.parse(raw) as SignedPolicyBundle;
+  } catch (e) {
+    process.stderr.write(`publish: cannot read ${file}: ${e instanceof Error ? e.message : String(e)}\n`);
+    return 1;
+  }
+
+  const transport = new HttpTransport(registry);
+  try {
+    const id = await publishPolicy(transport, bundle);
+    process.stdout.write(`✓ published ${id} to ${registry}\n`);
+    return 0;
+  } catch (e) {
+    process.stderr.write(`publish: ${e instanceof Error ? e.message : String(e)}\n`);
+    return 1;
+  }
+}
+
+// Bin entry — only fires when invoked as the binary, NOT when imported
+// in tests. `process.argv[1]` is the script path Node was launched with.
+const isMain = (() => {
+  const argv1 = process.argv[1];
+  if (argv1 === undefined) return false;
+  // dist/cli.js OR dist/cli.cjs both qualify.
+  return argv1.endsWith("/cli.js") || argv1.endsWith("/cli.cjs") || argv1.endsWith("\\cli.js");
+})();
+
+if (isMain) {
+  run(process.argv.slice(2)).then((code) => {
+    process.exit(code);
+  });
+}

--- a/sdks/typescript/marketplace/test/cli.test.ts
+++ b/sdks/typescript/marketplace/test/cli.test.ts
@@ -1,0 +1,372 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as ed25519 from "@noble/ed25519";
+import { bytesToHex } from "@noble/hashes/utils";
+
+import { run } from "../src/cli.js";
+import { signBundle } from "../src/index.js";
+
+async function makeIssuer(): Promise<{ priv: string; pub: string }> {
+  const priv = ed25519.utils.randomPrivateKey();
+  const pub = await ed25519.getPublicKeyAsync(priv);
+  return { priv: bytesToHex(priv), pub: bytesToHex(pub) };
+}
+
+const SAMPLE_POLICY = {
+  version: 1,
+  policy_id: "test-policy",
+  default_decision: "deny",
+  agents: [{ agent_id: "a", status: "active" }],
+  rules: [],
+};
+
+let tmpDir: string;
+let stdoutCalls: string[];
+let stderrCalls: string[];
+let stdoutSpy: ReturnType<typeof vi.spyOn> | undefined;
+let stderrSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+beforeEach(async () => {
+  // vitest workers forbid process.chdir; pass `cwd` to the CLI via the
+  // adopt path argument or by working from absolute --as paths.
+  tmpDir = await mkdtemp(join(tmpdir(), "sbo3l-marketplace-cli-"));
+  stdoutCalls = [];
+  stderrCalls = [];
+  // Untyped spy — vitest's strict types reject the narrow string-only
+  // signature against process.std{out,err}.write's overloaded shape.
+  stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((data: unknown) => {
+    stdoutCalls.push(typeof data === "string" ? data : String(data));
+    return true;
+  }) as never;
+  stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((data: unknown) => {
+    stderrCalls.push(typeof data === "string" ? data : String(data));
+    return true;
+  }) as never;
+});
+
+afterEach(async () => {
+  stdoutSpy?.mockRestore();
+  stderrSpy?.mockRestore();
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("cli — top-level dispatch", () => {
+  it("prints help when no command given (exit 2)", async () => {
+    expect(await run([])).toBe(2);
+    expect(stdoutCalls.join("")).toContain("USAGE:");
+  });
+
+  it("prints help on `help` (exit 0)", async () => {
+    expect(await run(["help"])).toBe(0);
+    expect(stdoutCalls.join("")).toContain("USAGE:");
+  });
+
+  it("rejects unknown command (exit 2)", async () => {
+    expect(await run(["bogus"])).toBe(2);
+    expect(stderrCalls.join("")).toContain("unknown command");
+  });
+});
+
+describe("cli adopt", () => {
+  it("adopt without --from exits 2", async () => {
+    expect(await run(["adopt"])).toBe(2);
+    expect(stderrCalls.join("")).toContain("--from");
+  });
+
+  it("adopt without --registry (and no env var) exits 2", async () => {
+    delete process.env["SBO3L_MARKETPLACE"];
+    expect(await run(["adopt", "--from", "sha256-abc"])).toBe(2);
+    expect(stderrCalls.join("")).toContain("--registry");
+  });
+
+  it("adopt fetches, verifies, writes the policy to .sbo3l/policies/", async () => {
+    const { priv, pub } = await makeIssuer();
+    const bundle = await signBundle({
+      policy: SAMPLE_POLICY,
+      issuer_id: "did:test:alice",
+      issuer_privkey_hex: priv,
+      issuer_pubkey_hex: pub,
+      metadata: {
+        label: "test policy",
+        risk_class: "low",
+        signed_at: "2099-01-01T00:00:00Z",
+      },
+    });
+
+    // Stub the global fetch so HttpTransport hits a fake registry that
+    // returns our locally-signed bundle.
+    const fakeFetch = vi.fn().mockImplementation(async (url: string) => {
+      if (url.endsWith(`/v1/policies/${bundle.policy_id}`)) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => bundle,
+        } as Response;
+      }
+      return { ok: false, status: 404 } as Response;
+    });
+    const prevFetch = globalThis.fetch;
+    globalThis.fetch = fakeFetch as never;
+
+    // Trusted-issuers config in the tmpdir.
+    const issuers = join(tmpDir, "trusted-issuers.json");
+    await writeFile(issuers, JSON.stringify({ "did:test:alice": pub }));
+
+    try {
+      const outDir = join(tmpDir, "out");
+      const code = await run([
+        "adopt",
+        "--from",
+        bundle.policy_id,
+        "--registry",
+        "https://registry.example.com",
+        "--as",
+        "my-policy",
+        "--issuers",
+        issuers,
+        "--out-dir",
+        outDir,
+      ]);
+      expect(code).toBe(0);
+      expect(stdoutCalls.join("")).toContain("✓ adopted");
+      expect(stdoutCalls.join("")).toContain("did:test:alice");
+      const written = await readFile(resolvePath(outDir, "my-policy.json"), "utf-8");
+      expect(JSON.parse(written)).toEqual(SAMPLE_POLICY);
+    } finally {
+      globalThis.fetch = prevFetch;
+    }
+  });
+
+  it("adopt refuses bundle whose policy_id ≠ content hash (registry tampering)", async () => {
+    const { priv, pub } = await makeIssuer();
+    const bundle = await signBundle({
+      policy: SAMPLE_POLICY,
+      issuer_id: "did:test:alice",
+      issuer_privkey_hex: priv,
+      issuer_pubkey_hex: pub,
+      metadata: {
+        label: "x",
+        risk_class: "low",
+        signed_at: "2099-01-01T00:00:00Z",
+      },
+    });
+
+    // Registry returns the bundle but caller asks for a DIFFERENT id.
+    const fakeFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => bundle,
+    } as Response);
+    const prevFetch = globalThis.fetch;
+    globalThis.fetch = fakeFetch as never;
+
+    try {
+      const code = await run([
+        "adopt",
+        "--from",
+        "sha256-" + "00".repeat(32), // bogus id
+        "--registry",
+        "https://registry.example.com",
+        "--as",
+        "my-policy",
+      ]);
+      expect(code).toBe(1);
+      expect(stderrCalls.join("")).toContain("content tampering");
+    } finally {
+      globalThis.fetch = prevFetch;
+    }
+  });
+
+  it("adopt 404 from registry exits 1 (not 2 — args were valid)", async () => {
+    const fakeFetch = vi.fn().mockResolvedValue({ ok: false, status: 404 } as Response);
+    const prevFetch = globalThis.fetch;
+    globalThis.fetch = fakeFetch as never;
+    try {
+      const code = await run([
+        "adopt",
+        "--from",
+        "sha256-abc",
+        "--registry",
+        "https://registry.example.com",
+        "--as",
+        "x",
+      ]);
+      expect(code).toBe(1);
+      expect(stderrCalls.join("")).toContain("no bundle for");
+    } finally {
+      globalThis.fetch = prevFetch;
+    }
+  });
+});
+
+describe("cli verify", () => {
+  it("verify without --file exits 2", async () => {
+    expect(await run(["verify"])).toBe(2);
+  });
+
+  it("verify reports missing file (exit 1)", async () => {
+    expect(await run(["verify", "--file", "/no/such/file.json"])).toBe(1);
+    expect(stderrCalls.join("")).toContain("cannot read");
+  });
+
+  it("verify rejects malformed JSON", async () => {
+    const path = join(tmpDir, "bad.json");
+    await writeFile(path, "{not-json");
+    expect(await run(["verify", "--file", path])).toBe(1);
+    expect(stderrCalls.join("")).toContain("not valid JSON");
+  });
+
+  it("verify ok on a freshly-signed bundle with matching trusted issuer", async () => {
+    const { priv, pub } = await makeIssuer();
+    const bundle = await signBundle({
+      policy: SAMPLE_POLICY,
+      issuer_id: "did:test:alice",
+      issuer_privkey_hex: priv,
+      issuer_pubkey_hex: pub,
+      metadata: {
+        label: "x",
+        risk_class: "low",
+        signed_at: "2099-01-01T00:00:00Z",
+      },
+    });
+    const path = join(tmpDir, "bundle.json");
+    await writeFile(path, JSON.stringify(bundle));
+    const issuers = join(tmpDir, "trusted-issuers.json");
+    await writeFile(issuers, JSON.stringify({ "did:test:alice": pub }));
+
+    const code = await run(["verify", "--file", path, "--issuers", issuers]);
+    expect(code).toBe(0);
+    expect(stdoutCalls.join("")).toContain("✓ verified");
+  });
+
+  it("verify rejects bundle whose issuer is not in registry", async () => {
+    const { priv, pub } = await makeIssuer();
+    const bundle = await signBundle({
+      policy: SAMPLE_POLICY,
+      issuer_id: "did:test:bob",
+      issuer_privkey_hex: priv,
+      issuer_pubkey_hex: pub,
+      metadata: {
+        label: "x",
+        risk_class: "low",
+        signed_at: "2099-01-01T00:00:00Z",
+      },
+    });
+    const path = join(tmpDir, "bundle.json");
+    await writeFile(path, JSON.stringify(bundle));
+    const issuers = join(tmpDir, "trusted-issuers.json");
+    await writeFile(issuers, JSON.stringify({ "did:test:alice": pub })); // bob NOT trusted
+
+    const code = await run(["verify", "--file", path, "--issuers", issuers]);
+    expect(code).toBe(1);
+    expect(stderrCalls.join("")).toContain("issuer_unknown");
+  });
+});
+
+describe("cli publish", () => {
+  it("publish without --file exits 2", async () => {
+    expect(await run(["publish", "--registry", "https://example.com"])).toBe(2);
+  });
+
+  it("publish without --registry (and no env) exits 2", async () => {
+    delete process.env["SBO3L_MARKETPLACE"];
+    const path = join(tmpDir, "bundle.json");
+    await writeFile(path, "{}");
+    expect(await run(["publish", "--file", path])).toBe(2);
+  });
+
+  it("publish PUTs the bundle to the registry", async () => {
+    const { priv, pub } = await makeIssuer();
+    const bundle = await signBundle({
+      policy: SAMPLE_POLICY,
+      issuer_id: "did:test:alice",
+      issuer_privkey_hex: priv,
+      issuer_pubkey_hex: pub,
+      metadata: {
+        label: "x",
+        risk_class: "low",
+        signed_at: "2099-01-01T00:00:00Z",
+      },
+    });
+    const path = join(tmpDir, "bundle.json");
+    await writeFile(path, JSON.stringify(bundle));
+
+    const fakeFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 } as Response);
+    const prevFetch = globalThis.fetch;
+    globalThis.fetch = fakeFetch as never;
+    try {
+      const code = await run([
+        "publish",
+        "--file",
+        path,
+        "--registry",
+        "https://registry.example.com",
+      ]);
+      expect(code).toBe(0);
+      expect(fakeFetch).toHaveBeenCalledWith(
+        `https://registry.example.com/v1/policies/${bundle.policy_id}`,
+        expect.objectContaining({ method: "PUT" }),
+      );
+      expect(stdoutCalls.join("")).toContain("✓ published");
+    } finally {
+      globalThis.fetch = prevFetch;
+    }
+  });
+});
+
+describe("loadIssuerRegistry — fallback", () => {
+  it("uses bootstrap (official-only) when no issuers file is found anywhere", async () => {
+    // Adopt with no --issuers and no XDG path → falls back to bootstrap.
+    // Verify must then fail with issuer_unknown for our test bundle.
+    const { priv, pub } = await makeIssuer();
+    const bundle = await signBundle({
+      policy: SAMPLE_POLICY,
+      issuer_id: "did:test:bob",
+      issuer_privkey_hex: priv,
+      issuer_pubkey_hex: pub,
+      metadata: {
+        label: "x",
+        risk_class: "low",
+        signed_at: "2099-01-01T00:00:00Z",
+      },
+    });
+    const fakeFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => bundle,
+    } as Response);
+    const prevFetch = globalThis.fetch;
+    globalThis.fetch = fakeFetch as never;
+
+    // Ensure the default discovery paths don't match by overriding HOME
+    // + XDG_CONFIG_HOME to the tmpdir (which has no issuers file).
+    const prevHome = process.env["HOME"];
+    const prevXdg = process.env["XDG_CONFIG_HOME"];
+    process.env["HOME"] = tmpDir;
+    delete process.env["XDG_CONFIG_HOME"];
+
+    try {
+      const code = await run([
+        "adopt",
+        "--from",
+        bundle.policy_id,
+        "--registry",
+        "https://r.example.com",
+        "--as",
+        "x",
+      ]);
+      expect(code).toBe(1);
+      // The fallback only trusts the official issuer, so a bob-signed
+      // bundle hits issuer_unknown — the loud failure mode the
+      // implementation comment promises.
+      expect(stderrCalls.join("")).toContain("issuer_unknown");
+    } finally {
+      globalThis.fetch = prevFetch;
+      if (prevHome !== undefined) process.env["HOME"] = prevHome;
+      if (prevXdg !== undefined) process.env["XDG_CONFIG_HOME"] = prevXdg;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Marketplace adoption flow as a standalone CLI binary on top of `@sbo3l/marketplace` v1.2.0 (SDK from PR #244, merged).

The UI-side 'Adopt this policy' button on `/marketplace/[id]` (Dev 3 territory, PR #241) shells out to this CLI.

## What ships

### `sbo3l-marketplace` bin (3 subcommands)

| Command | Behaviour |
|---|---|
| `adopt --from <id> --registry <url> --as <name>` | Fetches signed bundle → re-hashes content (catches CDN tampering, independent of signature) → `verifyBundle` (5 SDK invariants) → writes unwrapped policy to `.sbo3l/policies/<name>.json` |
| `verify --file <path>` | Reads bundle from disk → verifies → exit 0 / 1 |
| `publish --file <path> --registry <url>` | PUTs an already-signed bundle |

### Trusted-issuer discovery
Precedence: `--issuers <path>` → `\$XDG_CONFIG_HOME/sbo3l/trusted-issuers.json` → `~/.sbo3l/trusted-issuers.json` → fallback (SBO3L official only with placeholder pubkey → **every verify hits `issuer_pubkey_mismatch` until operator wires real keys**; loud failure beats silent trust).

### Two independent tamper checks on adopt
1. Re-hash registry-returned bytes; refuses if computed `policy_id` ≠ `--from` (catches misbehaving CDN / cache, **independent** of signature)
2. `verifyBundle()` runs all 5 SDK invariants

Either failure aborts the write and exits non-zero — adopted policies are always trustworthy by construction.

### Wire-up
- `package.json` adds `bin: { 'sbo3l-marketplace': './dist/cli.js' }` → `npx @sbo3l/marketplace adopt …` works out of the box
- New `./cli` subpath export for programmatic embedding (e.g. the future Rust `sbo3l policy adopt` shells through this)

## Test plan
- [x] **17 new vitest tests** (`test/cli.test.ts`):
  - Top-level dispatch (help, no-cmd, unknown-cmd)
  - `adopt`: missing args (×2), full happy path with fetch stub + on-disk write verification, content-tampering rejection, 404 from registry, fallback issuer registry hits `issuer_unknown`
  - `verify`: missing args, missing file, malformed JSON, ok with matching trusted issuer, untrusted issuer rejected
  - `publish`: missing args (×2), PUT call shape verification
- [x] Total marketplace tests: **47/47** (30 SDK + 17 CLI)
- [x] `npm run typecheck` → clean
- [x] `npm run build` → ESM + CJS + d.ts for index / policies / cli
- [x] `node dist/cli.js help` smoke prints expected USAGE block

## Out of scope
- Rust `sbo3l policy adopt` subcommand wired into the main CLI binary — Dev 1 territory; this TS bin is the canonical implementation it shells through
- Token-gated bundle badge on UI — Dev 3's `/marketplace/[id]` page; SDK-side metadata field for it is a fast-follow once Dev 4's NFT-ownership check (#237) lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)