### PR TITLE
docs(prod): production-rollout design — Postgres+RLS, Stripe, mobile (R13 P78)

### DIFF
--- a/docs/dev3/production/01-postgres-rls-migration.md
+++ b/docs/dev3/production/01-postgres-rls-migration.md
@@ -1,0 +1,139 @@
+# Production migration — SQLite mock → Postgres + RLS
+
+**Status:** design draft (R13 P78)
+**Owner:** Dev 3 (frontend) + Grace (daemon storage)
+**Trigger:** first paying tenant lands on `app.sbo3l.dev`
+
+## Today
+
+- Daemon writes per-tenant SQLite files at `~/.sbo3l/tenants/<uuid>.db`
+  (Grace's slice — see CTI-3-5 §4)
+- Hosted-app reads via `GET /v1/tenants/<slug>/*` proxied through the
+  daemon socket
+- 3 mock tenants seeded in `apps/hosted-app/lib/tenants.ts`
+- _Multi-tenant correctness today is "directory boundary"_ — each
+  tenant gets a separate file. No row-level cross-tenant queries
+  possible, no shared connection pool, no fan-out reporting.
+
+## Why move
+
+1. **Cross-tenant analytics** — admin/audit dashboards across tenants
+   require a single queryable surface. SQLite-per-tenant means N
+   queries fanned out + joined client-side.
+2. **HA** — SQLite single-writer doesn't survive daemon restart
+   without filesystem fsync + careful WAL handling. Postgres RDS
+   gets us multi-AZ + point-in-time recovery for free.
+3. **Migration tooling** — schema bumps in SQLite-per-tenant mean
+   walking N files in lockstep. Postgres + sqlx migrations is one
+   transaction.
+
+## Schema sketch
+
+```sql
+CREATE TABLE tenants (
+  uuid          UUID PRIMARY KEY,
+  slug          TEXT UNIQUE NOT NULL CHECK (slug ~ '^[a-z0-9](?:[a-z0-9-]{1,30}[a-z0-9])?$'),
+  display_name  TEXT NOT NULL,
+  tier          TEXT NOT NULL CHECK (tier IN ('free', 'pro', 'enterprise')),
+  ens_apex      TEXT,
+  stripe_id     TEXT,                  -- linked at billing onboarding
+  created_at    TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE memberships (
+  user_sub      TEXT NOT NULL,         -- nextauth subject (github login or email)
+  tenant_uuid   UUID NOT NULL REFERENCES tenants(uuid) ON DELETE CASCADE,
+  role          TEXT NOT NULL CHECK (role IN ('admin', 'operator', 'viewer')),
+  added_at      TIMESTAMPTZ DEFAULT now(),
+  PRIMARY KEY (user_sub, tenant_uuid)
+);
+
+CREATE TABLE agents (
+  agent_id      TEXT PRIMARY KEY,
+  tenant_uuid   UUID NOT NULL REFERENCES tenants(uuid) ON DELETE CASCADE,
+  ens_name      TEXT,
+  pubkey_b58    TEXT NOT NULL,
+  created_at    TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE audit_events (
+  event_id      TEXT PRIMARY KEY,
+  tenant_uuid   UUID NOT NULL REFERENCES tenants(uuid) ON DELETE CASCADE,
+  ts_ms         BIGINT NOT NULL,
+  kind          TEXT NOT NULL,
+  agent_id      TEXT,
+  payload_jsonb JSONB NOT NULL,
+  INDEX idx_audit_tenant_ts (tenant_uuid, ts_ms DESC)
+);
+
+CREATE TABLE capsules (
+  capsule_id    TEXT PRIMARY KEY,
+  tenant_uuid   UUID NOT NULL REFERENCES tenants(uuid) ON DELETE CASCADE,
+  agent_id      TEXT NOT NULL,
+  decision      TEXT,
+  emitted_at    TIMESTAMPTZ DEFAULT now(),
+  payload_b64   TEXT NOT NULL
+);
+```
+
+## Row-level security
+
+Every per-tenant table has an RLS policy keyed off
+`current_setting('app.tenant_uuid')`:
+
+```sql
+ALTER TABLE agents       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE audit_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE capsules     ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation_agents       ON agents
+  USING (tenant_uuid = current_setting('app.tenant_uuid')::uuid);
+CREATE POLICY tenant_isolation_audit_events ON audit_events
+  USING (tenant_uuid = current_setting('app.tenant_uuid')::uuid);
+CREATE POLICY tenant_isolation_capsules     ON capsules
+  USING (tenant_uuid = current_setting('app.tenant_uuid')::uuid);
+```
+
+Daemon sets the GUC at the start of every transaction:
+```sql
+SET LOCAL app.tenant_uuid = '<resolved-from-jwt>';
+```
+
+A bug in the daemon that leaks the wrong UUID is contained by the RLS
+fence; misconfiguration shows up as empty results, not data leakage.
+
+## Migration steps
+
+1. **Stand up Postgres** (Supabase free tier is fine for hackathon →
+   pilot migration). Apply schema + RLS policies.
+2. **Backfill** — write a one-shot Rust binary that walks
+   `~/.sbo3l/tenants/*.db`, opens each, dumps to a single Postgres
+   schema. Idempotent on re-run (use `INSERT ... ON CONFLICT DO NOTHING`).
+3. **Dual-write window** — daemon writes to both stores for 1 week.
+   Compare row counts daily via a CI cron.
+4. **Cutover** — flip `daemon.toml` from `storage = "sqlite-per-tenant"`
+   to `storage = "postgres"`. Roll back is a config flip + replay
+   (the SQLite files stay around).
+5. **SQLite drop** — after 30 days of clean Postgres metrics + zero
+   incidents, archive the SQLite files to S3 cold storage and remove
+   the SQLite code path.
+
+## Risks
+
+- **Row-count drift during dual-write** — need a daily reconciliation
+  job that flags any tenant where SQLite and Postgres disagree.
+- **GUC leak across queries** — connection pool MUST reset
+  `app.tenant_uuid` to NULL on connection return. `SET LOCAL` scopes
+  to transaction so commit/rollback resets it; abandoned transactions
+  could leak. Mitigation: pool with `idle_in_transaction_session_timeout = 30s`.
+- **Migration downtime** — schema changes that touch RLS need a
+  `BEGIN; ALTER TABLE ... DISABLE ROW LEVEL SECURITY; ... ENABLE; COMMIT`
+  dance to avoid temporarily exposing rows. Document in runbook.
+
+## Rollback plan
+
+The SQLite files are the source of truth until the 30-day soak period
+ends. Cutover is a `daemon.toml` flip; reverting takes <60s (restart
+the daemon). After the SQLite drop, rollback requires restoring from
+the most recent S3 archive — `<24h` tolerable, `<1h` requires the
+soak window to be revisited.

--- a/docs/dev3/production/02-stripe-billing-runbook.md
+++ b/docs/dev3/production/02-stripe-billing-runbook.md
@@ -1,0 +1,98 @@
+# Stripe billing — Free / Pro / Enterprise rollout runbook
+
+**Status:** design draft (R13 P78)
+**Owner:** Dev 3 (hosted-app) + business
+**Trigger:** SBO3L Cloud beta opens (post-hackathon)
+
+## Tiers
+
+| Tier | Price | Tenants | Agents | Decisions / mo | Audit retention | Support |
+|---|---|---|---|---|---|---|
+| **Free** | $0 | 1 | 3 | 10K | 30 days | Community |
+| **Pro** | $29 / mo | 5 | unlimited | 1M | 1 year | Email, 24h SLA |
+| **Enterprise** | from $499 / mo | unlimited | unlimited | unlimited | 7 years | Dedicated, 1h SLA |
+
+Tier is a column on the `tenants` table (see Postgres design doc); the
+daemon enforces caps at policy-decision time (deny with `policy.tier_quota`).
+
+## Stripe objects
+
+- **Product** — single \"SBO3L Cloud\" product
+- **Prices** — one per tier:
+  - `price_free` ($0/mo, recurring) — kept in Stripe so subscription
+    state machine is uniform
+  - `price_pro_monthly` ($29/mo)
+  - `price_enterprise_starter_monthly` ($499/mo)
+- **Customer** — one per tenant (NOT per user). Tenant `stripe_id`
+  column links to Customer.
+- **Subscription** — one active per tenant. Tier upgrades = swap
+  subscription items.
+- **Invoice** — Stripe-hosted, emailed monthly.
+
+## Webhook flow
+
+1. User clicks \"Upgrade to Pro\" on `/t/<slug>/admin/billing`
+2. Hosted-app creates a Checkout Session with
+   `metadata: { tenant_uuid }` + redirect URLs
+3. User completes Checkout on Stripe-hosted page
+4. Stripe POSTs `checkout.session.completed` webhook → hosted-app
+5. Webhook handler:
+   - verifies signature (HMAC `STRIPE_WEBHOOK_SECRET`)
+   - extracts `tenant_uuid` from session metadata
+   - updates `tenants.tier = 'pro'` and `tenants.stripe_id = customer_id`
+   - publishes `tenant.tier_changed` to the daemon's event bus so
+     in-flight policy decisions pick up the new quota immediately
+6. User redirects to `/t/<slug>/admin/billing?upgraded=1`
+
+## Routes
+
+- `POST /api/billing/checkout` — body `{ tenant_slug, target_tier }`,
+  returns `{ url }` for client redirect. Admin-role required.
+- `POST /api/billing/portal` — returns Stripe Customer Portal URL so
+  customers can update payment method + cancel without leaving the
+  app
+- `POST /api/billing/webhook` — Stripe-only, signature-verified.
+  Idempotent on `event.id`.
+
+## Failure modes + mitigation
+
+- **Webhook missed / delayed** — reconcile nightly: walk Stripe
+  subscriptions, compare to `tenants.tier`. Backfill mismatches with
+  a one-shot job. Alert if drift > 1.
+- **Card declined on renewal** — Stripe retries 3× over 21 days.
+  After final failure, downgrade to Free + email tenant admins.
+  Daemon enforces the new quota immediately, so Pro features
+  silently start denying. Add a UI banner that surfaces the
+  past-due state from the Customer Portal.
+- **Refund / chargeback** — manual ops procedure. Log in Stripe
+  Dashboard, replay the relevant webhook to flip tier. Track in
+  `accounting/incidents.md` for finance reconciliation.
+
+## Test plan
+
+- Stripe CLI replays for the 4 webhook events we care about:
+  `checkout.session.completed`, `customer.subscription.updated`,
+  `customer.subscription.deleted`, `invoice.payment_failed`
+- Local fixture mode: `STRIPE_MODE=test` mounts a mocked checkout
+  + auto-success webhook so PR CI can run end-to-end without
+  hitting Stripe
+- E2E playwright spec: \"contoso (free) upgrades to pro and
+  immediately spends past the free quota\" → expect allow
+
+## What this PR does NOT cover
+
+- **Annual billing** — needs a `Price` per period, doable later
+- **Coupon codes / referrals** — out of scope for v1
+- **Self-serve enterprise** — enterprise is sales-led, not Checkout-led
+- **Tax handling** — Stripe Tax is one toggle but adds VAT complexity
+  (need EU billing addresses); deferred until first EU tenant
+- **Per-seat pricing** — tier is per-tenant, not per-user. Adding
+  per-seat means Subscription items per-membership, which is a
+  whole different state machine.
+
+## Rollback
+
+Until first paying tenant: feature-flag the billing routes off and
+default everyone to `free` tier. Daemon already treats unknown
+tier as the most-restrictive (free) — so even a partial rollout
+fails closed.

--- a/docs/dev3/production/03-mobile-apps-design.md
+++ b/docs/dev3/production/03-mobile-apps-design.md
@@ -1,0 +1,112 @@
+# Mobile apps — iOS + Android design
+
+**Status:** design draft (R13 P78)
+**Owner:** Dev 3 (frontend), pending mobile specialist hire
+**Trigger:** post-hackathon roadmap, _not_ for the submission demo
+
+## Why mobile
+
+The hosted-app web surface covers desktop ops well, but tenant admins
+need to **approve human-in-the-loop policy decisions on the go** — the
+\"agent wants to send $50K, please confirm\" prompt is a mobile-first
+flow. Email + SMS work today but feel hacky.
+
+Targeting:
+- Tenant admins who get pinged for `human_2fa: true` decisions
+- Operators who want a glanceable health dashboard during ops
+- Auditors reviewing capsules from the field (read-only)
+
+## Stack — Expo / React Native
+
+Reasons to pick Expo over native (Swift / Kotlin):
+- **One codebase** — same TypeScript story as hosted-app
+- **Component reuse** — design tokens already live in
+  `packages/design-tokens`; React Native consumes them via
+  `react-native-styled-components` or NativeWind
+- **OTA updates** — Expo Updates ships patches without re-submitting
+  to App Store / Play Store (minor JS changes only)
+- **Push notifications** — Expo's push service abstracts APNs / FCM
+- **No Apple Developer / Google Play account needed for the MVP** —
+  Expo Go renders the app on a teammate's phone via QR code; full
+  store submission is a later milestone
+
+## Routes
+
+```
+/                           → Tenant picker (memberships from /v1/me)
+/t/<slug>                   → Dashboard (mirrors hosted-app, simpler layout)
+/t/<slug>/approvals         → Pending human_2fa decisions list
+/t/<slug>/approvals/<id>    → Decision detail + Approve / Deny buttons
+/t/<slug>/audit             → Read-only audit timeline (last 100 events)
+/t/<slug>/agents            → Agent list (read-only)
+/settings                   → Sign in / out, push toggles
+```
+
+## Authentication
+
+Same NextAuth backend the hosted-app uses, with native auth flows:
+- iOS — `expo-auth-session` opens GitHub OAuth in `SFAuthenticationSession`
+- Android — same package opens Custom Tabs
+
+Token stored in `expo-secure-store` (Keychain on iOS, Keystore on
+Android). 30-day expiry, silent refresh on app open.
+
+## Push notifications
+
+The daemon's existing `policy.decision.pending_2fa` event hooks
+into the push pipeline:
+
+1. Tenant admin enables push in `/settings`
+2. App registers with Expo Push, gets `ExponentPushToken[...]`,
+   POSTs to `/api/me/push-tokens` with `{ tenant_uuid, token }`
+3. Daemon emits `policy.decision.pending_2fa { tenant_uuid, decision_id }`
+4. Webhook receiver fans out to all push tokens for that tenant's
+   admins, payload `{ deeplink: \"sbo3l://t/<slug>/approvals/<id>\" }`
+5. Tap → app opens to the approval detail screen
+6. Admin taps Approve / Deny → POST `/v1/decisions/<id>/resolve`
+7. Daemon's resolution unblocks the agent
+
+## Offline + cache
+
+- **Audit timeline** — last 100 events cached via React Query +
+  `expo-sqlite` for offline read. Stale-while-revalidate on app
+  open. _No mutation offline_ — approvals require live daemon
+  contact (we can't sign a 2fa response without the current
+  challenge).
+- **Tenant memberships** — cached on sign-in. Stale OK; refresh
+  silently every hour.
+
+## Security
+
+- Cert pinning via `expo-network-pin` against the daemon TLS cert
+  (rotation procedure documented in
+  `docs/dev3/production/04-cert-pinning-rotation.md`, future)
+- Biometric gate on app open (Face ID / Touch ID / fingerprint)
+  via `expo-local-authentication` — required for Pro tier, optional
+  for Free
+- Approval flows always re-authenticate via biometric before sending
+  the resolve POST — defence against \"unlocked phone left on desk\"
+
+## Release cadence
+
+- **Internal TestFlight / Internal Track** — every merge to `main`
+- **Public beta** — gated on first paying customer's request
+- **App Store + Play Store** — gated on revenue milestone (don't
+  burn $99/yr Apple Developer + $25 Google Play until a customer
+  asks)
+
+## What's NOT in scope
+
+- Tablet / iPad layouts (use the web app)
+- Full offline mode with conflict resolution (approvals are
+  online-only; approval is a security boundary, not a sync surface)
+- macOS Catalyst / Mac Mac App Store — desktop users have the web app
+- Desktop notifications — out of scope; web app + SMTP cover it
+- Wear OS / watchOS — too small a surface for the approval detail UI
+
+## Rollback
+
+Native apps can't be \"rolled back\" — once on the App Store, the
+binary is permanent until the next submission. Mitigation: every
+flow gated behind a feature flag served from `/v1/feature-flags`,
+so a bad release is a server-side flag flip + force-reload.


### PR DESCRIPTION
## Summary

Three honest design docs for production items that **cannot be implemented in the Claude Code env** (no PG / Stripe account / Apple Developer):

1. **\`01-postgres-rls-migration.md\`** — schema, RLS policies keyed on \`app.tenant_uuid\` GUC, 5-step migration plan with dual-write reconciliation + 30-day soak.
2. **\`02-stripe-billing-runbook.md\`** — Free / Pro \$29 / Enterprise \$499+ tiers, Stripe object model, webhook flow with metadata.tenant_uuid handoff, failure-mode procedures.
3. **\`03-mobile-apps-design.md\`** — Expo + React Native, NextAuth-backed OAuth, push for \`human_2fa\` approvals, biometric re-auth, \"don't burn \$99/yr Apple Developer until a customer asks\" release cadence.

## Why now

R13 brief P1 / P2 / P5 asked for production-grade implementations. Hackathon env can't provide DB / Stripe / Apple credentials, so this PR is the **next-best deliverable** — a doc detailed enough that a future engineer implements directly from it. Anything implementable today (i18n, charts, Monaco, OG) shipped in PR #280 / #284 / #288 / #290 / #291.

## Test plan

- [ ] Each doc reviewed for technical accuracy
- [ ] Schema in 01 compiles via \`sqlx-cli\` against an empty Postgres
- [ ] Stripe webhook event names in 02 match Stripe API v2024-x
- [ ] Expo packages in 03 exist on npm at versions noted

🤖 Generated with [Claude Code](https://claude.com/claude-code)