### PR TITLE
feat(hosted-app): recharts decision viz on /admin/audit (R13 P3)

### DIFF
--- a/apps/hosted-app/app/admin/audit/AuditTimeline.tsx
+++ b/apps/hosted-app/app/admin/audit/AuditTimeline.tsx
@@ -1,33 +1,18 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import { isTimelineEvent, KIND_LABEL, type ConnState, type TimelineEvent } from "./audit-types";
 
 // Mirrors apps/trust-dns-viz/src/events.ts. Server emits the same
-// shape on /v1/events. Keep the union narrow + extend as Dev 1 ships
-// new event kinds.
-export type TimelineEvent =
-  | { kind: "agent.discovered";    agent_id: string; ens_name: string; pubkey_b58: string; ts_ms: number }
-  | { kind: "attestation.signed";  from: string; to: string; attestation_id: string; ts_ms: number }
-  | { kind: "decision.made";       agent_id: string; decision: "allow" | "deny"; deny_code?: string; ts_ms: number; intent?: string }
-  | { kind: "audit.checkpoint";    agent_id: string; chain_length: number; root_hash: string; ts_ms: number }
-  | { kind: "execution.confirmed"; agent_id: string; execution_ref: string; sponsor: string; ts_ms: number }
-  | { kind: "flag.changed";        flag_name: string; enabled: boolean; changed_by: string; ts_ms: number };
+// shape on /v1/events. Type union lives in ./audit-types so DecisionChart
+// can share it without circular imports.
+export type { TimelineEvent } from "./audit-types";
 
 interface Props {
   wsUrl: string;
 }
 
 const MAX_EVENTS = 200;
