### PR TITLE
feat(docs): Phase 3 expansion — 5 concept articles (P2)

### DIFF
--- a/apps/docs/src/content/docs/concepts/audit-anchoring.mdx
+++ b/apps/docs/src/content/docs/concepts/audit-anchoring.mdx
@@ -1,0 +1,89 @@
+---
+title: On-chain audit anchoring
+description: How SBO3L commits a Merkle root of the local audit chain to L1 so capsules become independently verifiable against chain history.
+audience: compliance teams, security reviewers, judges, agent platform engineers
+outcome: You'll know what gets anchored, when, where, and how a third party verifies a capsule's audit segment against the on-chain root without trusting SBO3L.
+prereqs:
+  - audit log read
+  - capsule v2 read
+---
+
+The local audit chain is tamper-evident **against the daemon's signing key**. On-chain anchoring extends that to **tamper-evident against ledger history** — anyone can verify a capsule's audit segment against a public root they didn't have to trust SBO3L for.
+
+## What gets anchored
+
+Every N events (configurable; default 100) the daemon computes a Merkle root over the most-recent contiguous chain slice and writes it to a registry contract on L1:
+
+```mermaid
+sequenceDiagram
+  participant Agent
+  participant Daemon
+  participant Registry as Anchor Registry
+  participant L1 as Ethereum L1
+
+  loop every N events
+    Daemon->>Daemon: build Merkle tree over chain[i..i+N]
+    Daemon->>Daemon: root = sha256(tree)
+    Daemon->>Registry: anchorRoot(agent_pubkey, root, height)
+    Registry->>L1: emit AuditRootAnchored(...)
+    L1-->>Daemon: tx confirmed
+    Daemon->>Daemon: write anchor_ref to audit chain
+  end
+  Agent->>Daemon: passport run --strict
+  Daemon->>Daemon: include anchor_ref in capsule
+  Note over Daemon: capsule now offline-verifiable<br/>+ chain-history-verifiable
+```
+
+The anchor record carries: `agent_pubkey` (which agent), `root` (the Merkle root), `height` (chain length covered), `block_number`, `tx_hash`. These are the four fields a third-party verifier needs.
+
+## How a verifier replays an anchor
+
+Given a Passport capsule with an embedded `anchor_ref`:
+
+1. Resolve the anchor record from L1 (`getAnchor(agent_pubkey, height)` — view function, no gas).
+2. Recompute the Merkle root from the capsule's `audit_segment` plus the inclusion proof (also embedded).
+3. Compare against the on-chain `root`.
+4. If equal: the audit segment is part of the canonical chain at the time of anchoring. If different: tamper or replacement.
+
+Steps 2–4 run inside `passport verify --strict --check-anchor`. The `--check-anchor` flag adds a 7th strict check on top of the existing 6 (see [capsule v2](/concepts/capsule#the-6-strict-mode-checks)). The CLI does the L1 RPC call against `SBO3L_ANCHOR_RPC_URL`; default mainnet, configurable for Sepolia smokes.
+
+```bash
+# Verify the embedded anchor against mainnet
+sbo3l passport verify --strict --check-anchor --path capsule.json
+# OK · 6 strict checks passed · anchor verified at block 19,234,567
+
+# Same on Sepolia (for development)
+SBO3L_ANCHOR_RPC_URL=https://ethereum-sepolia-rpc.publicnode.com \
+  sbo3l passport verify --strict --check-anchor --path capsule.json
+```
+
+## Why this matters
+
+Anchoring solves the **non-repudiation gap** in the local-only chain. Without an anchor, a daemon operator could in theory rewrite their own audit DB and sign over the rewrite. With an anchor, that requires also writing an alternate L1 history — practically impossible.
+
+For regulated industries (custody, payments) this turns the SBO3L audit chain from "trust the daemon operator's signing discipline" into "trust the daemon operator OR Ethereum, whichever you trust more". Most compliance teams strongly prefer the latter.
+
+## Cost + cadence
+
+| Anchor cadence | Gas cost / month* | Trade-off |
+|---|---|---|
+| Every 100 events | ~$2-15 (mainnet) | tightest non-repudiation window; ~minutes-stale verification |
+| Every 1k events | ~$0.20-1.50 (mainnet) | 10× cheaper; ~hour-stale window |
+| L2 anchoring (Optimism / Base) | <$0.01 | cheap; settles to L1 with 7-day finality |
+
+*Assumes 2026-Q2 base-fee levels and 3 events/sec average.
+
+For high-frequency agents, anchor to an L2 every 100 events; the L2 itself anchors to L1 on its own cadence, transitively giving you L1-grade finality at L2 cost.
+
+## Source pointers
+
+- Contract: `crates/sbo3l-anchor/contracts/AnchorRegistry.sol` (#245)
+- Rust client: `crates/sbo3l-anchor/src/lib.rs` (#246) — `anchor_root()` + `verify_anchor()` functions
+- Sepolia smoke: `bash demo-scripts/anchor-sepolia-smoke.sh` (broadcasts a real anchor tx; tx hash committed to `demo-scripts/artifacts/anchor-sepolia.json` after first run)
+- CLI flag: `--check-anchor` on `passport verify` (Bob's CLI surface)
+
+## See also
+
+- [Audit log](/concepts/audit-log) — what each event contains; anchoring covers contiguous slices.
+- [Self-contained capsule v2](/concepts/capsule) — the capsule already embeds the audit segment; anchoring adds the on-chain proof.
+- [Audit replay](/concepts/audit-replay) — `--check-anchor` is the seventh check on top of the offline six.

--- a/apps/docs/src/content/docs/concepts/cross-protocol-composition.mdx
+++ b/apps/docs/src/content/docs/concepts/cross-protocol-composition.mdx
@@ -1,0 +1,93 @@
+---
+title: Cross-protocol composition
+description: 14 framework adapters share one audit chain. The wallet-vs-mandate thesis demonstrated end-to-end across LangChain, AutoGen, ElizaOS, CrewAI, LlamaIndex, Vercel AI, LangGraph + 7 more.
+audience: agent platform engineers integrating SBO3L into existing stacks, framework authors
+outcome: You'll know how SBO3L composes across frameworks without re-doing trust per integration, and why the single-chain property matters.
+---
+
+The same agent can call a LangChain tool, hand off to an AutoGen multi-agent group, then trigger a CrewAI workflow — and SBO3L records every decision in **one chain** signed by **one daemon key**. The framework boundary doesn't fragment the trust surface.
+
+## Shipped adapters (14 total)
+
+| Language | Framework | Crate / package |
+|---|---|---|
+| TS | `@sbo3l/sdk` | core SDK |
+| TS | `@sbo3l/langchain` | LangChain JS |
+| TS | `@sbo3l/autogen` | AutoGen JS |
+| TS | `@sbo3l/elizaos` | ElizaOS plugin |
+| TS | `@sbo3l/vercel-ai` | Vercel AI SDK |
+| TS | `@sbo3l/marketplace` | marketplace registry client |
+| Py | `sbo3l-sdk` | core Python SDK |
+| Py | `sbo3l-langchain` | LangChain Py |
+| Py | `sbo3l-crewai` | CrewAI |
+| Py | `sbo3l-llamaindex` | LlamaIndex |
+| Py | `sbo3l-langgraph` | LangGraph |
+| Rust | `sbo3l-cli` | CLI |
+| Rust | `sbo3l-mcp` | MCP server |
+| Rust | `sbo3l-keeperhub-adapter` | KH guarded executor |
+
+Each adapter is thin — it wraps the framework's tool/agent extension point and routes intent through the same `POST /v1/payment-requests` boundary.
+
+## Single-chain property
+
+```mermaid
+sequenceDiagram
+  participant LC as LangChain agent
+  participant AG as AutoGen group
+  participant CW as CrewAI crew
+  participant Daemon as SBO3L daemon
+  participant Audit as Single audit chain
+
+  LC->>Daemon: APRP intent (web_search)
+  Daemon->>Audit: append event #N
+  Daemon-->>LC: signed receipt
+  LC->>AG: hand off to multi-agent group
+  AG->>Daemon: APRP intent (run_calculation)
+  Daemon->>Audit: append event #N+1
+  Daemon-->>AG: signed receipt
+  AG->>CW: trigger workflow
+  CW->>Daemon: APRP intent (file_write)
+  Daemon->>Audit: append event #N+2
+  Daemon-->>CW: signed receipt
+
+  Note over Audit: chain[N..N+2] is contiguous + signed<br/>even though three frameworks called it
+```
+
+Three calls, three frameworks, three signed receipts, **one contiguous audit chain**. A capsule emitted from any of the three calls embeds the chain segment up to that point — including the events from the OTHER two frameworks. Auditing the capsule shows the full cross-framework story.
+
+This property is hard to achieve without SBO3L. The alternative — each framework keeping its own audit log — fragments verification: a capsule from CrewAI can't show the LangChain context because CrewAI doesn't have it. SBO3L makes the framework boundary irrelevant to verification.
+
+## Why this matters for "wallet vs mandate"
+
+The brand promise: *Don't give your agent a wallet. Give it a mandate.*
+
+A wallet is a **single per-framework credential**: the LangChain agent has its keys, the AutoGen agent has different keys, neither knows about the other. Compromising one doesn't compromise the others, but auditing one tells you nothing about the others either.
+
+A mandate (the SBO3L policy receipt) is **framework-agnostic**: the same agent identity binds across frameworks because the daemon is the source of truth, not any single framework's runtime. Compromising the agent's authority compromises it everywhere — but auditing one event reveals everything.
+
+The 14-adapter coverage demonstrates this isn't a slogan. Every major TS + Py framework has a working SBO3L wrapper today, and a 10-step demo at [demo-scripts/cross-protocol-composition.sh](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/demo-scripts/cross-protocol-composition.sh) walks through:
+
+1. LangChain agent makes a `web_search` request → SBO3L allows.
+2. Hands off to an AutoGen group → group asks for `run_calculation` → allow.
+3. AutoGen invokes a CrewAI crew → crew asks for `file_write` → allow.
+4. CrewAI's tool wraps a LlamaIndex query → SBO3L allow.
+5. LlamaIndex result triggers a Vercel AI streaming completion → allow.
+6. Stream output is parsed by a LangGraph state graph → allow.
+7. State machine transitions trigger an ElizaOS plugin → allow.
+8. ElizaOS asks for `pay vendor` → SBO3L denies (budget exceeded).
+9. Audit chain export shows all 8 events under one chain head.
+10. Strict-verify the resulting capsule offline → 6/6 green.
+
+```bash
+bash demo-scripts/cross-protocol-composition.sh
+# 8 frameworks × 1 chain · final chain length: 8 events
+# capsule emitted: capsule.json (size 12,847 bytes)
+# strict verify: 6/6 checks passed · rc=0
+```
+
+## See also
+
+- [APRP wire format](/concepts/aprp) — the envelope every adapter produces.
+- [Audit log](/concepts/audit-log) — single-chain append guarantees.
+- [Self-contained capsule v2](/concepts/capsule) — what cross-framework verification looks like in one JSON file.
+- [Marketplace](/concepts/marketplace) — same composition story applied to policies.

--- a/apps/docs/src/content/docs/concepts/marketplace.mdx
+++ b/apps/docs/src/content/docs/concepts/marketplace.mdx
@@ -1,0 +1,118 @@
+---
+title: Marketplace
+description: Discover, publish, and adopt SBO3L policies. Content-addressed, signed, reputation-scored.
+audience: agent platform engineers, policy authors, ops adopting third-party policies
+outcome: You'll know how to publish a policy to the marketplace, how adopters fetch and verify it, and how reputation accrues.
+prereqs:
+  - policy decision read
+  - signing model read
+---
+
+The marketplace turns SBO3L policies from per-deploy artefacts into a **shareable, signed, reputation-scored catalog**. Authors publish; adopters pin; reputation accrues from observed decision outcomes across the fleet.
+
+## How a published policy is identified
+
+Every marketplace policy is content-addressed:
+
+```
+policy_id = base32(sha256(JCS-canonical-policy-body))[:24]
+```
+
+Two policies with byte-identical bodies have the same `policy_id`. Republishing the same content does NOT create a new entry — it bumps the download count + reputation observation window for the existing entry.
+
+## Publishing flow
+
+```mermaid
+flowchart LR
+  Author[Author] -->|1. edit| Editor[Monaco editor<br/>app.sbo3l.dev/policy/edit]
+  Editor -->|2. validate| Schema[sbo3l.policy.v1 schema]
+  Schema -->|3. sign| Signer[KMS-backed Signer]
+  Signer -->|4. POST| Registry[Marketplace Registry]
+  Registry -->|5. emit| Audit[policy.published audit event]
+  Registry -->|6. index| Catalog[Public catalog at<br/>sbo3l.dev/marketplace]
+```
+
+The author never uploads a private key to the marketplace; the registry only sees the signed policy + the issuer's public key. Verification (step 5) checks the signature against an issuer registry derived from ENS — see [signing model](/concepts/signing) for where issuer keys live.
+
+## Adoption flow
+
+Adopters pin one line in their daemon's `policy.toml`:
+
+```toml
+[policy]
+source = "sbo3l-marketplace"
+id = "research-low-risk-sepolia"
+version = "1.2.0"
+trust = "by-reputation"   # or "pinned-hash" for stricter integrity
+```
+
+On next request:
+
+1. Daemon fetches policy from the marketplace registry (cached locally).
+2. Verifies issuer signature against the embedded `issuer_pubkey`.
+3. Computes `policy_snapshot_hash` and starts using the policy.
+4. Every Passport capsule from that point on embeds `policy_marketplace_id` so consumers can re-derive provenance.
+
+## Trust modes
+
+| Mode | What it means | When to use |
+|---|---|---|
+| `by-reputation` | Accept any policy version with reputation ≥ threshold | trust the marketplace operator + the issuer reputation system |
+| `pinned-hash` | Lock to one specific policy_id; reject newer versions | regulated environments; explicit upgrade gates |
+| `pinned-issuer` | Accept any version from a named issuer | trust issuer but want their improvements |
+
+`by-reputation` is the default for community + hobby use; `pinned-hash` is recommended for production; `pinned-issuer` for partnered relationships.
+
+## Five starter bundles (live today)
+
+The marketplace ships with 5 seed policies authored by the SBO3L canonical issuer (`sbo3l.eth`):
+
+| ID | Use case | Reputation |
+|---|---|---|
+| `research-low-risk-sepolia` | Sepolia testnet swaps for research agents | ★ 0.94 |
+| `kh-workflow-strict` | KeeperHub workflow execution guard | ★ 0.89 |
+| `uniswap-universal-router-v3` | Per-step Uniswap UR command guards | ★ 0.91 |
+| `ens-subname-issuance` | Trust DNS fleet subname issuance limits | ★ 0.87 |
+| `langchain-research-strict` | LangChain research agent tool gate | ★ 0.72 |
+
+Browse them at [sbo3l-marketing.vercel.app/marketplace](https://sbo3l-marketing.vercel.app/marketplace).
+
+## Reputation system
+
+Each policy starts at score 0.50 (community baseline). Score evolves on three signals:
+
+1. **Adoption count** — number of distinct daemon instances fetching the policy in the last 30 days.
+2. **Decision outcome rate** — across observed daemons, the ratio of `allow` decisions to total decisions weighted by sponsor execution success (no broken sponsor calls).
+3. **Cross-agent attestations** — peer agents publicly endorsing the policy via signed ENS attestations.
+
+Score updates run hourly server-side; policy detail pages show the basis text alongside the score so adopters can audit how a number came to be.
+
+## CLI
+
+```bash
+# Search the marketplace
+sbo3l marketplace search "uniswap" --risk low
+# uniswap-universal-router-v3 ★ 0.91 medium  by sbo3l.eth
+# ...
+
+# Inspect a policy without adopting
+sbo3l marketplace show research-low-risk-sepolia
+# version: 1.2.0  rules: 3  budgets: 3
+# issuer: sbo3l.eth  reputation: 0.94
+# basis: 60-agent constellation observation, T-3-4 4-criteria scoring
+
+# Pin to your daemon
+sbo3l marketplace adopt research-low-risk-sepolia --version 1.2.0
+# Updated /etc/sbo3l/policy.toml; reload daemon to take effect
+```
+
+## Source pointers
+
+- Registry SDK: `@sbo3l/marketplace` on npm (#244)
+- UI: `apps/marketing/src/pages/marketplace/` (#241)
+- Policy schema: `sbo3l.policy.v1` (see [policy decision](/concepts/policy))
+- 5 seed policies: `apps/marketing/src/data/marketplace-policies.json`
+
+## See also
+
+[Policy decision](/concepts/policy) — what a policy contains. [Signing model](/concepts/signing) — issuer signature verification. [Trust DNS](/concepts/trust-dns) — issuer keys via ENS.

--- a/apps/docs/src/content/docs/concepts/multi-tenant.mdx
+++ b/apps/docs/src/content/docs/concepts/multi-tenant.mdx
@@ -1,0 +1,95 @@
+---
+title: Multi-tenant
+description: How SBO3L isolates one daemon process across many tenants — per-tenant audit chains, per-tenant signing keys, per-tenant policy.
+audience: ops, security teams, platform engineers running SBO3L for multiple customers
+outcome: You'll know the isolation boundary the daemon enforces between tenants and what the V010 schema migration changed.
+prereqs:
+  - audit log read
+  - signing model read
+---
+
+Phase 1 SBO3L was single-tenant: one daemon, one audit chain, one signing key. Phase 3.2 (V010 migration) makes a single daemon process serve **N tenants concurrently** with hard isolation.
+
+## What changed in V010
+
+V010 is the SQLite migration that adds a `tenant_id` column to every table. The migration is automatic on first daemon start after upgrade; it backfills `tenant_id = 'default'` for existing rows so single-tenant deployments are unaffected.
+
+```mermaid
+flowchart LR
+  subgraph "v009 — single tenant"
+    A1[(audit_events)]
+    A2[(policies)]
+    A3[(budgets)]
+  end
+
+  subgraph "v010 — multi-tenant"
+    B1[(audit_events<br/>tenant_id NOT NULL)]
+    B2[(policies<br/>tenant_id NOT NULL)]
+    B3[(budgets<br/>tenant_id NOT NULL)]
+  end
+
+  A1 --> B1
+  A2 --> B2
+  A3 --> B3
+```
+
+After V010:
+
+- Every read goes through `audit_events_for_tenant(tenant_id)` etc. Cross-tenant queries do not exist as a code path.
+- `tenant_id` is resolved from the request's `Authorization` header (JWT claim).
+- Each tenant has its own signing-key entry in the `signers` table; the daemon's `Signer` trait is dispatch-by-tenant.
+- ENS records publish under `<tenant>.sbo3lagent.eth` (subname per tenant) with agent subnames nested below: `agent-01.<tenant>.sbo3lagent.eth`.
+
+## Isolation guarantees
+
+Three layers, each enforced separately:
+
+1. **Database layer** — every query passed through the `_for_tenant` function family. The function takes `tenant_id` as a non-optional argument; there is no overload that omits it. Code review enforces this; there are no plans to relax it.
+2. **Signing layer** — `Signer::sign_for(tenant_id, payload)` looks up the tenant's configured signer and dispatches to it. A tenant signing with another tenant's key is a programming error caught at the dispatch site, not a runtime check.
+3. **HTTP layer** — middleware validates the JWT, extracts `tenant_id`, and passes it explicitly into every handler. Handlers never read `tenant_id` from request bodies.
+
+Combined effect: a confused-deputy attack would need to compromise the JWT-signing key, the daemon binary, AND the SQLite file on disk. Each layer is a separate failure to exploit; the whole stack is much stronger than any single layer.
+
+## Operator surface
+
+```bash
+# Create a tenant
+sbo3l admin tenant create acme-corp --tier pro --signer kms-aws --kms-key-id arn:...
+
+# List tenants
+sbo3l admin tenant list
+# tenant_id    tier  agents  decisions/day  audit_chain_length
+# default      pro   3       1,247          4,219
+# acme-corp    pro   1       0              0
+# research     free  2       127            942
+
+# Suspend a tenant (read-only; new requests rejected)
+sbo3l admin tenant suspend acme-corp --reason "billing"
+
+# Forensic export: audit chain + signed receipts for one tenant
+sbo3l audit export-bundle --tenant acme-corp --out acme.bundle
+```
+
+The hosted operator console at `app.sbo3l.dev/t/<tenant>/*` (CTI-3-5; design doc at [`docs/spec/CTI-3-5-operator-console.md`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/docs/spec/CTI-3-5-operator-console.md)) provides the same surface in a UI.
+
+## Backward compatibility
+
+Single-tenant operators upgrading from v009 → v010:
+
+- Migration runs on first start; existing audit chains end up under `tenant_id = 'default'`.
+- Existing API tokens continue to authenticate; the daemon synthesises `tenant_id = 'default'` from any token without the claim.
+- Existing capsules verify unchanged — the strict verifier ignores `tenant_id` (it's about who's authorising, not who's verifying).
+
+There is no rollback path from v010 → v009; the migration is one-way. Take a backup before upgrade.
+
+## Source pointers
+
+- Migration: `crates/sbo3l-storage/src/migrations/v010.rs` (#208)
+- Per-tenant audit fns: `crates/sbo3l-storage/src/audit.rs` — search for `_for_tenant`
+- Tenant management endpoints: `crates/sbo3l-server/src/handlers/admin_tenants.rs` (Dev 1 follow-up)
+- Operator-console design: [`docs/spec/CTI-3-5-operator-console.md`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/docs/spec/CTI-3-5-operator-console.md)
+
+## See also
+
+- [Audit log](/concepts/audit-log) — per-tenant chains use the same hash-chain semantics.
+- [Signing model](/concepts/signing) — per-tenant signers; KMS-backed in production.

--- a/apps/docs/src/content/docs/concepts/token-gated-identity.mdx
+++ b/apps/docs/src/content/docs/concepts/token-gated-identity.mdx
@@ -1,0 +1,104 @@
+---
+title: Token-gated identity
+description: Bind agent identity to ERC-721 / ERC-1155 ownership; compose with AnyOf / AllOf for sophisticated access policies.
+audience: agent platform engineers, NFT-project ops, regulated-industry compliance
+outcome: You'll know how to gate an SBO3L agent on token ownership, how composites work, and how time-windowed gates handle expiring credentials.
+prereqs:
+  - APRP wire format read
+  - signing model read
+---
+
+A token gate ties an agent's authorisation to ownership of an on-chain asset (NFT, soulbound token, semi-fungible). The gate evaluates at decision time: if the agent's wallet currently holds the required token, the policy may proceed; otherwise the request denies fail-closed with `auth.token_gate_failed`.
+
+## Why token gates
+
+Three concrete patterns:
+
+- **Membership-only agents** — only DAO members (`balanceOf >= 1` on the membership NFT) can run a research agent owned by the DAO.
+- **Time-windowed credentials** — an agent runs only while its operator holds an event-attendance NFT, with the gate auto-expiring N hours after the event.
+- **Tier-stratified policies** — Free / Pro / Enterprise tiers determined by which 1155 token type the operator holds.
+
+Without token gates, the same outcomes require off-chain user databases. With them, the credential lives where it should: on chain, public, transferable subject to the issuer's rules.
+
+## Gate shape
+
+```json
+{
+  "type": "token_gate",
+  "any_of": [
+    { "erc721":  { "address": "0xMembership...", "min_balance": 1 } },
+    { "erc1155": { "address": "0xPro...", "token_id": "1", "min_balance": 1 } }
+  ]
+}
+```
+
+`any_of` succeeds if either branch holds; `all_of` requires both. They nest:
+
+```json
+{
+  "all_of": [
+    { "erc721": { "address": "0xMembership...", "min_balance": 1 } },
+    { "any_of": [
+        { "erc1155": { "address": "0xPro...", "token_id": "1" } },
+        { "erc1155": { "address": "0xEnterprise...", "token_id": "1" } }
+      ]
+    }
+  ]
+}
+```
+
+Reads as: "must hold membership NFT AND (Pro OR Enterprise tier)".
+
+## Time-window extension
+
+Add a `valid_after` / `valid_before` pair:
+
+```json
+{
+  "type": "token_gate",
+  "valid_after":  "2026-06-01T00:00:00Z",
+  "valid_before": "2026-06-08T23:59:59Z",
+  "erc721": { "address": "0xConfNFT...", "min_balance": 1 }
+}
+```
+
+Useful for conference-attendance agents, event-bot policies, or any credential with an expiry. The gate checks both: token currently held AND now within window.
+
+## Risk-class presets
+
+For common patterns, the gate can reference a named preset:
+
+| Preset | Expansion |
+|---|---|
+| `risk:low` | accepts soulbound + non-transferable membership tokens; rejects transferable NFTs |
+| `risk:medium` | accepts any 721 / 1155 from a vetted issuer registry |
+| `risk:high` | accepts any 721 / 1155 from any issuer (maximum permissiveness) |
+
+Presets resolve at policy-load time; the resolved gate is what gets signed into the receipt. Updating a preset issuer registry doesn't retroactively change in-flight policies.
+
+## Evaluation cost
+
+The daemon caches token-balance lookups per `(address, agent_wallet)` pair for `--token-gate-cache-ttl` seconds (default 30 s). Within the TTL, no RPC call fires; afterwards, a single `eth_call` to `balanceOf` resolves it.
+
+For high-frequency agents with stable credentials, set TTL to 5 minutes — most gates are cheap. For credentials that revoke fast (sale of NFT mid-stream), set TTL to 5 seconds.
+
+```bash
+# CLI evaluation (dry-run a gate without running the daemon)
+sbo3l token-gate test \
+  --gate '{ "type": "token_gate", "erc721": { "address": "0xABC...", "min_balance": 1 } }' \
+  --wallet 0xDEF...
+# gate-passes: true
+# basis: balanceOf(0xDEF) = 3, min_balance = 1
+```
+
+## Source pointers
+
+- Implementation: `crates/sbo3l-policy/src/token_gate.rs` (#237)
+- Issuer registry: `crates/sbo3l-policy/src/registries/issuer.rs`
+- Test corpus: `tests/fixtures/token-gates/*.json` (good + adversarial cases)
+- Sepolia test contract: deployed at `0xConfNFT...` (see `demo-fixtures/sepolia-token-gates.json`)
+
+## See also
+
+- [Policy decision](/concepts/policy) — token gates are one predicate type among many.
+- [Signing model](/concepts/signing) — operator wallet signature on the gate config (rotation = re-sign).


### PR DESCRIPTION
## Summary

Five new concept articles in `apps/docs/src/content/docs/concepts/`:

- `audit-anchoring.mdx` (Phase 3.1)
- `multi-tenant.mdx` (Phase 3.2)
- `marketplace.mdx` (Phase 3.3)
- `token-gated-identity.mdx` (Phase 3.5)
- `cross-protocol-composition.mdx` (Phase 3.6)

Each: ~800-1200 words, 1 mermaid diagram, 1+ CLI example, audience+outcome frontmatter, source pointers, see-also cross-links.

## Why

P2 of round-11 brief. Stacks on #122 (docs chain). LoC: 499 insertions across 5 files (under cap).

## Test plan

```bash
cd apps/docs
npm install
npm run typecheck         # frontmatter schema validator confirms audience+outcome on all 5
npm run build
ls -la dist/concepts/audit-anchoring/index.html dist/concepts/multi-tenant/index.html \
       dist/concepts/marketplace/index.html dist/concepts/token-gated-identity/index.html \
       dist/concepts/cross-protocol-composition/index.html

npm run preview
# - Each article renders; mermaid diagrams render in the Starlight default theme
# - Cross-links to other concepts resolve
# - Pagefind search returns hits for "merkle root", "_for_tenant", "policy_id", "any_of", "wallet vs mandate"
```

## CI footprint

Touches only `apps/docs/src/content/docs/concepts/`. Path-filtered workflows that target docs (Astro build) run; the heavy Rust+Python matrix workflows skip via `paths:` filters in `.github/workflows/*.yml` (where configured).

## Out of scope

- Sidebar reorganization to group Phase-3 concepts under a "Phase 3" sub-section — single flat sidebar today; group later if it gets crowded.
- Cross-locale translations (EN-only) — same precedent as other concept articles; SK/KO follow when native reviewers cycle through.

## Dependencies

- Stacks on `agent/dev3/CTI-3-3` (#122 docs chain).
- Source pointers reference Dev 1 / Dev 2 PRs already on main per round-11 brief (#245, #246, #208, #244, #237).

🤖 Generated with [Claude Code](https://claude.com/claude-code)