### PR TITLE
feat(marketing): polish bundle — OG image + Twitter card + DocSearch runbook (R13 P7)

### DIFF
--- a/apps/marketing/public/og-default.svg
+++ b/apps/marketing/public/og-default.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0a0e1a"/>
+      <stop offset="1" stop-color="#111827"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#4ade80"/>
+      <stop offset="1" stop-color="#22c55e"/>
+    </linearGradient>
+    <filter id="glow"><feGaussianBlur stdDeviation="6"/></filter>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g opacity="0.08" stroke="#4ade80" stroke-width="1" fill="none">
+    <circle cx="900" cy="200" r="80"/>
+    <circle cx="900" cy="200" r="140"/>
+    <circle cx="900" cy="200" r="200"/>
+    <line x1="900" y1="80" x2="900" y2="320"/>
+    <line x1="780" y1="200" x2="1020" y2="200"/>
+  </g>
+  <g transform="translate(80, 120)">
+    <text font-family="ui-monospace, SF Mono, Menlo, monospace" font-size="22" font-weight="700" fill="url(#accent)" letter-spacing="4">SBO3L</text>
+    <text font-family="system-ui, -apple-system, Segoe UI, sans-serif" font-size="64" font-weight="800" fill="#f5f5f5" y="80">
+      <tspan x="0" dy="0">Don't give your agent</tspan>
+      <tspan x="0" dy="80">a wallet.</tspan>
+    </text>
+    <text font-family="system-ui, -apple-system, Segoe UI, sans-serif" font-size="64" font-weight="800" fill="url(#accent)" y="240">
+      Give it a mandate.
+    </text>
+    <rect x="0" y="290" width="80" height="3" fill="url(#accent)"/>
+    <text font-family="system-ui, -apple-system, Segoe UI, sans-serif" font-size="24" fill="#9ca3af" y="340" font-weight="400">
+      <tspan x="0" dy="0">The cryptographically verifiable trust</tspan>
+      <tspan x="0" dy="36">layer for autonomous AI agents.</tspan>
+    </text>
+  </g>
+  <g transform="translate(80, 540)" font-family="ui-monospace, SF Mono, Menlo, monospace" font-size="16" fill="#6b7280">
+    <text>ETHGlobal Open Agents 2026</text>
+    <text x="0" y="22" fill="#9ca3af">github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026</text>
+  </g>
+</svg>

--- a/apps/marketing/src/layouts/BaseLayout.astro
+++ b/apps/marketing/src/layouts/BaseLayout.astro
@@ -27,6 +27,14 @@ const {
     <meta property="og:title" content={ogTitle} />
     <meta property="og:description" content="Don't give your agent a wallet. Give it a mandate." />
     <meta property="og:type" content="website" />
+    <meta property="og:image" content="/og-default.svg" />
+    <meta property="og:image:alt" content="SBO3L — the cryptographically verifiable trust layer for autonomous AI agents." />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={ogTitle} />
+    <meta name="twitter:description" content="Don't give your agent a wallet. Give it a mandate." />
+    <meta name="twitter:image" content="/og-default.svg" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
   </head>
   <body>

--- a/docs/dev3/ALGOLIA-DOCSEARCH-SETUP.md
+++ b/docs/dev3/ALGOLIA-DOCSEARCH-SETUP.md
@@ -1,0 +1,58 @@
+# Algolia DocSearch — application + wiring runbook
+
+DocSearch is Algolia's free hosted search for OSS docs. Approved projects get an
+app ID + crawler config; the snippet below mounts the search box. This runbook
+documents the application path so the project can ship search the moment the
+keys land.
+
+## Application
+
+1. Apply at https://docsearch.algolia.com/apply
+2. Provide:
+   - Repo URL: `https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026`
+   - Docs URL: `https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/docs/`
+   - License: MIT (verified — root LICENSE)
+   - Owner email: `babjak_daniel@hotmail.com`
+3. Algolia replies in 1–2 weeks with `appId`, `apiKey`, `indexName`.
+
+## Wiring (one PR after keys land)
+
+Install:
+```sh
+pnpm --filter @sbo3l/docs add @docsearch/react @docsearch/css
+```
+
+Mount via Starlight component override (already used for the version selector
+in `apps/docs/src/components/StarlightOverrides.tsx`):
+
+```tsx
+import { DocSearch } from "@docsearch/react";
+import "@docsearch/css";
+
+export function SearchBox() {
+  return (
+    <DocSearch
+      appId={import.meta.env.PUBLIC_ALGOLIA_APP_ID}
+      apiKey={import.meta.env.PUBLIC_ALGOLIA_SEARCH_KEY}
+      indexName="sbo3l"
+    />
+  );
+}
+```
+
+Set `PUBLIC_ALGOLIA_APP_ID` + `PUBLIC_ALGOLIA_SEARCH_KEY` in Vercel env. The
+search-only key is safe to expose client-side.
+
+## Until approved
+
+Starlight ships pagefind built-in for static-site search — no external service
+needed and already works on the docs build. Pagefind covers ~80% of DocSearch's
+value (typo tolerance, prefix match, snippet preview). DocSearch wins on
+analytics + cross-version search; not blocking for hackathon submission.
+
+## Why this is a stub PR
+
+Hackathon judges expect to see "we know what production polish looks like."
+Shipping the runbook + meta-tags now means the demo URLs render correctly when
+shared on Twitter/LinkedIn (open graph) and the search story is visible
+without burning hackathon time on a 2-week approval queue.


### PR DESCRIPTION
## Summary

Three pieces of \"shareable submission\" polish:

1. **Branded OG image** at \`/og-default.svg\` — 1200×630, wallet→mandate tagline
2. **og:image + twitter:card meta tags** in BaseLayout — every route inherits
3. **DocSearch application runbook** at \`docs/dev3/ALGOLIA-DOCSEARCH-SETUP.md\` — 1-PR wiring template for when keys arrive

## Lottie deferred

No animation asset ready — landing a stub Lottie player without a JSON animation is just dead bundle. Easy to add when an animation lands: one component import + one route insertion.

## Test plan

- [ ] Twitter Card Validator (https://cards-dev.twitter.com/validator) renders correctly when given the deployed marketing URL
- [ ] OG SVG visible at \`/og-default.svg\` on Vercel deploy
- [ ] DocSearch runbook accurate for current Starlight setup
- [ ] BaseLayout still passes existing CSP (img-src 'self')

🤖 Generated with [Claude Code](https://claude.com/claude-code)