### PR TITLE
feat(hosted-app): operator console — date filters + CSV export + sbo3l-client (R14 P4)

### DIFF
--- a/apps/hosted-app/__tests__/audit-exports.test.ts
+++ b/apps/hosted-app/__tests__/audit-exports.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "@jest/globals";
+import { eventsToCsv, eventsToJsonl } from "../app/admin/audit/exports";
+import { eventMatchesFilters, EMPTY_FILTERS } from "../app/admin/audit/AuditFilters";
+import type { TimelineEvent } from "../app/admin/audit/audit-types";
+
+const sample: TimelineEvent[] = [
+  { kind: "decision.made", agent_id: "research-01", decision: "allow", ts_ms: 1714564961000, intent: "erc20.transfer" },
+  { kind: "decision.made", agent_id: "trader-02",   decision: "deny",  deny_code: "policy.budget_exceeded", ts_ms: 1714565000000 },
+  { kind: "audit.checkpoint", agent_id: "research-01", chain_length: 42, root_hash: "0xabcdef1234567890abc", ts_ms: 1714565100000 },
+];
+
+describe("eventsToCsv", () => {
+  it("emits RFC4180-compliant header + rows", () => {
+    const csv = eventsToCsv(sample);
+    expect(csv.startsWith("timestamp_iso,ts_ms,kind,agent_id,decision,deny_code,description")).toBe(true);
+    expect(csv).toContain("research-01");
+    expect(csv).toContain("policy.budget_exceeded");
+  });
+
+  it("escapes commas + quotes in description fields", () => {
+    const tricky: TimelineEvent[] = [{
+      kind: "agent.discovered",
+      agent_id: "test",
+      ens_name: "weird,name\"quoted.eth",
+      pubkey_b58: "ed25519:abc",
+      ts_ms: 1,
+    }];
+    const csv = eventsToCsv(tricky);
+    expect(csv).toContain('"test (weird,name""quoted.eth)"');
+  });
+});
+
+describe("eventsToJsonl", () => {
+  it("one JSON object per line, trailing newline", () => {
+    const out = eventsToJsonl(sample);
+    const lines = out.trimEnd().split("\n");
+    expect(lines).toHaveLength(3);
+    for (const l of lines) expect(() => JSON.parse(l)).not.toThrow();
+  });
+});
+
+describe("eventMatchesFilters", () => {
+  it("empty filter matches everything", () => {
+    for (const e of sample) expect(eventMatchesFilters(e, EMPTY_FILTERS)).toBe(true);
+  });
+
+  it("decision filter narrows to allow/deny", () => {
+    const allowOnly = sample.filter((e) => eventMatchesFilters(e, { ...EMPTY_FILTERS, decision: "allow" }));
+    expect(allowOnly).toHaveLength(1);
+    expect(allowOnly[0].kind).toBe("decision.made");
+  });
+
+  it("agent substring matches across kinds", () => {
+    const matched = sample.filter((e) => eventMatchesFilters(e, { ...EMPTY_FILTERS, agentSubstring: "research" }));
+    expect(matched).toHaveLength(2);
+  });
+
+  it("date range filters inclusive", () => {
+    const matched = sample.filter((e) => eventMatchesFilters(e, { ...EMPTY_FILTERS, fromTs: 1714565000000, toTs: 1714565100000 }));
+    expect(matched).toHaveLength(2);
+  });
+});