-const KIND_LABEL: Record<TimelineEvent["kind"], string> = {
-  "agent.discovered":    "agent.discovered",
-  "attestation.signed":  "attestation.signed",
-  "decision.made":       "decision.made",
-  "audit.checkpoint":    "audit.checkpoint",
-  "execution.confirmed": "execution.confirmed",
-  "flag.changed":        "flag.changed",
-};
-
-type ConnState = "connecting" | "live" | "offline";
 
 export function AuditTimeline({ wsUrl }: Props): JSX.Element {
   const [events, setEvents] = useState<TimelineEvent[]>([]);
@@ -158,12 +143,6 @@ export function AuditTimeline({ wsUrl }: Props): JSX.Element {
       </ol>
     </div>
   );
-}
-
-function isTimelineEvent(value: unknown): value is TimelineEvent {
-  if (typeof value !== "object" || value === null) return false;
-  const v = value as { kind?: unknown };
-  return typeof v.kind === "string" && v.kind in KIND_LABEL;
 }
 
 function matchesFilter(e: TimelineEvent, agentFilter: string, kindFilter: TimelineEvent["kind"] | ""): boolean {

--- a/apps/hosted-app/app/admin/audit/DecisionChart.tsx
+++ b/apps/hosted-app/app/admin/audit/DecisionChart.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  PieChart, Pie, Cell, ResponsiveContainer, Tooltip,
+  BarChart, Bar, XAxis, YAxis,
+} from "recharts";
+import { isTimelineEvent, type ConnState, type TimelineEvent } from "./audit-types";
+
+interface Props {
+  wsUrl: string;
+}
+
+const MAX_EVENTS = 500;
+const ALLOW_FILL = "#4ade80";
+const DENY_FILL = "#f87171";
+
+export function DecisionChart({ wsUrl }: Props): JSX.Element {
+  const [events, setEvents] = useState<TimelineEvent[]>([]);
+  const [state, setState] = useState<ConnState>("connecting");
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimer = useRef<number | null>(null);
+
+  useEffect(() => {
+    const connect = (): void => {
+      setState("connecting");
+      let ws: WebSocket;
+      try {
+        ws = new WebSocket(wsUrl);
+      } catch {
+        setState("offline");
+        reconnectTimer.current = window.setTimeout(connect, 3000);
+        return;
+      }
+      wsRef.current = ws;
+      ws.addEventListener("open", () => setState("live"));
+      ws.addEventListener("message", (msg) => {
+        try {
+          const ev = JSON.parse(msg.data as string) as unknown;
+          if (!isTimelineEvent(ev)) return;
+          setEvents((prev) => [ev, ...prev].slice(0, MAX_EVENTS));
+        } catch { /* ignore malformed */ }
+      });
+      ws.addEventListener("close", () => {
+        setState("offline");
+        reconnectTimer.current = window.setTimeout(connect, 3000);
+      });
+      ws.addEventListener("error", () => setState("offline"));
+    };
+    connect();
+    return () => {
+      if (reconnectTimer.current !== null) window.clearTimeout(reconnectTimer.current);
+      wsRef.current?.close();
+    };
+  }, [wsUrl]);
+
+  const decisionData = useMemo(() => {
+    let allow = 0, deny = 0;
+    for (const e of events) {
+      if (e.kind !== "decision.made") continue;
+      if (e.decision === "allow") allow += 1;
+      else deny += 1;
+    }
+    return [
+      { name: "allow", value: allow, fill: ALLOW_FILL },
+      { name: "deny",  value: deny,  fill: DENY_FILL },
+    ];
+  }, [events]);
+
+  const denyCodeData = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const e of events) {
+      if (e.kind !== "decision.made" || e.decision !== "deny" || !e.deny_code) continue;
+      counts.set(e.deny_code, (counts.get(e.deny_code) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .map(([code, count]) => ({ code, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 6);
+  }, [events]);
+
+  const totalDecisions = decisionData[0].value + decisionData[1].value;
+
+  return (
+    <section style={{ marginBottom: "1.5em", display: "grid", gridTemplateColumns: "1fr 2fr", gap: "1em", alignItems: "stretch" }}>
+      <div style={{ background: "var(--code-bg)", border: "1px solid var(--border)", borderRadius: "var(--r-md)", padding: "0.8em 1em" }}>
+        <h2 style={{ margin: "0 0 0.4em", fontSize: "0.95em" }}>
+          Decisions
+          <span style={{ marginLeft: "0.6em", color: "var(--muted)", fontSize: "0.8em", fontFamily: "var(--font-mono)" }}>
+            {state === "live" ? `● ${totalDecisions} in window` : `● ${state}`}
+          </span>
+        </h2>
+        {totalDecisions === 0 ? (
+          <p style={{ color: "var(--muted)", fontSize: "0.85em", margin: 0, padding: "2em 0", textAlign: "center" }}>
+            Waiting for decisions…
+          </p>
+        ) : (
+          <ResponsiveContainer width="100%" height={180}>
+            <PieChart>
+              <Pie data={decisionData} dataKey="value" nameKey="name" innerRadius={40} outerRadius={70} paddingAngle={2}>
+                {decisionData.map((d) => <Cell key={d.name} fill={d.fill} />)}
+              </Pie>
+              <Tooltip contentStyle={{ background: "var(--code-bg)", border: "1px solid var(--border)", borderRadius: 4 }} />
+            </PieChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+      <div style={{ background: "var(--code-bg)", border: "1px solid var(--border)", borderRadius: "var(--r-md)", padding: "0.8em 1em" }}>
+        <h2 style={{ margin: "0 0 0.4em", fontSize: "0.95em" }}>Top deny reasons</h2>
+        {denyCodeData.length === 0 ? (
+          <p style={{ color: "var(--muted)", fontSize: "0.85em", margin: 0, padding: "2em 0", textAlign: "center" }}>
+            No denies in window — policies are letting everything through.
+          </p>
+        ) : (
+          <ResponsiveContainer width="100%" height={180}>
+            <BarChart data={denyCodeData} layout="vertical" margin={{ left: 12, right: 12, top: 4, bottom: 4 }}>
+              <XAxis type="number" hide />
+              <YAxis type="category" dataKey="code" width={140} tick={{ fill: "var(--muted)", fontSize: 11, fontFamily: "var(--font-mono)" }} axisLine={false} tickLine={false} />
+              <Tooltip contentStyle={{ background: "var(--code-bg)", border: "1px solid var(--border)", borderRadius: 4 }} />
+              <Bar dataKey="count" fill={DENY_FILL} radius={[0, 4, 4, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/hosted-app/app/admin/audit/audit-types.ts
+++ b/apps/hosted-app/app/admin/audit/audit-types.ts
@@ -1,0 +1,29 @@
+// Shared types + WS plumbing for the audit page.
+// Both <AuditTimeline> (textual feed) and <DecisionChart> (recharts viz)
+// consume the same /v1/events shape. Keeping the union in one place
+// avoids drift when Dev 1 ships new event kinds.
+
+export type TimelineEvent =
+  | { kind: "agent.discovered";    agent_id: string; ens_name: string; pubkey_b58: string; ts_ms: number }
+  | { kind: "attestation.signed";  from: string; to: string; attestation_id: string; ts_ms: number }
+  | { kind: "decision.made";       agent_id: string; decision: "allow" | "deny"; deny_code?: string; ts_ms: number; intent?: string }
+  | { kind: "audit.checkpoint";    agent_id: string; chain_length: number; root_hash: string; ts_ms: number }
+  | { kind: "execution.confirmed"; agent_id: string; execution_ref: string; sponsor: string; ts_ms: number }
+  | { kind: "flag.changed";        flag_name: string; enabled: boolean; changed_by: string; ts_ms: number };
+
+export type ConnState = "connecting" | "live" | "offline";
+
+export const KIND_LABEL: Record<TimelineEvent["kind"], string> = {
+  "agent.discovered":    "agent.discovered",
+  "attestation.signed":  "attestation.signed",
+  "decision.made":       "decision.made",
+  "audit.checkpoint":    "audit.checkpoint",
+  "execution.confirmed": "execution.confirmed",
+  "flag.changed":        "flag.changed",
+};
+
+export function isTimelineEvent(value: unknown): value is TimelineEvent {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as { kind?: unknown };
+  return typeof v.kind === "string" && v.kind in KIND_LABEL;
+}

--- a/apps/hosted-app/app/admin/audit/page.tsx
+++ b/apps/hosted-app/app/admin/audit/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { eventsWebSocketUrl } from "@/lib/sbo3l-client";
 import { AuditTimeline } from "./AuditTimeline";
+import { DecisionChart } from "./DecisionChart";
 
 export const dynamic = "force-dynamic";
 
@@ -26,6 +27,7 @@ export default function AdminAuditPage() {
         events scroll off (full chain remains in the daemon's audit DB).
       </p>
 
+      <DecisionChart wsUrl={wsUrl} />
       <AuditTimeline wsUrl={wsUrl} />
 
       <aside style={{ marginTop: "2em", padding: "1em 1.2em", background: "var(--code-bg)", border: "1px solid var(--border)", borderLeft: "3px solid var(--accent)", borderRadius: "var(--r-md)", color: "var(--muted)", fontSize: "0.9em" }}>

--- a/apps/hosted-app/package.json
+++ b/apps/hosted-app/package.json
@@ -17,6 +17,7 @@
     "next-auth": "5.0.0-beta.20",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "recharts": "^2.13.0",
     "swr": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Adds **two real-time charts** above the existing audit timeline:
- **Allow vs Deny** pie chart (rolling 500-event window)
- **Top deny reasons** horizontal bar chart (deny_code histogram, top 6)

Both subscribe to \`/v1/events\` via their own WebSocket — no shared state with \`AuditTimeline\` so existing tail behaviour is unchanged. Type union extracted to \`audit-types.ts\` so both components share it without circular imports.

## CSP

\`recharts\` ships pure JS (SVG-rendered), no inline scripts. Strict \`default-src 'self'; style-src 'self' 'unsafe-inline'\` covers it.

## Test plan

- [ ] CI typecheck green (recharts 2.13+ has React 19 support)
- [ ] Page renders both charts above timeline at /admin/audit
- [ ] Empty state copy shows when no decisions in window
- [ ] No regression on AuditTimeline filter/export behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)