### PR TITLE
fix(sdk-ts): broken package.json — missing }, between cross-agent and uniswap exports

### DIFF
--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -52,6 +52,7 @@
       "types": "./dist/cross-agent.d.ts",
       "import": "./dist/cross-agent.js",
       "require": "./dist/cross-agent.cjs"
+    },
     "./uniswap": {
       "types": "./dist/uniswap.d.ts",
       "import": "./dist/uniswap.js",


### PR DESCRIPTION
## Summary

🚨 **P0 cascade-health fix.** `sdks/typescript/package.json` on main has invalid JSON — the `./cross-agent` export block is missing its closing `},` before the `./uniswap` export block. This breaks `JSON.parse` and fails every npm integration build job (autogen, elizaos, langchain-ts, vercel-ai) on every open PR in the cascade.

**Likely origin:** bad merge of #182 (cross-agent TS port) and #165 (T-5-1 Uniswap swap construction) — both touched the exports section, comma-stripping conflict resolution dropped the closing brace.

**Reproducer:**
```bash
node -e "JSON.parse(require('fs').readFileSync('sdks/typescript/package.json'))"
# Before: SyntaxError: Expected ',' or '}' after property value in JSON at position 1488
# After:  parses cleanly
```

**Diff:** one-line — adds `},` between line 54 and 55.

## Test plan
- [x] `node -e "JSON.parse(...)"` parses cleanly
- [ ] All 4 npm integration build jobs go green on this PR's CI
- [ ] Once merged, all 7 currently-open PRs in the cascade can rebase and unblock

🤖 Generated with [Claude Code](https://claude.com/claude-code)