### PR TITLE
feat(contracts): SBO3LReputationRegistry — narrowly-scoped on-chain reputation log (R11 P1)

### DIFF
--- a/crates/sbo3l-identity/contracts/SBO3LReputationRegistry.sol
+++ b/crates/sbo3l-identity/contracts/SBO3LReputationRegistry.sol
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title  SBO3L-ReputationRegistry — narrowly-scoped on-chain reputation log
+/// @author SBO3L (Round 11 P1)
+/// @notice Stores per-tenant, per-agent reputation entries timestamped to
+///         the block they were written at. ECDSA-gated writes: anyone
+///         can submit, contract verifies the signature recovers to
+///         the tenant's pinned signer before accepting.
+///
+/// @dev    Why a SBO3L registry rather than ERC-8004:
+///         the public ERC-8004 reference impl is not yet shipped at
+///         hackathon time. This contract narrows scope to the single
+///         operation we actually need (publish a reputation_score for
+///         an agent) without bundling the full ERC-8004 surface
+///         (registration, attestations, validators). When ERC-8004
+///         lands a downstream PR can mirror writes into both.
+///
+///         Design choices preserved:
+///         1. Append-only. Each (tenantId, agent) write goes to the
+///            next sequence position; the contract never overwrites
+///            an existing entry.
+///         2. Multi-tenant via bytes32 tenantId (typically
+///            keccak256(ENS-name)). Distinct tenants are isolated.
+///         3. ECDSA-gated. Anyone can submit a write but only sigs
+///            that recover to the tenant's pinned signer are
+///            accepted. Sequence is part of the signed payload so
+///            sigs can't be replayed.
+///         4. No admin / upgrade path. Same posture as
+///            AnchorRegistry (round 9 P6) and OffchainResolver
+///            (T-4-1) — anchors are evidence, not state to redact.
+///         5. No fees. payable would be operator policy; we don't
+///            bake it in.
+
+/// @dev EIP-191 prefix-style domain string. Pinned in the
+///      `_digestFor` helper. Sigs computed over this exact string
+///      bound to the registry contract — sigs from a copy of this
+///      contract on a different address don't validate (the
+///      contract address is part of the digest).
+bytes32 constant DOMAIN = keccak256("SBO3L-Reputation-Registry-v1");
+
+event ReputationWritten(
+    bytes32 indexed tenantId,
+    address indexed agent,
+    uint256 indexed sequence,
+    uint8 score,
+    uint64 chainHeadBlock,
+    uint64 publishedAt,
+    address signer
+);
+
+event TenantClaimed(bytes32 indexed tenantId, address indexed signer);
+
+error InvalidTenantId();
+error InvalidScore(uint8 score);
+error InvalidSignatureLength(uint256 length);
+error TenantAlreadyClaimed(bytes32 tenantId, address existingSigner);
+error TenantNotClaimed(bytes32 tenantId);
+error UnauthorizedSigner(address recovered, address expected);
+error WrongSequence(uint256 expected, uint256 provided);
+error EntryAlreadyExists(bytes32 tenantId, address agent, uint256 sequence);
+
+contract SBO3LReputationRegistry {
+    struct Entry {
+        /// @dev 0..=100 reputation score.
+        uint8 score;
+        /// @dev block.timestamp at which the entry was written.
+        uint64 publishedAt;
+        /// @dev Off-chain audit-chain block height the score was
+        ///      sampled at. Lets a verifier re-derive from the
+        ///      audit log captured at this block.
+        uint64 chainHeadBlock;
+        /// @dev Recovered signer address. Should equal
+        ///      `tenantSigner[tenantId]`; pinned here so a future
+        ///      audit can verify even if the tenant signer rotates.
+        address signer;
+    }
+
+    /// @notice Per-tenant pinned signer. Set on first call to
+    ///         `claimTenant`; immutable thereafter. Tenants that
+    ///         want multi-sig governance should claim under a
+    ///         multi-sig address.
+    mapping(bytes32 => address) public tenantSigner;
+
+    /// @notice Per-tenant per-agent next-sequence counter. Reads
+    ///         return the sequence of the *next* entry write (so
+    ///         the first write goes to sequence 0).
+    mapping(bytes32 => mapping(address => uint256)) public nextSequence;
+
+    /// @notice Entry storage. `_entries[tenantId][agent][sequence]`
+    ///         is the entry written at sequence position.
+    mapping(bytes32 => mapping(address => mapping(uint256 => Entry))) internal _entries;
+
+    /// @notice Claim a tenant_id. The first caller becomes the
+    ///         tenant's permanent signer (the address whose sigs
+    ///         will be required for `writeReputation` calls under
+    ///         this tenant).
+    function claimTenant(bytes32 tenantId) external {
+        if (tenantId == bytes32(0)) revert InvalidTenantId();
+        address existing = tenantSigner[tenantId];
+        if (existing != address(0)) revert TenantAlreadyClaimed(tenantId, existing);
+        tenantSigner[tenantId] = msg.sender;
+        emit TenantClaimed(tenantId, msg.sender);
+    }
+
+    /// @notice Write a reputation entry. Caller doesn't need to be
+    ///         the tenant's signer — they need to provide a
+    ///         signature that recovers to the tenant's signer.
+    ///         The expected sequence is part of the digest so a
+    ///         signature can't be replayed across sequence
+    ///         positions.
+    /// @param  tenantId          Tenant to write under (must be claimed).
+    /// @param  agent             Subject of the reputation entry.
+    /// @param  score             0..=100 reputation score.
+    /// @param  chainHeadBlock    Off-chain audit-chain block height.
+    /// @param  expectedSequence  Sequence the caller expects to write at.
+    ///                           Must equal `nextSequence[tenantId][agent]`.
+    /// @param  signature         65-byte (r||s||v) ECDSA signature
+    ///                           over the EIP-191-shaped digest (see
+    ///                           `_digestFor`).
+    function writeReputation(
+        bytes32 tenantId,
+        address agent,
+        uint8 score,
+        uint64 chainHeadBlock,
+        uint256 expectedSequence,
+        bytes calldata signature
+    ) external returns (uint256 sequence) {
+        if (signature.length != 65) revert InvalidSignatureLength(signature.length);
+        if (score > 100) revert InvalidScore(score);
+        address signer = tenantSigner[tenantId];
+        if (signer == address(0)) revert TenantNotClaimed(tenantId);
+
+        sequence = nextSequence[tenantId][agent];
+        if (expectedSequence != sequence) revert WrongSequence(sequence, expectedSequence);
+
+        bytes32 digest = _digestFor(tenantId, agent, score, chainHeadBlock, sequence);
+        address recovered = _recoverSigner(digest, signature);
+        if (recovered != signer) revert UnauthorizedSigner(recovered, signer);
+
+        // Defense-in-depth: never overwrite. Sequence counter alone
+        // guarantees this; the explicit check survives any future
+        // refactor that ever resets the counter.
+        Entry storage existing = _entries[tenantId][agent][sequence];
+        if (existing.publishedAt != 0) {
+            revert EntryAlreadyExists(tenantId, agent, sequence);
+        }
+
+        _entries[tenantId][agent][sequence] = Entry({
+            score: score,
+            publishedAt: uint64(block.timestamp),
+            chainHeadBlock: chainHeadBlock,
+            signer: recovered
+        });
+        nextSequence[tenantId][agent] = sequence + 1;
+
+        emit ReputationWritten(
+            tenantId,
+            agent,
+            sequence,
+            score,
+            chainHeadBlock,
+            uint64(block.timestamp),
+            recovered
+        );
+    }
+
+    /// @notice Read the latest reputation entry for an agent under
+    ///         a tenant. Reverts if no entries written yet.
+    function reputationOf(bytes32 tenantId, address agent)
+        external
+        view
+        returns (Entry memory entry)
+    {
+        uint256 count = nextSequence[tenantId][agent];
+        if (count == 0) revert TenantNotClaimed(tenantId);
+        entry = _entries[tenantId][agent][count - 1];
+    }
+
+    /// @notice Direct read of a specific sequence position. Returns
+    ///         the zero-entry if unset; callers compare
+    ///         `publishedAt != 0` to disambiguate.
+    function entryAt(bytes32 tenantId, address agent, uint256 sequence)
+        external
+        view
+        returns (Entry memory entry)
+    {
+        entry = _entries[tenantId][agent][sequence];
+    }
+
+    /// @notice Number of entries written under (tenantId, agent).
+    function entryCount(bytes32 tenantId, address agent) external view returns (uint256) {
+        return nextSequence[tenantId][agent];
+    }
+
+    /// @notice Compute the EIP-191-shaped digest a signer commits
+    ///         to. Pure / view so an off-chain caller can produce
+    ///         the same digest without calling on-chain.
+    function digestFor(
+        bytes32 tenantId,
+        address agent,
+        uint8 score,
+        uint64 chainHeadBlock,
+        uint256 expectedSequence
+    ) external view returns (bytes32) {
+        return _digestFor(tenantId, agent, score, chainHeadBlock, expectedSequence);
+    }
+
+    /// @dev Internal digest builder. Binds tenantId + agent + score
+    ///      + chainHeadBlock + sequence + DOMAIN + this contract
+    ///      address into one 32-byte hash. Signers signing this
+    ///      hash can't have their sigs replayed across:
+    ///      - different sequence positions (sequence in payload)
+    ///      - different agents (agent in payload)
+    ///      - different scores (score in payload)
+    ///      - different contracts (address(this) in payload)
+    ///      - different schemes (DOMAIN constant in payload)
+    function _digestFor(
+        bytes32 tenantId,
+        address agent,
+        uint8 score,
+        uint64 chainHeadBlock,
+        uint256 expectedSequence
+    ) internal view returns (bytes32) {
+        return keccak256(
+            abi.encodePacked(
+                hex"1900",
+                address(this),
+                DOMAIN,
+                tenantId,
+                agent,
+                score,
+                chainHeadBlock,
+                expectedSequence
+            )
+        );
+    }
+
+    /// @dev ECDSA recovery for a 65-byte (r, s, v) signature.
+    function _recoverSigner(bytes32 digest, bytes calldata sig)
+        internal
+        pure
+        returns (address)
+    {
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        assembly {
+            // r at sig.offset, s at sig.offset+32, v at sig.offset+64
+            r := calldataload(sig.offset)
+            s := calldataload(add(sig.offset, 0x20))
+            v := byte(0, calldataload(add(sig.offset, 0x40)))
+        }
+        if (v < 27) v += 27;
+        return ecrecover(digest, v, r, s);
+    }
+
+    /// @notice ERC-165 advertisement. Currently advertises only
+    ///         IERC165; specific reputation-registry interface id
+    ///         reserved for the ENSIP-N PR (Round 11 P4).
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == 0x01ffc9a7;
+    }
+}

