### PR TITLE
fix(deps): sync Cargo.lock — add missing proptest entry (Docker build fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3419,6 +3419,7 @@ dependencies = [
  "hex",
  "jsonschema",
  "k256",
+ "proptest",
  "rand 0.8.6",
  "rust_decimal",
  "serde",


### PR DESCRIPTION
## Summary
PR #289 added proptest as a dev-dep to sbo3l-core but the Cargo.lock entry wasn't committed. Docker builds (using --locked) failing with:

```
error: cannot update the lock file /build/Cargo.lock because --locked was passed
```

## Fix
`cargo update --workspace` regenerates the lock entry. One line added.

## Test plan
- [x] `cargo check --locked --workspace` passes
- [ ] Docker build green on this PR
- [ ] Multi-framework smoke green