--- a/apps/hosted-app/app/admin/audit/AuditFilters.tsx
+++ b/apps/hosted-app/app/admin/audit/AuditFilters.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import type { TimelineEvent } from "./audit-types";
+
+export interface FilterState {
+  agentSubstring: string;
+  kind: TimelineEvent["kind"] | "";
+  decision: "allow" | "deny" | "";
+  fromTs: number | null;
+  toTs: number | null;
+}
+
+export const EMPTY_FILTERS: FilterState = {
+  agentSubstring: "",
+  kind: "",
+  decision: "",
+  fromTs: null,
+  toTs: null,
+};
+
+interface Props {
+  value: FilterState;
+  onChange: (next: FilterState) => void;
+  matchedCount: number;
+  totalCount: number;
+}
+
+const inputStyle = {
+  background: "var(--code-bg)",
+  color: "var(--fg)",
+  border: "1px solid var(--border)",
+  borderRadius: "var(--r-sm)",
+  padding: "0.45em 0.7em",
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.85em",
+} as const;
+
+function tsToInputValue(ts: number | null): string {
+  if (ts === null) return "";
+  return new Date(ts).toISOString().slice(0, 16);
+}
+
+function inputValueToTs(s: string): number | null {
+  if (!s) return null;
+  const t = Date.parse(s);
+  return Number.isFinite(t) ? t : null;
+}
+
+export function AuditFilters({ value, onChange, matchedCount, totalCount }: Props): JSX.Element {
+  const set = <K extends keyof FilterState>(key: K, v: FilterState[K]): void => onChange({ ...value, [key]: v });
+  const reset = (): void => onChange(EMPTY_FILTERS);
+  const isFiltered = value.agentSubstring || value.kind || value.decision || value.fromTs !== null || value.toTs !== null;
+
+  return (
+    <section style={{ background: "var(--code-bg)", border: "1px solid var(--border)", borderRadius: "var(--r-md)", padding: "0.8em 1em", marginBottom: "1em" }}>
+      <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "0.6em" }}>
+        <span style={{ fontSize: "0.88em", color: "var(--muted)", fontFamily: "var(--font-mono)" }}>
+          {isFiltered ? `${matchedCount.toLocaleString()} / ${totalCount.toLocaleString()} match` : `${totalCount.toLocaleString()} events`}
+        </span>
+        {isFiltered && (
+          <button onClick={reset} className="ghost" style={{ fontSize: "0.78em" }}>Clear filters</button>
+        )}
+      </header>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: "0.5em" }}>
+        <input
+          aria-label="Agent ID substring"
+          type="text"
+          placeholder="Agent ID substring"
+          value={value.agentSubstring}
+          onChange={(e) => set("agentSubstring", e.target.value)}
+          style={inputStyle}
+        />
+        <select
+          aria-label="Decision"
+          value={value.decision}
+          onChange={(e) => set("decision", e.target.value as FilterState["decision"])}
+          style={inputStyle}
+        >
+          <option value="">all decisions</option>
+          <option value="allow">allow</option>
+          <option value="deny">deny</option>
+        </select>
+        <select
+          aria-label="Event kind"
+          value={value.kind}
+          onChange={(e) => set("kind", e.target.value as FilterState["kind"])}
+          style={inputStyle}
+        >
+          <option value="">all kinds</option>
+          <option value="decision.made">decision.made</option>
+          <option value="execution.confirmed">execution.confirmed</option>
+          <option value="audit.checkpoint">audit.checkpoint</option>
+          <option value="flag.changed">flag.changed</option>
+          <option value="agent.discovered">agent.discovered</option>
+          <option value="attestation.signed">attestation.signed</option>
+        </select>
+        <input
+          aria-label="From timestamp"
+          type="datetime-local"
+          value={tsToInputValue(value.fromTs)}
+          onChange={(e) => set("fromTs", inputValueToTs(e.target.value))}
+          style={inputStyle}
+        />
+        <input
+          aria-label="To timestamp"
+          type="datetime-local"
+          value={tsToInputValue(value.toTs)}
+          onChange={(e) => set("toTs", inputValueToTs(e.target.value))}
+          style={inputStyle}
+        />
+      </div>
+    </section>
+  );
+}
+
+export function eventMatchesFilters(e: TimelineEvent, f: FilterState): boolean {
+  if (f.kind && e.kind !== f.kind) return false;
+  if (f.decision && (e.kind !== "decision.made" || e.decision !== f.decision)) return false;
+  if (f.fromTs !== null && e.ts_ms < f.fromTs) return false;
+  if (f.toTs !== null && e.ts_ms > f.toTs) return false;
+  if (f.agentSubstring) {
+    const needle = f.agentSubstring.toLowerCase();
+    const haystacks: string[] = [];
+    if ("agent_id" in e && e.agent_id) haystacks.push(e.agent_id.toLowerCase());
+    if (e.kind === "attestation.signed") haystacks.push(e.from.toLowerCase(), e.to.toLowerCase());
+    if (!haystacks.some((s) => s.includes(needle))) return false;
+  }
+  return true;
+}

--- a/apps/hosted-app/app/admin/audit/AuditTimeline.tsx
+++ b/apps/hosted-app/app/admin/audit/AuditTimeline.tsx
@@ -1,24 +1,25 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { isTimelineEvent, KIND_LABEL, type ConnState, type TimelineEvent } from "./audit-types";
+import { isTimelineEvent, type ConnState, type TimelineEvent } from "./audit-types";
+import { AuditFilters, EMPTY_FILTERS, eventMatchesFilters, type FilterState } from "./AuditFilters";
+import { downloadBlob, eventsToCsv, eventsToJsonl } from "./exports";
 
 // Mirrors apps/trust-dns-viz/src/events.ts. Server emits the same
