### PR TITLE
feat(hosted-app): CTI-3-5 multi-tenant scaffold /t/[slug]/* (R12 P1)

### DIFF
--- a/apps/hosted-app/app/t/[tenant]/agents/page.tsx
+++ b/apps/hosted-app/app/t/[tenant]/agents/page.tsx
@@ -1,0 +1,42 @@
+import { notFound } from "next/navigation";
+import { tenantBySlug } from "@/lib/tenants";
+import { dataForTenant } from "@/lib/tenant-mock-data";
+
+interface Props { params: Promise<{ tenant: string }> }
+
+export default async function TenantAgents({ params }: Props): Promise<JSX.Element> {
+  const { tenant: slug } = await params;
+  if (!tenantBySlug(slug)) notFound();
+  const data = dataForTenant(slug);
+  const agents = data?.agents ?? [];
+
+  return (
+    <main>
+      <h1>Agents — {slug}</h1>
+      <p style={{ color: "var(--muted)", marginBottom: "1.5em" }}>{agents.length} agents registered to this tenant.</p>
+      {agents.length === 0 && <p>No agents yet.</p>}
+      {agents.length > 0 && (
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead>
+            <tr style={{ borderBottom: "1px solid var(--border)", textAlign: "left", color: "var(--muted)" }}>
+              <th style={{ padding: "0.5em 0.8em" }}>Agent ID</th>
+              <th style={{ padding: "0.5em 0.8em" }}>ENS</th>
+              <th style={{ padding: "0.5em 0.8em" }}>Pubkey</th>
+              <th style={{ padding: "0.5em 0.8em" }}>Created</th>
+            </tr>
+          </thead>
+          <tbody>
+            {agents.map((a) => (
+              <tr key={a.agentId} style={{ borderBottom: "1px solid var(--border)" }}>
+                <td style={{ padding: "0.6em 0.8em" }}><code>{a.agentId}</code></td>
+                <td style={{ padding: "0.6em 0.8em", color: "var(--muted)" }}>{a.ensName}</td>
+                <td style={{ padding: "0.6em 0.8em", color: "var(--muted)" }}><code>{a.pubkeyPrefix}</code></td>
+                <td style={{ padding: "0.6em 0.8em", color: "var(--muted)" }}>{new Date(a.createdAt).toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </main>
+  );
+}

--- a/apps/hosted-app/app/t/[tenant]/audit/page.tsx
+++ b/apps/hosted-app/app/t/[tenant]/audit/page.tsx
@@ -1,0 +1,46 @@
+import { notFound } from "next/navigation";
+import { tenantBySlug } from "@/lib/tenants";
+import { dataForTenant } from "@/lib/tenant-mock-data";
+
+interface Props { params: Promise<{ tenant: string }> }
+
+export default async function TenantAudit({ params }: Props): Promise<JSX.Element> {
+  const { tenant: slug } = await params;
+  if (!tenantBySlug(slug)) notFound();
+  const events = dataForTenant(slug)?.audit ?? [];
+
+  return (
+    <main>
+      <h1>Audit log — {slug}</h1>
+      <p style={{ color: "var(--muted)", marginBottom: "1.5em" }}>
+        {events.length} events on this tenant's chain. Cross-tenant queries don't exist as a code path (V010 isolation; see <a href="https://sbo3l-docs.vercel.app/concepts/multi-tenant">/concepts/multi-tenant</a>).
+      </p>
+      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.92em" }}>
+        <thead>
+          <tr style={{ borderBottom: "1px solid var(--border)", textAlign: "left", color: "var(--muted)" }}>
+            <th style={{ padding: "0.5em 0.8em" }}>Time</th>
+            <th style={{ padding: "0.5em 0.8em" }}>Type</th>
+            <th style={{ padding: "0.5em 0.8em" }}>Agent</th>
+            <th style={{ padding: "0.5em 0.8em" }}>Outcome</th>
+            <th style={{ padding: "0.5em 0.8em" }}>Request hash</th>
+          </tr>
+        </thead>
+        <tbody>
+          {events.map((e) => (
+            <tr key={e.eventId} style={{ borderBottom: "1px solid var(--border)" }}>
+              <td style={{ padding: "0.5em 0.8em", color: "var(--muted)", fontFamily: "var(--font-mono)" }}>{new Date(e.tsUnixMs).toLocaleTimeString()}</td>
+              <td style={{ padding: "0.5em 0.8em", color: "var(--muted)" }}><code>{e.eventType}</code></td>
+              <td style={{ padding: "0.5em 0.8em" }}><code>{e.agentId}</code></td>
+              <td style={{ padding: "0.5em 0.8em" }}>
+                {e.decision === "allow" && <span style={{ color: "var(--accent)" }}>✓ allow</span>}
+                {e.decision === "deny" && <span style={{ color: "#ff6b6b" }}>✗ deny <code style={{ marginLeft: "0.4em", fontSize: "0.85em" }}>{e.denyCode}</code></span>}
+                {!e.decision && <span style={{ color: "var(--muted)" }}>checkpoint</span>}
+              </td>
+              <td style={{ padding: "0.5em 0.8em", color: "var(--muted)", fontFamily: "var(--font-mono)" }}>{e.requestHashPrefix}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}

--- a/apps/hosted-app/app/t/[tenant]/capsules/page.tsx
+++ b/apps/hosted-app/app/t/[tenant]/capsules/page.tsx
@@ -1,0 +1,34 @@
+import { notFound } from "next/navigation";
+import { tenantBySlug } from "@/lib/tenants";
+import { dataForTenant } from "@/lib/tenant-mock-data";
+
+interface Props { params: Promise<{ tenant: string }> }
+
+export default async function TenantCapsules({ params }: Props): Promise<JSX.Element> {
+  const { tenant: slug } = await params;
+  if (!tenantBySlug(slug)) notFound();
+  const capsules = dataForTenant(slug)?.capsules ?? [];
+
+  return (
+    <main>
+      <h1>Capsules — {slug}</h1>
+      <p style={{ color: "var(--muted)", marginBottom: "1.5em" }}>
+        {capsules.length} capsules emitted by agents in this tenant. Each is offline-verifiable; click <a href="https://sbo3l-marketing.vercel.app/proof">/proof</a> to verify in your browser.
+      </p>
+      <ul style={{ listStyle: "none", padding: 0, display: "grid", gap: "0.8em" }}>
+        {capsules.map((c) => (
+          <li key={c.capsuleId} style={{ display: "grid", gridTemplateColumns: "1fr auto auto", gap: "1em", alignItems: "center", padding: "1em", border: "1px solid var(--border)", borderRadius: "var(--r-md)", background: "var(--code-bg)" }}>
+            <div>
+              <code style={{ fontSize: "0.85em" }}>{c.capsuleId}</code>
+              <div style={{ color: "var(--muted)", fontSize: "0.85em", marginTop: "0.3em" }}>
+                <code>{c.agentId}</code> · {new Date(c.emittedAt).toLocaleString()}
+              </div>
+            </div>
+            <span style={{ color: c.decision === "allow" ? "var(--accent)" : "#ff6b6b", fontWeight: 600 }}>{c.decision}</span>
+            <span style={{ color: "var(--muted)", fontSize: "0.85em" }}>{(c.sizeBytes / 1024).toFixed(1)} KB</span>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/apps/hosted-app/app/t/[tenant]/dashboard/page.tsx
+++ b/apps/hosted-app/app/t/[tenant]/dashboard/page.tsx
@@ -1,0 +1,49 @@
+import { tenantBySlug, userHasAccessTo } from "@/lib/tenants";
+import { dataForTenant } from "@/lib/tenant-mock-data";
+import { auth } from "@/auth";
+import { notFound } from "next/navigation";
+
+interface Props { params: Promise<{ tenant: string }> }
+
+export default async function TenantDashboard({ params }: Props): Promise<JSX.Element> {
+  const { tenant: slug } = await params;
+  const tenant = tenantBySlug(slug);
+  if (!tenant) notFound();
+
+  const session = await auth();
+  const userId = session?.user?.githubLogin ?? session?.user?.email ?? null;
+  const membership = userHasAccessTo(userId, slug);
+  if (!membership) notFound();
+
+  const data = dataForTenant(slug);
+  const decisionsTotal = data?.audit.filter((e) => e.eventType === "policy.decision").length ?? 0;
+  const allowCount = data?.audit.filter((e) => e.decision === "allow").length ?? 0;
+  const denyCount = data?.audit.filter((e) => e.decision === "deny").length ?? 0;
+
+  return (
+    <main>
+      <header style={{ marginBottom: "2em" }}>
+        <h1>Dashboard — {tenant.display_name}</h1>
+        <p style={{ color: "var(--muted)", marginTop: "0.4em" }}>
+          Tier <code>{tenant.tier}</code> · ENS apex <code>{tenant.ens_apex}</code> · your role <code>{membership.role}</code>
+        </p>
+      </header>
+
+      <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: "1em" }}>
+        <Card title="Agents"            value={`${data?.agents.length ?? 0}`}  hint="registered to this tenant" />
+        <Card title="Decisions"         value={`${decisionsTotal}`}            hint={`allow ${allowCount} · deny ${denyCount}`} />
+        <Card title="Capsules emitted"  value={`${data?.capsules.length ?? 0}`} hint="downloadable + offline-verifiable" />
+      </section>
+    </main>
+  );
+}
+
+function Card({ title, value, hint }: { title: string; value: string; hint: string }): JSX.Element {
+  return (
+    <article style={{ border: "1px solid var(--border)", borderRadius: "var(--r-lg)", padding: "1.2em", background: "var(--code-bg)" }}>
+      <h2 style={{ fontSize: "0.9em", color: "var(--muted)", fontWeight: 500 }}>{title}</h2>
+      <p style={{ fontSize: "1.6em", fontWeight: 700, color: "var(--accent)", margin: "0.3em 0" }}>{value}</p>
+      <p style={{ fontSize: "0.85em", color: "var(--muted)" }}>{hint}</p>
+    </article>
+  );
+}

--- a/apps/hosted-app/app/t/[tenant]/layout.tsx
+++ b/apps/hosted-app/app/t/[tenant]/layout.tsx
@@ -1,0 +1,58 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { auth, signOut } from "@/auth";
+import { tenantBySlug, userHasAccessTo, membershipsForUser, MOCK_TENANTS } from "@/lib/tenants";
+import { TenantSwitcher } from "@/components/TenantSwitcher";
+
+interface Props {
+  children: React.ReactNode;
+  params: Promise<{ tenant: string }>;
+}
+
+// Server-side tenant guard — runs on every nested page render.
+// Validates slug shape, looks up the tenant, and confirms the user
+// has a membership entry for it. notFound() on any failure (404 vs
+// 403 chosen deliberately: "we don't reveal whether the tenant
+// exists at all to users without access" — minor info-disclosure
+// hardening for the multi-tenant boundary).
+export default async function TenantLayout({ children, params }: Props): Promise<JSX.Element> {
+  const { tenant: slug } = await params;
+  const tenant = tenantBySlug(slug);
+  if (!tenant) notFound();
+
+  const session = await auth();
+  const userId = session?.user?.githubLogin ?? session?.user?.email ?? null;
+  const membership = userHasAccessTo(userId, slug);
+  if (!membership) notFound();
+
+  const memberships = membershipsForUser(userId);
+
+  return (
+    <>
+      <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "0.7em 1.5em", borderBottom: "1px solid var(--border)" }}>
+        <nav style={{ display: "flex", gap: "1.2em", alignItems: "center", flexWrap: "wrap", fontSize: "0.92em" }}>
+          <Link href={`/t/${slug}/dashboard`} style={{ fontWeight: 700 }}>SBO3L</Link>
+          <Link href={`/t/${slug}/dashboard`}>Dashboard</Link>
+          <Link href={`/t/${slug}/agents`}>Agents</Link>
+          <Link href={`/t/${slug}/audit`}>Audit</Link>
+          <Link href={`/t/${slug}/capsules`}>Capsules</Link>
+          {(membership.role === "admin" || membership.role === "operator") && (
+            <Link href={`/t/${slug}/admin/audit`}>Admin</Link>
+          )}
+        </nav>
+        <div style={{ display: "flex", gap: "0.6em", alignItems: "center" }}>
+          <TenantSwitcher
+            current={slug}
+            memberships={memberships}
+            tenants={MOCK_TENANTS}
+            basePath="/dashboard"
+          />
+          <form action={async () => { "use server"; await signOut({ redirectTo: "/" }); }}>
+            <button type="submit" className="ghost" style={{ fontSize: "0.85em" }}>Sign out</button>
+          </form>
+        </div>
+      </header>
+      {children}
+    </>
+  );
+}

--- a/apps/hosted-app/app/tenants/page.tsx
+++ b/apps/hosted-app/app/tenants/page.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link";
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import { membershipsForUser, MOCK_TENANTS } from "@/lib/tenants";
+
+export const dynamic = "force-dynamic";
+
+// Post-login tenant picker. If the user has exactly one tenant
+// membership, redirect straight into it. Otherwise show a card
+// per tenant.
+export default async function TenantsPage(): Promise<JSX.Element> {
+  const session = await auth();
+  if (!session) redirect("/login");
+  const userId = session.user?.githubLogin ?? session.user?.email ?? null;
+  const memberships = membershipsForUser(userId);
+
+  if (memberships.length === 1) {
+    redirect(`/t/${memberships[0]!.tenant_slug}/dashboard`);
+  }
+
+  return (
+    <main>
+      <section style={{ maxWidth: 720, margin: "4em auto", padding: "0 1.5em" }}>
+        <h1 style={{ marginBottom: "0.5em" }}>Pick a tenant</h1>
+        <p style={{ color: "var(--muted)", marginBottom: "2em" }}>
+          You have access to {memberships.length} tenants. Pick one to continue; switch later via the dropdown in the top-right of any page.
+        </p>
+        <ul style={{ listStyle: "none", padding: 0, display: "grid", gap: "0.8em" }}>
+          {memberships.map((m) => {
+            const tenant = MOCK_TENANTS.find((t) => t.slug === m.tenant_slug);
+            if (!tenant) return null;
+            return (
+              <li key={m.tenant_slug}>
+                <Link
+                  href={`/t/${m.tenant_slug}/dashboard`}
+                  style={{ display: "grid", gridTemplateColumns: "1fr auto", gap: "0.5em 1em", padding: "1.2em 1.4em", border: "1px solid var(--border)", borderRadius: "var(--r-md)", background: "var(--code-bg)", color: "var(--fg)", textDecoration: "none" }}
+                >
+                  <div>
+                    <strong>{tenant.display_name}</strong>{" "}
+                    <code style={{ color: "var(--muted)", marginLeft: "0.5em", fontSize: "0.85em" }}>{tenant.slug}</code>
+                  </div>
+                  <span style={{ color: "var(--accent)", fontFamily: "var(--font-mono)", fontSize: "0.82em" }}>{m.role}</span>
+                  <p style={{ color: "var(--muted)", fontSize: "0.88em", margin: 0, gridColumn: "1 / -1" }}>
+                    Tier <code>{tenant.tier}</code> · ENS <code>{tenant.ens_apex}</code>
+                  </p>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/apps/hosted-app/components/TenantSwitcher.tsx
+++ b/apps/hosted-app/components/TenantSwitcher.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import type { TenantMembership, Tenant } from "@/lib/tenants";
+
+interface Props {
+  current: string;
+  memberships: TenantMembership[];
+  tenants: Tenant[];
+  basePath: string;
+}
+
+export function TenantSwitcher({ current, memberships, tenants, basePath }: Props): JSX.Element {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const currentTenant = tenants.find((t) => t.slug === current);
+
+  return (
+    <div className="tenant-switcher">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={`Tenant: ${currentTenant?.display_name ?? current}`}
+      >
+        <span className="dot" aria-hidden="true"></span>
+        <strong>{currentTenant?.display_name ?? current}</strong>
+        <code>{current}</code>
+        <span aria-hidden="true">▾</span>
+      </button>
+      {open && (
+        <ul role="listbox" aria-label="Switch tenant">
+          {memberships.map((m) => {
+            const t = tenants.find((x) => x.slug === m.tenant_slug);
+            if (!t) return null;
+            return (
+              <li key={m.tenant_slug}>
+                <button
+                  type="button"
+                  onClick={() => { setOpen(false); router.push(`/t/${m.tenant_slug}${basePath}`); }}
+                  aria-current={m.tenant_slug === current ? "true" : undefined}
+                >
+                  <span><strong>{t.display_name}</strong> <code>{t.slug}</code></span>
+                  <span className="role">{m.role}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+      <style jsx>{`
+        .tenant-switcher { position: relative; }
+        button {
+          background: var(--code-bg); color: var(--fg); border: 1px solid var(--border);
+          border-radius: var(--r-sm); padding: 0.4em 0.8em; font: inherit; font-size: 0.9em;
+          cursor: pointer; display: inline-flex; align-items: center; gap: 0.5em;
+        }
+        .dot { width: 0.5em; height: 0.5em; border-radius: 50%; background: var(--accent); }
+        button code { color: var(--muted); font-size: 0.78em; }
+        ul {
+          position: absolute; top: calc(100% + 4px); right: 0; margin: 0; padding: 0.4em 0;
+          list-style: none; background: var(--bg); border: 1px solid var(--border);
+          border-radius: var(--r-sm); min-width: 240px; box-shadow: 0 4px 16px rgba(0,0,0,0.4); z-index: 20;
+        }
+        li button {
+          display: grid; grid-template-columns: 1fr auto; gap: 0.4em;
+          padding: 0.55em 0.9em; width: 100%; background: transparent; border: none;
+          color: var(--fg); font-size: 0.9em; text-align: left; cursor: pointer; border-radius: 0;
+        }
+        li button:hover { background: var(--code-bg); }
+        li button .role { color: var(--accent); font-family: var(--font-mono); font-size: 0.8em; }
+        li button code { color: var(--muted); margin-left: 0.6em; font-size: 0.85em; }
+      `}</style>
+    </div>
+  );
+}

--- a/apps/hosted-app/lib/tenant-mock-data.ts
+++ b/apps/hosted-app/lib/tenant-mock-data.ts
@@ -1,0 +1,71 @@
+// Per-tenant mock fixtures — keyed by tenant slug. Extends the
+// existing tenant-implicit lib/mock-data.ts (which now stays as the
+// "default" tenant view for backward compat with /dashboard etc.).
+//
+// CTI-3-5 slice-c (Grace + Dev 1) replaces these with daemon
+// round-trips scoped by JWT tenant claim. The shape mirrors what
+// the daemon endpoints return so the swap is one-file.
+
+import type { Agent, AuditEvent, Capsule } from "./mock-data";
+
+export interface TenantData {
+  agents: Agent[];
+  audit: AuditEvent[];
+  capsules: Capsule[];
+}
+
+// 3 tenants × distinct fixtures so cross-tenant isolation is
+// visually obvious during demo (different agent counts, different
+// audit chains).
+export const TENANT_DATA: Record<string, TenantData> = {
+  acme: {
+    agents: [
+      { agentId: "research-acme-01", ensName: "research-01.acme.sbo3lagent.eth", pubkeyPrefix: "ed25519:9aF3..", createdAt: "2026-04-15T10:23:00Z" },
+      { agentId: "trader-acme-02",   ensName: "trader-02.acme.sbo3lagent.eth",   pubkeyPrefix: "ed25519:7bC8..", createdAt: "2026-04-22T14:01:00Z" },
+      { agentId: "auditor-acme-03",  ensName: "auditor-03.acme.sbo3lagent.eth",  pubkeyPrefix: "ed25519:2dE1..", createdAt: "2026-04-29T09:15:00Z" },
+    ],
+    audit: [
+      { eventId: "01HZ-ACME-A1", tsUnixMs: 1714564961000, eventType: "policy.decision", agentId: "research-acme-01", decision: "allow", requestHashPrefix: "0xe044f1.." },
+      { eventId: "01HZ-ACME-A2", tsUnixMs: 1714564838000, eventType: "policy.decision", agentId: "trader-acme-02",   decision: "allow", requestHashPrefix: "0x9bc7de.." },
+      { eventId: "01HZ-ACME-A3", tsUnixMs: 1714564613000, eventType: "audit.checkpoint", agentId: "research-acme-01", requestHashPrefix: "0x4f10ee.." },
+    ],
+    capsules: [
+      { capsuleId: "cap-acme-A1", agentId: "research-acme-01", decision: "allow", emittedAt: "2026-05-02T08:42:41Z", sizeBytes: 11_240 },
+      { capsuleId: "cap-acme-A2", agentId: "trader-acme-02",   decision: "allow", emittedAt: "2026-05-02T08:36:53Z", sizeBytes: 10_802 },
+    ],
+  },
+  contoso: {
+    agents: [
+      { agentId: "research-contoso", ensName: "research.contoso.sbo3lagent.eth", pubkeyPrefix: "ed25519:5f8A..", createdAt: "2026-04-22T14:00:00Z" },
+    ],
+    audit: [
+      { eventId: "01HZ-CONT-B1", tsUnixMs: 1714564401000, eventType: "policy.decision", agentId: "research-contoso", decision: "deny", denyCode: "policy.budget_exceeded", requestHashPrefix: "0x12ab34.." },
+    ],
+    capsules: [
+      { capsuleId: "cap-contoso-B1", agentId: "research-contoso", decision: "deny", emittedAt: "2026-05-02T08:28:22Z", sizeBytes: 9_614 },
+    ],
+  },
+  fabrikam: {
+    agents: [
+      { agentId: "fabrikam-treasury", ensName: "treasury.fabrikam.sbo3lagent.eth", pubkeyPrefix: "ed25519:3e7C..", createdAt: "2026-04-29T09:00:00Z" },
+      { agentId: "fabrikam-research", ensName: "research.fabrikam.sbo3lagent.eth", pubkeyPrefix: "ed25519:4d8B..", createdAt: "2026-04-30T10:30:00Z" },
+      { agentId: "fabrikam-auditor",  ensName: "auditor.fabrikam.sbo3lagent.eth",  pubkeyPrefix: "ed25519:6e9D..", createdAt: "2026-05-01T11:15:00Z" },
+      { agentId: "fabrikam-router",   ensName: "router.fabrikam.sbo3lagent.eth",   pubkeyPrefix: "ed25519:8a1F..", createdAt: "2026-05-01T16:45:00Z" },
+    ],
+    audit: [
+      { eventId: "01HZ-FAB-C1", tsUnixMs: 1714565100000, eventType: "policy.decision", agentId: "fabrikam-treasury", decision: "allow", requestHashPrefix: "0xab12cd.." },
+      { eventId: "01HZ-FAB-C2", tsUnixMs: 1714565205000, eventType: "policy.decision", agentId: "fabrikam-research", decision: "allow", requestHashPrefix: "0xef34gh.." },
+      { eventId: "01HZ-FAB-C3", tsUnixMs: 1714565310000, eventType: "policy.decision", agentId: "fabrikam-auditor",  decision: "deny", denyCode: "policy.deny_unknown_provider", requestHashPrefix: "0x56ij78.." },
+      { eventId: "01HZ-FAB-C4", tsUnixMs: 1714565415000, eventType: "audit.checkpoint", agentId: "fabrikam-router",   requestHashPrefix: "0x90kl12.." },
+    ],
+    capsules: [
+      { capsuleId: "cap-fab-C1", agentId: "fabrikam-treasury", decision: "allow", emittedAt: "2026-05-02T09:01:00Z", sizeBytes: 11_980 },
+      { capsuleId: "cap-fab-C2", agentId: "fabrikam-research", decision: "allow", emittedAt: "2026-05-02T09:02:45Z", sizeBytes: 12_104 },
+      { capsuleId: "cap-fab-C3", agentId: "fabrikam-auditor",  decision: "deny", emittedAt: "2026-05-02T09:04:30Z", sizeBytes: 9_810 },
+    ],
+  },
+};
+
+export function dataForTenant(slug: string): TenantData | undefined {
+  return TENANT_DATA[slug];
+}

--- a/apps/hosted-app/lib/tenants.ts
+++ b/apps/hosted-app/lib/tenants.ts
@@ -1,0 +1,65 @@
+// Tenant resolution + 3 mock tenants (CTI-3-5 §7 Q2: slug,
+// kebab-case). Cross-tenant access enforced server-side in
+// /t/[tenant]/layout.tsx via notFound().
+import type { Role } from "./roles";
+
+export const SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{1,30}[a-z0-9])?$/;
+
+export interface Tenant {
+  slug: string;
+  display_name: string;
+  uuid: string;
+  tier: "free" | "pro" | "enterprise";
+  ens_apex: string;
+  created_at: string;
+}
+
+// Three seeded tenants per round-12 brief. UUIDs are deterministic
+// (uuidv5 over a fixed namespace + slug) so they're stable across
+// rebuilds; the mock data layer doesn't actually use them yet but
+// the daemon-side per-tenant SQLite path layout (Grace's slice)
+// will key off uuid for renaming-stable file paths.
+export const MOCK_TENANTS: Tenant[] = [
+  { slug: "acme",     display_name: "Acme Corp",      uuid: "tnt-01HZRG-acme",     tier: "pro",        ens_apex: "acme.sbo3lagent.eth",     created_at: "2026-04-15T10:00:00Z" },
+  { slug: "contoso",  display_name: "Contoso Ltd",    uuid: "tnt-01HZRG-contoso",  tier: "free",       ens_apex: "contoso.sbo3lagent.eth",  created_at: "2026-04-22T14:00:00Z" },
+  { slug: "fabrikam", display_name: "Fabrikam Inc",   uuid: "tnt-01HZRG-fabrikam", tier: "enterprise", ens_apex: "fabrikam.sbo3lagent.eth", created_at: "2026-04-29T09:00:00Z" },
+];
+
+export interface TenantMembership {
+  tenant_slug: string;
+  role: Role;
+  added_at: string;
+}
+
+// Mock membership map keyed by user identifier. In production this
+// comes from a daemon-side per-tenant memberships table (Grace's
+// slice). Today we hard-wire so all three mock tenants are visible
+// to anyone signed in for the scaffold demo.
+const MOCK_MEMBERSHIPS_BY_USER: Record<string, TenantMembership[]> = {
+  // Default fallback — every signed-in user has access to all three
+  // tenants with operator role. Replace with real lookups when the
+  // memberships endpoint ships.
+  "*": [
+    { tenant_slug: "acme",     role: "operator", added_at: "2026-04-15T10:00:00Z" },
+    { tenant_slug: "contoso",  role: "viewer",   added_at: "2026-04-22T14:00:00Z" },
+    { tenant_slug: "fabrikam", role: "admin",    added_at: "2026-04-29T09:00:00Z" },
+  ],
+};
+
+export function membershipsForUser(userId?: string | null): TenantMembership[] {
+  if (userId && MOCK_MEMBERSHIPS_BY_USER[userId]) return MOCK_MEMBERSHIPS_BY_USER[userId]!;
+  return MOCK_MEMBERSHIPS_BY_USER["*"]!;
+}
+
+export function tenantBySlug(slug: string): Tenant | undefined {
+  if (!SLUG_RE.test(slug)) return undefined;
+  return MOCK_TENANTS.find((t) => t.slug === slug);
+}
+
+export function userHasAccessTo(userId: string | null | undefined, tenantSlug: string): TenantMembership | undefined {
+  return membershipsForUser(userId).find((m) => m.tenant_slug === tenantSlug);
+}
+
+export function isValidSlug(slug: string): boolean {
+  return slug.length >= 3 && slug.length <= 32 && SLUG_RE.test(slug);
+}


### PR DESCRIPTION
## Summary

CTI-3-5 implementation slice **(a)** per design doc #248 §6. Slug answered: kebab-case, `[a-z0-9-]{3,32}`. 3 mock tenants seeded (acme / contoso / fabrikam).

- `lib/tenants.ts` + `lib/tenant-mock-data.ts` — types, helpers, fixtures.
- `app/t/[tenant]/layout.tsx` — server-side guard; `notFound()` on missing access.
- `app/t/[tenant]/{dashboard,agents,audit,capsules}/page.tsx` — tenant-scoped views.
- `app/tenants/page.tsx` — post-login picker (auto-redirect if user has exactly one tenant).
- `components/TenantSwitcher.tsx` — top-right dropdown; ARIA-correct; `aria-current` on the active row.

LoC: 497 insertions across 9 files (under 500 cap).

## Why

P1 of round-12 brief. Daniel's §7 Q2 answer (slug, NOT UUID) unblocked this slice. URL prefix `/t/<slug>/*` per the design doc.

## Test plan — manual smoke

```bash
cd apps/hosted-app
npm install && npm run typecheck && npm run build
npm run dev          # http://localhost:3000

# Sign in (any provider)
# → redirects to /tenants picker
# → 3 cards (Acme Pro · Contoso Free · Fabrikam Enterprise) with role badges
# Click "Acme Corp" → /t/acme/dashboard
# Header nav: SBO3L home / Dashboard / Agents / Audit / Capsules / [Admin if op+]
#             top-right: TenantSwitcher dropdown + Sign out
# Click /t/acme/agents       → 3 agent rows
# Click /t/acme/audit        → 3 events (allow/allow/checkpoint)
# Click /t/acme/capsules     → 2 capsules

# Tenant switcher (top-right)
# Click "Fabrikam Inc" → URL becomes /t/fabrikam/dashboard
# Stats reflect Fabrikam (4 agents, 3 decisions, 3 capsules)
# Different agents listed; different audit chain; isolation visible

# Direct URL bypass attempt
# Visit /t/notreal/dashboard           → 404
# Visit /t/!badslug!/dashboard         → 404 (slug regex rejects)
# Visit /t/acme/dashboard signed-out   → NextAuth /login redirect

# Auto-redirect to single tenant
# (manual: edit lib/tenants.ts to give the test user only `acme`)
# Sign in → skips picker, lands directly on /t/acme/dashboard
```

## A11y

- `aria-haspopup` + `aria-expanded` on the switcher button; `role="listbox"` on the dropdown.
- `aria-current="true"` on the currently-active tenant row.
- `aria-label` describes current tenant for screen readers.

## Out of scope

- Daemon-side per-tenant SQLite path layout — Grace's slice (slice **c** in design doc §6).
- `/t/<slug>/admin/*` re-mount of existing admin pages under tenant scope — own slice.
- `/t/<slug>/admin/billing` Stripe surface — slice **b** (Daniel answers §7 Q1).
- `/admin/tenants` cross-tenant listing — slice **d**.
- Playwright e2e for the isolation regression — separate ticket; manual checklist above.

## Dependencies

- CTI-3-5 design doc (#248) on main.
- Auth + role gates from #190 (ROLE_GATES) on main.
- Tenant memberships are hard-wired mock; daemon endpoint is the swap-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)