### PR TITLE
feat(contracts): SBO3LSubnameAuction.sol — English auction for premium subnames (R13 P3)

### DIFF
--- a/crates/sbo3l-identity/contracts/SBO3LSubnameAuction.sol
+++ b/crates/sbo3l-identity/contracts/SBO3LSubnameAuction.sol
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+// SBO3LSubnameAuction — English auction for premium SBO3L subnames.
+// Author: SBO3L (Round 13 P3).
+//
+// 24-hour English auction with a 5% minimum bid increment and
+// optional reserve price. The contract escrows bids, refunds
+// outbid bidders automatically, and on settlement transfers
+// the won subname's right-of-issuance to the winning bidder.
+//
+// Right-of-issuance, NOT the subname itself: this contract
+// doesn't take custody of `sbo3lagent.eth` or perform the
+// actual `setSubnodeRecord` call. After the auction settles,
+// the operator (off-chain) executes the issuance against the
+// winning bidder using the existing `sbo3l agent register`
+// flow. The auction's on-chain commitment is the **economic
+// right** + the proof that this bidder won.
+//
+// This split keeps the contract small, no-fund-movement
+// beyond bid escrow, no integration with the ENS Registry's
+// ownership model. Operators who want the contract to also
+// issue the name can wrap it; we don't bake that in.
+//
+// Lifecycle
+//
+// 1. Operator calls `createAuction(label, reserve, duration)`.
+//    `label` is the agent slug (e.g. `"premium-trader"`); the auction
+//    binds it as `<label>.sbo3lagent.eth`. `duration` is in seconds,
+//    bounded `[1 hour, 7 days]`.
+// 2. Bidders call `bid(auctionId)` with `msg.value`. First bid must
+//    be >= reserve. Subsequent bids must beat the current high by
+//    at least `MIN_INCREMENT_BPS` (5%). Outbid bidders' funds are
+//    queued for `withdrawRefund(auctionId)`.
+// 3. After `endTime`, anyone can call `settle(auctionId)`. The
+//    operator collects the winning bid; the winner emits a
+//    `AuctionSettled(auctionId, winner, label, finalBid)` event.
+// 4. If no bid clears the reserve, the auction settles with no
+//    winner and the operator emits `AuctionUnsold(auctionId)`.
+
+error InvalidLabel(string reason);
+error InvalidReserve(uint256 reserve);
+error InvalidDuration(uint64 duration);
+error AuctionNotFound(uint256 id);
+error AuctionAlreadyEnded(uint256 id);
+error AuctionStillRunning(uint256 id);
+error AuctionAlreadySettled(uint256 id);
+error BidBelowReserve(uint256 bid, uint256 reserve);
+error BidIncrementTooSmall(uint256 bid, uint256 minBidRequired);
+error CallerNotOperator(address caller, address expected);
+error NoRefundOwed(address bidder, uint256 id);
+error RefundFailed(uint256 amount);
+error PayoutFailed(uint256 amount);
+
+event AuctionCreated(
+    uint256 indexed id,
+    string label,
+    uint256 reserve,
+    uint64 endTime,
+    address operator
+);
+
+event BidPlaced(
+    uint256 indexed id,
+    address indexed bidder,
+    uint256 bid,
+    address previousHighBidder,
+    uint256 previousHighBid
+);
+
+event AuctionSettled(
+    uint256 indexed id,
+    address indexed winner,
+    string label,
+    uint256 winningBid
+);
+
+event AuctionUnsold(uint256 indexed id, string label);
+
+event RefundWithdrawn(uint256 indexed id, address indexed bidder, uint256 amount);
+
+contract SBO3LSubnameAuction {
+    /// @notice Minimum bid increment over the current high bid, in
+    ///         basis points (1 bp = 0.01%). 500 bp = 5%.
+    uint256 public constant MIN_INCREMENT_BPS = 500;
+
+    /// @notice Bound on `duration` passed to `createAuction`.
+    uint64 public constant MIN_DURATION = 1 hours;
+    uint64 public constant MAX_DURATION = 7 days;
+
+    /// @notice Maximum subname-label length. ENS labels are bounded
+    ///         to 255 bytes by the registry; we further cap at 64
+    ///         bytes here to keep gas costs predictable.
+    uint256 public constant MAX_LABEL_BYTES = 64;
+
+    struct Auction {
+        string label;
+        uint256 reserve;
+        uint64 endTime;
+        address operator;
+        address highBidder;
+        uint256 highBid;
+        bool settled;
+    }
+
+    /// @notice Per-auction state. Sequence is the auction id; ids
+    ///         start at 0 and increment per `createAuction` call.
+    mapping(uint256 => Auction) internal _auctions;
+    uint256 public auctionCount;
+
+    /// @notice Per-(auction, bidder) refund balance. When a bidder
+    ///         is outbid, their stake moves here. Pull-pattern (vs
+    ///         push-pattern transfer) so a malicious previous bidder
+    ///         can't lock the auction with a revert-on-receive
+    ///         contract.
+    mapping(uint256 => mapping(address => uint256)) internal _refundsOwed;
+
+    /// @notice Create an auction. Caller becomes the operator entitled
+    ///         to the winning bid on settlement.
+    function createAuction(
+        string calldata label,
+        uint256 reserve,
+        uint64 duration
+    ) external returns (uint256 id) {
+        bytes memory labelBytes = bytes(label);
+        if (labelBytes.length == 0) revert InvalidLabel("empty");
+        if (labelBytes.length > MAX_LABEL_BYTES) revert InvalidLabel("too long");
+        for (uint256 i = 0; i < labelBytes.length; i++) {
+            bytes1 c = labelBytes[i];
+            // Allow lowercase a-z, 0-9, '-'. ENS DNS-label conventions.
+            bool ok = (c >= 0x61 && c <= 0x7A) // a-z
+                || (c >= 0x30 && c <= 0x39)    // 0-9
+                || c == 0x2D;                  // '-'
+            if (!ok) revert InvalidLabel("char");
+        }
+        // Reject leading/trailing hyphens for a hint of DNS hygiene.
+        if (labelBytes[0] == 0x2D || labelBytes[labelBytes.length - 1] == 0x2D) {
+            revert InvalidLabel("hyphen-edge");
+        }
+
+        if (reserve == 0) revert InvalidReserve(reserve);
+        if (duration < MIN_DURATION || duration > MAX_DURATION) {
+            revert InvalidDuration(duration);
+        }
+
+        id = auctionCount;
+        auctionCount = id + 1;
+        _auctions[id] = Auction({
+            label: label,
+            reserve: reserve,
+            endTime: uint64(block.timestamp) + duration,
+            operator: msg.sender,
+            highBidder: address(0),
+            highBid: 0,
+            settled: false
+        });
+        emit AuctionCreated(id, label, reserve, uint64(block.timestamp) + duration, msg.sender);
+    }
+
+    /// @notice Place a bid. Pay msg.value. Must be >= reserve for the
+    ///         first bid; subsequent bids must beat the current high
+    ///         by at least `MIN_INCREMENT_BPS` basis points.
+    function bid(uint256 id) external payable {
+        Auction storage a = _auctions[id];
+        if (a.endTime == 0) revert AuctionNotFound(id);
+        if (block.timestamp >= a.endTime) revert AuctionAlreadyEnded(id);
+
+        if (a.highBid == 0) {
+            // First bid — must clear reserve.
+            if (msg.value < a.reserve) revert BidBelowReserve(msg.value, a.reserve);
+        } else {
+            // Subsequent bid — must beat current high by min increment.
+            uint256 minRequired = a.highBid + (a.highBid * MIN_INCREMENT_BPS) / 10_000;
+            if (msg.value < minRequired) {
+                revert BidIncrementTooSmall(msg.value, minRequired);
+            }
+        }
+
+        address prevBidder = a.highBidder;
+        uint256 prevBid = a.highBid;
+
+        a.highBidder = msg.sender;
+        a.highBid = msg.value;
+
+        // Queue refund for the outbid bidder. Pull-pattern.
+        if (prevBidder != address(0)) {
+            _refundsOwed[id][prevBidder] += prevBid;
+        }
+
+        emit BidPlaced(id, msg.sender, msg.value, prevBidder, prevBid);
+    }
+
+    /// @notice Withdraw a queued refund. Pull-pattern protects the
+    ///         auction from a malicious previous bidder using a
+    ///         revert-on-receive contract.
+    function withdrawRefund(uint256 id) external returns (uint256 amount) {
+        amount = _refundsOwed[id][msg.sender];
+        if (amount == 0) revert NoRefundOwed(msg.sender, id);
+        _refundsOwed[id][msg.sender] = 0;
+        (bool ok, ) = payable(msg.sender).call{value: amount}("");
+        if (!ok) revert RefundFailed(amount);
+        emit RefundWithdrawn(id, msg.sender, amount);
+    }
+
+    /// @notice Settle an auction. Anyone can call after the end time;
+    ///         the operator collects the winning bid (if any).
+    ///         Idempotent — second call reverts with
+    ///         `AuctionAlreadySettled`.
+    function settle(uint256 id) external {
+        Auction storage a = _auctions[id];
+        if (a.endTime == 0) revert AuctionNotFound(id);
+        if (block.timestamp < a.endTime) revert AuctionStillRunning(id);
+        if (a.settled) revert AuctionAlreadySettled(id);
+
+        a.settled = true;
+
+        if (a.highBidder == address(0)) {
+            // No bids cleared the reserve.
+            emit AuctionUnsold(id, a.label);
+            return;
+        }
+
+        uint256 winningBid = a.highBid;
+        emit AuctionSettled(id, a.highBidder, a.label, winningBid);
+
+        (bool ok, ) = payable(a.operator).call{value: winningBid}("");
+        if (!ok) revert PayoutFailed(winningBid);
+    }
+
+    /// @notice Read an auction's full state. Returns the zero-shape
+    ///         for an unknown id (callers compare `endTime != 0`).
+    function getAuction(uint256 id) external view returns (Auction memory) {
+        return _auctions[id];
+    }
+
+    /// @notice Read the queued refund balance for (auction, bidder).
+    function refundOwed(uint256 id, address bidder) external view returns (uint256) {
+        return _refundsOwed[id][bidder];
+    }
+
+    /// @notice ERC-165 advertisement. Currently advertises only IERC165;
+    ///         specific auction interface id is reserved for future
+    ///         standardisation.
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == 0x01ffc9a7;
+    }
+}

