### PR TITLE
test(fuzz): cargo-fuzz harnesses + nightly workflow + OSS-Fuzz scaffolding (R13 P3)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,146 @@
+name: Fuzz harnesses
+
+# R13 P3 — nightly fuzzing for parsers + verifiers reachable from
+# untrusted input. Each target runs 10 min/night (50 min total) on the
+# free GitHub-hosted runners. OSS-Fuzz integration runs separately via
+# Google's infrastructure once submitted.
+#
+# Run locally:
+#   cargo install cargo-fuzz
+#   cd fuzz && cargo fuzz run aprp_parser -- -max_total_time=600
+
+on:
+  schedule:
+    # 04:00 UTC nightly.
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+    inputs:
+      duration_seconds:
+        description: "Per-target fuzz duration in seconds (default 600)"
+        required: false
+        default: "600"
+      target_filter:
+        description: "Only run a specific target (default: all)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  fuzz:
+    name: Fuzz ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - aprp_parser
+          - capsule_deserialize
+          - policy_yaml
+          - audit_event
+          - canonical_json
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Skip non-matching target
+        id: filter
+        run: |
+          requested="${{ inputs.target_filter }}"
+          if [[ -z "$requested" || "$requested" == "${{ matrix.target }}" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping ${{ matrix.target }} (filter=$requested)"
+          fi
+
+      - name: Install Rust nightly + cargo-fuzz
+        if: steps.filter.outputs.run == 'true'
+        run: |
+          rustup toolchain install nightly --profile minimal
+          rustup default nightly
+          cargo install cargo-fuzz --version "^0.12"
+
+      - name: Cache fuzz target build
+        if: steps.filter.outputs.run == 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            fuzz/target
+            ~/.cargo/registry
+          key: fuzz-${{ matrix.target }}-${{ runner.os }}-${{ hashFiles('fuzz/Cargo.toml') }}
+
+      - name: Restore corpus from previous run
+        if: steps.filter.outputs.run == 'true'
+        uses: actions/cache@v4
+        with:
+          path: fuzz/corpus
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_number }}
+          restore-keys: |
+            fuzz-corpus-${{ matrix.target }}-
+
+      - name: Seed corpus from test-corpus/
+        if: steps.filter.outputs.run == 'true'
+        run: |
+          mkdir -p fuzz/corpus/${{ matrix.target }}
+          # Best-effort seeding — directories may not exist for every target.
+          case "${{ matrix.target }}" in
+            aprp_parser)
+              find test-corpus -name '*aprp*.json' -exec cp {} fuzz/corpus/aprp_parser/ \; 2>/dev/null || true
+              ;;
+            capsule_deserialize)
+              find test-corpus/passport -name '*.json' -exec cp {} fuzz/corpus/capsule_deserialize/ \; 2>/dev/null || true
+              ;;
+            policy_yaml)
+              find test-corpus -name '*policy*.yaml' -o -name '*policy*.json' | xargs -I{} cp {} fuzz/corpus/policy_yaml/ 2>/dev/null || true
+              ;;
+            audit_event)
+              find test-corpus -name '*audit*.json' -exec cp {} fuzz/corpus/audit_event/ \; 2>/dev/null || true
+              ;;
+            canonical_json)
+              # Use APRP + policy fixtures as canonicalizer seeds.
+              find test-corpus -name '*.json' -exec cp {} fuzz/corpus/canonical_json/ \; 2>/dev/null || true
+              ;;
+          esac
+          echo "Seeded $(ls fuzz/corpus/${{ matrix.target }} 2>/dev/null | wc -l) files"
+
+      - name: Run fuzz target
+        if: steps.filter.outputs.run == 'true'
+        env:
+          DURATION: ${{ inputs.duration_seconds || '600' }}
+        run: |
+          cd fuzz
+          cargo fuzz run ${{ matrix.target }} -- -max_total_time=$DURATION
+
+      - name: Upload crash artifacts
+        if: failure() && steps.filter.outputs.run == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-crashes-${{ matrix.target }}
+          path: |
+            fuzz/artifacts/${{ matrix.target }}/
+          if-no-files-found: ignore
+
+      - name: Open issue on crash
+        if: failure() && steps.filter.outputs.run == 'true' && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `🔥 Fuzz crash: ${{ matrix.target }} (run #${context.runNumber})`,
+              body: [
+                `Nightly fuzz run found a crash in target \`${{ matrix.target }}\`.`,
+                ``,
+                `**Reproducer:** download the artifact from the workflow run + run \`cargo fuzz run ${{ matrix.target }} <crash-file>\`.`,
+                ``,
+                `**Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                ``,
+                `**Severity:** to triage. Likely Medium per SECURITY.md (DoS class) unless escalation criteria apply.`,
+                ``,
+                `cc: @B2JK-Industry`,
+              ].join('\n'),
+              labels: ['fuzz-crash', 'needs-triage', 'security'],
+            })

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,5 @@
+# cargo-fuzz artifacts
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,59 @@
+[package]
+name = "sbo3l-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+serde_json = "1"
+
+[dependencies.sbo3l-core]
+path = "../crates/sbo3l-core"
+
+[dependencies.sbo3l-policy]
+path = "../crates/sbo3l-policy"
+
+# `cargo fuzz run <target>` builds with these profile overrides.
+# Optimized so 10M iterations completes in nightly window.
+[profile.release]
+debug = 1
+debug-assertions = true
+overflow-checks = true
+
+[[bin]]
+name = "aprp_parser"
+path = "fuzz_targets/aprp_parser.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "capsule_deserialize"
+path = "fuzz_targets/capsule_deserialize.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "policy_yaml"
+path = "fuzz_targets/policy_yaml.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "audit_event"
+path = "fuzz_targets/audit_event.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "canonical_json"
+path = "fuzz_targets/canonical_json.rs"
+test = false
+doc = false
+
+[workspace]
+# Fuzz pkg is its own workspace so it doesn't pull the production
+# workspace's lockfile. cargo-fuzz documented practice.

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,73 @@
+# SBO3L fuzz targets (R13 P3)
+
+> 5 cargo-fuzz harnesses covering the parsers + verifiers reachable from untrusted input. Default nightly run: 1h per target. OSS-Fuzz integration: see `oss-fuzz/`.
+
+## Targets
+
+| Target | What it fuzzes | Reachable from |
+|---|---|---|
+| `aprp_parser` | `serde_json::from_*` → `PaymentRequest` | HTTP request body |
+| `capsule_deserialize` | `verify_capsule(&Value)` | `/proof` page WASM, `sbo3l verify-capsule` CLI |
+| `policy_yaml` | `Policy::parse_yaml` + `Policy::parse_json` | Daemon startup; admin policy upload |
+| `audit_event` | `AuditEvent` + `SignedAuditEvent` parse + `canonical_hash` | Audit chain export/import |
+| `canonical_json` | JCS canonicalizer + `request_hash` | Every sign/verify operation |
+
+## Setup
+
+```bash
+# Install cargo-fuzz (one-time)
+cargo install cargo-fuzz
+
+# List available targets
+cargo fuzz list
+
+# Run a target for 10 minutes
+cargo fuzz run aprp_parser -- -max_total_time=600
+
+# Run for 10M iterations
+cargo fuzz run capsule_deserialize -- -runs=10000000
+
+# Continuous run (Ctrl-C to stop)
+cargo fuzz run policy_yaml
+```
+
+## Corpus
+
+cargo-fuzz manages corpus files under `fuzz/corpus/<target>/` (gitignored). Seed corpus from existing test fixtures:
+
+```bash
+# Seed APRP corpus from golden fixtures
+mkdir -p fuzz/corpus/aprp_parser
+cp test-corpus/aprp/*.json fuzz/corpus/aprp_parser/
+
+# Seed capsule corpus
+mkdir -p fuzz/corpus/capsule_deserialize
+cp test-corpus/passport/*.json fuzz/corpus/capsule_deserialize/
+
+# Seed policy corpus
+mkdir -p fuzz/corpus/policy_yaml
+cp test-corpus/policy/*.yaml fuzz/corpus/policy_yaml/
+cp test-corpus/policy/*.json fuzz/corpus/policy_yaml/
+```
+
+## CI integration
+
+`.github/workflows/fuzz.yml` runs each target for 10 minutes nightly (50 min total). On crash:
+- The crash artifact is uploaded.
+- A GitHub issue is opened with the reproducer + target name.
+- The CI job fails (red).
+
+## OSS-Fuzz
+
+> **Status:** scaffolding shipped at `fuzz/oss-fuzz/`. Submission to `google/oss-fuzz` is a Daniel-side action (requires Google email + project owner approval). Estimate: 1 day from "go" to first builds.
+
+## Reporting findings
+
+If a fuzz target crashes locally, the crash file is at `fuzz/artifacts/<target>/crash-<hash>`. Report via:
+1. `SECURITY.md` channels (private; do NOT commit the crash file to a public branch).
+2. Include: target name, libfuzzer reproducer command, crash file SHA-256, severity self-assessment.
+
+## See also
+
+- [`SECURITY.md`](../SECURITY.md) — disclosure policy.
+- `crates/sbo3l-core/tests/proptest_invariants.rs` — property-based tests (correctness invariants; complementary to fuzzing's "no panic" focus).

--- a/fuzz/fuzz_targets/aprp_parser.rs
+++ b/fuzz/fuzz_targets/aprp_parser.rs
@@ -1,0 +1,30 @@
+//! Fuzz the APRP wire-format parser.
+//!
+//! Goal: serde_json::from_str + serde_json::from_slice into PaymentRequest
+//! must NEVER panic, regardless of input bytes. A `Result::Err` is fine —
+//! a `panic!` is a bug.
+//!
+//! Coverage targets:
+//! - All Intent / Destination / PaymentProtocol / RiskClass enum branches
+//! - Optional field combinations (x402_payload, expected_result)
+//! - Unicode in string fields
+//! - Numeric overflow in `expiry`
+//! - Adversarial JSON shapes (deeply nested, missing fields, extra fields)
+//!
+//! Run: `cargo fuzz run aprp_parser -- -max_total_time=600`
+//! Long-run: `cargo fuzz run aprp_parser -- -runs=10000000`
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use sbo3l_core::aprp::PaymentRequest;
+
+fuzz_target!(|data: &[u8]| {
+    // Path 1: from_slice (binary input).
+    let _ = serde_json::from_slice::<PaymentRequest>(data);
+
+    // Path 2: from_str (utf8 input). Skip if not valid utf8.
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = serde_json::from_str::<PaymentRequest>(s);
+    }
+});

--- a/fuzz/fuzz_targets/audit_event.rs
+++ b/fuzz/fuzz_targets/audit_event.rs
@@ -1,0 +1,29 @@
+//! Fuzz the AuditEvent + SignedAuditEvent deserializers.
+//!
+//! Goal: parsing an adversarial audit-row blob (e.g. one synthesized by
+//! an attacker who wants the verifier to crash before checking the
+//! signature) must NEVER panic. Parse errors are fine; panics are bugs.
+//!
+//! Adversarial shapes to surface:
+//! - Missing required fields (version, seq, prev_event_hash, payload_hash)
+//! - Numeric overflows on `seq`
+//! - Invalid hex in `payload_hash` / `prev_event_hash`
+//! - Unicode in `actor` / `subject_id` / `event_type`
+//! - Deep object nesting in `metadata`
+//!
+//! Run: `cargo fuzz run audit_event -- -max_total_time=600`
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use sbo3l_core::audit::{AuditEvent, SignedAuditEvent};
+
+fuzz_target!(|data: &[u8]| {
+    let _ = serde_json::from_slice::<AuditEvent>(data);
+    let _ = serde_json::from_slice::<SignedAuditEvent>(data);
+
+    // Also fuzz the canonical-hash recompute on whatever we parsed.
+    if let Ok(event) = serde_json::from_slice::<AuditEvent>(data) {
+        let _ = event.canonical_hash();
+    }
+});

--- a/fuzz/fuzz_targets/canonical_json.rs
+++ b/fuzz/fuzz_targets/canonical_json.rs
@@ -1,0 +1,19 @@
+//! Fuzz the JCS-canonical-JSON serializer.
+//!
+//! Goal: `canonical_json` must NEVER panic. It's invoked on every
+//! audit-row append, every PolicyReceipt sign, every capsule build —
+//! a panic in this function takes down the daemon's request path.
+//!
+//! Run: `cargo fuzz run canonical_json -- -max_total_time=600`
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use sbo3l_core::hashing::{canonical_json, request_hash};
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(v) = serde_json::from_slice::<serde_json::Value>(data) {
+        let _ = canonical_json(&v);
+        let _ = request_hash(&v);
+    }
+});

--- a/fuzz/fuzz_targets/capsule_deserialize.rs
+++ b/fuzz/fuzz_targets/capsule_deserialize.rs
@@ -1,0 +1,24 @@
+//! Fuzz the Passport capsule verifier.
+//!
+//! Goal: `verify_capsule` must NEVER panic on adversarial input. The
+//! function is invoked by the marketing /proof page WASM and by the CLI;
+//! both are reachable by untrusted input.
+//!
+//! Note: this does NOT fuzz the cryptographic primitives themselves
+//! (Ed25519, SHA-256) — those are crates we depend on (`ed25519-dalek`,
+//! `sha2`) and have their own fuzz harnesses upstream. We fuzz the
+//! BOUNDARY: how SBO3L parses + dispatches against capsule-shaped input.
+//!
+//! Run: `cargo fuzz run capsule_deserialize -- -max_total_time=600`
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use sbo3l_core::passport::verify_capsule;
+
+fuzz_target!(|data: &[u8]| {
+    // Try parsing as a JSON Value first — capsules are JSON objects.
+    if let Ok(v) = serde_json::from_slice::<serde_json::Value>(data) {
+        let _ = verify_capsule(&v);
+    }
+});

--- a/fuzz/fuzz_targets/policy_yaml.rs
+++ b/fuzz/fuzz_targets/policy_yaml.rs
@@ -1,0 +1,20 @@
+//! Fuzz the policy YAML/JSON parser.
+//!
+//! Goal: `Policy::parse_yaml` and `Policy::parse_json` must NEVER panic
+//! on adversarial input. Customer-supplied policy files are loaded by
+//! the daemon at startup; a panic on a malformed policy is a DoS that
+//! prevents the daemon from booting.
+//!
+//! Run: `cargo fuzz run policy_yaml -- -max_total_time=600`
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use sbo3l_policy::model::Policy;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = Policy::parse_yaml(s);
+        let _ = Policy::parse_json(s);
+    }
+});

--- a/fuzz/oss-fuzz/Dockerfile
+++ b/fuzz/oss-fuzz/Dockerfile
@@ -1,0 +1,10 @@
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential pkg-config libssl-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026 sbo3l
+
+WORKDIR $SRC/sbo3l
+COPY build.sh $SRC/

--- a/fuzz/oss-fuzz/build.sh
+++ b/fuzz/oss-fuzz/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# OSS-Fuzz build script for SBO3L.
+#
+# Path: $SRC/sbo3l/fuzz/oss-fuzz/build.sh — invoked by the OSS-Fuzz Docker
+# image at build time. Refer to:
+#   https://google.github.io/oss-fuzz/getting-started/new-project-guide/rust-lang/
+
+set -euxo pipefail
+
+cd "$SRC/sbo3l/fuzz"
+
+# Build all fuzz targets in OSS-Fuzz mode.
+cargo fuzz build -O --debug-assertions
+
+# Copy each binary + matching seed corpus into $OUT.
+for target in aprp_parser capsule_deserialize policy_yaml audit_event canonical_json; do
+  cp "target/x86_64-unknown-linux-gnu/release/$target" "$OUT/$target"
+
+  # Optional seed corpus (zip per OSS-Fuzz convention).
+  if [[ -d "$SRC/sbo3l/test-corpus/$target" ]]; then
+    (cd "$SRC/sbo3l/test-corpus/$target" && zip -r "$OUT/${target}_seed_corpus.zip" .)
+  fi
+done

--- a/fuzz/oss-fuzz/project.yaml
+++ b/fuzz/oss-fuzz/project.yaml
@@ -1,0 +1,16 @@
+# OSS-Fuzz project descriptor.
+# Submit by PR to https://github.com/google/oss-fuzz adding a directory
+# `projects/sbo3l/` containing this file + Dockerfile + build.sh.
+
+homepage: "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026"
+language: rust
+primary_contact: "security@sbo3l.dev"
+auto_ccs:
+  - "babjak_daniel@hotmail.com"
+sanitizers:
+  - address
+  - undefined
+fuzzing_engines:
+  - libfuzzer
+main_repo: "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026"
+file_github_issue: true


### PR DESCRIPTION
## Summary

R13 P3 — 5 cargo-fuzz harnesses covering every parser + verifier reachable from untrusted input.

**Targets:**

| Target | What it fuzzes | Reachable from |
|---|---|---|
| \`aprp_parser\` | \`serde_json::from_*\` → \`PaymentRequest\` | HTTP request body |
| \`capsule_deserialize\` | \`verify_capsule(&Value)\` | \`/proof\` WASM, \`sbo3l verify-capsule\` |
| \`policy_yaml\` | \`Policy::parse_yaml\` + \`parse_json\` | Daemon startup; admin policy upload |
| \`audit_event\` | \`AuditEvent\` + \`SignedAuditEvent\` + \`canonical_hash\` | Audit chain export/import |
| \`canonical_json\` | JCS canonicalizer + \`request_hash\` | Every sign/verify operation |

**Goal of every target:** NEVER panic on adversarial input. \`Result::Err\` fine; \`panic!\` is a bug.

**Workflow** (\`.github/workflows/fuzz.yml\`):
- Nightly cron 04:00 UTC; 10 min/target × 5 targets = 50 min.
- Manual dispatch with duration + target filter.
- Build + corpus caching across runs.
- Best-effort seed corpus from \`test-corpus/\`.
- On crash: upload artifact + open GH issue + Medium-severity tag (DoS class per SECURITY.md).

**OSS-Fuzz scaffolding** (\`fuzz/oss-fuzz/\`):
- \`build.sh\` + \`Dockerfile\` + \`project.yaml\` for submission to \`google/oss-fuzz\`.
- Daniel-side action: 1 day from "go" to first builds.

## Test plan
- [x] Workflow YAML syntax valid
- [x] Cargo.toml structure follows cargo-fuzz convention
- [ ] First nightly run validates all 5 targets compile + run for 10 min without panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)