--- a/crates/sbo3l-identity/contracts/script/DeployReputationRegistry.s.sol
+++ b/crates/sbo3l-identity/contracts/script/DeployReputationRegistry.s.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Script, console} from "forge-std/Script.sol";
+import {SBO3LReputationRegistry} from "../SBO3LReputationRegistry.sol";
+
+/// @title  Deploy SBO3LReputationRegistry to a target chain
+/// @notice Stateless deploy script. The contract has no constructor
+///         args (multi-tenant; signers are pinned per-tenant via
+///         `claimTenant` post-deploy), so the same script works
+///         verbatim across Sepolia, Optimism Sepolia, Base Sepolia,
+///         and mainnet.
+///
+/// @dev    Usage:
+///
+///         export PRIVATE_KEY=0x<deployer-key>
+///         forge script script/DeployReputationRegistry.s.sol \
+///           --rpc-url $SEPOLIA_RPC_URL \
+///           --broadcast --verify
+///
+///         The deployed address is printed to stdout. Pin it in
+///         `crates/sbo3l-identity/src/contracts.rs` (round 9 P1
+///         pin module) under the appropriate network row.
+contract DeployReputationRegistry is Script {
+    function run() external returns (SBO3LReputationRegistry registry) {
+        uint256 deployerKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerKey);
+        registry = new SBO3LReputationRegistry();
+        vm.stopBroadcast();
+        console.log("SBO3LReputationRegistry deployed to:", address(registry));
+    }
+}

