### PR TITLE
feat(marketing): i18n JA Japanese — 21st locale (R13 P4c)

### DIFF
--- a/apps/marketing/astro.config.mjs
+++ b/apps/marketing/astro.config.mjs
@@ -22,7 +22,7 @@ export default defineConfig({
   i18n: {
     defaultLocale: 'en',
     locales: [
-      'en', 'sk', 'ko',
+      'en', 'sk', 'ko', 'ja',
       'de', 'fr', 'it', 'es', 'pt-br', 'pl', 'cs', 'hu',
       'ar', 'he', 'zh-cn', 'zh-tw', 'ru', 'uk', 'tr', 'hi', 'th',
     ],

--- a/apps/marketing/src/components/LocaleSwitcher.astro
+++ b/apps/marketing/src/components/LocaleSwitcher.astro
@@ -12,6 +12,7 @@ const labels: Record<Locale, string> = {
   en: "English",
   sk: "Slovenčina",
   ko: "한국어",
+  ja: "日本語",
   de: "Deutsch",
   fr: "Français",
   it: "Italiano",

--- a/apps/marketing/src/i18n/index.ts
+++ b/apps/marketing/src/i18n/index.ts
@@ -13,6 +13,7 @@
 import en from "./en.json";
 import sk from "./sk.json";
 import ko from "./ko.json";
+import ja from "./ja.json";
 import de from "./de.json";
 import fr from "./fr.json";
 import it from "./it.json";
@@ -32,7 +33,7 @@ import hi from "./hi.json";
 import th from "./th.json";
 
 export const LOCALES = [
-  "en", "sk", "ko",
+  "en", "sk", "ko", "ja",
   "de", "fr", "it", "es", "pt-br", "pl", "cs", "hu",
   "ar", "he", "zh-cn", "zh-tw", "ru", "uk", "tr", "hi", "th",
 ] as const;
@@ -40,7 +41,7 @@ export type Locale = (typeof LOCALES)[number];
 export const DEFAULT_LOCALE: Locale = "en";
 
 const dictionaries = {
-  en, sk, ko,
+  en, sk, ko, ja,
   de, fr, it, es, "pt-br": ptBr, pl, cs, hu,
   ar, he, "zh-cn": zhCn, "zh-tw": zhTw, ru, uk, tr, hi, th,
 } as const;

--- a/apps/marketing/src/i18n/ja.json
+++ b/apps/marketing/src/i18n/ja.json
@@ -1,0 +1,24 @@
+{
+  "common": {
+    "tagline_part1": "エージェントにウォレットを渡すな。",
+    "tagline_part2": "委任状を渡せ。",
+    "_TODO_JA_REVIEW_tagline": "Native Japanese reviewer: '委任状' (proxy/letter of attorney) preserves the noun-form mandate framing; alternative '権限' (authority) loses the parallel structure with ウォレット.",
+    "cta_start": "5分で始める",
+    "cta_view_source": "ソースを見る",
+    "cta_walk_demo": "デモを見る",
+    "cta_verify": "カプセルを自分で検証",
+    "nav_features": "機能",
+    "nav_proof": "証明",
+    "nav_demo": "デモ",
+    "nav_docs": "ドキュメント",
+    "nav_github": "GitHub",
+    "nav_quickstart": "クイックスタート",
+    "footer_about": "SBO3L · ETHGlobal Open Agents 2026 — 提出作品"
+  },
+  "index": {
+    "lede": "SBO3L は自律型 AI エージェント向けの暗号学的に検証可能な信頼レイヤーです。エージェントが実行するすべてのアクション — 支払い、スワップ、ストレージ、計算、調整 — はまず SBO3L のポリシー境界を通過します。"
+  },
+  "submission": {
+    "h1": "自律型 AI エージェント向けの暗号学的に検証可能な信頼レイヤー。"
+  }
+}


### PR DESCRIPTION
## Summary

Closes a gap in the R13 P4 brief: **JA** was listed alongside KO/DE/FR as an existing locale but never actually shipped (only KO landed in R9 — DE/FR landed in R13 P4a #280, RTL+CJK in #284). Adding it now brings the total to **21 locales**.

Brand wordplay preserved: **\"委任状\"** (proxy / letter of attorney) keeps the noun-form parallel with **ウォレット**. \`_TODO_JA_REVIEW_tagline\` flags the \"委任状 vs 権限\" judgment call for native review.

## Test plan

- [ ] CI build green (Astro 5 generates /ja/ for JA routes)
- [ ] LocaleSwitcher renders 21 entries
- [ ] _TODO marker doesn't leak into rendered UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)