### PR TITLE
feat(marketing): R14 polish — Cmd+K + animated hero (R14 P5)

### DIFF
--- a/apps/marketing/src/components/Nav.astro
+++ b/apps/marketing/src/components/Nav.astro
@@ -1,5 +1,6 @@
 ---
 const githubRepoUrl = "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026";
+const docsUrl = "https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/docs/";
 ---
 <header role="banner">
   <nav aria-label="Primary">
@@ -8,9 +9,33 @@ const githubRepoUrl = "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagen
       <a href={githubRepoUrl} rel="noopener">GitHub</a>
       <a href="/proof">Proof</a>
       <a href={`${githubRepoUrl}/blob/main/QUICKSTART.md`} rel="noopener">Quickstart</a>
+      <a href={docsUrl} class="search-hint" data-docs-url={docsUrl} aria-label="Search docs (Cmd+K)">
+        <span aria-hidden="true">⌘K</span>
+        <span class="sr-only">Search docs</span>
+      </a>
     </div>
   </nav>
 </header>
+
+<script is:inline>
+  // Cmd+K (Mac) / Ctrl+K (others) → open docs site (Starlight has
+  // built-in pagefind search). On the docs site itself the same
+  // shortcut focuses Starlight's native search box.
+  (function () {
+    function onKey(e) {
+      const isCmdK = (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k";
+      if (!isCmdK) return;
+      const target = e.target;
+      const isInput = target instanceof HTMLElement && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable);
+      if (isInput) return;
+      e.preventDefault();
+      const link = document.querySelector("a.search-hint");
+      const url = link instanceof HTMLAnchorElement ? link.getAttribute("data-docs-url") : null;
+      if (url) window.location.href = url;
+    }
+    document.addEventListener("keydown", onKey);
+  })();
+</script>
 
 <style>
   header { border-bottom: 1px solid var(--border); padding: 1em 1.5em; }
@@ -25,9 +50,30 @@ const githubRepoUrl = "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagen
   }
   .brand { font-weight: 700; font-size: 1.2em; color: var(--fg); }
   .brand:hover { text-decoration: none; color: var(--accent); }
-  .links { display: flex; gap: 1.6em; flex-wrap: wrap; }
+  .links { display: flex; gap: 1.6em; flex-wrap: wrap; align-items: center; }
+  .search-hint {
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    border: 1px solid var(--border);
+    border-radius: var(--r-sm);
+    padding: 0.2em 0.5em;
+    color: var(--muted);
+  }
+  .search-hint:hover { color: var(--fg); border-color: var(--accent); text-decoration: none; }
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
   @media (max-width: 640px) {
     nav { gap: 1em; }
     .links { gap: 1em; font-size: 0.95em; }
+    .search-hint { display: none; }
   }
 </style>

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -23,7 +23,10 @@ const blocks = [
 ---
 <BaseLayout title="SBO3L — Don't give your agent a wallet. Give it a mandate.">
   <section class="hero">
-    <h1>Don't give your agent a wallet.<br />Give it a mandate.</h1>
+    <h1>
+      <span class="line line-1">Don't give your agent a wallet.</span>
+      <span class="line line-2">Give it a mandate.</span>
+    </h1>
     <p class="lede">
       SBO3L is the cryptographically verifiable <strong>trust layer</strong> for
       autonomous AI agents. Every action your agent takes — pay, swap, store,
@@ -161,14 +164,44 @@ SBO3L_UNISWAP_TOKEN_OUT=0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238 \\
     line-height: 1.2;
     margin-bottom: 0.7em;
   }
+  .hero h1 .line {
+    display: block;
+    opacity: 0;
+    transform: translateY(0.4em);
+    animation: heroLineIn 0.7s cubic-bezier(.2, .7, .2, 1) forwards;
+  }
+  .hero h1 .line-1 { animation-delay: 0.05s; }
+  .hero h1 .line-2 { animation-delay: 0.25s; color: var(--accent); }
   .hero .lede {
     font-size: var(--fs-2);
     color: var(--muted);
     margin-bottom: 1.5em;
     max-width: 700px;
+    opacity: 0;
+    animation: heroFadeIn 0.7s cubic-bezier(.2, .7, .2, 1) 0.5s forwards;
   }
   .hero strong { color: var(--fg); }
-  .cta { display: flex; gap: 1em; flex-wrap: wrap; }
+  .cta {
+    display: flex;
+    gap: 1em;
+    flex-wrap: wrap;
+    opacity: 0;
+    animation: heroFadeIn 0.7s cubic-bezier(.2, .7, .2, 1) 0.7s forwards;
+  }
+
+  @keyframes heroLineIn {
+    to { opacity: 1; transform: translateY(0); }
+  }
+  @keyframes heroFadeIn {
+    to { opacity: 1; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .hero h1 .line, .hero .lede, .cta {
+      animation: none;
+      opacity: 1;
+      transform: none;
+    }
+  }
 
   ul.blocks { padding-left: 0; }
   ul.blocks li { list-style: none; padding-left: 1.4em; position: relative; }


### PR DESCRIPTION
## Summary

Three polish items from the R14 P5 brief:

### 1. Cmd+K shortcut

\`Nav.astro\` listens for Cmd+K (Mac) / Ctrl+K (others) globally. Redirects to the deployed docs site so Starlight's built-in pagefind search takes over. Native input fields exempt so users can ⌘K inside forms without bouncing.

Visible \`⌘K\` pill in the Nav so the shortcut is discoverable. Hidden on mobile.

### 2. Animated hero

Two-line tagline staggered slide-up + fade-in:
- Line 1 \"Don't give your agent a wallet.\" at 50ms
- Line 2 \"Give it a mandate.\" at 250ms (tinted \`--accent\`)
- Lede paragraph at 500ms
- CTA buttons at 700ms

\`prefers-reduced-motion\` disables it entirely.

### Why CSS keyframes vs Framer Motion

Marketing is Astro static. Framer Motion would mean adding \`@astrojs/react\` + a client island just for the hero. CSS keyframes ship 0 KB JS, animate via GPU, same visual effect, no React hydration cost on the landing page.

### 3. Screenshot CI triggered

\`gh workflow run capture-demo-screenshots.yml --ref main\` — fresh PNG captures of the /demo flow for the submission deck. Run [25255456648](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/actions/runs/25255456648).

### What's NOT in this PR

- DocSearch wiring proper — gated on Algolia approval (1-2 wk turnaround per the runbook in #291). Cmd+K bounces to Starlight Pagefind in the meantime.
- Framer Motion proper — out of scope for the static landing page; adding React just for one animation is the wrong tradeoff.

## Test plan

- [ ] / loads with hero animation visible (or static under prefers-reduced-motion)
- [ ] Cmd+K outside any input redirects to docs
- [ ] Cmd+K inside an input still types literally
- [ ] Mobile: ⌘K hint hidden, hero still animates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)