--- a/crates/sbo3l-identity/contracts/test/SBO3LReputationRegistry.t.sol
+++ b/crates/sbo3l-identity/contracts/test/SBO3LReputationRegistry.t.sol
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {
+    SBO3LReputationRegistry,
+    InvalidTenantId,
+    InvalidScore,
+    InvalidSignatureLength,
+    TenantAlreadyClaimed,
+    TenantNotClaimed,
+    UnauthorizedSigner,
+    WrongSequence,
+    EntryAlreadyExists,
+    ReputationWritten,
+    TenantClaimed
+} from "../SBO3LReputationRegistry.sol";
+
+contract SBO3LReputationRegistryTest is Test {
+    SBO3LReputationRegistry internal registry;
+
+    uint256 internal signerKey;
+    address internal signer;
+    address internal otherAddr;
+    address internal agent;
+    bytes32 internal tenantA;
+
+    function setUp() public {
+        registry = new SBO3LReputationRegistry();
+        signerKey = uint256(keccak256("rep-signer"));
+        signer = vm.addr(signerKey);
+        otherAddr = vm.addr(uint256(keccak256("other")));
+        agent = vm.addr(uint256(keccak256("agent-1")));
+        tenantA = keccak256("sbo3lagent.eth");
+    }
+
+    function _signFor(
+        bytes32 tenantId,
+        address a,
+        uint8 score,
+        uint64 chainHeadBlock,
+        uint256 sequence,
+        uint256 key
+    ) internal view returns (bytes memory sig) {
+        bytes32 digest = registry.digestFor(tenantId, a, score, chainHeadBlock, sequence);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(key, digest);
+        sig = abi.encodePacked(r, s, v);
+    }
+
+    // ============================================================
+    // Tenant claim
+    // ============================================================
+
+    function test_claimTenant_assignsSenderAsSigner() public {
+        vm.prank(signer);
+        registry.claimTenant(tenantA);
+        assertEq(registry.tenantSigner(tenantA), signer);
+    }
+
+    function test_claimTenant_emitsEvent() public {
+        vm.expectEmit(true, true, false, false);
+        emit TenantClaimed(tenantA, signer);
+        vm.prank(signer);
+        registry.claimTenant(tenantA);
+    }
+
+    function test_claimTenant_rejectsZeroId() public {
+        vm.prank(signer);
+        vm.expectRevert(InvalidTenantId.selector);
+        registry.claimTenant(bytes32(0));
+    }
+
+    function test_claimTenant_rejectsDoubleClaim() public {
+        vm.prank(signer);
+        registry.claimTenant(tenantA);
+        vm.prank(otherAddr);
+        vm.expectRevert(abi.encodeWithSelector(TenantAlreadyClaimed.selector, tenantA, signer));
+        registry.claimTenant(tenantA);
+    }
+
+    // ============================================================
+    // Write happy path
+    // ============================================================
+
+    function test_writeReputation_firstWriteAtSequenceZero() public {
+        vm.prank(signer);
+        registry.claimTenant(tenantA);
+
+        bytes memory sig = _signFor(tenantA, agent, 87, 100, 0, signerKey);
+        uint256 seq = registry.writeReputation(tenantA, agent, 87, 100, 0, sig);
+        assertEq(seq, 0);
+        assertEq(registry.entryCount(tenantA, agent), 1);
+
+        SBO3LReputationRegistry.Entry memory e = registry.reputationOf(tenantA, agent);
+        assertEq(e.score, 87);
+        assertEq(e.chainHeadBlock, 100);
+        assertEq(e.publishedAt, uint64(block.timestamp));
+        assertEq(e.signer, signer);
+    }
+
+    function test_writeReputation_appendsToSequence() public {
+        vm.prank(signer);
+        registry.claimTenant(tenantA);
+
+        bytes memory s0 = _signFor(tenantA, agent, 80, 100, 0, signerKey);
+        bytes memory s1 = _signFor(tenantA, agent, 85, 101, 1, signerKey);
+        bytes memory s2 = _signFor(tenantA, agent, 90, 102, 2, signerKey);
+        registry.writeReputation(tenantA, agent, 80, 100, 0, s0);
+        registry.writeReputation(tenantA, agent, 85, 101, 1, s1);
+        registry.writeReputation(tenantA, agent, 90, 102, 2, s2);
+
+        assertEq(registry.entryCount(tenantA, agent), 3);
+        assertEq(registry.reputationOf(tenantA, agent).score, 90);
+        assertEq(registry.entryAt(tenantA, agent, 0).score, 80);
+        assertEq(registry.entryAt(tenantA, agent, 1).score, 85);
+    }
+
+    function test_writeReputation_emitsEvent() public {
+        vm.prank(signer);
+        registry.claimTenant(tenantA);
+        bytes memory sig = _signFor(tenantA, agent, 87, 100, 0, signerKey);
+
+        vm.expectEmit(true, true, true, true);
+        emit ReputationWritten(tenantA, agent, 0, 87, 100, uint64(block.timestamp), signer);
+        registry.writeReputation(tenantA, agent, 87, 100, 0, sig);
+    }
+
+    function test_writeReputation_anyoneMayCall_signatureGated() public {
+        vm.prank(signer);
+        registry.claimTenant(tenantA);
+        bytes memory sig = _signFor(tenantA, agent, 87, 100, 0, signerKey);
+        // Caller is `otherAddr`, NOT the tenant signer. The sig
+        // recovers to signer though, so the write succeeds.
+        vm.prank(otherAddr);
+        registry.writeReputation(tenantA, agent, 87, 100, 0, sig);
+        assertEq(registry.reputationOf(tenantA, agent).score, 87);
+    }
+
+    // ============================================================
+    // Failure modes
+    // ============================================================
+
+    function test_writeReputation_rejectsUnclaimedTenant() public {
+        bytes memory sig = _signFor(tenantA, agent, 87, 100, 0, signerKey);
+        vm.expectRevert(abi.encodeWithSelector(TenantNotClaimed.selector, tenantA));
+        registry.writeReputation(tenantA, agent, 87, 100, 0, sig);
+    }
+
+    function test_writeReputation_rejectsWrongSignatureLength() public {
+        vm.prank(signer);
+        registry.claimTenant(tenantA);
+        bytes memory shortSig = hex"deadbeef";
+        vm.expectRevert(abi.encodeWithSelector(InvalidSignatureLength.selector, 4));
+        registry.writeReputation(tenantA, agent, 87, 100, 0, shortSig);
+    }
+
+    function test_writeReputation_rejectsScoreAbove100() public {
+        vm.prank(signer);
+        registry.claimTenant(tenantA);
+        bytes memory sig = _signFor(tenantA, agent, 101, 100, 0, signerKey);
+        vm.expectRevert(abi.encodeWithSelector(InvalidScore.selector, 101));
+        registry.writeReputation(tenantA, agent, 101, 100, 0, sig);
+    }
+
+    function test_writeReputation_rejectsUnauthorizedSigner() public {
+        vm.prank(signer);
+        registry.claimTenant(tenantA);
+        // Sign with a different key.
+        uint256 attackerKey = uint256(keccak256("attacker"));
+        bytes memory sig = _signFor(tenantA, agent, 87, 100, 0, attackerKey);
+        address attacker = vm.addr(attackerKey);
+        vm.expectRevert(abi.encodeWithSelector(UnauthorizedSigner.selector, attacker, signer));
+        registry.writeReputation(tenantA, agent, 87, 100, 0, sig);
+    }
+
+    function test_writeReputation_rejectsWrongSequence() public {
+        vm.prank(signer);
+        registry.claimTenant(tenantA);
+        bytes memory sig = _signFor(tenantA, agent, 87, 100, 5, signerKey);
+        // Caller claims expectedSequence=5 but actual nextSequence is 0.
+        vm.expectRevert(abi.encodeWithSelector(WrongSequence.selector, 0, 5));
+        registry.writeReputation(tenantA, agent, 87, 100, 5, sig);
+    }
+
+    function test_writeReputation_rejectsTamperedScore() public {
+        vm.prank(signer);
+        registry.claimTenant(tenantA);
+        // Sign for score=87 but submit score=88. Digest doesn't
+        // match → recovered signer != tenant signer.
+        bytes memory sig = _signFor(tenantA, agent, 87, 100, 0, signerKey);
+        vm.expectRevert(); // UnauthorizedSigner with random recovered addr
+        registry.writeReputation(tenantA, agent, 88, 100, 0, sig);
+    }
+
+    function test_writeReputation_rejectsTamperedAgent() public {
+        vm.prank(signer);
+        registry.claimTenant(tenantA);
+        address otherAgent = vm.addr(uint256(keccak256("other-agent")));
+        // Sign for `agent` but submit `otherAgent`. Digest doesn't match.
+        bytes memory sig = _signFor(tenantA, agent, 87, 100, 0, signerKey);
+        vm.expectRevert();
+        registry.writeReputation(tenantA, otherAgent, 87, 100, 0, sig);
+    }
+
+    function test_writeReputation_replayRejectedAfterFirstWrite() public {
+        vm.prank(signer);
+        registry.claimTenant(tenantA);
+        bytes memory sig = _signFor(tenantA, agent, 87, 100, 0, signerKey);
+        registry.writeReputation(tenantA, agent, 87, 100, 0, sig);
+        // Same sig, same args — second submission would be at
+        // sequence=1 (next position) but the sig is bound to
+        // sequence=0. Rejected with WrongSequence (caller passed
+        // expectedSequence=0 but actual is 1).
+        vm.expectRevert(abi.encodeWithSelector(WrongSequence.selector, 1, 0));
+        registry.writeReputation(tenantA, agent, 87, 100, 0, sig);
+    }
+
+    // ============================================================
+    // Cross-tenant isolation
+    // ============================================================
+
+    function test_writeReputation_crossTenantIsolation() public {
+        bytes32 tenantB = keccak256("partner-org.eth");
+        uint256 otherKey = uint256(keccak256("rep-signer-b"));
+        address otherSigner = vm.addr(otherKey);
+
+        vm.prank(signer);
+        registry.claimTenant(tenantA);
+        vm.prank(otherSigner);
+        registry.claimTenant(tenantB);
+
+        // Sign for tenantA but submit under tenantB → reject.
+        bytes memory sigA = _signFor(tenantA, agent, 87, 100, 0, signerKey);
+        vm.expectRevert();
+        registry.writeReputation(tenantB, agent, 87, 100, 0, sigA);
+
+        // Each tenant's own signer works under its own tenant.
+        bytes memory sigB = _signFor(tenantB, agent, 50, 100, 0, otherKey);
+        registry.writeReputation(tenantB, agent, 50, 100, 0, sigB);
+
+        bytes memory sigA2 = _signFor(tenantA, agent, 87, 100, 0, signerKey);
+        registry.writeReputation(tenantA, agent, 87, 100, 0, sigA2);
+
+        assertEq(registry.reputationOf(tenantA, agent).score, 87);
+        assertEq(registry.reputationOf(tenantB, agent).score, 50);
+    }
+
+    // ============================================================
+    // Reads
+    // ============================================================
+
+    function test_reputationOf_revertsOnNoEntries() public {
+        vm.expectRevert(abi.encodeWithSelector(TenantNotClaimed.selector, tenantA));
+        registry.reputationOf(tenantA, agent);
+    }
+
+    function test_entryAt_unsetReturnsZeroEntry() public view {
+        SBO3LReputationRegistry.Entry memory e = registry.entryAt(tenantA, agent, 42);
+        assertEq(e.score, 0);
+        assertEq(e.publishedAt, 0);
+    }
+
+    function test_supportsInterface() public view {
+        assertTrue(registry.supportsInterface(0x01ffc9a7));
+        assertFalse(registry.supportsInterface(0xdeadbeef));
+    }
+}
+
+/// @title  Fuzz suite for SBO3LReputationRegistry
+contract SBO3LReputationRegistryFuzzTest is Test {
+    SBO3LReputationRegistry internal registry;
+
+    function setUp() public {
+        registry = new SBO3LReputationRegistry();
+    }
+
+    function testFuzz_validSignatureAlwaysAccepted(
+        bytes32 tenantId,
+        uint256 signerSeed,
+        address agent,
+        uint8 score,
+        uint64 chainHeadBlock
+    ) public {
+        vm.assume(tenantId != bytes32(0));
+        vm.assume(score <= 100);
+        // Constrain signerSeed to a valid secp256k1 range.
+        uint256 signerKey = bound(
+            signerSeed,
+            1,
+            0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140
+        );
+        address signer = vm.addr(signerKey);
+
+        vm.prank(signer);
+        registry.claimTenant(tenantId);
+
+        bytes32 digest = registry.digestFor(tenantId, agent, score, chainHeadBlock, 0);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerKey, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        registry.writeReputation(tenantId, agent, score, chainHeadBlock, 0, sig);
+
+        SBO3LReputationRegistry.Entry memory e = registry.reputationOf(tenantId, agent);
+        assertEq(e.score, score);
+        assertEq(e.chainHeadBlock, chainHeadBlock);
+        assertEq(e.signer, signer);
+    }
+
+    function testFuzz_scoreAbove100AlwaysRejected(
+        bytes32 tenantId,
+        address agent,
+        uint8 score,
+        uint64 chainHeadBlock
+    ) public {
+        vm.assume(tenantId != bytes32(0));
+        vm.assume(score > 100);
+        uint256 signerKey = uint256(keccak256(abi.encode("fuzz-signer", tenantId)));
+        address signer = vm.addr(signerKey);
+
+        vm.prank(signer);
+        registry.claimTenant(tenantId);
+
+        bytes32 digest = registry.digestFor(tenantId, agent, score, chainHeadBlock, 0);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerKey, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        vm.expectRevert(abi.encodeWithSelector(InvalidScore.selector, score));
+        registry.writeReputation(tenantId, agent, score, chainHeadBlock, 0, sig);
+    }
+
+    function testFuzz_wrongSequenceAlwaysRejected(
+        bytes32 tenantId,
+        address agent,
+        uint8 score,
+        uint64 chainHeadBlock,
+        uint256 wrongSeq
+    ) public {
+        vm.assume(tenantId != bytes32(0));
+        vm.assume(score <= 100);
+        vm.assume(wrongSeq != 0);
+        uint256 signerKey = uint256(keccak256(abi.encode("fuzz-signer-seq", tenantId)));
+        address signer = vm.addr(signerKey);
+
+        vm.prank(signer);
+        registry.claimTenant(tenantId);
+
+        bytes32 digest = registry.digestFor(tenantId, agent, score, chainHeadBlock, wrongSeq);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerKey, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        // Real sequence is 0; sig commits to wrongSeq. Even though
+        // sig recovers to the right signer, sequence check rejects.
+        vm.expectRevert(abi.encodeWithSelector(WrongSequence.selector, 0, wrongSeq));
+        registry.writeReputation(tenantId, agent, score, chainHeadBlock, wrongSeq, sig);
+    }
+}