--- a/crates/sbo3l-identity/contracts/script/DeploySubnameAuction.s.sol
+++ b/crates/sbo3l-identity/contracts/script/DeploySubnameAuction.s.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Script, console} from "forge-std/Script.sol";
+import {SBO3LSubnameAuction} from "../SBO3LSubnameAuction.sol";
+
+// Stateless deploy script for SBO3LSubnameAuction. Same pattern as
+// DeployReputationRegistry.s.sol — no constructor args; per-network
+// pin is captured by the deploy-shell wrapper.
+//
+// Usage:
+//   export PRIVATE_KEY=0x<deployer>
+//   forge script script/DeploySubnameAuction.s.sol \
+//     --rpc-url $SEPOLIA_RPC_URL --broadcast --verify
+contract DeploySubnameAuction is Script {
+    function run() external returns (SBO3LSubnameAuction auction) {
+        uint256 deployerKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerKey);
+        auction = new SBO3LSubnameAuction();
+        vm.stopBroadcast();
+        console.log("SBO3LSubnameAuction deployed to:", address(auction));
+    }
+}

--- a/crates/sbo3l-identity/contracts/test/SBO3LSubnameAuction.t.sol
+++ b/crates/sbo3l-identity/contracts/test/SBO3LSubnameAuction.t.sol
@@ -1,0 +1,416 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {
+    SBO3LSubnameAuction,
+    InvalidLabel,
+    InvalidReserve,
+    InvalidDuration,
+    AuctionNotFound,
+    AuctionAlreadyEnded,
+    AuctionStillRunning,
+    AuctionAlreadySettled,
+    BidBelowReserve,
+    BidIncrementTooSmall,
+    NoRefundOwed,
+    AuctionCreated,
+    BidPlaced,
+    AuctionSettled,
+    AuctionUnsold,
+    RefundWithdrawn
+} from "../SBO3LSubnameAuction.sol";
+
+contract RevertingReceiver {
+    function bid(SBO3LSubnameAuction auction, uint256 id) external payable {
+        auction.bid{value: msg.value}(id);
+    }
+
+    receive() external payable {
+        revert("nope");
+    }
+}
+
+contract SBO3LSubnameAuctionTest is Test {
+    SBO3LSubnameAuction internal auction;
+
+    address internal operator;
+    address internal alice;
+    address internal bob;
+    address internal carol;
+
+    function setUp() public {
+        auction = new SBO3LSubnameAuction();
+        operator = vm.addr(uint256(keccak256("operator")));
+        alice = vm.addr(uint256(keccak256("alice")));
+        bob = vm.addr(uint256(keccak256("bob")));
+        carol = vm.addr(uint256(keccak256("carol")));
+        vm.deal(alice, 100 ether);
+        vm.deal(bob, 100 ether);
+        vm.deal(carol, 100 ether);
+    }
+
+    // ============================================================
+    // createAuction
+    // ============================================================
+
+    function test_createAuction_assignsSequentialIds() public {
+        vm.prank(operator);
+        uint256 id1 = auction.createAuction("alpha", 1 ether, 1 days);
+        vm.prank(operator);
+        uint256 id2 = auction.createAuction("beta", 1 ether, 1 days);
+        assertEq(id1, 0);
+        assertEq(id2, 1);
+        assertEq(auction.auctionCount(), 2);
+    }
+
+    function test_createAuction_emitsEvent() public {
+        vm.expectEmit(true, false, false, true);
+        emit AuctionCreated(0, "alpha", 2 ether, uint64(block.timestamp) + 1 days, operator);
+        vm.prank(operator);
+        auction.createAuction("alpha", 2 ether, 1 days);
+    }
+
+    function test_createAuction_rejectsEmptyLabel() public {
+        vm.expectRevert(abi.encodeWithSelector(InvalidLabel.selector, "empty"));
+        auction.createAuction("", 1 ether, 1 days);
+    }
+
+    function test_createAuction_rejectsTooLongLabel() public {
+        bytes memory longLabel = new bytes(65);
+        for (uint256 i = 0; i < 65; i++) longLabel[i] = "a";
+        vm.expectRevert(abi.encodeWithSelector(InvalidLabel.selector, "too long"));
+        auction.createAuction(string(longLabel), 1 ether, 1 days);
+    }
+
+    function test_createAuction_rejectsInvalidChars() public {
+        vm.expectRevert(abi.encodeWithSelector(InvalidLabel.selector, "char"));
+        auction.createAuction("UPPERCASE", 1 ether, 1 days);
+
+        vm.expectRevert(abi.encodeWithSelector(InvalidLabel.selector, "char"));
+        auction.createAuction("under_score", 1 ether, 1 days);
+    }
+
+    function test_createAuction_rejectsLeadingTrailingHyphen() public {
+        vm.expectRevert(abi.encodeWithSelector(InvalidLabel.selector, "hyphen-edge"));
+        auction.createAuction("-alpha", 1 ether, 1 days);
+
+        vm.expectRevert(abi.encodeWithSelector(InvalidLabel.selector, "hyphen-edge"));
+        auction.createAuction("alpha-", 1 ether, 1 days);
+    }
+
+    function test_createAuction_rejectsZeroReserve() public {
+        vm.expectRevert(abi.encodeWithSelector(InvalidReserve.selector, 0));
+        auction.createAuction("alpha", 0, 1 days);
+    }
+
+    function test_createAuction_rejectsTooShortDuration() public {
+        vm.expectRevert(abi.encodeWithSelector(InvalidDuration.selector, uint64(59 minutes)));
+        auction.createAuction("alpha", 1 ether, 59 minutes);
+    }
+
+    function test_createAuction_rejectsTooLongDuration() public {
+        vm.expectRevert(abi.encodeWithSelector(InvalidDuration.selector, uint64(8 days)));
+        auction.createAuction("alpha", 1 ether, 8 days);
+    }
+
+    // ============================================================
+    // bid
+    // ============================================================
+
+    function _create() internal returns (uint256 id) {
+        vm.prank(operator);
+        id = auction.createAuction("premium-trader", 1 ether, 1 days);
+    }
+
+    function test_bid_firstBidMustClearReserve() public {
+        uint256 id = _create();
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(BidBelowReserve.selector, 0.5 ether, 1 ether));
+        auction.bid{value: 0.5 ether}(id);
+    }
+
+    function test_bid_firstBidAtReserveAccepted() public {
+        uint256 id = _create();
+        vm.prank(alice);
+        auction.bid{value: 1 ether}(id);
+        SBO3LSubnameAuction.Auction memory a = auction.getAuction(id);
+        assertEq(a.highBidder, alice);
+        assertEq(a.highBid, 1 ether);
+    }
+
+    function test_bid_subsequentBidMustBeatBy5Percent() public {
+        uint256 id = _create();
+        vm.prank(alice);
+        auction.bid{value: 1 ether}(id);
+
+        // 1 ether + 5% = 1.05 ether minimum.
+        vm.prank(bob);
+        vm.expectRevert(
+            abi.encodeWithSelector(BidIncrementTooSmall.selector, 1.04 ether, 1.05 ether)
+        );
+        auction.bid{value: 1.04 ether}(id);
+
+        // Exactly 5% accepted.
+        vm.prank(bob);
+        auction.bid{value: 1.05 ether}(id);
+        SBO3LSubnameAuction.Auction memory a = auction.getAuction(id);
+        assertEq(a.highBidder, bob);
+        assertEq(a.highBid, 1.05 ether);
+    }
+
+    function test_bid_outbidQueuesRefund() public {
+        uint256 id = _create();
+        vm.prank(alice);
+        auction.bid{value: 1 ether}(id);
+        vm.prank(bob);
+        auction.bid{value: 2 ether}(id);
+
+        assertEq(auction.refundOwed(id, alice), 1 ether);
+        assertEq(auction.refundOwed(id, bob), 0);
+    }
+
+    function test_bid_emitsEvent() public {
+        uint256 id = _create();
+        vm.expectEmit(true, true, false, true);
+        emit BidPlaced(id, alice, 1 ether, address(0), 0);
+        vm.prank(alice);
+        auction.bid{value: 1 ether}(id);
+
+        vm.expectEmit(true, true, false, true);
+        emit BidPlaced(id, bob, 2 ether, alice, 1 ether);
+        vm.prank(bob);
+        auction.bid{value: 2 ether}(id);
+    }
+
+    function test_bid_rejectsAfterEnd() public {
+        uint256 id = _create();
+        vm.warp(block.timestamp + 1 days + 1);
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(AuctionAlreadyEnded.selector, id));
+        auction.bid{value: 1 ether}(id);
+    }
+
+    function test_bid_rejectsUnknownAuction() public {
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(AuctionNotFound.selector, 99));
+        auction.bid{value: 1 ether}(99);
+    }
+
+    // ============================================================
+    // withdrawRefund
+    // ============================================================
+
+    function test_withdrawRefund_returnsOutbidStake() public {
+        uint256 id = _create();
+        vm.prank(alice);
+        auction.bid{value: 1 ether}(id);
+        vm.prank(bob);
+        auction.bid{value: 2 ether}(id);
+
+        uint256 balBefore = alice.balance;
+        vm.prank(alice);
+        uint256 amount = auction.withdrawRefund(id);
+        assertEq(amount, 1 ether);
+        assertEq(alice.balance, balBefore + 1 ether);
+        assertEq(auction.refundOwed(id, alice), 0);
+    }
+
+    function test_withdrawRefund_rejectsZeroBalance() public {
+        uint256 id = _create();
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(NoRefundOwed.selector, alice, id));
+        auction.withdrawRefund(id);
+    }
+
+    function test_withdrawRefund_idempotentRejectsDouble() public {
+        uint256 id = _create();
+        vm.prank(alice);
+        auction.bid{value: 1 ether}(id);
+        vm.prank(bob);
+        auction.bid{value: 2 ether}(id);
+        vm.prank(alice);
+        auction.withdrawRefund(id);
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(NoRefundOwed.selector, alice, id));
+        auction.withdrawRefund(id);
+    }
+
+    function test_withdrawRefund_pullPatternSurvivesRevertingPreviousBidder() public {
+        uint256 id = _create();
+        // Reverting bidder bids first.
+        RevertingReceiver attacker = new RevertingReceiver();
+        vm.deal(address(attacker), 10 ether);
+        attacker.bid{value: 1 ether}(auction, id);
+
+        // Bob outbids — push-style refund would fail here, but
+        // pull-pattern queues. Bid succeeds.
+        vm.prank(bob);
+        auction.bid{value: 2 ether}(id);
+        SBO3LSubnameAuction.Auction memory a = auction.getAuction(id);
+        assertEq(a.highBidder, bob);
+
+        // Attacker's refund is queued but not yet drawn. Settlement
+        // proceeds; attacker can never withdraw (their receive() reverts)
+        // but the auction is unblocked.
+        assertEq(auction.refundOwed(id, address(attacker)), 1 ether);
+    }
+
+    // ============================================================
+    // settle
+    // ============================================================
+
+    function test_settle_withWinnerPaysOperator() public {
+        uint256 id = _create();
+        vm.prank(alice);
+        auction.bid{value: 1 ether}(id);
+        vm.prank(bob);
+        auction.bid{value: 2 ether}(id);
+
+        vm.warp(block.timestamp + 1 days + 1);
+        uint256 opBefore = operator.balance;
+        vm.expectEmit(true, true, false, true);
+        emit AuctionSettled(id, bob, "premium-trader", 2 ether);
+        auction.settle(id);
+        assertEq(operator.balance, opBefore + 2 ether);
+        assertTrue(auction.getAuction(id).settled);
+    }
+
+    function test_settle_withoutWinnerEmitsUnsold() public {
+        uint256 id = _create();
+        vm.warp(block.timestamp + 1 days + 1);
+        vm.expectEmit(true, false, false, true);
+        emit AuctionUnsold(id, "premium-trader");
+        auction.settle(id);
+        assertTrue(auction.getAuction(id).settled);
+    }
+
+    function test_settle_rejectsBeforeEnd() public {
+        uint256 id = _create();
+        vm.expectRevert(abi.encodeWithSelector(AuctionStillRunning.selector, id));
+        auction.settle(id);
+    }
+
+    function test_settle_idempotentRejectsDouble() public {
+        uint256 id = _create();
+        vm.warp(block.timestamp + 1 days + 1);
+        auction.settle(id);
+        vm.expectRevert(abi.encodeWithSelector(AuctionAlreadySettled.selector, id));
+        auction.settle(id);
+    }
+
+    function test_settle_anyoneMayCall() public {
+        uint256 id = _create();
+        vm.prank(alice);
+        auction.bid{value: 1 ether}(id);
+        vm.warp(block.timestamp + 1 days + 1);
+        // carol settles (not the operator, not a bidder).
+        vm.prank(carol);
+        auction.settle(id);
+        assertTrue(auction.getAuction(id).settled);
+    }
+
+    // ============================================================
+    // ERC-165
+    // ============================================================
+
+    function test_supportsInterface() public view {
+        assertTrue(auction.supportsInterface(0x01ffc9a7));
+        assertFalse(auction.supportsInterface(0xdeadbeef));
+    }
+}
+
+/// @title  Fuzz suite for SBO3LSubnameAuction
+contract SBO3LSubnameAuctionFuzzTest is Test {
+    SBO3LSubnameAuction internal auction;
+    address internal operator;
+
+    function setUp() public {
+        auction = new SBO3LSubnameAuction();
+        operator = vm.addr(uint256(keccak256("fuzz-op")));
+    }
+
+    function testFuzz_durationBoundsRespected(uint64 duration) public {
+        vm.assume(duration >= 1 hours && duration <= 7 days);
+        vm.prank(operator);
+        uint256 id = auction.createAuction("alpha", 1 ether, duration);
+        assertEq(auction.getAuction(id).endTime, uint64(block.timestamp) + duration);
+    }
+
+    function testFuzz_durationOutOfBoundsRejected(uint64 duration) public {
+        vm.assume(duration < 1 hours || duration > 7 days);
+        vm.expectRevert(abi.encodeWithSelector(InvalidDuration.selector, duration));
+        auction.createAuction("alpha", 1 ether, duration);
+    }
+
+    function testFuzz_firstBidAlwaysAtLeastReserve(
+        uint256 reserve,
+        uint256 bidAmount
+    ) public {
+        reserve = bound(reserve, 1, 100 ether);
+        bidAmount = bound(bidAmount, 1, 100 ether);
+
+        vm.prank(operator);
+        uint256 id = auction.createAuction("alpha", reserve, 1 days);
+
+        address bidder = vm.addr(uint256(keccak256(abi.encode("bidder", reserve))));
+        vm.deal(bidder, bidAmount);
+
+        if (bidAmount < reserve) {
+            vm.prank(bidder);
+            vm.expectRevert(abi.encodeWithSelector(BidBelowReserve.selector, bidAmount, reserve));
+            auction.bid{value: bidAmount}(id);
+        } else {
+            vm.prank(bidder);
+            auction.bid{value: bidAmount}(id);
+            assertEq(auction.getAuction(id).highBid, bidAmount);
+        }
+    }
+
+    function testFuzz_subsequentBidMust5PercentBeatPrevious(
+        uint256 firstBid,
+        uint256 secondBid
+    ) public {
+        firstBid = bound(firstBid, 1 ether, 100 ether);
+        secondBid = bound(secondBid, 1, 200 ether);
+        uint256 minRequired = firstBid + (firstBid * 500) / 10_000;
+
+        vm.prank(operator);
+        uint256 id = auction.createAuction("alpha", firstBid, 1 days);
+
+        address alice = vm.addr(uint256(keccak256(abi.encode("a", firstBid))));
+        address bob = vm.addr(uint256(keccak256(abi.encode("b", firstBid))));
+        vm.deal(alice, firstBid);
+        vm.deal(bob, secondBid);
+
+        vm.prank(alice);
+        auction.bid{value: firstBid}(id);
+
+        if (secondBid < minRequired) {
+            vm.prank(bob);
+            vm.expectRevert(
+                abi.encodeWithSelector(BidIncrementTooSmall.selector, secondBid, minRequired)
+            );
+            auction.bid{value: secondBid}(id);
+        } else {
+            vm.prank(bob);
+            auction.bid{value: secondBid}(id);
+            assertEq(auction.getAuction(id).highBidder, bob);
+        }
+    }
+
+    function testFuzz_settleAfterEndAlwaysSucceedsWhenUnsettled(
+        uint256 reserve,
+        uint64 duration
+    ) public {
+        reserve = bound(reserve, 1, 10 ether);
+        duration = uint64(bound(duration, 1 hours, 7 days));
+
+        vm.prank(operator);
+        uint256 id = auction.createAuction("alpha", reserve, duration);
+
+        vm.warp(block.timestamp + duration + 1);
+        auction.settle(id);
+        assertTrue(auction.getAuction(id).settled);
+    }
+}


### PR DESCRIPTION
## Summary

24-hour English auction with 5% min bid increment, optional reserve, and pull-pattern refunds (revert-on-receive bidder can't lock the auction).

**Right-of-issuance, NOT subname custody**: contract escrows bids only. After settlement the operator runs the existing `sbo3l agent register --broadcast` flow against the winning bidder. Keeps the contract small + no ENS Registry integration risk.

## Tests

- 26 unit tests (label validation, bid lifecycle, settle paths, ERC-165, pull-pattern survival)
- 5 fuzz tests at **10 000 runs each** (duration bounds, reserve invariant, increment invariant, settle-after-end)
- **31/31 pass**

## Test plan

- [x] `forge test --fuzz-runs 10000` — 31/31
- [x] Slither CI gate from R9 P11 #240 will run automatically
- [ ] Sepolia deploy follow-up via `script/DeploySubnameAuction.s.sol`

🤖 Generated with [Claude Code](https://claude.com/claude-code)