### PR TITLE
fix(ci): docker-compose multi-framework smoke — set SBO3L_DEV_ONLY_SIGNER (R13 P0)

### DIFF
--- a/examples/multi-framework-agent/docker-compose.yml
+++ b/examples/multi-framework-agent/docker-compose.yml
@@ -30,6 +30,13 @@ services:
       # acknowledges the non-loopback bind (the F-4 safety gate).
       SBO3L_LISTEN: "0.0.0.0:8730"
       SBO3L_ALLOW_UNSAFE_PUBLIC_BIND: "1"
+      # F-5 signer-factory gate: the `dev` backend (default) refuses to
+      # start unless this is explicitly set. Without it the server
+      # exits with code 2 ("DEV signer requires SBO3L_DEV_ONLY_SIGNER=1
+      # to be set"). Demo containers ship with public dev seeds — fine
+      # for the cross-framework smoke; production should configure a
+      # real KMS backend instead.
+      SBO3L_DEV_ONLY_SIGNER: "1"
     ports:
       - "8730:8730"
     healthcheck:


### PR DESCRIPTION
## Summary

CI failing on every PR with:

> dependency failed to start: container multi-framework-agent-sbo3l-server-1 exited (2)

Root cause: `crates/sbo3l-server/src/main.rs:76-83` (the F-5 signer-factory gate) calls `signer_from_env(\"audit\")` at boot, which requires `SBO3L_DEV_ONLY_SIGNER=1` for the default `dev` backend. Without it the server prints

```
ERROR: refusing to start; signer backend rejected:
  DEV signer requires SBO3L_DEV_ONLY_SIGNER=1 to be set;
  public dev seeds anyone can derive locally.
```

and exits with code 2 (`SIGNER_LOCKOUT_EXIT_CODE`).

The compose env was setting `SBO3L_ALLOW_UNAUTHENTICATED`, `SBO3L_LISTEN`, and `SBO3L_ALLOW_UNSAFE_PUBLIC_BIND` — but missing the dev-signer flag. The top-level `docker-compose.yml` already sets it (line 53); the multi-framework example didn't.

## Fix

Added `SBO3L_DEV_ONLY_SIGNER: \"1\"` to the `sbo3l-server` service env with a comment naming the gate so future readers don't repeat the debug.

## Why this single line is enough

With this set, `signer_from_env(\"audit\")` and `signer_from_env(\"receipt\")` both return Ok, the server boots, the healthcheck (`wget /v1/health | grep ok`) passes, and the plan/execute/confirm services can start under `depends_on: condition: service_healthy`. The orchestrator service then completes the 3-step demo end-to-end.

## Test plan

- [ ] CI green: `multi-framework-smoke.yml` reaches \"Run orchestrator end-to-end\" step and the orchestrator output contains the 3 boundary markers (`step 1: plan`, `step 2: execute`, `step 3: confirm`).
- [x] Verified locally that `main.rs:76` is the lockout point and that the top-level compose already sets this flag.

## Why not also fix the healthcheck

`/v1/health` exists in the router (`crates/sbo3l-server/src/lib.rs:164`) and returns the literal string `ok` — the healthcheck `wget -qO- /v1/health | grep -q ok` is correct as-is. The crash was happening before any healthcheck got a chance to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)