### PR TITLE
feat(hosted-app): Monaco policy editor at /t/[slug]/admin/policy/edit (R13 P6)

### DIFF
--- a/apps/hosted-app/app/t/[tenant]/admin/policy/edit/PolicyEditor.tsx
+++ b/apps/hosted-app/app/t/[tenant]/admin/policy/edit/PolicyEditor.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useState } from "react";
+
+// Monaco is heavy + browser-only — dynamic import so it stays out of
+// the server bundle and the SSR pass. The wrapper handles its own
+// lazy AMD loader; we just feed it props.
+const MonacoEditor = dynamic(
+  () => import("@monaco-editor/react").then((m) => m.default),
+  { ssr: false, loading: () => <p style={{ color: "var(--muted)", padding: "1em" }}>Loading editor…</p> },
+);
+
+interface Props {
+  initialYaml: string;
+  version: number;
+  signedBy: string;
+  updatedAt: string;
+  tenantSlug: string;
+}
+
+type SaveState = "idle" | "validating" | "saving" | "saved" | "error";
+
+export function PolicyEditor({ initialYaml, version, signedBy, updatedAt, tenantSlug }: Props): JSX.Element {
+  const [yaml, setYaml] = useState(initialYaml);
+  const [state, setState] = useState<SaveState>("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+  const dirty = yaml !== initialYaml;
+
+  const onValidate = (): void => {
+    setState("validating");
+    setErrorMsg("");
+    // Mock client-side validation. Real impl: POST to daemon
+    // /v1/tenants/<slug>/policy/validate which returns parse errors
+    // with line numbers so we can decorate Monaco markers.
+    setTimeout(() => {
+      if (!yaml.includes("schema: sbo3l.policy.v1")) {
+        setState("error");
+        setErrorMsg("Missing required field: schema: sbo3l.policy.v1");
+        return;
+      }
+      setState("saved");
+      setErrorMsg("Validation passed (mock — daemon-side validation pending P3.5).");
+    }, 400);
+  };
+
+  const onSave = (): void => {
+    setState("saving");
+    // Mock save. Real impl: POST /v1/tenants/<slug>/policy with the
+    // YAML body + If-Match: <version> for optimistic concurrency.
+    setTimeout(() => {
+      setState("saved");
+      setErrorMsg(`Saved as draft v${version + 1} (mock — daemon round-trip pending P3.5).`);
+    }, 600);
+  };
+
+  return (
+    <div style={{ display: "grid", gap: "1em" }}>
+      <header style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", flexWrap: "wrap", gap: "0.6em" }}>
+        <span style={{ color: "var(--muted)", fontSize: "0.9em", fontFamily: "var(--font-mono)" }}>
+          {tenantSlug} · v{version} · signed by <code>{signedBy}</code> · updated {new Date(updatedAt).toLocaleDateString()}
+        </span>
+        <span style={{ fontSize: "0.85em", color: dirty ? "var(--accent)" : "var(--muted)" }}>
+          {dirty ? "● unsaved changes" : "○ no changes"}
+        </span>
+      </header>
+      <div style={{ border: "1px solid var(--border)", borderRadius: "var(--r-md)", overflow: "hidden" }}>
+        <MonacoEditor
+          height="60vh"
+          defaultLanguage="yaml"
+          theme="vs-dark"
+          value={yaml}
+          onChange={(v) => setYaml(v ?? "")}
+          options={{
+            fontFamily: "var(--font-mono), Menlo, Monaco, monospace",
+            fontSize: 13,
+            minimap: { enabled: false },
+            scrollBeyondLastLine: false,
+            wordWrap: "on",
+            tabSize: 2,
+            renderWhitespace: "boundary",
+            automaticLayout: true,
+          }}
+        />
+      </div>
+      <footer style={{ display: "flex", gap: "0.6em", alignItems: "center", flexWrap: "wrap" }}>
+        <button onClick={onValidate} disabled={state === "validating" || state === "saving"} className="ghost">
+          {state === "validating" ? "Validating…" : "Validate"}
+        </button>
+        <button onClick={onSave} disabled={!dirty || state === "saving" || state === "validating"}>
+          {state === "saving" ? "Saving…" : "Save draft"}
+        </button>
+        {errorMsg && (
+          <span style={{ fontSize: "0.85em", color: state === "error" ? "#f87171" : "var(--muted)" }}>{errorMsg}</span>
+        )}
+      </footer>
+    </div>
+  );
+}

--- a/apps/hosted-app/app/t/[tenant]/admin/policy/edit/page.tsx
+++ b/apps/hosted-app/app/t/[tenant]/admin/policy/edit/page.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { auth } from "@/auth";
+import { tenantBySlug, userHasAccessTo } from "@/lib/tenants";
+import { policyForTenant } from "@/lib/tenant-policies";
+import { PolicyEditor } from "./PolicyEditor";
+
+interface Props { params: Promise<{ tenant: string }> }
+
+export const dynamic = "force-dynamic";
+
+export default async function TenantPolicyEditPage({ params }: Props): Promise<JSX.Element> {
+  const { tenant: slug } = await params;
+  const tenant = tenantBySlug(slug);
+  if (!tenant) notFound();
+
+  const session = await auth();
+  const userId = session?.user?.githubLogin ?? session?.user?.email ?? null;
+  const membership = userHasAccessTo(userId, slug);
+  if (!membership) notFound();
+  // Editing the policy is an admin-only operation; viewers + operators
+  // see a read-only message linking back to dashboard. notFound() is
+  // already enforced by the tenant guard for non-members.
+  if (membership.role !== "admin") {
+    return (
+      <main>
+        <h1>Policy editor — {tenant.display_name}</h1>
+        <p style={{ color: "var(--muted)", margin: "1em 0", maxWidth: 760 }}>
+          Your role is <code>{membership.role}</code>. Only <code>admin</code>
+          can modify the tenant policy. Ask an admin in your tenant to invite
+          you with the higher role.
+        </p>
+        <p>
+          <Link href={`/t/${slug}/dashboard`}>← Back to dashboard</Link>
+        </p>
+      </main>
+    );
+  }
+
+  const policy = policyForTenant(slug);
+  if (!policy) notFound();
+
+  return (
+    <main>
+      <header style={{ marginBottom: "1.2em" }}>
+        <h1 style={{ marginBottom: "0.2em" }}>Policy editor — {tenant.display_name}</h1>
+        <p style={{ color: "var(--muted)", margin: 0, maxWidth: 760 }}>
+          The YAML below overrides <code>sbo3l.root@1</code> for tenant
+          <code> {slug}</code>. Saved drafts are signed by your admin key
+          and pushed to the daemon's signed-policy store. Live policy serves
+          from the daemon — drafts here don't take effect until promoted.
+        </p>
+      </header>
+      <PolicyEditor
+        initialYaml={policy.yaml}
+        version={policy.version}
+        signedBy={policy.signed_by}
+        updatedAt={policy.updated_at}
+        tenantSlug={slug}
+      />
+    </main>
+  );
+}

--- a/apps/hosted-app/app/t/[tenant]/layout.tsx
+++ b/apps/hosted-app/app/t/[tenant]/layout.tsx
@@ -39,6 +39,9 @@ export default async function TenantLayout({ children, params }: Props): Promise
           {(membership.role === "admin" || membership.role === "operator") && (
             <Link href={`/t/${slug}/admin/audit`}>Admin</Link>
           )}
+          {membership.role === "admin" && (
+            <Link href={`/t/${slug}/admin/policy/edit`}>Policy</Link>
+          )}
         </nav>
         <div style={{ display: "flex", gap: "0.6em", alignItems: "center" }}>
           <TenantSwitcher

--- a/apps/hosted-app/lib/tenant-policies.ts
+++ b/apps/hosted-app/lib/tenant-policies.ts
@@ -1,0 +1,112 @@
+// Mock per-tenant policy YAML. The real source of truth is the daemon
+// (P3.5: GET /v1/tenants/<slug>/policy returns signed YAML + version).
+// This stub exists so the Monaco editor at /t/[slug]/admin/policy/edit
+// has realistic content to render and round-trip during demos.
+//
+// Schema: sbo3l.policy.v1 (see crates/sbo3l-policy/src/schema.rs).
+// _Tenant policies inherit from the tenant's root mandate_ — only the
+// override surface is shown here, not the full effective set.
+
+export interface TenantPolicy {
+  yaml: string;
+  version: number;
+  updated_at: string;
+  signed_by: string;
+}
+
+const ACME_POLICY = `# acme.sbo3lagent.eth — policy override v3
+# Inherits: sbo3l.root@1
+schema: sbo3l.policy.v1
+tenant: acme
+version: 3
+updated_at: 2026-04-29T15:42:00Z
+
+intents:
+  - name: erc20.transfer
+    where:
+      to:    { allowlist: [acme-treasury, acme-payroll] }
+      token: { allowlist: [USDC, USDT, DAI] }
+      amount: { lte_per_24h: 50000 }
+    require:
+      - human_2fa: true
+        when: { amount: { gt: 10000 } }
+
+  - name: uniswap.swap
+    where:
+      tokenIn:  { allowlist: [USDC, WETH] }
+      tokenOut: { allowlist: [USDC, WETH] }
+      slippage_bps: { lte: 50 }
+
+  - name: cron.payroll
+    where:
+      schedule: "0 9 1,15 * *"   # 1st + 15th, 09:00 UTC
+    require:
+      - tier: pro
+`;
+
+const CONTOSO_POLICY = `# contoso.sbo3lagent.eth — policy override v1
+# Inherits: sbo3l.root@1
+# (Free tier — most overrides locked; upgrade for full surface.)
+schema: sbo3l.policy.v1
+tenant: contoso
+version: 1
+updated_at: 2026-04-22T14:30:00Z
+
+intents:
+  - name: erc20.transfer
+    where:
+      amount: { lte_per_24h: 1000 }   # free-tier cap
+    require:
+      - human_2fa: true
+`;
+
+const FABRIKAM_POLICY = `# fabrikam.sbo3lagent.eth — policy override v7
+# Inherits: sbo3l.root@1, fabrikam.compliance@2
+schema: sbo3l.policy.v1
+tenant: fabrikam
+version: 7
+updated_at: 2026-05-01T11:18:00Z
+
+intents:
+  - name: erc20.transfer
+    where:
+      to:    { allowlist_resolver: ens, suffix: ".fabrikam.eth" }
+      token: { allowlist: [USDC, EURC] }
+      amount: { lte_per_24h: 250000 }
+    require:
+      - quorum:    2_of_3
+        signers:   [treasury-ops, treasury-cfo, treasury-cto]
+      - audit_log: enterprise
+
+  - name: opencompute.train
+    where:
+      model: { allowlist: [llama-3-8b, mistral-7b] }
+      duration_minutes: { lte: 240 }
+    require:
+      - tier: enterprise
+`;
+
+const POLICIES: Record<string, TenantPolicy> = {
+  acme: {
+    yaml: ACME_POLICY,
+    version: 3,
+    updated_at: "2026-04-29T15:42:00Z",
+    signed_by: "acme-admin@acme.sbo3lagent.eth",
+  },
+  contoso: {
+    yaml: CONTOSO_POLICY,
+    version: 1,
+    updated_at: "2026-04-22T14:30:00Z",
+    signed_by: "contoso-admin@contoso.sbo3lagent.eth",
+  },
+  fabrikam: {
+    yaml: FABRIKAM_POLICY,
+    version: 7,
+    updated_at: "2026-05-01T11:18:00Z",
+    signed_by: "fabrikam-cto@fabrikam.sbo3lagent.eth",
+  },
+};
+
+export function policyForTenant(slug: string): TenantPolicy | undefined {
+  return POLICIES[slug];
+}

--- a/apps/hosted-app/package.json
+++ b/apps/hosted-app/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.6.0",
     "@sbo3l/design-tokens": "file:../../packages/design-tokens",
     "next": "^15.0.0",
     "next-auth": "5.0.0-beta.20",


### PR DESCRIPTION
## Summary

Per-tenant policy editor — **admin-only**, Monaco-backed, YAML mode + dark theme. Mock policies seeded for **acme** (v3), **contoso** (v1, free-tier), **fabrikam** (v7, enterprise quorum) so the editor has realistic content during demos.

## Components

- **\`page.tsx\`** (server) — tenant + admin-role gate. Non-admins see a read-only message rather than 404 so they understand they need a role promotion.
- **\`PolicyEditor.tsx\`** (client) — dynamic import of \`@monaco-editor/react\` with \`ssr: false\` so Monaco stays out of the server bundle. Validate + Save buttons mock the daemon round-trip (real wiring in P3.5).
- **\`lib/tenant-policies.ts\`** — mock per-tenant YAML; will be replaced when daemon serves \`GET /v1/tenants/<slug>/policy\`.

## Layout change

The admin nav exposes a new **Policy** link only when \`role === \"admin\"\` (operator + viewer don't see it).

## CSP note

\`@monaco-editor/react\` loads its AMD bundle from jsdelivr by default. Production CSP will need:

\`\`\`
script-src 'self' https://cdn.jsdelivr.net;
worker-src 'self' https://cdn.jsdelivr.net;
\`\`\`

OR a self-hosted vendored Monaco bundle. Hosted-app has no explicit CSP today so no immediate regression; **flagging for the production hardening pass**.

## Test plan

- [ ] CI typecheck green
- [ ] /t/acme/admin/policy/edit renders Monaco for admin user
- [ ] /t/contoso/admin/policy/edit shows read-only message for viewer/operator role
- [ ] Save + Validate buttons toggle states without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)