--- a/docs/design/sbo3l-reputation-registry.md
+++ b/docs/design/sbo3l-reputation-registry.md
@@ -1,0 +1,187 @@
+# SBO3LReputationRegistry — narrowly-scoped on-chain reputation log (R11 P1)
+
+**Status:** Solidity contract + foundry test suite shipped (this PR).
+Deploy to Sepolia + Optimism Sepolia + Base Sepolia tracked as
+follow-ups (Daniel-side gas commit).
+**Source:** [`crates/sbo3l-identity/contracts/SBO3LReputationRegistry.sol`](../../crates/sbo3l-identity/contracts/SBO3LReputationRegistry.sol).
+**Tests:** [`crates/sbo3l-identity/contracts/test/SBO3LReputationRegistry.t.sol`](../../crates/sbo3l-identity/contracts/test/SBO3LReputationRegistry.t.sol).
+**Companion:** [`docs/design/anchor-registry.md`](anchor-registry.md)
+— same multi-tenant + append-only pattern, applied to a different
+record shape.
+
+## Why a SBO3L registry instead of ERC-8004
+
+ERC-8004's reference implementation is not yet shipped at hackathon
+time. SBO3L's reputation publisher (T-4-6 / #201 — merged) emits
+dry-run envelopes; what's missing is the on-chain target. This
+contract narrows scope to the single operation we actually need —
+publish a reputation_score for an agent — without bundling the full
+ERC-8004 surface (registration, attestations, validators).
+
+When ERC-8004 lands, a downstream PR can mirror writes into both:
+SBO3L registry today (live), ERC-8004 registry once available
+(future). The `cross_chain_reputation` aggregator (#222 / merged)
+already operates over the *generic* shape — it doesn't care which
+registry the score lives in.
+
+## Surface
+
+```solidity
+contract SBO3LReputationRegistry {
+    struct Entry {
+        uint8 score;            // 0..=100
+        uint64 publishedAt;     // block.timestamp at write
+        uint64 chainHeadBlock;  // off-chain audit-chain block sampled
+        address signer;         // recovered from sig (== tenantSigner[tenantId])
+    }
+
+    mapping(bytes32 => address) public tenantSigner;
+    mapping(bytes32 => mapping(address => uint256)) public nextSequence;
+
+    function claimTenant(bytes32 tenantId) external;
+    function writeReputation(
+        bytes32 tenantId,
+        address agent,
+        uint8 score,
+        uint64 chainHeadBlock,
+        uint256 expectedSequence,
+        bytes calldata signature
+    ) external returns (uint256 sequence);
+    function reputationOf(bytes32 tenantId, address agent) external view returns (Entry memory);
+    function entryAt(bytes32 tenantId, address agent, uint256 sequence) external view returns (Entry memory);
+    function entryCount(bytes32 tenantId, address agent) external view returns (uint256);
+    function digestFor(bytes32 tenantId, address agent, uint8 score, uint64 chainHeadBlock, uint256 expectedSequence)
+        external view returns (bytes32);
+}
+```
+
+## Trust model
+
+- **Multi-tenant.** Tenants identified by `bytes32 tenantId`
+  (typically `keccak256(ENS-name)`). Distinct tenants have isolated
+  signer pins + sequence counters; tampering with one tenant can't
+  affect another.
+- **ECDSA-gated writes.** Anyone can submit a write; only sigs
+  recovering to `tenantSigner[tenantId]` are accepted. Sequence is
+  part of the signed payload (`digestFor(...)`) so a sig can't be
+  replayed across positions.
+- **Append-only.** Each `(tenantId, agent)` write goes to
+  `nextSequence[...]`; the contract never overwrites. A future
+  refactor that ever resets the counter is still caught by a
+  defense-in-depth `existing.publishedAt != 0` check.
+- **No admin path.** Same posture as `OffchainResolver` (T-4-1) and
+  `AnchorRegistry` (R9 P6): anchors / receipts / reputations are
+  *evidence*, not state to redact.
+
+## Digest format (what gets signed)
+
+```solidity
+keccak256(
+    abi.encodePacked(
+        hex"1900",                // EIP-191 prefix
+        address(this),            // contract address (binds to deployment)
+        DOMAIN,                   // keccak256("SBO3L-Reputation-Registry-v1")
+        tenantId,
+        agent,
+        score,
+        chainHeadBlock,
+        expectedSequence
+    )
+);
+```
+
+A signer signing this hash can't have their sigs replayed across:
+
+- Different sequence positions (`expectedSequence` in payload).
+- Different agents (`agent` in payload).
+- Different scores (`score` in payload).
+- Different contracts on the same chain (`address(this)` in payload).
+- Different schemes / future versions (`DOMAIN` constant, bumped on
+  any breaking change).
+
+## Test suite
+
+20 unit tests + 3 fuzz tests at 10 000 runs each. **23/23 pass.**
+
+| Test | Property |
+|---|---|
+| `claimTenant_assignsSenderAsSigner` | First claim pins `msg.sender` |
+| `claimTenant_emitsEvent` | `TenantClaimed` event surfaces |
+| `claimTenant_rejectsZeroId` | `bytes32(0)` rejected |
+| `claimTenant_rejectsDoubleClaim` | Second claim reverts |
+| `writeReputation_firstWriteAtSequenceZero` | First write at seq 0 |
+| `writeReputation_appendsToSequence` | Subsequent writes increment |
+| `writeReputation_emitsEvent` | `ReputationWritten` with correct fields |
+| `writeReputation_anyoneMayCall_signatureGated` | Caller != signer OK if sig recovers correctly |
+| `writeReputation_rejectsUnclaimedTenant` | Pre-claim writes refused |
+| `writeReputation_rejectsWrongSignatureLength` | sig length != 65 → revert |
+| `writeReputation_rejectsScoreAbove100` | score > 100 → revert |
+| `writeReputation_rejectsUnauthorizedSigner` | non-tenant-signer sig rejected |
+| `writeReputation_rejectsWrongSequence` | Wrong expectedSequence → revert |
+| `writeReputation_rejectsTamperedScore` | Score change post-sign → recovery yields wrong addr |
+| `writeReputation_rejectsTamperedAgent` | Agent change post-sign → recovery yields wrong addr |
+| `writeReputation_replayRejectedAfterFirstWrite` | Same sig replayed → wrong-sequence rejection |
+| `writeReputation_crossTenantIsolation` | Sig for tenant A can't write under tenant B |
+| `reputationOf_revertsOnNoEntries` | No-entries read clearly errors |
+| `entryAt_unsetReturnsZeroEntry` | Direct read of unset slot returns zero shape |
+| `supportsInterface` | ERC-165 stable |
+| `testFuzz_validSignatureAlwaysAccepted` | Random signer + score + block → write succeeds |
+| `testFuzz_scoreAbove100AlwaysRejected` | Any score > 100 always reverts |
+| `testFuzz_wrongSequenceAlwaysRejected` | Any non-zero `wrongSeq` always reverts |
+
+CI gate: the slither job from R9 P11 (#240) runs against this
+contract automatically. Same gate applies pre-mainnet-deploy.
+
+## Deploy plan
+
+1. **Sepolia** (gas: ~0.001 SEP-ETH on testnet, free).
+   ```bash
+   export PRIVATE_KEY=0x<deployer-key>
+   forge script script/DeployReputationRegistry.s.sol \
+     --rpc-url $SEPOLIA_RPC_URL --broadcast --verify
+   ```
+   Pin the address in
+   [`crates/sbo3l-identity/src/contracts.rs`](../../crates/sbo3l-identity/src/contracts.rs)
+   under `SBO3L_REPUTATION_REGISTRY_SEPOLIA`.
+
+2. **Optimism Sepolia + Base Sepolia** (R11 P2 multi-chain
+   broadcast).
+   Same script, different `--rpc-url`. Each chain gets its own
+   address pin (the contract code is network-independent so the
+   only network-specific detail is the deployed address).
+
+3. **Mainnet** (cost ceiling ~$10 mainnet gas at 50 gwei).
+   Same script, mainnet RPC, plus the standard
+   `SBO3L_ALLOW_MAINNET_TX=1` double-gate for any subsequent
+   `claimTenant` / `writeReputation` calls from SBO3L tooling.
+
+## Coordination with R10 P1 (#250 reputation broadcast)
+
+#250 ships the broadcast pipeline that signs + sends a `setText`
+tx for `sbo3l:reputation_score` on the agent's ENS resolver.
+
+This contract is the **other** target. The follow-up R11 P2 PR
+extends `agent_reputation_broadcast.rs` with a new mode that
+broadcasts to `SBO3LReputationRegistry.writeReputation` instead of
+the ENS resolver — preserving the existing `setText` path
+(operators choose which target they want).
+
+Both flows share the same:
+- Score computation (`compute_reputation_v2`)
+- Signer harness (`PrivateKeySigner` from env)
+- Mainnet double-gate (`SBO3L_ALLOW_MAINNET_TX=1`)
+- Etherscan-link emission shape
+
+Difference is only the recipient + calldata.
+
+## Future work
+
+- **L2 deploys** + cross-chain consistency tooling (R11 P2).
+- **Slither audit** of the contract pre-mainnet (CI gate from R9
+  P11 already runs).
+- **ERC-8004 mirror writes** once the public reference impl ships.
+- **EIP-712 typed-data domain** rather than the EIP-191-shaped hash
+  — operators using hardware wallets see a structured prompt
+  rather than raw hex. Trade-off: the EIP-712 domain separator
+  pulls more contract surface; EIP-191 keeps the contract small.
+  Reconsider once a hardware-wallet operator workflow is needed.


### PR DESCRIPTION
## Summary

ECDSA-gated, multi-tenant, append-only reputation registry. Narrows scope vs ERC-8004 (whose reference impl isn't shipped at hackathon time) to the single operation we actually need: **publish a reputation_score for an agent.**

- 20 unit tests + 3 fuzz tests at **10 000 runs each** — 23/23 pass
- Foundry deploy script — stateless, same script works on Sepolia / Optimism Sepolia / Base Sepolia / mainnet
- Doc: \`docs/design/sbo3l-reputation-registry.md\` walks the trust model + deploy plan + coordination with R10 #250

## Surface

| Function | Purpose |
|---|---|
| \`claimTenant(tenantId)\` | First caller becomes permanent tenant signer |
| \`writeReputation(tenantId, agent, score, chainHeadBlock, expectedSequence, sig)\` | Anyone may call; sig must recover to tenant signer and bind to expectedSequence |
| \`reputationOf(tenantId, agent)\` | Latest entry; reverts on empty |
| \`entryAt(tenantId, agent, sequence)\` | Direct read; zero-entry on unset |
| \`entryCount(tenantId, agent)\` | Mirror of \`nextSequence\` |
| \`digestFor(...)\` | Pure helper for off-chain signers |

## Trust model

- **Multi-tenant** via \`bytes32 tenantId\` (typically \`keccak256(ENS-name)\`)
- **ECDSA-gated**: anyone submits, sig must recover to \`tenantSigner[tenantId]\`
- **Sequence-bound** sig payload → no replay across positions
- **Append-only**: never overwrites; defense-in-depth \`EntryAlreadyExists\` check
- **Address-bound** (\`address(this)\` in digest) → sigs don't replay across deployments
- **DOMAIN-bound** (constant in digest) → bump on breaking changes

## Why not ERC-8004

Reference impl not yet shipped. This contract narrows scope to one operation; when ERC-8004 lands a downstream PR mirrors writes to both registries. Cross-chain reputation aggregator (#222) operates on the *generic shape*, doesn't care which registry the score lives in.

## Coordination with R10 P1 (#250 reputation broadcast)

Both flows share the same harness (PrivateKeySigner from env, mainnet double-gate, Etherscan-link emission shape). R10 #250 targets the ENS resolver \`setText\` path; R11 P2 (next PR) extends \`agent_reputation_broadcast.rs\` with a target-switch flag to pick \`SBO3LReputationRegistry.writeReputation\` instead.

## Test plan

- [x] \`forge test --fuzz-runs 10000\` — 23/23 pass in ~1.6s
- [x] Foundry build clean (only forge-std lint warnings, none on our contract)
- [x] Slither CI gate from #240 will run on this contract automatically
- [ ] Sepolia deploy follow-up (Daniel-side gas commit, ~0.001 SEP-ETH)
- [ ] Address pinned in \`contracts.rs\` once each network's deploy completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)