### PR TITLE
docs(impl-status): bump cargo test count 377 → 777

### DIFF
--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -17,7 +17,7 @@ For the **B5 final audit (earlier snapshot)** see [`FINAL_REVIEW_B5.md`](FINAL_R
 |---|---|
 | `cargo fmt --check` | ✅ |
 | `cargo clippy --workspace --all-targets -- -D warnings` | ✅ no warnings |
-| `cargo test --workspace --all-targets` | ✅ **377 / 377 pass** (0 fail, 0 ignored) |
+| `cargo test --workspace --tests --no-fail-fast` | ✅ **777 / 777 pass** (0 fail) across 37 test binaries on 10 crates |
 | `python3 scripts/validate_schemas.py` | ✅ (7 schemas + 14 corpus fixtures) |
 | `python3 scripts/validate_openapi.py` | ✅ (`docs/api/openapi.json` valid) |
 | `bash demo-scripts/run-openagents-final.sh` | ✅ all **13 gates** green incl. audit-chain tamper detection and agent no-key proof (~10s end-to-end) |


### PR DESCRIPTION
Stale row in IMPLEMENTATION_STATUS.md table — verified locally 777/777 across 37 binaries on main HEAD.