### PR TITLE
feat(hosted-app): per-tenant billing UI at /t/[slug]/admin/billing (R13 P9)

### DIFF
--- a/apps/hosted-app/app/t/[tenant]/admin/billing/page.tsx
+++ b/apps/hosted-app/app/t/[tenant]/admin/billing/page.tsx
@@ -1,0 +1,99 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { auth } from "@/auth";
+import { tenantBySlug, userHasAccessTo } from "@/lib/tenants";
+import { billingForTenant, TIER_LIMITS, fmtNumber, type Tier } from "@/lib/tenant-billing";
+
+interface Props { params: Promise<{ tenant: string }> }
+
+export const dynamic = "force-dynamic";
+
+export default async function TenantBillingPage({ params }: Props): Promise<JSX.Element> {
+  const { tenant: slug } = await params;
+  const tenant = tenantBySlug(slug);
+  if (!tenant) notFound();
+
+  const session = await auth();
+  const userId = session?.user?.githubLogin ?? session?.user?.email ?? null;
+  const membership = userHasAccessTo(userId, slug);
+  if (!membership) notFound();
+  if (membership.role !== "admin") {
+    return (
+      <main>
+        <h1>Billing — {tenant.display_name}</h1>
+        <p style={{ color: "var(--muted)", margin: "1em 0" }}>
+          Billing settings are <code>admin</code>-only. Your role is <code>{membership.role}</code>.
+        </p>
+        <p><Link href={`/t/${slug}/dashboard`}>← Back to dashboard</Link></p>
+      </main>
+    );
+  }
+
+  const billing = billingForTenant(slug);
+  if (!billing) notFound();
+
+  const current = TIER_LIMITS[billing.tier];
+  const decisionsCap = typeof current.decisions_per_month === "number" ? current.decisions_per_month : Infinity;
+  const decisionsPct = decisionsCap === Infinity ? 0 : Math.min(100, (billing.decisions_this_month / decisionsCap) * 100);
+
+  return (
+    <main>
+      <header style={{ marginBottom: "1.5em" }}>
+        <h1 style={{ marginBottom: "0.2em" }}>Billing — {tenant.display_name}</h1>
+        <p style={{ color: "var(--muted)", margin: 0, maxWidth: 760 }}>
+          Tier <code>{billing.tier}</code>{billing.next_invoice_at && <> · next invoice {new Date(billing.next_invoice_at).toLocaleDateString()}</>}
+          {billing.payment_method && <> · {billing.payment_method}</>}.
+        </p>
+      </header>
+
+      <section style={{ background: "var(--code-bg)", border: "1px solid var(--border)", borderRadius: "var(--r-md)", padding: "1em 1.2em", marginBottom: "1.5em" }}>
+        <h2 style={{ margin: "0 0 0.4em", fontSize: "0.95em" }}>This month's usage</h2>
+        <div style={{ display: "grid", gap: "0.4em", fontFamily: "var(--font-mono)", fontSize: "0.88em" }}>
+          <div>Decisions: <strong>{billing.decisions_this_month.toLocaleString()}</strong> / {fmtNumber(current.decisions_per_month)}</div>
+          {decisionsCap !== Infinity && (
+            <div role="progressbar" aria-valuenow={Math.round(decisionsPct)} aria-valuemin={0} aria-valuemax={100} style={{ height: 6, background: "var(--border)", borderRadius: 3, overflow: "hidden" }}>
+              <div style={{ width: `${decisionsPct}%`, height: "100%", background: decisionsPct > 80 ? "#f87171" : "var(--accent)" }} />
+            </div>
+          )}
+          <div>Agents: <strong>{billing.agents_count}</strong> / {fmtNumber(current.agents)}</div>
+        </div>
+      </section>
+
+      <h2 style={{ fontSize: "1em", margin: "0 0 0.6em" }}>Plans</h2>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: "0.8em" }}>
+        {(Object.keys(TIER_LIMITS) as Tier[]).map((tier) => {
+          const limits = TIER_LIMITS[tier];
+          const isCurrent = tier === billing.tier;
+          return (
+            <div key={tier} style={{ border: `1px solid ${isCurrent ? "var(--accent)" : "var(--border)"}`, borderRadius: "var(--r-md)", padding: "1em 1.1em", background: "var(--code-bg)" }}>
+              <h3 style={{ margin: "0 0 0.2em", textTransform: "capitalize", fontSize: "1.05em" }}>{tier}</h3>
+              <p style={{ margin: "0 0 0.6em", color: "var(--muted)", fontFamily: "var(--font-mono)", fontSize: "1.1em" }}>
+                {limits.monthly_usd === 0 ? "$0" : `$${limits.monthly_usd}`}<span style={{ fontSize: "0.7em" }}>/mo</span>
+              </p>
+              <ul style={{ listStyle: "none", padding: 0, margin: 0, fontSize: "0.85em", display: "grid", gap: "0.2em", color: "var(--muted)" }}>
+                <li>· {fmtNumber(limits.agents)} agents</li>
+                <li>· {fmtNumber(limits.decisions_per_month)} decisions/mo</li>
+                <li>· {limits.audit_retention_days}-day audit</li>
+                <li>· {limits.support_sla}</li>
+              </ul>
+              <div style={{ marginTop: "0.8em" }}>
+                {isCurrent ? (
+                  <span style={{ fontSize: "0.85em", color: "var(--accent)" }}>● current plan</span>
+                ) : (
+                  <button disabled className="ghost" style={{ fontSize: "0.85em", width: "100%" }}>
+                    {limits.monthly_usd > (TIER_LIMITS[billing.tier].monthly_usd) ? "Upgrade" : "Downgrade"} (Stripe checkout — coming P3.5)
+                  </button>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <aside style={{ marginTop: "1.5em", padding: "1em 1.2em", background: "var(--code-bg)", border: "1px solid var(--border)", borderLeft: "3px solid var(--accent)", borderRadius: "var(--r-md)", color: "var(--muted)", fontSize: "0.88em" }}>
+        <strong style={{ color: "var(--fg)" }}>Stripe wiring is mocked.</strong>{" "}
+        See <Link href="https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/docs/dev3/production/02-stripe-billing-runbook.md" target="_blank" rel="noopener">docs/dev3/production/02-stripe-billing-runbook.md</Link> for the full webhook flow + tier-change state machine. Real Checkout sessions require the daemon's <code>/api/billing/checkout</code> endpoint plus a Stripe account linked at tenant onboarding.
+      </aside>
+    </main>
+  );
+}

--- a/apps/hosted-app/lib/tenant-billing.ts
+++ b/apps/hosted-app/lib/tenant-billing.ts
@@ -1,0 +1,67 @@
+// Mock per-tenant billing snapshot. Real source: Stripe Subscription
+// for the tenant's customer. Hosted-app reads via /v1/tenants/<slug>/billing
+// (proxied to Stripe Subscription Get + cached for 60s).
+//
+// See docs/dev3/production/02-stripe-billing-runbook.md for the
+// production wiring plan.
+
+export type Tier = "free" | "pro" | "enterprise";
+
+export interface TierLimits {
+  tenants: number | "unlimited";
+  agents: number | "unlimited";
+  decisions_per_month: number | "unlimited";
+  audit_retention_days: number;
+  support_sla: string;
+  monthly_usd: number;
+}
+
+export const TIER_LIMITS: Record<Tier, TierLimits> = {
+  free: {
+    tenants: 1,
+    agents: 3,
+    decisions_per_month: 10_000,
+    audit_retention_days: 30,
+    support_sla: "Community",
+    monthly_usd: 0,
+  },
+  pro: {
+    tenants: 5,
+    agents: "unlimited",
+    decisions_per_month: 1_000_000,
+    audit_retention_days: 365,
+    support_sla: "Email · 24h response",
+    monthly_usd: 29,
+  },
+  enterprise: {
+    tenants: "unlimited",
+    agents: "unlimited",
+    decisions_per_month: "unlimited",
+    audit_retention_days: 2555,
+    support_sla: "Dedicated · 1h response",
+    monthly_usd: 499,
+  },
+};
+
+export interface TenantBilling {
+  tier: Tier;
+  next_invoice_at?: string;
+  decisions_this_month: number;
+  agents_count: number;
+  payment_method?: string;
+}
+
+const BILLING_SNAPSHOTS: Record<string, TenantBilling> = {
+  acme:     { tier: "pro",        next_invoice_at: "2026-06-01", decisions_this_month: 47_320, agents_count: 3, payment_method: "Visa •• 4242" },
+  contoso:  { tier: "free",                                       decisions_this_month: 1_204,  agents_count: 1 },
+  fabrikam: { tier: "enterprise", next_invoice_at: "2026-06-01", decisions_this_month: 2_104_802, agents_count: 4, payment_method: "Wire transfer · NET-30" },
+};
+
+export function billingForTenant(slug: string): TenantBilling | undefined {
+  return BILLING_SNAPSHOTS[slug];
+}
+
+export function fmtNumber(value: number | "unlimited"): string {
+  if (value === "unlimited") return "unlimited";
+  return value.toLocaleString();
+}


### PR DESCRIPTION
## Summary

Visible companion to **\`docs/dev3/production/02-stripe-billing-runbook.md\`** (merged in #294). Per-tenant billing surface:

- **Current tier badge** + next invoice date + payment method
- **This-month usage** with progress bar (decisions/mo, agents)
- **3-tier pricing matrix** (Free / Pro \$29 / Enterprise \$499) with upgrade/downgrade buttons (disabled — Stripe wiring lands in P3.5)
- **Inline pointer to the runbook** for the full webhook state machine

Mock fixtures per tenant: **acme** is Pro mid-month (47K decisions), **contoso** is Free near limit, **fabrikam** is Enterprise at 2.1M decisions.

Admin-role gated (matches the Policy editor in #290). Layout nav link deferred to avoid conflict with #290 — discovered via direct URL.

## Test plan

- [ ] /t/acme/admin/billing renders Pro tier card highlighted
- [ ] /t/contoso/admin/billing shows Free progress bar near 12% (1.2K/10K)
- [ ] /t/fabrikam/admin/billing shows Enterprise with NET-30 wire transfer
- [ ] Viewer/operator role sees \"admin only\" fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)