-// shape on /v1/events. Type union lives in ./audit-types so DecisionChart
-// can share it without circular imports.
+// shape on /v1/admin/events. Type union lives in ./audit-types so
+// DecisionChart can share it without circular imports.
 export type { TimelineEvent } from "./audit-types";
 
 interface Props {
   wsUrl: string;
 }
 
-const MAX_EVENTS = 200;
+const MAX_EVENTS = 500;
 
 export function AuditTimeline({ wsUrl }: Props): JSX.Element {
   const [events, setEvents] = useState<TimelineEvent[]>([]);
   const [state, setState] = useState<ConnState>("connecting");
-  const [agentFilter, setAgentFilter] = useState("");
-  const [kindFilter, setKindFilter] = useState<TimelineEvent["kind"] | "">("");
+  const [filters, setFilters] = useState<FilterState>(EMPTY_FILTERS);
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimer = useRef<number | null>(null);
 
@@ -34,26 +35,20 @@ export function AuditTimeline({ wsUrl }: Props): JSX.Element {
         return;
       }
       wsRef.current = ws;
-
       ws.addEventListener("open", () => setState("live"));
       ws.addEventListener("message", (msg) => {
         try {
           const ev = JSON.parse(msg.data as string) as TimelineEvent;
           if (!isTimelineEvent(ev)) return;
           setEvents((prev) => [ev, ...prev].slice(0, MAX_EVENTS));
-        } catch {
-          /* ignore malformed payload */
-        }
+        } catch { /* ignore malformed payload */ }
       });
       ws.addEventListener("close", () => {
         setState("offline");
         reconnectTimer.current = window.setTimeout(connect, 3000);
       });
-      ws.addEventListener("error", () => {
-        setState("offline");
-      });
+      ws.addEventListener("error", () => setState("offline"));
     };
-
     connect();
     return () => {
       if (reconnectTimer.current !== null) window.clearTimeout(reconnectTimer.current);
@@ -62,57 +57,31 @@ export function AuditTimeline({ wsUrl }: Props): JSX.Element {
   }, [wsUrl]);
 
   const filtered = useMemo(
-    () => events.filter((e) => matchesFilter(e, agentFilter, kindFilter)),
-    [events, agentFilter, kindFilter],
+    () => events.filter((e) => eventMatchesFilters(e, filters)),
+    [events, filters],
   );
 
