### PR TITLE
test(mutation): cargo-mutants weekly workflow + config (R13 P2)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,44 @@
+# cargo-mutants config (R13 P2).
+#
+# Drives weekly mutation testing on sbo3l-core, sbo3l-policy, sbo3l-identity.
+# Goal: 90%+ mutation kill rate across these three crates. Alive
+# mutations file GitHub issues for triage.
+#
+# Local run:
+#   cargo install cargo-mutants
+#   cargo mutants --in-place --package sbo3l-core
+#
+# Reference: https://mutants.rs/
+
+# Only mutate the listed packages. Other workspace members (server, cli,
+# adapters) are out-of-scope for the initial run since they are mostly
+# wiring — the high-leverage code is in core/policy/identity.
+test_package = ["sbo3l-core", "sbo3l-policy", "sbo3l-identity"]
+
+# Skip files that are generated, vendored, or otherwise not target code.
+exclude_globs = [
+    "**/build.rs",
+    "**/wasm.rs",
+    "**/wasm_types.rs",
+    "**/mock_kms.rs",
+    "**/tests/**",
+    "**/benches/**",
+]
+
+# Skip individual functions that mutation-testing struggles with.
+exclude_re = [
+    # WASM glue functions are exercised through wasm-pack tests, not unit tests
+    "^wasm_.*",
+]
+
+# Per-mutant timeout. cargo-mutants default is 300s; we use 180 since
+# our test suite is fast (regression-on-main runs in ~3 min total).
+timeout = 180
+
+# Minimum line of test output to capture for triage.
+output = "mutants.out"
+
+# Run cargo test with `--release` to match production execution
+# semantics (avoids debug-only `assert!` paths inflating kill rate).
+test_tool = "cargo"
+test_args = ["--release"]

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,168 @@
+name: Mutation testing
+
+# R13 P2 — cargo-mutants weekly mutation testing on sbo3l-core,
+# sbo3l-policy, sbo3l-identity. Goal: 90%+ kill rate. Alive mutations
+# file GitHub issues for triage.
+#
+# Reference: https://mutants.rs/
+#
+# Local run:
+#   cargo install cargo-mutants
+#   cargo mutants --in-place --package sbo3l-core
+
+on:
+  schedule:
+    # Weekly Sunday 02:00 UTC — full mutation run is ~30-90 min.
+    - cron: "0 2 * * 0"
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: "Comma-separated package list (default: core,policy,identity)"
+        required: false
+        default: "sbo3l-core,sbo3l-policy,sbo3l-identity"
+      file:
+        description: "Specific file to mutate (e.g. crates/sbo3l-core/src/aprp.rs)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  mutants:
+    name: Mutate ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - sbo3l-core
+          - sbo3l-policy
+          - sbo3l-identity
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Filter package
+        id: filter
+        run: |
+          requested="${{ inputs.packages }}"
+          if [[ -z "$requested" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [[ ",$requested," == *",${{ matrix.package }},"* ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping ${{ matrix.package }} (not in $requested)"
+          fi
+
+      - name: Install Rust + cargo-mutants
+        if: steps.filter.outputs.run == 'true'
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          cargo install cargo-mutants --version "^25"
+
+      - name: Cache cargo
+        if: steps.filter.outputs.run == 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: mutants-${{ matrix.package }}-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+
+      - name: Run cargo-mutants
+        if: steps.filter.outputs.run == 'true'
+        env:
+          FILE_FILTER: ${{ inputs.file }}
+        run: |
+          ARGS=(--package ${{ matrix.package }} --output mutants.out --json)
+          if [[ -n "$FILE_FILTER" ]]; then
+            ARGS+=(--file "$FILE_FILTER")
+          fi
+          cargo mutants "${ARGS[@]}" || true
+          # Print summary regardless of exit code; we summarize from the JSON below.
+          echo "::notice::cargo-mutants finished — see summary step"
+
+      - name: Summarize results
+        if: steps.filter.outputs.run == 'true'
+        id: summary
+        run: |
+          if [[ ! -d mutants.out ]]; then
+            echo "::warning::no mutants.out directory; cargo-mutants likely failed early"
+            echo "kill_rate=0" >> "$GITHUB_OUTPUT"
+            echo "alive=0" >> "$GITHUB_OUTPUT"
+            echo "missed=0" >> "$GITHUB_OUTPUT"
+            echo "caught=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Aggregate per-mutant outcomes from outcomes.json.
+          python3 - <<'PY'
+          import json, os
+          path = "mutants.out/outcomes.json"
+          try:
+              with open(path) as f:
+                  outcomes = json.load(f)
+          except FileNotFoundError:
+              outcomes = []
+          tally = {}
+          for o in outcomes:
+              s = o.get("summary", "unknown")
+              tally[s] = tally.get(s, 0) + 1
+          caught = tally.get("CAUGHT", 0)
+          missed = tally.get("MISSED", 0)
+          timeout = tally.get("TIMEOUT", 0)
+          unviable = tally.get("UNVIABLE", 0)
+          total = caught + missed + timeout + unviable
+          kill_rate = (caught / max(1, caught + missed)) * 100 if (caught + missed) else 0.0
+          print(f"caught={caught} missed={missed} timeout={timeout} unviable={unviable} kill_rate={kill_rate:.1f}%")
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"kill_rate={kill_rate:.1f}\n")
+              f.write(f"caught={caught}\n")
+              f.write(f"missed={missed}\n")
+              f.write(f"alive={missed}\n")
+          PY
+
+      - name: Upload mutants.out
+        if: steps.filter.outputs.run == 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutants-${{ matrix.package }}
+          path: mutants.out/
+          if-no-files-found: ignore
+
+      - name: Open issue if kill rate < 90%
+        if: steps.filter.outputs.run == 'true' && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const killRate = parseFloat('${{ steps.summary.outputs.kill_rate }}') || 0;
+            const alive = parseInt('${{ steps.summary.outputs.alive }}', 10) || 0;
+            if (killRate >= 90.0 && alive === 0) {
+              core.notice(`✅ ${{ matrix.package }} mutation kill rate ${killRate.toFixed(1)}% — above 90% target.`);
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `🧬 Mutation kill rate < 90% on ${{ matrix.package }} (${killRate.toFixed(1)}%)`,
+              body: [
+                `Weekly mutation run found **${alive} alive mutation(s)** in \`${{ matrix.package }}\`. Kill rate: **${killRate.toFixed(1)}%** (target: ≥ 90%).`,
+                ``,
+                `**Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                ``,
+                `**To triage locally:**`,
+                "```bash",
+                `cargo install cargo-mutants`,
+                `cargo mutants --package ${{ matrix.package }}`,
+                "```",
+                ``,
+                `**Pattern:** alive mutations indicate either (a) missing test coverage of the mutated branch, or (b) a deliberately equivalent transformation. Add a test for (a); add an \`# [mutants::skip]\` annotation with rationale for (b).`,
+                ``,
+                `cc: @B2JK-Industry`,
+              ].join('\n'),
+              labels: ['mutation-testing', 'needs-triage', 'test-coverage'],
+            })


### PR DESCRIPTION
## Summary

R13 P2 — adds \`cargo-mutants\` weekly mutation testing on the three high-leverage crates: \`sbo3l-core\`, \`sbo3l-policy\`, \`sbo3l-identity\`. Goal: maintain ≥ 90% kill rate.

**\`.cargo/mutants.toml\`:**
- 3 packages in scope (server, cli, adapters out — mostly wiring).
- Excludes: build.rs, wasm modules, mock_kms, tests, benches.
- 180s per-mutant timeout; \`test_args=["--release"]\` to match prod.

**\`.github/workflows/mutation-testing.yml\`:**
- Cron: weekly Sun 02:00 UTC (~30–90 min runtime).
- Manual dispatch with package + file filters.
- Per-package matrix (3 jobs in parallel; fail-fast off).
- Summary step parses \`outcomes.json\` → caught / missed / kill_rate.
- On scheduled run: opens GH issue if kill_rate < 90% OR alive > 0.
- Issue body: local repro + triage pattern (missing test vs equivalent transform).

## Why these 3 crates

- \`sbo3l-core\` — capsule + audit + APRP + hash + signing primitives. Highest blast radius if a mutation slips through.
- \`sbo3l-policy\` — budget + MEV guard + reputation evaluation. Boundary logic.
- \`sbo3l-identity\` — Ed25519 + secp256k1 + EIP-55 + KMS factory. Cryptographic boundary.

Server / CLI / adapters are out-of-scope for R13 — they're mostly wiring and the mutation signal-to-noise is lower.

## Test plan
- [x] \`mutants.toml\` parses (cargo-mutants config schema)
- [x] Workflow YAML lints
- [ ] First scheduled run lands kill rate baseline; create followup issues for any < 90%

🤖 Generated with [Claude Code](https://claude.com/claude-code)