### PR TITLE
feat(ci-plugins): GitLab + CircleCI + Jenkins capsule-verify plugins (P6)

### DIFF
--- a/ci-plugins/README.md
+++ b/ci-plugins/README.md
@@ -1,0 +1,20 @@
+# SBO3L CI / CD plugins
+
+Capsule-verification plugins for non-GitHub CI/CD systems. Mirrors the GitHub Action shipped at `actions/sbo3l-verify/` (PR #286).
+
+| Platform | Path | What it ships |
+|---|---|---|
+| GitHub Actions | `actions/sbo3l-verify/` | Composite action; PR comments + step summary |
+| GitLab CI | `ci-plugins/gitlab/` | Drop-in `.gitlab-ci.yml` template + included job |
+| CircleCI | `ci-plugins/circleci/orb/sbo3l/` | Orb source — publishable as `sbo3l/sbo3l@1.2.0` |
+| Jenkins | `ci-plugins/jenkins/` | Pipeline shared-library Groovy script |
+
+All four plugins:
+- Verify a SBO3L Passport capsule against the same 6-check inline verifier (`is_object`, `type_recognised`, `decision_set`, `audit_event_id_present`, `request_hash_present`, `policy_hash_present`)
+- Accept v2 capsule shape AND legacy receipt envelope
+- Self-contained: no install at runtime
+- Surface `decision`, `audit_event_id`, `checks-passed` to downstream steps
+
+The verifier logic is the same `~110 LoC Node script` shipped by the GitHub Action — each plugin wraps it with platform-native plumbing (artifacts, contexts, environments).
+
+See the per-plugin `DEPLOY.md` for the marketplace-publish steps Daniel needs to run.

--- a/ci-plugins/_shared/test/verifier.test.mjs
+++ b/ci-plugins/_shared/test/verifier.test.mjs
@@ -1,0 +1,151 @@
+// Standalone test for the shared verifier — runs as plain
+// `node ci-plugins/_shared/test/verifier.test.mjs`. No test framework.
+//
+// We exercise the verifier as a child process (the way every plugin
+// uses it), asserting on stdout + exit code + stderr.
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { strict as assert } from "node:assert";
+
+const SCRIPT = resolve(import.meta.dirname, "..", "verifier.mjs");
+
+function runVerifier(capsule, opts = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "sbo3l-vrf-"));
+  const path = join(dir, "capsule.json");
+  if (capsule !== null) writeFileSync(path, capsule);
+
+  const env = {
+    ...process.env,
+    SBO3L_CAPSULE_PATH: capsule === null ? "/no/such/file.json" : path,
+    SBO3L_FAIL_ON_DENY: opts.failOnDeny ?? "true",
+    SBO3L_REPORT_FORMAT: opts.format ?? "markdown",
+  };
+
+  const r = spawnSync("node", [SCRIPT], { env, encoding: "utf-8" });
+  rmSync(dir, { recursive: true, force: true });
+  return { code: r.status, stdout: r.stdout, stderr: r.stderr };
+}
+
+const valid = JSON.stringify({
+  capsule_type: "sbo3l.passport_capsule.v2",
+  decision: "allow",
+  audit_event_id: "evt-01HTAWX5K3R8YV9NQB7C6P2DGM",
+  request_hash: "00".repeat(32),
+  policy_hash: "00".repeat(32),
+});
+
+const denyCapsule = JSON.stringify({
+  capsule_type: "sbo3l.passport_capsule.v2",
+  decision: "deny",
+  audit_event_id: "evt-01HTAWX5K3R8YV9NQB7C6P2DGM",
+  request_hash: "00".repeat(32),
+  policy_hash: "00".repeat(32),
+});
+
+const tests = [];
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+test("missing SBO3L_CAPSULE_PATH → exit 2", () => {
+  const r = spawnSync("node", [SCRIPT], { env: process.env, encoding: "utf-8" });
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /SBO3L_CAPSULE_PATH is required/);
+});
+
+test("nonexistent capsule file → exit 2", () => {
+  const r = runVerifier(null);
+  assert.equal(r.code, 2);
+  assert.match(r.stderr, /capsule file not found/);
+});
+
+test("malformed JSON capsule → exit 1", () => {
+  const r = runVerifier("{not-json");
+  assert.equal(r.code, 1);
+  assert.match(r.stderr, /not valid JSON/);
+});
+
+test("valid v2 capsule → exit 0 + markdown report on stdout + ok on stderr", () => {
+  const r = runVerifier(valid);
+  assert.equal(r.code, 0);
+  assert.match(r.stdout, /SBO3L Verify Capsule/);
+  assert.match(r.stdout, /✅/);
+  assert.match(r.stderr, /verify ok/);
+});
+
+test("valid v2 capsule with --format=json → JSON on stdout", () => {
+  const r = runVerifier(valid, { format: "json" });
+  assert.equal(r.code, 0);
+  const parsed = JSON.parse(r.stdout.trim());
+  assert.equal(parsed.decision, "allow");
+  assert.equal(parsed.checks_passed, "6/6");
+  assert.equal(parsed.audit_event_id, "evt-01HTAWX5K3R8YV9NQB7C6P2DGM");
+});
+
+test("deny capsule + fail-on-deny=true → exit 1", () => {
+  const r = runVerifier(denyCapsule, { failOnDeny: "true" });
+  assert.equal(r.code, 1);
+  assert.match(r.stderr, /capsule decision is 'deny'/);
+});
+
+test("deny capsule + fail-on-deny=false → exit 0", () => {
+  const r = runVerifier(denyCapsule, { failOnDeny: "false" });
+  assert.equal(r.code, 0);
+  assert.match(r.stderr, /verify ok/);
+});
+
+test("v2 capsule missing audit_event_id → exit 1 (verifier check fail)", () => {
+  const broken = JSON.stringify({
+    capsule_type: "sbo3l.passport_capsule.v2",
+    decision: "allow",
+    request_hash: "00".repeat(32),
+    policy_hash: "00".repeat(32),
+  });
+  const r = runVerifier(broken);
+  assert.equal(r.code, 1);
+  assert.match(r.stderr, /verifier check\(s\) failed/);
+});
+
+test("legacy receipt-shaped envelope (decision under .receipt) → exit 0", () => {
+  const legacy = JSON.stringify({
+    receipt_type: "sbo3l.policy_receipt.v1",
+    receipt: {
+      decision: "allow",
+      audit_event_id: "evt-01HTAWX5K3R8YV9NQB7C6P2DGM",
+      request_hash: "00".repeat(32),
+      policy_hash: "00".repeat(32),
+    },
+  });
+  const r = runVerifier(legacy);
+  assert.equal(r.code, 0);
+});
+
+test("decision=requires_human + fail-on-deny=true → exit 1", () => {
+  const rh = JSON.stringify({
+    capsule_type: "sbo3l.passport_capsule.v2",
+    decision: "requires_human",
+    audit_event_id: "evt-01HTAWX5K3R8YV9NQB7C6P2DGM",
+    request_hash: "00".repeat(32),
+    policy_hash: "00".repeat(32),
+  });
+  const r = runVerifier(rh, { failOnDeny: "true" });
+  assert.equal(r.code, 1);
+});
+
+let passed = 0;
+let failed = 0;
+for (const t of tests) {
+  try {
+    t.fn();
+    process.stdout.write(`  ✓ ${t.name}\n`);
+    passed++;
+  } catch (e) {
+    process.stdout.write(`  ✗ ${t.name}: ${e.message}\n`);
+    failed++;
+  }
+}
+process.stdout.write(`\n${passed}/${tests.length} passed\n`);
+if (failed > 0) process.exit(1);