-  const onExport = (): void => {
-    const lines = events.map((e) => JSON.stringify(e)).join("\n");
-    const blob = new Blob([lines + "\n"], { type: "application/x-jsonlines" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `sbo3l-audit-${new Date().toISOString().replace(/[:.]/g, "-")}.jsonl`;
-    document.body.append(a);
-    a.click();
-    a.remove();
-    URL.revokeObjectURL(url);
-  };
+  const exportFilename = (ext: string): string =>
+    `sbo3l-audit-${new Date().toISOString().replace(/[:.]/g, "-")}.${ext}`;
+
+  const onExportJsonl = (): void => downloadBlob(eventsToJsonl(filtered), "application/x-jsonlines", exportFilename("jsonl"));
+  const onExportCsv   = (): void => downloadBlob(eventsToCsv(filtered),   "text/csv",                 exportFilename("csv"));
 
   return (
     <div>
-      <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1em", flexWrap: "wrap", gap: "0.6em" }}>
+      <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "0.6em", flexWrap: "wrap", gap: "0.6em" }}>
         <span style={{ color: "var(--muted)", fontSize: "0.85em", fontFamily: "var(--font-mono)" }}>
-          {state === "live" && <span style={{ color: "var(--accent)" }}>● live · {events.length}/{MAX_EVENTS} events buffered</span>}
+          {state === "live" && <span style={{ color: "var(--accent)" }}>● live · {events.length}/{MAX_EVENTS} buffered</span>}
           {state === "connecting" && <span>● connecting…</span>}
           {state === "offline" && <span style={{ color: "#ff6b6b" }}>● offline · auto-reconnecting</span>}
         </span>
-        <button onClick={onExport} disabled={events.length === 0} className="ghost">
-          Export {events.length} events as JSONL
-        </button>
+        <div style={{ display: "flex", gap: "0.5em" }}>
+          <button onClick={onExportCsv}   disabled={filtered.length === 0} className="ghost">Export CSV ({filtered.length})</button>
+          <button onClick={onExportJsonl} disabled={filtered.length === 0} className="ghost">Export JSONL ({filtered.length})</button>
+        </div>
       </header>
 
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "0.6em", marginBottom: "1em" }}>
-        <input
-          type="text"
-          placeholder="Filter by agent_id (substring)"
-          value={agentFilter}
-          onChange={(ev) => setAgentFilter(ev.target.value)}
-          aria-label="Filter by agent ID"
-          style={{ background: "var(--code-bg)", color: "var(--fg)", border: "1px solid var(--border)", borderRadius: "var(--r-sm)", padding: "0.5em 0.7em", fontFamily: "var(--font-mono)" }}
-        />
-        <select
-          value={kindFilter}
-          onChange={(ev) => setKindFilter(ev.target.value as TimelineEvent["kind"] | "")}
-          aria-label="Filter by event kind"
-          style={{ background: "var(--code-bg)", color: "var(--fg)", border: "1px solid var(--border)", borderRadius: "var(--r-sm)", padding: "0.5em 0.7em", fontFamily: "var(--font-mono)" }}
-        >
-          <option value="">all event kinds</option>
-          {Object.values(KIND_LABEL).map((k) => (
-            <option key={k} value={k}>{k}</option>
-          ))}
-        </select>
-      </div>
+      <AuditFilters value={filters} onChange={setFilters} matchedCount={filtered.length} totalCount={events.length} />
 
       <ol style={{ listStyle: "none", padding: 0, margin: 0, display: "grid", gap: "0.4em" }}>
         {filtered.length === 0 && (
@@ -143,15 +112,6 @@ export function AuditTimeline({ wsUrl }: Props): JSX.Element {
       </ol>
     </div>
   );
-}
-
-function matchesFilter(e: TimelineEvent, agentFilter: string, kindFilter: TimelineEvent["kind"] | ""): boolean {
-  if (kindFilter && e.kind !== kindFilter) return false;
-  if (!agentFilter) return true;
-  const f = agentFilter.toLowerCase();
-  if ("agent_id" in e && e.agent_id.toLowerCase().includes(f)) return true;
-  if (e.kind === "attestation.signed" && (e.from.toLowerCase().includes(f) || e.to.toLowerCase().includes(f))) return true;
-  return false;
 }
 
 function describe(e: TimelineEvent): string {

--- a/apps/hosted-app/app/admin/audit/exports.ts
+++ b/apps/hosted-app/app/admin/audit/exports.ts
@@ -1,0 +1,72 @@
+import type { TimelineEvent } from "./audit-types";
+
+// CSV columns chosen to make the file useful in Excel / Google Sheets
+// without the reader needing to understand SBO3L semantics: timestamp
+// in ISO + UNIX-ms, kind, agent, decision, deny code, free-form
+// description in the last column. JSONL stays as the lossless path
+// (no field flattening).
+
+const CSV_HEADERS = [
+  "timestamp_iso",
+  "ts_ms",
+  "kind",
+  "agent_id",
+  "decision",
+  "deny_code",
+  "description",
+] as const;
+
+function describe(e: TimelineEvent): string {
+  switch (e.kind) {
+    case "agent.discovered":    return `${e.agent_id} (${e.ens_name})`;
+    case "attestation.signed":  return `${e.from} → ${e.to} ${e.attestation_id}`;
+    case "decision.made":       return e.intent ?? "";
+    case "audit.checkpoint":    return `chain_length=${e.chain_length} root=${e.root_hash.slice(0, 14)}…`;
+    case "execution.confirmed": return `→ ${e.sponsor} ref=${e.execution_ref}`;
+    case "flag.changed":        return `${e.flag_name} → ${e.enabled ? "on" : "off"} (by ${e.changed_by})`;
+  }
+}
+
+function escapeCsvField(value: string): string {
+  // RFC 4180: quote when the field contains comma, quote, or newline,
+  // and double any embedded quotes.
+  if (/[",\r\n]/.test(value)) return `"${value.replace(/"/g, '""')}"`;
+  return value;
+}
+
+export function eventsToCsv(events: TimelineEvent[]): string {
+  const rows = events.map((e) => {
+    const agentId = "agent_id" in e ? e.agent_id : e.kind === "attestation.signed" ? `${e.from}→${e.to}` : "";
+    const decision = e.kind === "decision.made" ? e.decision : "";
+    const denyCode = e.kind === "decision.made" ? e.deny_code ?? "" : "";
+    return [
+      new Date(e.ts_ms).toISOString(),
+      String(e.ts_ms),
+      e.kind,
+      agentId,
+      decision,
+      denyCode,
+      describe(e),
+    ];
+  });
+  return [
+    CSV_HEADERS.join(","),
+    ...rows.map((r) => r.map(escapeCsvField).join(",")),
+  ].join("\r\n") + "\r\n";
+}
+
+export function eventsToJsonl(events: TimelineEvent[]): string {
+  return events.map((e) => JSON.stringify(e)).join("\n") + "\n";
+}
+
+export function downloadBlob(content: string, mime: string, filename: string): void {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.append(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/apps/hosted-app/lib/sbo3l-client.ts
+++ b/apps/hosted-app/lib/sbo3l-client.ts
@@ -1,0 +1,23 @@
+// Daemon URL helpers. Server-only constants for SSR routes; the WS
+// helper returns the public ws://… URL so the browser can connect
+// directly to /v1/events (no Next.js proxy in between).
+//
+// The daemon is configured via SBO3L_DAEMON_URL (production) or
+// SBO3L_PUBLIC_DAEMON_URL (separate hostname for the WS bus when
+// the HTTP API is behind a reverse proxy).
+
+export const DAEMON_URL = process.env.SBO3L_DAEMON_URL ?? "http://localhost:8080";
+
+/**
+ * Convert the configured daemon URL to its WebSocket counterpart.
+ * Browser code calls this server-side at SSR time so the resolved
+ * URL bakes into the page payload.
+ */
+export function eventsWebSocketUrl(): string {
+  const explicit = process.env.SBO3L_PUBLIC_DAEMON_URL ?? DAEMON_URL;
+  if (explicit.startsWith("https://")) return `wss://${explicit.slice("https://".length)}/v1/admin/events`;
+  if (explicit.startsWith("http://"))  return `ws://${explicit.slice("http://".length)}/v1/admin/events`;
+  // Already ws:// or wss:// — pass through but ensure the path.
+  if (explicit.endsWith("/v1/admin/events")) return explicit;
+  return `${explicit.replace(/\/$/, "")}/v1/admin/events`;
+}


### PR DESCRIPTION
## Summary

Three things wired into /admin/audit so operators can do real work:

### 1. Filter panel (\`AuditFilters.tsx\`)

Replaces the inline two-input strip. Five filter dimensions:

- Agent ID substring
- Decision = allow / deny / any
- Event kind (any / 6 specific kinds)
- From timestamp (datetime-local)
- To timestamp (datetime-local)

Live counter shows \"N matched / M buffered\". Clear-all button when any filter is active.

### 2. Export buttons — CSV alongside JSONL

CSV columns: \`timestamp_iso, ts_ms, kind, agent_id, decision, deny_code, description\`. RFC 4180 escaping for quotes + commas. Export respects active filters so operators save a filtered slice.

### 3. \`lib/sbo3l-client.ts\` — was missing on main

The audit page imported \`eventsWebSocketUrl\` from there but the file didn't exist (lost in a merge somewhere). Restored with:

- \`DAEMON_URL\` from \`SBO3L_DAEMON_URL\` env
- \`eventsWebSocketUrl()\` converts \`http://\` → \`ws://\`, points at \`/v1/admin/events\` (Dev 1 #301 endpoint)
- \`SBO3L_PUBLIC_DAEMON_URL\` override for split-host setups

Bumped \`MAX_EVENTS\` 200 → 500 to align with DecisionChart's window.

## Tests

6 unit tests covering CSV escaping, JSONL roundtrip, filter predicate (empty / decision / agent / date range).

## What's NOT in this PR

Per the brief but heavier than 500 LoC alone:
- Setup wizard (separate PR — operator onboarding flow)
- Full-page Settings (KMS / RPC / retention surfaces)
- Playwright e2e (daemon-dependent, gated on live deployment)

## Test plan

- [ ] Jest tests pass
- [ ] /admin/audit renders filter panel + 2 export buttons
- [ ] CSV opens cleanly in Excel
- [ ] Date range filter excludes events outside window

🤖 Generated with [Claude Code](https://claude.com/claude-code)