### PR TITLE
fix(sdk-ts): URGENT hotfix — sdks/typescript/package.json broken JSON on main

### DIFF
--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -52,6 +52,7 @@
       "types": "./dist/cross-agent.d.ts",
       "import": "./dist/cross-agent.js",
       "require": "./dist/cross-agent.cjs"
+    },
     "./uniswap": {
       "types": "./dist/uniswap.d.ts",
       "import": "./dist/uniswap.js",


### PR DESCRIPTION
## URGENT — blocks every TS adapter test on main

CI failing on every PR with:
```
EJSONPARSE: Expected ',' or '}' after property value in JSON at position 1488
```

Two subpath-export PRs (`./cross-agent` and `./uniswap`) landed independently and the merge concatenated their objects without the closing brace + comma between them. `file:../../sdks/typescript` deps fail on `npm install` for every adapter package.

## Diff
+1 line. Adds the missing `},` between the two subpath blocks.

## Verification
```
node -e "require('./sdks/typescript/package.json')"   # before: SyntaxError; after: silent
```

## Why this slipped past my R12 PR (#273)
#273 was opened with this fix included, but #273 hasn't merged yet (BEHIND, in queue). This standalone hotfix unblocks main immediately so the cascade can drain without waiting on #273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)