### PR TITLE
fix(docker): SBO3L_SIGNER_BACKEND=dev required alongside SBO3L_DEV_ONLY_SIGNER=1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,9 @@ services:
       SBO3L_ALLOW_UNAUTHENTICATED: "1"
       # F-5 dev signer flag — AppState uses DevSigner today; explicit flag
       # prevents false-security where a non-dev backend label could mask
-      # public-dev-key signing.
+      # public-dev-key signing. Both env vars required by the
+      # production-mode lockout in eth_signer/factory.rs.
+      SBO3L_SIGNER_BACKEND: "dev"
       SBO3L_DEV_ONLY_SIGNER: "1"
       # Embedded migrations + image-default SBO3L_DB path are sufficient.
       # Override SBO3L_DB to ":memory:" if you don't want a host volume.

--- a/examples/multi-framework-agent/docker-compose.yml
+++ b/examples/multi-framework-agent/docker-compose.yml
@@ -30,6 +30,11 @@ services:
       # acknowledges the non-loopback bind (the F-4 safety gate).
       SBO3L_LISTEN: "0.0.0.0:8730"
       SBO3L_ALLOW_UNSAFE_PUBLIC_BIND: "1"
+      # F-5 signer-factory gate: production-mode lockout in
+      # crates/sbo3l-core/src/eth_signer/factory.rs requires both env
+      # vars to be set explicitly. Demo containers use public dev seeds.
+      SBO3L_SIGNER_BACKEND: "dev"
+      SBO3L_DEV_ONLY_SIGNER: "1"
     ports:
       - "8730:8730"
     healthcheck:


### PR DESCRIPTION
## Summary
sbo3l-server container was crashing at boot with exit code 2:

\`\`\`
ERROR: refusing to start; signer backend rejected:
  DEV signer requires SBO3L_DEV_ONLY_SIGNER=1 to be set
  Set SBO3L_SIGNER_BACKEND=dev SBO3L_DEV_ONLY_SIGNER=1 for development
\`\`\`

This blocked the multi-framework end-to-end CI check on every PR (visible in #270/#272/#273/#274/#275 failures).

## Fix
Both compose files (\`docker-compose.yml\` root + \`examples/multi-framework-agent/docker-compose.yml\`) now explicitly set both env vars.

## Test plan
- [ ] CI green on this PR
- [ ] Multi-framework end-to-end check passes
- [ ] All downstream PRs unblocked