### PR TITLE
fix(sdks/typescript): repair broken JSON in package.json exports

### DIFF
--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -52,6 +52,7 @@
       "types": "./dist/cross-agent.d.ts",
       "import": "./dist/cross-agent.js",
       "require": "./dist/cross-agent.cjs"
+    },
     "./uniswap": {
       "types": "./dist/uniswap.d.ts",
       "import": "./dist/uniswap.js",


### PR DESCRIPTION
## Summary
\`sdks/typescript/package.json\` had broken JSON — \`./cross-agent\` exports block was missing its closing \`},\` before \`./uniswap\`. This caused EJSONPARSE on \`npm install\` in CI for every PR, blocking all 4 npm integration adapter test jobs (\`langchain-ts\`, \`autogen\`, \`elizaos\`, \`vercel-ai\`).

## Fix
Two-char patch: add \`},\` between the two export entries.

## Test plan
- [x] \`node -e "JSON.parse(...)"\` passes locally
- [ ] CI green on this PR
- [ ] \`npm install\` works at \`sdks/typescript\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)