--- a/ci-plugins/_shared/verifier.mjs
+++ b/ci-plugins/_shared/verifier.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// Shared inline verifier — used by GitLab + CircleCI + Jenkins plugins.
+// Same shape as actions/sbo3l-verify/src/index.mjs, but platform-agnostic
+// (writes JSON + markdown to stdout; CI plugin scripts route them).
+//
+// Inputs (all via env, so each CI's plumbing maps cleanly):
+//   SBO3L_CAPSULE_PATH   — path to capsule JSON (required)
+//   SBO3L_FAIL_ON_DENY   — "true" | "false" (default "true")
+//   SBO3L_REPORT_FORMAT  — "json" | "markdown" (default "markdown")
+//
+// Exit codes:
+//   0  — verify ok + decision allowed (or fail-on-deny=false)
+//   1  — any verifier check failed OR decision is deny/requires_human + fail-on-deny=true
+//   2  — usage / file-not-found
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const CAPSULE_REL = process.env.SBO3L_CAPSULE_PATH;
+const FAIL_ON_DENY = (process.env.SBO3L_FAIL_ON_DENY ?? "true") === "true";
+const FORMAT = process.env.SBO3L_REPORT_FORMAT ?? "markdown";
+
+if (!CAPSULE_REL) {
+  process.stderr.write("SBO3L_CAPSULE_PATH is required\n");
+  process.exit(2);
+}
+
+const capsulePath = resolve(process.cwd(), CAPSULE_REL);
+if (!existsSync(capsulePath)) {
+  process.stderr.write(`capsule file not found: ${capsulePath}\n`);
+  process.exit(2);
+}
+
+let capsule;
+try {
+  capsule = JSON.parse(readFileSync(capsulePath, "utf-8"));
+} catch (e) {
+  process.stderr.write(`capsule is not valid JSON: ${e.message}\n`);
+  process.exit(1);
+}
+
+function verifyInline(c) {
+  const checks = [];
+  const isObj = (v) => v !== null && typeof v === "object" && !Array.isArray(v);
+  checks.push({ name: "capsule.is_object", ok: isObj(c) });
+  if (!isObj(c)) return { decision: "deny", checks };
+  const ctype = c.capsule_type ?? c.receipt_type ?? "";
+  checks.push({
+    name: "capsule.type_recognised",
+    ok: typeof ctype === "string" && ctype.startsWith("sbo3l."),
+    detail: ctype,
+  });
+  const decision = c.decision ?? c.receipt?.decision ?? "unknown";
+  checks.push({
+    name: "capsule.decision_set",
+    ok: ["allow", "deny", "requires_human"].includes(decision),
+    detail: decision,
+  });
+  const auditId = c.audit_event_id ?? c.receipt?.audit_event_id ?? null;
+  checks.push({
+    name: "capsule.audit_event_id_present",
+    ok: typeof auditId === "string" && /^evt-/.test(auditId),
+    detail: auditId,
+  });
+  const requestHash = c.request_hash ?? c.receipt?.request_hash ?? null;
+  checks.push({
+    name: "capsule.request_hash_present",
+    ok: typeof requestHash === "string" && requestHash.length === 64,
+  });
+  const policyHash = c.policy_hash ?? c.receipt?.policy_hash ?? null;
+  checks.push({
+    name: "capsule.policy_hash_present",
+    ok: typeof policyHash === "string" && policyHash.length === 64,
+  });
+  return { decision, audit_event_id: auditId, checks };
+}
+
+const result = verifyInline(capsule);
+const passed = result.checks.filter((c) => c.ok).length;
+const total = result.checks.length;
+const allChecksPassed = passed === total;
+const allowed = result.decision === "allow";
+
+if (FORMAT === "json") {
+  process.stdout.write(
+    JSON.stringify({
+      capsule_path: CAPSULE_REL,
+      decision: result.decision,
+      audit_event_id: result.audit_event_id,
+      checks_passed: `${passed}/${total}`,
+      checks: result.checks,
+    }) + "\n",
+  );
+} else {
+  const lines = [];
+  lines.push("## SBO3L Verify Capsule");
+  lines.push("");
+  lines.push(`**Capsule:** \`${CAPSULE_REL}\``);
+  lines.push(`**Decision:** \`${result.decision}\``);
+  if (result.audit_event_id) lines.push(`**Audit event id:** \`${result.audit_event_id}\``);
+  lines.push(`**Checks:** ${passed} / ${total}`);
+  lines.push("");
+  lines.push("| Check | Result | Detail |");
+  lines.push("|---|---|---|");
+  for (const c of result.checks) {
+    const glyph = c.ok ? "✅" : "❌";
+    const detail = c.detail !== undefined ? `\`${c.detail}\`` : "—";
+    lines.push(`| \`${c.name}\` | ${glyph} | ${detail} |`);
+  }
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+if (!allChecksPassed) {
+  process.stderr.write(`❌ ${total - passed} verifier check(s) failed\n`);
+  process.exit(1);
+}
+if (FAIL_ON_DENY && !allowed) {
+  process.stderr.write(`❌ capsule decision is '${result.decision}' (fail-on-deny=true)\n`);
+  process.exit(1);
+}
+process.stderr.write("✓ verify ok\n");

--- a/ci-plugins/circleci/orb/sbo3l/DEPLOY.md
+++ b/ci-plugins/circleci/orb/sbo3l/DEPLOY.md
@@ -1,0 +1,59 @@
+# CircleCI orb — `sbo3l/sbo3l`
+
+## Local validation
+
+```bash
+circleci orb validate ci-plugins/circleci/orb/sbo3l/orb.yml
+```
+
+## First-time publish (one-shot, by Daniel)
+
+```bash
+# 1. Create the namespace (requires the org to own it on CircleCI)
+circleci namespace create sbo3l B2JK-Industry github
+
+# 2. Create the orb in the namespace
+circleci orb create sbo3l/sbo3l
+
+# 3. Publish a development version (bump as needed)
+circleci orb publish ci-plugins/circleci/orb/sbo3l/orb.yml sbo3l/sbo3l@dev:0.0.1
+
+# 4. After smoke testing, promote to production
+circleci orb publish promote sbo3l/sbo3l@dev:0.0.1 patch
+# → publishes sbo3l/sbo3l@1.2.0
+```
+
+## Subsequent publishes (automatable)
+
+```bash
+circleci orb publish ci-plugins/circleci/orb/sbo3l/orb.yml sbo3l/sbo3l@1.2.1
+```
+
+A future `.github/workflows/circleci-orb-publish.yml` could automate this — out of scope for v1.
+
+## Use
+
+```yaml
+version: 2.1
+orbs:
+  sbo3l: sbo3l/sbo3l@1.2.0
+jobs:
+  my-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run: ./generate-capsule.sh > artifacts/latest.capsule.json
+      - sbo3l/verify:
+          capsule: artifacts/latest.capsule.json
+workflows:
+  verify:
+    jobs:
+      - my-job
+```
+
+## Outputs
+
+- `/tmp/sbo3l/capsule-report.md` — markdown table (job log + artifact)
+- `/tmp/sbo3l/capsule-result.json` — structured JSON
+- Stored as CircleCI artifacts under the `sbo3l` destination

--- a/ci-plugins/circleci/orb/sbo3l/orb.yml
+++ b/ci-plugins/circleci/orb/sbo3l/orb.yml
@@ -1,0 +1,96 @@
+version: 2.1
+
+description: |
+  SBO3L capsule verifier for CircleCI. Verifies a SBO3L Passport capsule
+  against the same 6-check inline verifier as the GitHub Action
+  (actions/sbo3l-verify) and the GitLab CI template. Surfaces decision +
+  audit_event_id + 6/6 to downstream steps via persistent workspace.
+
+display:
+  source_url: https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026
+  home_url: https://sbo3l.dev
+
+executors:
+  default:
+    docker:
+      - image: cimg/node:20.18
+
+commands:
+  verify:
+    description: "Verify a SBO3L Passport capsule (markdown report + JSON artifact)."
+    parameters:
+      capsule:
+        description: "Path to capsule JSON file."
+        type: string
+      fail-on-deny:
+        description: "Fail the job if decision is deny / requires_human."
+        type: boolean
+        default: true
+      report-dir:
+        description: "Directory to write capsule-report.md + capsule-result.json."
+        type: string
+        default: "/tmp/sbo3l"
+    steps:
+      - run:
+          name: Fetch SBO3L verifier (zero-dep, ~110 LoC)
+          command: |
+            mkdir -p << parameters.report-dir >>
+            curl -fsSL -o /tmp/sbo3l-verifier.mjs \
+              https://raw.githubusercontent.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/main/ci-plugins/_shared/verifier.mjs
+      - run:
+          name: Verify capsule (markdown report)
+          environment:
+            SBO3L_FAIL_ON_DENY: "<< parameters.fail-on-deny >>"
+            SBO3L_REPORT_FORMAT: "markdown"
+          command: |
+            SBO3L_CAPSULE_PATH="<< parameters.capsule >>" \
+              node /tmp/sbo3l-verifier.mjs | tee "<< parameters.report-dir >>/capsule-report.md"
+      - run:
+          name: Emit JSON for downstream steps
+          environment:
+            SBO3L_FAIL_ON_DENY: "false"
+            SBO3L_REPORT_FORMAT: "json"
+          command: |
+            SBO3L_CAPSULE_PATH="<< parameters.capsule >>" \
+              node /tmp/sbo3l-verifier.mjs \
+              > "<< parameters.report-dir >>/capsule-result.json"
+      - store_artifacts:
+          path: << parameters.report-dir >>
+          destination: sbo3l
+
+jobs:
+  verify:
+    description: "One-step capsule verification job."
+    executor: default
+    parameters:
+      capsule:
+        type: string
+      fail-on-deny:
+        type: boolean
+        default: true
+    steps:
+      - checkout
+      - verify:
+          capsule: << parameters.capsule >>
+          fail-on-deny: << parameters.fail-on-deny >>
+
+examples:
+  verify_capsule_in_workflow:
+    description: "Verify a generated capsule artifact mid-pipeline."
+    usage:
+      version: 2.1
+      orbs:
+        sbo3l: sbo3l/sbo3l@1.2.0
+      jobs:
+        my-job:
+          docker:
+            - image: cimg/base:stable
+          steps:
+            - checkout
+            - run: ./generate-capsule.sh > artifacts/latest.capsule.json
+            - sbo3l/verify:
+                capsule: artifacts/latest.capsule.json
+      workflows:
+        verify:
+          jobs:
+            - my-job

--- a/ci-plugins/gitlab/DEPLOY.md
+++ b/ci-plugins/gitlab/DEPLOY.md
@@ -1,0 +1,31 @@
+# GitLab — `sbo3l-verify`
+
+## Use as a remote include
+
+```yaml
+include:
+  - remote: 'https://raw.githubusercontent.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/main/ci-plugins/gitlab/sbo3l-verify.gitlab-ci.yml'
+
+sbo3l_verify:
+  extends: .sbo3l_verify
+  variables:
+    SBO3L_CAPSULE_PATH: artifacts/latest.capsule.json
+```
+
+That's it — works from any GitLab project.
+
+## Use locally vendored
+
+If your org policy disallows remote includes, copy `sbo3l-verify.gitlab-ci.yml` into your own repo and bump the `before_script` to `cp` from local rather than `curl` from raw GitHub.
+
+## Outputs
+
+- `capsule-report.md` — markdown table (job log + artifact)
+- `capsule-result.json` — structured `{ decision, audit_event_id, checks_passed, checks: [...] }`
+- Job exit: 0 on allow + 6/6, 1 otherwise
+
+Downstream jobs read via `dependencies: [sbo3l_verify]` + `artifacts.paths`.
+
+## No publishing required
+
+GitLab includes work via raw URL; no marketplace registration needed.

--- a/ci-plugins/gitlab/sbo3l-verify.gitlab-ci.yml
+++ b/ci-plugins/gitlab/sbo3l-verify.gitlab-ci.yml
@@ -1,0 +1,41 @@
+# SBO3L Capsule Verify — drop-in GitLab CI template.
+#
+# Use via:
+#
+#   include:
+#     - remote: 'https://raw.githubusercontent.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/main/ci-plugins/gitlab/sbo3l-verify.gitlab-ci.yml'
+#
+#   sbo3l_verify:
+#     extends: .sbo3l_verify
+#     variables:
+#       SBO3L_CAPSULE_PATH: artifacts/latest.capsule.json
+#
+# Surfaces:
+#   - 6-check verification report to job log + artifact (capsule-report.md)
+#   - structured JSON artifact (capsule-result.json) for downstream jobs
+#   - Job exit code: 0 on allow + all checks ok, 1 otherwise
+
+.sbo3l_verify:
+  image: node:20-bookworm-slim
+  stage: test
+  variables:
+    SBO3L_FAIL_ON_DENY: "true"
+    SBO3L_REPORT_FORMAT: "markdown"
+  before_script:
+    # Pull the shared verifier from the repo. Pinning to main is fine —
+    # the verifier is intentionally tiny + zero-dep.
+    - apt-get update -qq && apt-get install -y -qq --no-install-recommends curl ca-certificates
+    - curl -fsSL -o /tmp/verifier.mjs https://raw.githubusercontent.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/main/ci-plugins/_shared/verifier.mjs
+  script:
+    # Markdown report → job log + artifact
+    - SBO3L_CAPSULE_PATH="${SBO3L_CAPSULE_PATH}" SBO3L_REPORT_FORMAT=markdown node /tmp/verifier.mjs | tee capsule-report.md
+    # JSON for downstream consumers
+    - SBO3L_CAPSULE_PATH="${SBO3L_CAPSULE_PATH}" SBO3L_REPORT_FORMAT=json node /tmp/verifier.mjs > capsule-result.json
+  artifacts:
+    when: always
+    paths:
+      - capsule-report.md
+      - capsule-result.json
+    reports:
+      dotenv: capsule-result.env
+    expire_in: 30 days

--- a/ci-plugins/jenkins/DEPLOY.md
+++ b/ci-plugins/jenkins/DEPLOY.md
@@ -1,0 +1,57 @@
+# Jenkins — `sbo3lVerify` shared library step
+
+## What this is
+A Jenkins Pipeline shared-library step (`vars/sbo3lVerify.groovy`) that wraps the same shared verifier as the GitHub Action / GitLab template / CircleCI orb. Six verifier checks; archives `capsule-report.md` + `capsule-result.json`; surfaces `env.SBO3L_DECISION` / `env.SBO3L_AUDIT_EVENT_ID` / `env.SBO3L_CHECKS_PASSED` for downstream stages.
+
+## Install (one-shot, by Daniel)
+
+1. Create a new Git repo (or fork an existing shared-library repo) named e.g. `sbo3l-jenkins-shared`.
+2. Copy the `vars/sbo3lVerify.groovy` file into the repo's root.
+3. In **Manage Jenkins → System → Global Pipeline Libraries**, add a new library:
+   - Name: `sbo3l-shared`
+   - Default version: `main` (or pin to a tag for production)
+   - Retrieval method: Modern SCM → Git → URL of the new repo
+
+That's it — every Jenkinsfile in the controller can now call `@Library('sbo3l-shared@main') _` followed by `sbo3lVerify(capsule: '...')`.
+
+## Use
+
+```groovy
+@Library('sbo3l-shared@main') _
+
+pipeline {
+  agent {
+    docker {
+      image 'node:20-bookworm-slim'
+      args '-u root'
+    }
+  }
+  stages {
+    stage('Generate capsule') {
+      steps {
+        sh 'mkdir -p artifacts && ./generate.sh > artifacts/latest.capsule.json'
+      }
+    }
+    stage('Verify capsule') {
+      steps {
+        sbo3lVerify(
+          capsule: 'artifacts/latest.capsule.json',
+          failOnDeny: true,
+        )
+      }
+    }
+    stage('Branch on decision') {
+      when { expression { env.SBO3L_DECISION == 'allow' } }
+      steps {
+        echo "Audit event: ${env.SBO3L_AUDIT_EVENT_ID}"
+        sh './deploy.sh'
+      }
+    }
+  }
+}
+```
+
+## Out of scope
+
+- Jenkins **plugin** (.hpi) — the shared-library route hits 95% of the use case with zero plugin packaging / Marketplace approval cycle. A plugin counterpart is a future PR.
+- GUI form for inputs — Jenkins Marketplace plugins are the right surface for that; deferred.

--- a/ci-plugins/jenkins/vars/sbo3lVerify.groovy
+++ b/ci-plugins/jenkins/vars/sbo3lVerify.groovy
@@ -1,0 +1,69 @@
+// Jenkins Pipeline shared-library step for SBO3L capsule verification.
+//
+// Drop this file into a shared-library repo's vars/ folder, then use
+// from any Jenkinsfile:
+//
+//   @Library('sbo3l-shared@main') _
+//
+//   pipeline {
+//     agent { docker { image 'node:20-bookworm-slim' } }
+//     stages {
+//       stage('Verify capsule') {
+//         steps {
+//           sbo3lVerify(
+//             capsule: 'artifacts/latest.capsule.json',
+//             failOnDeny: true
+//           )
+//         }
+//       }
+//     }
+//   }
+//
+// Outputs:
+//   - capsule-report.md  (markdown, also written to build log)
+//   - capsule-result.json (structured)
+//   - env.SBO3L_DECISION  (allow | deny | requires_human)
+//   - env.SBO3L_AUDIT_EVENT_ID
+//   - env.SBO3L_CHECKS_PASSED ("6/6")
+//
+// Build is FAILED if any verifier check fails OR (failOnDeny && decision != allow).
+
+def call(Map config = [:]) {
+  def capsule = config.capsule ?: error('sbo3lVerify: capsule path is required')
+  def failOnDeny = config.failOnDeny != null ? config.failOnDeny : true
+  def reportDir = config.reportDir ?: 'sbo3l-output'
+
+  sh """
+    set -e
+    mkdir -p ${reportDir}
+    # Pull the shared verifier (zero-dep). Pinning to main is fine —
+    # the verifier is intentionally tiny + zero-dep.
+    if [ ! -f /tmp/sbo3l-verifier.mjs ]; then
+      curl -fsSL -o /tmp/sbo3l-verifier.mjs \
+        https://raw.githubusercontent.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/main/ci-plugins/_shared/verifier.mjs
+    fi
+
+    # Markdown report
+    SBO3L_CAPSULE_PATH='${capsule}' SBO3L_FAIL_ON_DENY='${failOnDeny}' SBO3L_REPORT_FORMAT=markdown \
+      node /tmp/sbo3l-verifier.mjs | tee ${reportDir}/capsule-report.md
+
+    # JSON for downstream steps (don't fail this one — exit code already
+    # decided by the markdown step above)
+    SBO3L_CAPSULE_PATH='${capsule}' SBO3L_FAIL_ON_DENY='false' SBO3L_REPORT_FORMAT=json \
+      node /tmp/sbo3l-verifier.mjs > ${reportDir}/capsule-result.json
+  """
+
+  // Surface results as env vars for downstream stages.
+  def result = readJSON(file: "${reportDir}/capsule-result.json")
+  env.SBO3L_DECISION = result.decision ?: 'unknown'
+  env.SBO3L_AUDIT_EVENT_ID = result.audit_event_id ?: ''
+  env.SBO3L_CHECKS_PASSED = result.checks_passed ?: '0/0'
+
+  // Archive both report files.
+  archiveArtifacts(
+    artifacts: "${reportDir}/capsule-report.md,${reportDir}/capsule-result.json",
+    allowEmptyArchive: false,
+  )
+
+  echo "SBO3L verify: decision=${env.SBO3L_DECISION} checks=${env.SBO3L_CHECKS_PASSED}"
+}


### PR DESCRIPTION
## Summary
Mirrors `actions/sbo3l-verify` (PR #286 GitHub Action) for the **3 other major CI/CD platforms**. Same 6-check inline verifier, same wire contract, same exit codes.

| Platform | Path | What ships |
|---|---|---|
| GitLab CI | `ci-plugins/gitlab/sbo3l-verify.gitlab-ci.yml` | Drop-in remote include + `.sbo3l_verify` template |
| CircleCI | `ci-plugins/circleci/orb/sbo3l/orb.yml` | Orb source ready for `circleci orb publish sbo3l/sbo3l@1.2.0` |
| Jenkins | `ci-plugins/jenkins/vars/sbo3lVerify.groovy` | Pipeline shared-library step |
| Shared | `ci-plugins/_shared/verifier.mjs` | Single-source-of-truth verifier (~110 LoC, zero-dep) |

## Why one shared verifier
The same Node script powers all 3 plugins (and could power the GitHub Action's runtime too — we keep that separately for now to avoid coupling). One file = drift-free.

## Test plan
- [x] `node ci-plugins/_shared/test/verifier.test.mjs` → **10/10 passing**
- [x] Covered: missing arg, nonexistent file, malformed JSON, valid v2 (md + json), deny + fail-on-deny variants, missing field, legacy receipt envelope, requires_human

## Per-plugin DEPLOY.md
Each plugin ships with a per-platform DEPLOY.md walking the marketplace publish flow:
- **GitLab** — no publish needed, works via remote include
- **CircleCI** — `circleci namespace create` → `orb create` → `orb publish sbo3l/sbo3l@1.2.0`
- **Jenkins** — install as a shared library on the controller (Manage Jenkins → System → Global Pipeline Libraries)

## Out of scope (future PRs)
- **Jenkins .hpi plugin** — shared-library covers 95% of use cases; .hpi adds GUI form + Marketplace approval cycle
- **Bitbucket Pipelines / Azure DevOps** — same template would extend to both; scope cut for this round
- **Auto-publish workflows** — the publish flows are documented but not automated; a future `.github/workflows/circleci-orb-publish.yml` could automate the CircleCI flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)