### PR TITLE
docs(changelog): mark v1.2.0 released + Phase 3 [Unreleased] section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,72 @@ All notable changes to SBO3L are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — Phase 2 closeout (target: v1.2.0)
+## [Unreleased] — Phase 3 (post-v1.2.0)
 
-> **Draft.** This section tracks every PR merged on `main` after `v1.0.1` (commit `c90f571`).
-> The release PR opens early so judges and reviewers can preview the Phase 2 surface; the
-> tag is pushed only when the Phase 2 done-bar is met (Track 1: 8/8 ✅, Track 3: T-3-1..7
-> ✅ or 🟡, Track 4: T-4-1..3 ✅ or 🟡, Track 5: at least 3/6 ✅, CTI-3: SDK refs + Redoc +
-> landing page main content ✅). Run-book at [`docs/release/v1.2.0-prep.md`](docs/release/v1.2.0-prep.md).
+> Phase 3 work landed after the v1.2.0 tag (2026-05-02). Tracked here pending the next
+> tag bump.
+
+### Added
+- **Phase 3.1 audit anchoring** — `sbo3l-anchor` workspace crate (#246) +
+  `AnchorRegistry.sol` Foundry-tested contract (#245) + GH Actions `anchor-publish.yml`
+  cron workflow.
+- **Phase 3.3 marketplace** — `@sbo3l/marketplace` content-addressed signed-policy
+  registry (#244) + `/marketplace` browse + detail + publish UI (#241) + `sbo3l-marketplace`
+  CLI bin (#256).
+- **Phase 3.4 load test harness** — pure-Rust load gen with honest p50/p95/p99
+  measurements (#261).
+- **Phase 3.5 token-gated identity** — ERC-721 / ERC-1155 ownership gates +
+  AnyOf/AllOf composites + risk-class presets (#237) + time-window extension (#263).
+- **Phase 3.6 cross-protocol composition** — 14 framework adapters all landed; killer
+  cross-framework demo (#155).
+- **F-5 EthSigner production wiring** — secp256k1 local-file backend + EIP-55 +
+  ecrecover-verified contract + KMS factory stubs (#243).
+- **T-3-9 cross-chain reputation aggregator** — reputation_score ENSIP draft (#222) +
+  L2 broadcast scaffolding (#250) + SBO3LReputationRegistry contract (#257).
+- **T-3-4 cross-agent verification protocol** — Rust + TS port (#167, #182).
+- **T-3-8 cross-chain agent identity** — EIP-712 attestation + consistency (#197).
+- **T-4-5 ENS Universal Resolver** — single-RPC batch text-record fetch (#194).
+- **T-4-7 reputation-publish broadcast** — `sbo3l agent reputation-publish --broadcast` (#250).
+- **WASM verifier slice** — sbo3l-core builds for wasm32 + wasm-pack pipeline (#134).
+- **ENS DNS gateway** — RFC 8484 DoH route + 16 tests (#262); ENSIP-N submission
+  draft (#264).
+- **Hosted app** — real SBO3L daemon wiring (#136) + /admin/users (#206) + /admin/audit
+  (#231) + /admin/keys (#233) + /admin/flags (#217) + Vercel deploy workflow (#229).
+- **Marketing** — /demo 4-step walkthrough (#150) + /demo/3 verifier playground (#238)
+  + /marketplace launch (#241) + /submission per-bounty pages (#211) + i18n EN/SK (#203)
+  + Korean (#236) + ArchDiagram v2 (#175).
+- **Trust-DNS viz canvas renderer** — ≥100 agents at 60fps (#164).
+- **Multi-tenant isolation** — V010 migration + audit_*_for_tenant fn family (#208).
+- **MEV guard** — slippage + recipient allowlist (#179).
+- **APRP expiry enforcement** — protocol.aprp_expired rejection (#226).
+- **Audit DB persistence across SIGKILL** — chaos test fix (#227).
+- **Feature flags** — /v1/admin/flags + audit chain integration (#213).
+- **Observability dashboard** — apps/observability 4-panel /v1/admin/metrics (#252).
+- **5 framework integrations** — @sbo3l/anthropic, @sbo3l/anthropic-computer-use,
+  @sbo3l/openai-assistants, @sbo3l/mastra, @sbo3l/vellum, sbo3l-agno, @sbo3l/langflow,
+  @sbo3l/inngest, sbo3l-pydantic-ai (#193, #207, #214, #220, #249).
+
+### Fixed
+- **CHAOS-1** — preserve audit DB across daemon SIGKILL+restart (#227).
+- **CHAOS-2** — enforce APRP expiry; reject expired requests (#226).
+- **MEV zero-quote bypass** — server APPROVED swap regardless of slippage when
+  quote.expected_amount_out == 0 (#179 P1 SECURITY).
+- **crates-publish workflow** — restrict trigger to semver tags + correct prefix strip
+  for `vercel-ai-v*` etc. (#247).
+
+### Infrastructure
+- **AnchorRegistry.sol on Sepolia** — Foundry deploy + verify on Etherscan.
+- **CCIP gateway** — Vercel deploy at `https://sbo3l-ccip.vercel.app`.
+- **`allow_update_branch=true`** repo setting + admin bypass on main ruleset for
+  cascade unstuck.
+
+---
+
+## [1.2.0] — 2026-05-02
+
+> **Phase 2 closeout.** All Phase 2 acceptance criteria met. Cascade landed across the
+> day; v1.2.0 tag pushed at 09:37Z; publishes completed for crates.io + 3 PyPI integration
+> packages by 11:00Z. npm publishes pending NPM_TOKEN provision.
 
 ### Added
 - **T-4-1 ENSIP-25 CCIP-Read gateway** (#124, #130) — production-shape off-chain text-record
@@ -88,7 +147,8 @@ T-3-5 e2e, T-4-2, T-5-1, T-5-4, T-5-6, framework demos, CTI-3-3, CTI-3-4 slice 2
 `@sbo3l/elizaos` was at 0.1.0 (v1.0.0 publish workflow caught the cascade-late merge of
 #115); v1.2.0 brings it into lockstep with the rest of the npm scope at 1.2.0.
 
-[Unreleased]: https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/releases/tag/v1.2.0
 
 ---
 


### PR DESCRIPTION
## Summary
After v1.2.0 tag landed and crates.io + 3 PyPI publishes succeeded, refresh the changelog:
- Flip Phase 2 closeout draft → versioned [1.2.0] release entry (2026-05-02)
- Start fresh [Unreleased] section for Phase 3 work landing post-tag
- Update [Unreleased] compare link from v1.0.1 → v1.2.0

## Test plan
- [ ] Manually verify links resolve
- [ ] Confirm Keep-a-Changelog format