### PR TITLE
feat(core): AWS + GCP KMS EthSigner backends — code-ready, integration tests gated (R14 P3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,7 +141,7 @@ dependencies = [
  "derive_more 1.0.0",
  "once_cell",
  "serde",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -201,7 +207,7 @@ dependencies = [
  "derive_more 2.1.1",
  "foldhash",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "k256",
  "keccak-asm",
@@ -291,7 +297,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "url",
  "wasmtimer",
@@ -392,7 +398,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -442,7 +448,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "url",
  "wasmtimer",
@@ -458,7 +464,7 @@ dependencies = [
  "alloy-transport",
  "reqwest",
  "serde_json",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "url",
 ]
@@ -718,6 +724,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +779,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +820,391 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-config"
+version = "1.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 1.4.0",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-kms"
+version = "1.106.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2336350f96efcf9c2552b7fdb4dd07a0c1fef11f22b28fb020a9e33e7925cf9d"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.103.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2 0.11.0",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-protocol-test",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "h2 0.3.27",
+ "h2 0.4.13",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "hyper 0.14.32",
+ "hyper 1.9.0",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "indexmap 2.14.0",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.40",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower 0.5.3",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-mocks"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9a9490933f8faa0aeb1eb9fbb8bf4f1c214b3149c61b3a4074b68030b21bd5"
+dependencies = [
+ "aws-smithy-http-client",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-protocol-test"
+version = "0.63.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b227aa94af99a8e5ee52551cc7e3ee30a217019ef99207b6f0b7a1527685941"
+dependencies = [
+ "assert-json-diff",
+ "aws-smithy-runtime-api",
+ "base64-simd",
+ "cbor-diag",
+ "ciborium",
+ "http 0.2.12",
+ "pretty_assertions",
+ "regex-lite",
+ "roxmltree",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version 0.4.1",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,10 +1215,10 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -829,7 +1235,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.24.0",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -844,8 +1250,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -873,6 +1279,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -928,6 +1344,9 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitvec"
@@ -942,12 +1361,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -994,6 +1436,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -1052,6 +1503,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "c-kzg"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,12 +1528,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbor-diag"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc245b6ecd09b23901a4fbad1ad975701fd5061ceaef6afa93a2d70605a64429"
+dependencies = [
+ "bs58",
+ "chrono",
+ "data-encoding",
+ "half",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "separator",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1103,12 +1585,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -1153,6 +1662,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,6 +1701,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-crc32-nostd"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,7 +1722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -1199,6 +1732,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const_format"
@@ -1222,12 +1761,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1246,10 +1801,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -1286,13 +1883,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -1339,7 +1954,8 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1419,6 +2035,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,10 +2055,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -1458,6 +2092,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dunce"
@@ -1499,7 +2139,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1521,6 +2161,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -1552,6 +2195,15 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "enum-ordinalize"
@@ -1587,6 +2239,28 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1674,6 +2348,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1737,7 +2432,7 @@ dependencies = [
  "frost-core",
  "frost-rerandomized",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1752,6 +2447,12 @@ dependencies = [
  "hex",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -1799,6 +2500,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1886,9 +2598,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1896,6 +2621,92 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "google-cloud-auth"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57a13fbacc5e9c41ded3ad8d0373175a6b7a6ad430d99e89d314ac121b7ab06"
+dependencies = [
+ "async-trait",
+ "base64 0.21.7",
+ "google-cloud-metadata",
+ "google-cloud-token",
+ "home",
+ "jsonwebtoken",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tracing",
+ "urlencoding",
+]
+
+[[package]]
+name = "google-cloud-gax"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de13e62d7e0ffc3eb40a0113ddf753cf6ec741be739164442b08893db4f9bfca"
+dependencies = [
+ "google-cloud-token",
+ "http 1.4.0",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-retry2",
+ "tonic",
+ "tower 0.4.13",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-googleapis"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886aa8ec755382a1fdf4651f6e6ec01f2f3bf49f2cb0f068b9a74cafd574a715"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
+name = "google-cloud-kms"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8842723521d34b9bf43305c84fd469c4d1858c42a630e1cb8c0d9c53781551"
+dependencies = [
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-googleapis",
+ "google-cloud-token",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-metadata"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d901aeb453fd80e51d64df4ee005014f6cf39f2d736dd64f7239c132d9d39a6a"
+dependencies = [
+ "reqwest",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-token"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c12ba8b21d128a2ce8585955246977fbce4415f680ebf9199b6f9d6d725f"
+dependencies = [
+ "async-trait",
+]
 
 [[package]]
 name = "group"
@@ -1910,6 +2721,25 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -1919,12 +2749,23 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
- "indexmap",
+ "http 1.4.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1958,6 +2799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.12",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -2020,12 +2862,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
@@ -2040,12 +2920,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -2056,8 +2947,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2074,6 +2965,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2083,9 +3007,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -2097,18 +3021,47 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.9.0",
  "hyper-util",
- "rustls",
+ "rustls 0.23.40",
+ "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.9.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2121,14 +3074,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2241,6 +3194,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2279,6 +3238,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2330,7 +3299,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
 dependencies = [
- "nom",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -2365,6 +3334,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2431,7 +3410,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -2441,7 +3420,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2474,6 +3453,15 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -2486,6 +3474,18 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2573,6 +3573,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2583,6 +3593,22 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -2605,10 +3631,10 @@ dependencies = [
  "bytes",
  "colored",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "log",
  "pin-project-lite",
@@ -2618,6 +3644,16 @@ dependencies = [
  "serde_urlencoded",
  "similar",
  "tokio",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2660,6 +3696,22 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -2768,6 +3820,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2796,6 +3860,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2813,7 +3883,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2832,6 +3902,15 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2883,6 +3962,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2897,6 +3987,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "postcard"
@@ -2933,6 +4029,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3006,6 +4122,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3043,8 +4191,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
- "socket2",
+ "rustls 0.23.40",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3063,7 +4211,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -3081,7 +4229,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3100,6 +4248,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -3186,6 +4340,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3207,6 +4370,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
@@ -3231,36 +4400,38 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
- "tower",
+ "tokio-rustls 0.26.4",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3281,7 +4452,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "tracing-subscriber",
  "ulid",
@@ -3293,7 +4464,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -3348,6 +4519,35 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3460,16 +4660,51 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3484,10 +4719,21 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3534,7 +4780,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tiny-keccak",
 ]
@@ -3566,7 +4812,7 @@ dependencies = [
  "tempfile",
  "tiny-keccak",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "tracing-subscriber",
  "ulid",
@@ -3576,10 +4822,22 @@ dependencies = [
 name = "sbo3l-core"
 version = "1.2.0"
 dependencies = [
+ "async-trait",
+ "aws-config",
+ "aws-sdk-kms",
+ "aws-smithy-mocks",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "base64 0.22.1",
+ "blake3",
  "chrono",
+ "curve25519-dalek",
  "ed25519-dalek",
  "frost-ed25519",
  "getrandom 0.3.4",
+ "google-cloud-auth",
+ "google-cloud-googleapis",
+ "google-cloud-kms",
  "hex",
  "jsonschema",
  "k256",
@@ -3590,10 +4848,11 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "serde_json_canonicalizer",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 1.0.69",
  "tiny-keccak",
+ "tokio",
  "ulid",
  "wasm-bindgen",
 ]
@@ -3610,7 +4869,7 @@ dependencies = [
  "sbo3l-keeperhub-adapter",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tiny-keccak",
  "ulid",
@@ -3628,7 +4887,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tiny-keccak",
 ]
@@ -3669,7 +4928,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3687,7 +4946,7 @@ dependencies = [
  "serde_json",
  "serde_json_canonicalizer",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 1.0.69",
 ]
@@ -3716,7 +4975,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-tungstenite 0.21.0",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "tracing-subscriber",
  "ulid",
@@ -3735,10 +4994,22 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
- "sha2",
+ "sha2 0.10.9",
+ "sqlx",
  "tempfile",
  "thiserror 1.0.69",
+ "tokio",
  "ulid",
+ "uuid",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3759,6 +5030,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3776,6 +5057,29 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3801,6 +5105,12 @@ checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 dependencies = [
  "pest",
 ]
+
+[[package]]
+name = "separator"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "serde"
@@ -3849,6 +5159,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -3896,7 +5207,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -3920,7 +5231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -3931,8 +5242,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3991,6 +5313,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4025,6 +5353,19 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -4056,6 +5397,218 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlformat"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
+dependencies = [
+ "nom 7.1.3",
+ "unicode_categories",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27144619c6e5802f1380337a209d2ac1c431002dd74c6e60aebff3c506dc4f0c"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a999083c1af5b5d6c071d34a708a19ba3e02106ad82ef7bbd69f5e48266b613b"
+dependencies = [
+ "atoi",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-channel",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.14.5",
+ "hashlink",
+ "hex",
+ "indexmap 2.14.0",
+ "log",
+ "memchr",
+ "once_cell",
+ "paste",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlformat",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23217eb7d86c584b8cbe0337b9eacf12ab76fe7673c513141ec42565698bb88"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a099220ae541c5db479c6424bdf1b200987934033c2584f79a0e1693601e776"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.117",
+ "tempfile",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5afe4c38a9b417b6a9a5eeffe7235d0a106716495536e7727d1c7f4b1ff3eba6"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 1.0.69",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1dbb157e65f10dbe01f729339c06d239120221c9ad9fa0ba8408c4cc18ecf21"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 1.0.69",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b2cdd83c008a622d94499c0006d8ee5f821f36c89b7d625c900e5dc30b5c5ee"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4066,6 +5619,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -4308,7 +5872,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4325,12 +5889,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-retry2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0a122635e32bd827df297f311ca5e0292636bbd82f67ff84a4bedeab06dbeb"
+dependencies = [
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -4398,7 +5982,7 @@ version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -4411,6 +5995,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "flate2",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "rustls-pemfile",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4438,11 +6072,11 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -4536,7 +6170,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.8.6",
@@ -4555,7 +6189,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.8.6",
@@ -4605,10 +6239,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -4621,6 +6276,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -4647,6 +6308,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4670,6 +6337,7 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -4704,6 +6372,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4733,8 +6407,23 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -4793,6 +6482,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver 1.0.28",
+]
+
+[[package]]
 name = "wasmtimer"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4828,11 +6551,30 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]
@@ -4896,6 +6638,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4919,6 +6670,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4956,6 +6722,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4968,6 +6740,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4977,6 +6755,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5004,6 +6788,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5013,6 +6803,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5028,6 +6824,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5037,6 +6839,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5061,9 +6869,97 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver 1.0.28",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -5079,6 +6975,18 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/crates/sbo3l-core/Cargo.toml
+++ b/crates/sbo3l-core/Cargo.toml
@@ -48,6 +48,35 @@ curve25519-dalek = { version = "4.1.3", features = ["rand_core", "digest"] }
 blake3 = "1.8.5"
 frost-ed25519 = { version = "3", features = ["serialization"] }
 
+# R14 P3 — live AWS KMS EthSigner backend (feature `eth_kms_aws`).
+# Pulls aws-sdk-kms (~80 transitive crates); kept behind a dedicated
+# feature so the existing `aws_kms` Ed25519 stub stays compile-only.
+# `aws-smithy-mocks` provides a Rule-based MockResponseInterceptor so
+# unit tests exercise the real client + interceptor stack without a
+# network round-trip. `aws-smithy-types` is needed for `Blob`.
+aws-sdk-kms = { version = "1", default-features = false, features = ["rt-tokio", "rustls"], optional = true }
+aws-config = { version = "1", default-features = false, features = ["rt-tokio", "rustls"], optional = true }
+aws-smithy-types = { version = "1", optional = true }
+aws-smithy-mocks = { version = "0.2", optional = true }
+aws-smithy-runtime-api = { version = "1", optional = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true }
+
+# R14 P3 — live GCP KMS EthSigner backend (feature `eth_kms_gcp`).
+# `google-cloud-kms` 0.6 ships an `eth` feature wiring secp256k1 +
+# k256 directly — that path bypasses the manual DER-decode dance
+# entirely. We use the lower-level `AsymmetricSign` + `GetPublicKey`
+# RPCs ourselves to keep the mock-test surface portable across
+# AWS/GCP and to avoid pulling ethers-* into the dep tree.
+google-cloud-kms = { version = "0.6", default-features = false, features = ["rustls-tls", "auth"], optional = true }
+google-cloud-auth = { version = "0.17", default-features = false, features = ["rustls-tls"], optional = true }
+google-cloud-googleapis = { version = "0.16", optional = true }
+async-trait = { version = "0.1", optional = true }
+
+# `base64` is only used to strip the PEM envelope GCP returns for
+# pubkeys; both KMS features pull base64 transitively (smithy / tonic),
+# so making it a direct optional dep doesn't grow the dep tree.
+base64 = { version = "0.22", optional = true }
+
 # wasm32 verifier slice (`scripts/build-wasm-verifier.sh`): pin
 # `getrandom = { version = "0.3", features = ["wasm_js"] }` for the
 # wasm target so OsRng has a JS-side entropy source. Native targets
@@ -76,6 +105,29 @@ phala_tee = []
 # default off so KeeperHub-only consumers don't pay for the EVM
 # stack they don't use.
 eth_signer = ["dep:k256", "dep:tiny-keccak"]
+
+# R14 P3 — live cloud-KMS secp256k1 backends. Each pulls its own
+# vendor SDK only when the feature is enabled. `eth_signer` is an
+# implicit dep (you can't sign EVM digests without the trait).
+eth_kms_aws = [
+    "eth_signer",
+    "dep:aws-sdk-kms",
+    "dep:aws-config",
+    "dep:aws-smithy-types",
+    "dep:aws-smithy-mocks",
+    "dep:aws-smithy-runtime-api",
+    "dep:tokio",
+    "dep:async-trait",
+]
+eth_kms_gcp = [
+    "eth_signer",
+    "dep:google-cloud-kms",
+    "dep:google-cloud-auth",
+    "dep:google-cloud-googleapis",
+    "dep:async-trait",
+    "dep:tokio",
+    "dep:base64",
+]
 
 [dev-dependencies]
 # `local_file` signer tests write secrets to per-test temp files +

--- a/crates/sbo3l-core/src/signers/eth_kms_aws_live.rs
+++ b/crates/sbo3l-core/src/signers/eth_kms_aws_live.rs
@@ -1,0 +1,601 @@
+//! `eth_kms_aws_live` — live AWS KMS [`EthSigner`] backend (R14 P3).
+//!
+//! Compiled only with `--features eth_kms_aws`. This pulls
+//! `aws-sdk-kms` + `aws-config` (~80 transitive crates), so the existing
+//! `eth_kms::aws` stub stays compile-only behind the older `aws_kms`
+//! feature for callers that just want the trait plumbing.
+//!
+//! # Honest status
+//!
+//! No real KMS round-trip has been verified — Daniel does NOT have AWS
+//! creds in this round. The unit tests below exercise the response-
+//! decoding logic against canned-DER fixtures and the live integration
+//! test in `tests/aws_kms_live.rs` skips cleanly unless
+//! `AWS_KMS_TEST_ENABLED=1` is set with real creds. Daniel runs the
+//! gated integration tests in R15 once the KMS key is provisioned.
+//!
+//! # Sign + recovery shape
+//!
+//! AWS KMS Sign API returns a DER-encoded ECDSA signature
+//! (`SEQUENCE { r INTEGER, s INTEGER }`). EVM `ecrecover` wants 65-byte
+//! `r || s || v` where `v` is the recovery id. The flow:
+//!
+//! 1. [`AwsEthKmsLiveSigner::new`] fetches the public key once via
+//!    `GetPublicKey`, parses the SEC1 SubjectPublicKeyInfo DER, derives
+//!    the EIP-55 address, caches both.
+//! 2. [`EthSigner::sign_digest_hex`] calls KMS `Sign` with
+//!    `MessageType::Digest` + `SigningAlgorithmSpec::EcdsaSha256`,
+//!    receives DER, parses to `(r, s)`.
+//! 3. Normalizes `s` to low-S (EIP-2: `s <= n/2`).
+//! 4. Recovers `v` by trying recovery ids 0 and 1; whichever recovers
+//!    a public key matching the cached pubkey wins.
+//!
+//! Step 4 is the single EVM-specific subtlety vs the Ed25519 KMS path.
+//!
+//! # Why a `KmsClient` trait
+//!
+//! `aws-sdk-kms::Client` is a concrete struct with no public mock
+//! surface in the version pinned here. Wrapping the two methods we
+//! need (`sign`, `get_public_key`) behind a small async trait lets
+//! unit tests inject a fake without spinning a smithy interceptor
+//! stack. Production uses the SDK-backed adapter; tests use a hand
+//! rolled fake.
+
+use std::sync::OnceLock;
+
+use async_trait::async_trait;
+use aws_sdk_kms::primitives::Blob;
+use aws_sdk_kms::types::{KeySpec, MessageType, SigningAlgorithmSpec};
+use aws_sdk_kms::Client as AwsKmsClient;
+use k256::ecdsa::VerifyingKey;
+
+use super::eth_kms_common::{address_from_verifying_key, der_to_rsv, parse_spki_secp256k1};
+use super::{eth::EthSigner, SignerError};
+
+/// Minimal surface this signer needs from AWS KMS. Wrapping it lets
+/// unit tests swap a fake without instantiating a real smithy client.
+#[async_trait]
+pub trait KmsClient: Send + Sync {
+    /// `Sign` API. Returns the raw DER signature bytes.
+    async fn sign_digest(&self, key_id: &str, digest: &[u8; 32]) -> Result<Vec<u8>, SignerError>;
+
+    /// `GetPublicKey` API. Returns the raw SubjectPublicKeyInfo DER
+    /// bytes plus the reported key spec (so the constructor can reject
+    /// non-secp256k1 keys cleanly).
+    async fn get_public_key(&self, key_id: &str)
+        -> Result<(Vec<u8>, Option<KeySpec>), SignerError>;
+}
+
+/// SDK-backed adapter — wraps an `aws_sdk_kms::Client`.
+pub struct SdkKmsClient {
+    inner: AwsKmsClient,
+}
+
+impl SdkKmsClient {
+    pub fn new(inner: AwsKmsClient) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl KmsClient for SdkKmsClient {
+    async fn sign_digest(&self, key_id: &str, digest: &[u8; 32]) -> Result<Vec<u8>, SignerError> {
+        let resp = self
+            .inner
+            .sign()
+            .key_id(key_id)
+            .message(Blob::new(digest.to_vec()))
+            .message_type(MessageType::Digest)
+            .signing_algorithm(SigningAlgorithmSpec::EcdsaSha256)
+            .send()
+            .await
+            .map_err(|e| SignerError::Kms(format!("aws kms sign({key_id}): {e}")))?;
+        let sig = resp.signature().ok_or_else(|| {
+            SignerError::Kms(format!("aws kms sign({key_id}): no signature in response"))
+        })?;
+        Ok(sig.as_ref().to_vec())
+    }
+
+    async fn get_public_key(
+        &self,
+        key_id: &str,
+    ) -> Result<(Vec<u8>, Option<KeySpec>), SignerError> {
+        let resp = self
+            .inner
+            .get_public_key()
+            .key_id(key_id)
+            .send()
+            .await
+            .map_err(|e| SignerError::Kms(format!("aws kms get_public_key({key_id}): {e}")))?;
+        let pk = resp
+            .public_key()
+            .ok_or_else(|| {
+                SignerError::Kms(format!(
+                    "aws kms get_public_key({key_id}): no PublicKey field"
+                ))
+            })?
+            .as_ref()
+            .to_vec();
+        let spec = resp.key_spec().cloned();
+        Ok((pk, spec))
+    }
+}
+
+/// Live AWS KMS secp256k1 EVM signer.
+pub struct AwsEthKmsLiveSigner {
+    client: Box<dyn KmsClient>,
+    key_id: String,
+    cached_verifying_key: OnceLock<VerifyingKey>,
+    cached_address: OnceLock<String>,
+}
+
+impl std::fmt::Debug for AwsEthKmsLiveSigner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AwsEthKmsLiveSigner")
+            .field("key_id", &self.key_id)
+            .field(
+                "cached_pubkey_present",
+                &self.cached_verifying_key.get().is_some(),
+            )
+            .finish()
+    }
+}
+
+impl AwsEthKmsLiveSigner {
+    /// Construct from env. Reads `SBO3L_ETH_AWS_KMS_KEY_ID`. Uses the
+    /// default AWS credentials chain (env vars / IAM role / shared
+    /// config) via `aws_config::load_defaults`.
+    ///
+    /// Synchronous wrapper — the daemon's startup path is sync today.
+    /// We block on a one-shot tokio runtime for the credential load
+    /// and the initial `GetPublicKey`. After construction every
+    /// signing call hits the cached pubkey plus a single `Sign`
+    /// round-trip.
+    pub fn from_env(_role: &str) -> Result<Self, SignerError> {
+        let key_id = std::env::var("SBO3L_ETH_AWS_KMS_KEY_ID")
+            .or_else(|_| std::env::var("SBO3L_ETH_AWS_KMS_KEY_ARN"))
+            .map_err(|_| SignerError::MissingEnv("SBO3L_ETH_AWS_KMS_KEY_ID"))?;
+        if key_id.is_empty() {
+            return Err(SignerError::MissingEnv("SBO3L_ETH_AWS_KMS_KEY_ID"));
+        }
+
+        // Build a single-thread tokio runtime to drive the async SDK
+        // calls from a sync constructor. The daemon may already have
+        // its own runtime; we deliberately don't try to reuse it
+        // because that requires `block_in_place` which only works
+        // inside a multi-thread runtime context.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| SignerError::Kms(format!("aws kms: build tokio rt: {e}")))?;
+        let client = rt.block_on(async {
+            let cfg = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+            AwsKmsClient::new(&cfg)
+        });
+
+        Self::with_client(Box::new(SdkKmsClient::new(client)), key_id)
+    }
+
+    /// Construct with an explicit client. Used by unit tests (with a
+    /// fake) and by callers that want to share a configured client.
+    /// Validates the key spec + caches the verifying key + address.
+    pub fn with_client(client: Box<dyn KmsClient>, key_id: String) -> Result<Self, SignerError> {
+        let s = Self {
+            client,
+            key_id,
+            cached_verifying_key: OnceLock::new(),
+            cached_address: OnceLock::new(),
+        };
+        // Eager-fetch the pubkey so misconfiguration surfaces at
+        // construction, not on the first sign call.
+        s.address()?;
+        Ok(s)
+    }
+
+    /// Synchronous block-on helper for the `EthSigner` impl. Builds a
+    /// fresh single-thread runtime per call. AWS KMS Sign is a few-ms
+    /// round-trip; the runtime construction overhead is dwarfed by
+    /// network latency.
+    fn block_on<T>(
+        &self,
+        fut: impl std::future::Future<Output = Result<T, SignerError>>,
+    ) -> Result<T, SignerError> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| SignerError::Kms(format!("aws kms: build tokio rt: {e}")))?;
+        rt.block_on(fut)
+    }
+
+    /// Fetch + cache the verifying key. First call hits KMS; subsequent
+    /// calls return the cached value.
+    fn verifying_key(&self) -> Result<&VerifyingKey, SignerError> {
+        if let Some(vk) = self.cached_verifying_key.get() {
+            return Ok(vk);
+        }
+        let key_id = self.key_id.clone();
+        let (der, spec) = self.block_on(async { self.client.get_public_key(&key_id).await })?;
+        if let Some(spec) = spec {
+            if !is_secp256k1_spec(&spec) {
+                return Err(SignerError::KeySpecMismatch {
+                    key_id: self.key_id.clone(),
+                    found_spec: format!("{spec:?}"),
+                });
+            }
+        }
+        let vk = parse_spki_secp256k1(&der)?;
+        // OnceLock is racy-safe: parallel callers will both compute
+        // the same value; whoever wins set_*() loses gracefully.
+        let _ = self.cached_verifying_key.set(vk);
+        Ok(self.cached_verifying_key.get().expect("just set above"))
+    }
+
+    /// Fetch + cache the EIP-55 address.
+    fn address(&self) -> Result<&str, SignerError> {
+        if let Some(addr) = self.cached_address.get() {
+            return Ok(addr);
+        }
+        let vk = self.verifying_key()?;
+        let addr = address_from_verifying_key(vk);
+        let _ = self.cached_address.set(addr);
+        Ok(self.cached_address.get().expect("just set above"))
+    }
+}
+
+impl EthSigner for AwsEthKmsLiveSigner {
+    fn sign_digest_hex(&self, digest: &[u8; 32]) -> Result<String, SignerError> {
+        let key_id = self.key_id.clone();
+        let der = self.block_on(async { self.client.sign_digest(&key_id, digest).await })?;
+        let vk = self.verifying_key()?;
+        let sig_bytes = der_to_rsv(&der, digest, vk)?;
+        Ok(format!("0x{}", hex::encode(sig_bytes)))
+    }
+
+    fn eth_address(&self) -> Result<String, SignerError> {
+        Ok(self.address()?.to_string())
+    }
+
+    fn key_id(&self) -> &str {
+        &self.key_id
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AWS-specific helpers. The shared SPKI / DER / address parsing lives in
+// `eth_kms_common`.
+// ---------------------------------------------------------------------------
+
+fn is_secp256k1_spec(spec: &KeySpec) -> bool {
+    matches!(spec, KeySpec::EccSecgP256K1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k256::ecdsa::signature::hazmat::PrehashSigner;
+    use k256::ecdsa::{RecoveryId, Signature, SigningKey};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    /// Env-var tests in this module run serially under one mutex.
+    /// Cargo runs unit tests in parallel by default, so concurrent
+    /// `set_var` / `remove_var` between sibling tests races the
+    /// `from_env` constructor — manifesting as the "wrong variable
+    /// missing" assertion failure. Mutex pins them to one-at-a-time.
+    fn env_lock() -> &'static Mutex<()> {
+        static M: std::sync::OnceLock<Mutex<()>> = std::sync::OnceLock::new();
+        M.get_or_init(|| Mutex::new(()))
+    }
+
+    /// Hand-rolled fake KMS client. Holds a signing key and counters
+    /// so tests can assert caching + call counts.
+    struct FakeKms {
+        signing: SigningKey,
+        spec: Option<KeySpec>,
+        spki_override: Option<Vec<u8>>,
+        sign_calls: Arc<AtomicUsize>,
+        get_public_key_calls: Arc<AtomicUsize>,
+        sign_error: Option<String>,
+        get_public_key_error: Option<String>,
+    }
+
+    impl FakeKms {
+        fn new(secret: [u8; 32]) -> Self {
+            Self {
+                signing: SigningKey::from_bytes((&secret).into()).unwrap(),
+                spec: Some(KeySpec::EccSecgP256K1),
+                spki_override: None,
+                sign_calls: Arc::new(AtomicUsize::new(0)),
+                get_public_key_calls: Arc::new(AtomicUsize::new(0)),
+                sign_error: None,
+                get_public_key_error: None,
+            }
+        }
+
+        fn spki(&self) -> Vec<u8> {
+            if let Some(o) = &self.spki_override {
+                return o.clone();
+            }
+            // Real-shaped SPKI for secp256k1: header is constant for
+            // this curve. We embed the raw 65-byte SEC1 point at the
+            // end and prepend the standard 23-byte AlgorithmIdentifier
+            // + BIT STRING wrapper. Our parser is forgiving so we
+            // could shortcut, but feeding it the real shape catches
+            // header-edit regressions.
+            let pk = self.signing.verifying_key().to_encoded_point(false);
+            let pk_bytes = pk.as_bytes();
+            assert_eq!(pk_bytes.len(), 65);
+            // 0x30 0x56 -> SEQUENCE, 86 bytes
+            //   0x30 0x10 SEQUENCE, 16 bytes (AlgorithmIdentifier)
+            //     0x06 0x07 1.2.840.10045.2.1 (id-ecPublicKey)
+            //     0x06 0x05 1.3.132.0.10 (secp256k1)
+            //   0x03 0x42 BIT STRING, 66 bytes
+            //     0x00 (no unused bits)
+            //     65 bytes of point
+            let mut out = Vec::with_capacity(88);
+            out.extend_from_slice(&[
+                0x30, 0x56, 0x30, 0x10, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06,
+                0x05, 0x2b, 0x81, 0x04, 0x00, 0x0a, 0x03, 0x42, 0x00,
+            ]);
+            out.extend_from_slice(pk_bytes);
+            out
+        }
+    }
+
+    #[async_trait]
+    impl KmsClient for FakeKms {
+        async fn sign_digest(
+            &self,
+            _key_id: &str,
+            digest: &[u8; 32],
+        ) -> Result<Vec<u8>, SignerError> {
+            self.sign_calls.fetch_add(1, Ordering::SeqCst);
+            if let Some(e) = &self.sign_error {
+                return Err(SignerError::Kms(e.clone()));
+            }
+            // Real KMS returns DER. Use k256 to produce a deterministic
+            // (RFC 6979) signature, then DER-encode it.
+            let (sig, _recid): (Signature, RecoveryId) = self
+                .signing
+                .sign_prehash(digest)
+                .map_err(|e| SignerError::Kms(format!("fake sign: {e}")))?;
+            Ok(sig.to_der().as_bytes().to_vec())
+        }
+
+        async fn get_public_key(
+            &self,
+            _key_id: &str,
+        ) -> Result<(Vec<u8>, Option<KeySpec>), SignerError> {
+            self.get_public_key_calls.fetch_add(1, Ordering::SeqCst);
+            if let Some(e) = &self.get_public_key_error {
+                return Err(SignerError::Kms(e.clone()));
+            }
+            Ok((self.spki(), self.spec.clone()))
+        }
+    }
+
+    fn fixed_secret() -> [u8; 32] {
+        [0x11; 32]
+    }
+
+    fn make_signer() -> AwsEthKmsLiveSigner {
+        let fake = FakeKms::new(fixed_secret());
+        AwsEthKmsLiveSigner::with_client(Box::new(fake), "test-key".to_string()).unwrap()
+    }
+
+    #[test]
+    fn constructor_caches_pubkey_with_one_get_public_key_call() {
+        let fake = FakeKms::new(fixed_secret());
+        let counter = fake.get_public_key_calls.clone();
+        let signer =
+            AwsEthKmsLiveSigner::with_client(Box::new(fake), "test-key".to_string()).unwrap();
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        // Repeated `eth_address()` calls hit the OnceLock, not the client.
+        for _ in 0..5 {
+            let _ = signer.eth_address().unwrap();
+        }
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn sign_digest_hex_round_trip_recovers_signers_address() {
+        let signer = make_signer();
+        let digest = [0xAB; 32];
+        let sig_hex = signer.sign_digest_hex(&digest).unwrap();
+        assert!(sig_hex.starts_with("0x"));
+        assert_eq!(sig_hex.len(), 132);
+        let raw = hex::decode(&sig_hex[2..]).unwrap();
+        assert_eq!(raw.len(), 65);
+        let sig = Signature::from_slice(&raw[..64]).unwrap();
+        let recid = RecoveryId::try_from(raw[64]).unwrap();
+        let recovered = VerifyingKey::recover_from_prehash(&digest, &sig, recid).unwrap();
+        let recovered_addr = address_from_verifying_key(&recovered);
+        assert_eq!(recovered_addr, signer.eth_address().unwrap());
+    }
+
+    #[test]
+    fn address_matches_local_signer_for_same_secret() {
+        // Cross-check: the AWS-shaped path must derive the same EIP-55
+        // address that the local-file backend would for the same key.
+        let signer = make_signer();
+        let local = SigningKey::from_bytes((&fixed_secret()).into()).unwrap();
+        let local_addr = address_from_verifying_key(local.verifying_key());
+        assert_eq!(signer.eth_address().unwrap(), local_addr);
+    }
+
+    #[test]
+    fn constructor_rejects_non_secp256k1_keyspec() {
+        let mut fake = FakeKms::new(fixed_secret());
+        fake.spec = Some(KeySpec::EccNistP256);
+        let err = AwsEthKmsLiveSigner::with_client(Box::new(fake), "test-key".to_string())
+            .expect_err("must reject non-secp256k1");
+        match err {
+            SignerError::KeySpecMismatch { found_spec, .. } => {
+                assert!(found_spec.contains("Nist") || found_spec.contains("P256"));
+            }
+            other => panic!("expected KeySpecMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn constructor_propagates_get_public_key_error() {
+        let mut fake = FakeKms::new(fixed_secret());
+        fake.get_public_key_error = Some("AccessDenied".to_string());
+        let err = AwsEthKmsLiveSigner::with_client(Box::new(fake), "test-key".to_string())
+            .expect_err("must propagate");
+        match err {
+            SignerError::Kms(m) => assert!(m.contains("AccessDenied"), "got: {m}"),
+            other => panic!("expected Kms, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sign_propagates_kms_error() {
+        let fake = FakeKms::new(fixed_secret());
+        let mut signer =
+            AwsEthKmsLiveSigner::with_client(Box::new(fake), "test-key".to_string()).unwrap();
+        // Swap the client for one that errors on sign.
+        let mut bad = FakeKms::new(fixed_secret());
+        bad.sign_error = Some("KMSInvalidSignatureException".to_string());
+        signer.client = Box::new(bad);
+        let err = signer.sign_digest_hex(&[0u8; 32]).expect_err("must error");
+        match err {
+            SignerError::Kms(m) => assert!(m.contains("KMSInvalid"), "got: {m}"),
+            other => panic!("expected Kms, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sign_called_n_times_calls_client_n_times_but_pubkey_only_once() {
+        let fake = FakeKms::new(fixed_secret());
+        let sign_counter = fake.sign_calls.clone();
+        let pk_counter = fake.get_public_key_calls.clone();
+        let signer =
+            AwsEthKmsLiveSigner::with_client(Box::new(fake), "test-key".to_string()).unwrap();
+        for _ in 0..3 {
+            signer.sign_digest_hex(&[0xCD; 32]).unwrap();
+        }
+        assert_eq!(sign_counter.load(Ordering::SeqCst), 3);
+        assert_eq!(pk_counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn from_env_missing_var_errors_clearly() {
+        let _guard = env_lock().lock().unwrap();
+        // The constructor reads SBO3L_ETH_AWS_KMS_KEY_ID. We touch only
+        // our own var here — leave any pre-set value alone.
+        // Test in isolation: capture original, clear, restore at end.
+        let original_id = std::env::var("SBO3L_ETH_AWS_KMS_KEY_ID").ok();
+        let original_arn = std::env::var("SBO3L_ETH_AWS_KMS_KEY_ARN").ok();
+        unsafe {
+            std::env::remove_var("SBO3L_ETH_AWS_KMS_KEY_ID");
+            std::env::remove_var("SBO3L_ETH_AWS_KMS_KEY_ARN");
+        }
+        let err = AwsEthKmsLiveSigner::from_env("audit").expect_err("must error");
+        match err {
+            SignerError::MissingEnv("SBO3L_ETH_AWS_KMS_KEY_ID") => {}
+            other => panic!("expected MissingEnv, got {other:?}"),
+        }
+        // Restore.
+        unsafe {
+            if let Some(v) = original_id {
+                std::env::set_var("SBO3L_ETH_AWS_KMS_KEY_ID", v);
+            }
+            if let Some(v) = original_arn {
+                std::env::set_var("SBO3L_ETH_AWS_KMS_KEY_ARN", v);
+            }
+        }
+    }
+
+    #[test]
+    fn key_id_returns_configured_value() {
+        let signer = make_signer();
+        assert_eq!(signer.key_id(), "test-key");
+    }
+
+    #[test]
+    fn signature_byte_identical_across_two_calls_with_same_input() {
+        // Determinism: deterministic-k ECDSA + the cached pubkey →
+        // two calls with the same digest must produce byte-identical
+        // signatures (including the recovery byte).
+        let signer = make_signer();
+        let digest = [0x33; 32];
+        let s1 = signer.sign_digest_hex(&digest).unwrap();
+        let s2 = signer.sign_digest_hex(&digest).unwrap();
+        assert_eq!(s1, s2);
+    }
+
+    #[test]
+    fn signature_verifies_against_address_from_ecrecover_pattern() {
+        // Full E2E mock: sign, recover address from signature, assert
+        // it equals signer.eth_address(). This is the contract every
+        // on-chain ecrecover relies on.
+        let signer = make_signer();
+        let digest = [0x99u8; 32];
+        let sig_hex = signer.sign_digest_hex(&digest).unwrap();
+        let raw = hex::decode(sig_hex.strip_prefix("0x").unwrap()).unwrap();
+        let sig = Signature::from_slice(&raw[..64]).unwrap();
+        let recid = RecoveryId::try_from(raw[64]).unwrap();
+        let recovered = VerifyingKey::recover_from_prehash(&digest, &sig, recid).unwrap();
+        let addr = address_from_verifying_key(&recovered);
+        assert_eq!(addr, signer.eth_address().unwrap());
+    }
+
+    #[test]
+    fn empty_key_id_env_treated_as_missing() {
+        let _guard = env_lock().lock().unwrap();
+        let original_id = std::env::var("SBO3L_ETH_AWS_KMS_KEY_ID").ok();
+        let original_arn = std::env::var("SBO3L_ETH_AWS_KMS_KEY_ARN").ok();
+        unsafe {
+            std::env::set_var("SBO3L_ETH_AWS_KMS_KEY_ID", "");
+            std::env::remove_var("SBO3L_ETH_AWS_KMS_KEY_ARN");
+        }
+        let err = AwsEthKmsLiveSigner::from_env("audit").expect_err("must reject empty");
+        match err {
+            SignerError::MissingEnv(_) => {}
+            other => panic!("expected MissingEnv, got {other:?}"),
+        }
+        unsafe {
+            std::env::remove_var("SBO3L_ETH_AWS_KMS_KEY_ID");
+            if let Some(v) = original_id {
+                std::env::set_var("SBO3L_ETH_AWS_KMS_KEY_ID", v);
+            }
+            if let Some(v) = original_arn {
+                std::env::set_var("SBO3L_ETH_AWS_KMS_KEY_ARN", v);
+            }
+        }
+    }
+
+    #[test]
+    fn key_arn_env_var_also_accepted() {
+        let _guard = env_lock().lock().unwrap();
+        let original_id = std::env::var("SBO3L_ETH_AWS_KMS_KEY_ID").ok();
+        let original_arn = std::env::var("SBO3L_ETH_AWS_KMS_KEY_ARN").ok();
+        unsafe {
+            std::env::remove_var("SBO3L_ETH_AWS_KMS_KEY_ID");
+            std::env::set_var(
+                "SBO3L_ETH_AWS_KMS_KEY_ARN",
+                "arn:aws:kms:us-east-1:000:key/abc",
+            );
+        }
+        // We can't really construct it (would call real AWS), but we
+        // can verify the env-read step succeeds before the network
+        // call by using `from_env`. The from_env path tries to build
+        // a runtime + load creds; that's fine for the test as long
+        // as we don't depend on a particular outcome.
+        // Instead, just verify the env-var fallback by directly
+        // reading.
+        let id = std::env::var("SBO3L_ETH_AWS_KMS_KEY_ID")
+            .or_else(|_| std::env::var("SBO3L_ETH_AWS_KMS_KEY_ARN"));
+        assert!(id.is_ok());
+        unsafe {
+            std::env::remove_var("SBO3L_ETH_AWS_KMS_KEY_ARN");
+            if let Some(v) = original_id {
+                std::env::set_var("SBO3L_ETH_AWS_KMS_KEY_ID", v);
+            }
+            if let Some(v) = original_arn {
+                std::env::set_var("SBO3L_ETH_AWS_KMS_KEY_ARN", v);
+            }
+        }
+    }
+}

--- a/crates/sbo3l-core/src/signers/eth_kms_common.rs
+++ b/crates/sbo3l-core/src/signers/eth_kms_common.rs
@@ -1,0 +1,379 @@
+//! `eth_kms_common` — DER + SPKI helpers shared by the AWS and GCP
+//! KMS EthSigner backends.
+//!
+//! Compiled when EITHER `eth_kms_aws` OR `eth_kms_gcp` is on (the
+//! `cfg(any(...))` predicate at the module declaration site). Both
+//! KMS APIs return ASN.1-DER signatures over secp256k1 + SubjectPublic
+//! KeyInfo-encoded public keys; the parsing logic is identical, so it
+//! lives here rather than being duplicated in each backend.
+//!
+//! See `eth_kms_aws_live::AwsEthKmsLiveSigner` for the high-level
+//! flow these helpers participate in.
+
+use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
+use k256::EncodedPoint;
+use tiny_keccak::{Hasher as _, Keccak};
+
+use super::eth_local::eip55_checksum;
+use super::SignerError;
+
+/// Parse a SubjectPublicKeyInfo DER (`SEQUENCE { algorithm, BIT STRING }`)
+/// holding a SEC1-uncompressed secp256k1 public key, return a
+/// [`VerifyingKey`].
+///
+/// Both AWS KMS and GCP KMS return X.509 SPKI per RFC 5280; the BIT
+/// STRING holds the 0x04 || X || Y SEC1-uncompressed point. We don't
+/// parse the algorithm OID here — the calling backend validates the
+/// key spec / algorithm enum separately. Strategy: scan for the last
+/// 65-byte window starting with 0x04 that decodes as a valid
+/// secp256k1 point. Matches the trick `ethers-rs` uses in its own
+/// KMS adapters.
+pub fn parse_spki_secp256k1(spki_der: &[u8]) -> Result<VerifyingKey, SignerError> {
+    if spki_der.len() < 65 {
+        return Err(SignerError::Kms(format!(
+            "kms: SPKI DER too short ({} bytes; need >= 65)",
+            spki_der.len()
+        )));
+    }
+    for start in (0..=spki_der.len() - 65).rev() {
+        if spki_der[start] != 0x04 {
+            continue;
+        }
+        let candidate = &spki_der[start..start + 65];
+        if let Ok(point) = EncodedPoint::from_bytes(candidate) {
+            if let Ok(vk) = VerifyingKey::from_encoded_point(&point) {
+                return Ok(vk);
+            }
+        }
+    }
+    Err(SignerError::Kms(
+        "kms: SPKI DER did not contain a parseable secp256k1 point".to_string(),
+    ))
+}
+
+/// Compute the EIP-55 address from a [`VerifyingKey`]. Mirrors the
+/// derivation in [`crate::signers::eth_local`].
+pub fn address_from_verifying_key(vk: &VerifyingKey) -> String {
+    let encoded = vk.to_encoded_point(false);
+    let pk_bytes = encoded.as_bytes();
+    debug_assert_eq!(pk_bytes.len(), 65);
+    debug_assert_eq!(pk_bytes[0], 0x04);
+    let mut h = Keccak::v256();
+    h.update(&pk_bytes[1..]);
+    let mut hash = [0u8; 32];
+    h.finalize(&mut hash);
+    let mut addr = [0u8; 20];
+    addr.copy_from_slice(&hash[12..]);
+    eip55_checksum(&addr)
+}
+
+/// Parse an ASN.1 DER `SEQUENCE { r INTEGER, s INTEGER }` into a
+/// 64-byte `r || s` blob. Both integers are zero-padded to 32 bytes
+/// (DER strips leading zeros and re-adds a 0x00 sign byte for high
+/// bit scalars; we undo both).
+pub fn der_to_rs(der: &[u8]) -> Result<[u8; 64], SignerError> {
+    let mut p = 0usize;
+    if der.is_empty() || der[p] != 0x30 {
+        return Err(SignerError::Kms(format!(
+            "der_to_rs: not a SEQUENCE (got 0x{:02x})",
+            der.first().copied().unwrap_or(0)
+        )));
+    }
+    p += 1;
+    let (seq_len, ll) = read_der_len(&der[p..])?;
+    p += ll;
+    if seq_len + p > der.len() {
+        return Err(SignerError::Kms(format!(
+            "der_to_rs: truncated SEQUENCE (need {} more bytes)",
+            seq_len + p - der.len()
+        )));
+    }
+    let r = read_der_int(der, &mut p)?;
+    let s = read_der_int(der, &mut p)?;
+    if r.len() > 32 || s.len() > 32 {
+        return Err(SignerError::Kms(format!(
+            "der_to_rs: r/s longer than 32 bytes (r={}, s={})",
+            r.len(),
+            s.len()
+        )));
+    }
+    let mut out = [0u8; 64];
+    out[32 - r.len()..32].copy_from_slice(r);
+    out[64 - s.len()..64].copy_from_slice(s);
+    Ok(out)
+}
+
+fn read_der_len(buf: &[u8]) -> Result<(usize, usize), SignerError> {
+    if buf.is_empty() {
+        return Err(SignerError::Kms("der_to_rs: empty length".to_string()));
+    }
+    let first = buf[0];
+    if first < 0x80 {
+        return Ok((first as usize, 1));
+    }
+    let n = (first & 0x7f) as usize;
+    if n == 0 || n > 4 || buf.len() < 1 + n {
+        return Err(SignerError::Kms(format!(
+            "der_to_rs: bad length prefix 0x{first:02x}"
+        )));
+    }
+    let mut len = 0usize;
+    for &b in &buf[1..=n] {
+        len = (len << 8) | b as usize;
+    }
+    Ok((len, 1 + n))
+}
+
+fn read_der_int<'a>(buf: &'a [u8], p: &mut usize) -> Result<&'a [u8], SignerError> {
+    if *p >= buf.len() || buf[*p] != 0x02 {
+        return Err(SignerError::Kms(
+            "der_to_rs: expected INTEGER tag".to_string(),
+        ));
+    }
+    *p += 1;
+    let (len, ll) = read_der_len(&buf[*p..])?;
+    *p += ll;
+    if *p + len > buf.len() {
+        return Err(SignerError::Kms("der_to_rs: truncated INTEGER".to_string()));
+    }
+    let mut bytes = &buf[*p..*p + len];
+    if bytes.len() > 1 && bytes[0] == 0x00 && bytes[1] & 0x80 != 0 {
+        bytes = &bytes[1..];
+    }
+    *p += len;
+    Ok(bytes)
+}
+
+/// Parse DER, normalize to low-S, recover `v`, return 65-byte
+/// `r || s || v`. KMS APIs don't return `v` themselves — we recover
+/// it by trying both 0 and 1 and matching the cached pubkey.
+pub fn der_to_rsv(
+    der: &[u8],
+    digest: &[u8; 32],
+    expected_pubkey: &VerifyingKey,
+) -> Result<[u8; 65], SignerError> {
+    let rs = der_to_rs(der)?;
+    let mut sig = Signature::from_slice(&rs)
+        .map_err(|e| SignerError::Kms(format!("der_to_rsv: bad r||s: {e}")))?;
+    if let Some(normalized) = sig.normalize_s() {
+        sig = normalized;
+    }
+    for v in 0u8..=1 {
+        let recid = RecoveryId::try_from(v)
+            .map_err(|e| SignerError::Kms(format!("der_to_rsv: bad recid {v}: {e}")))?;
+        if let Ok(recovered) = VerifyingKey::recover_from_prehash(digest, &sig, recid) {
+            if &recovered == expected_pubkey {
+                let mut out = [0u8; 65];
+                out[..64].copy_from_slice(&sig.to_bytes());
+                out[64] = v;
+                return Ok(out);
+            }
+        }
+    }
+    Err(SignerError::Kms(
+        "der_to_rsv: neither recovery id produced the cached pubkey".to_string(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k256::ecdsa::signature::hazmat::PrehashSigner;
+    use k256::ecdsa::SigningKey;
+
+    #[test]
+    fn der_to_rs_strips_leading_zero_for_high_bit_scalars() {
+        let mut der = Vec::new();
+        der.push(0x30);
+        der.push(70);
+        der.extend_from_slice(&[0x02, 33, 0x00, 0x80]);
+        der.extend_from_slice(&[0u8; 31]);
+        der.extend_from_slice(&[0x02, 33, 0x00, 0x90]);
+        der.extend_from_slice(&[0u8; 31]);
+        let rs = der_to_rs(&der).unwrap();
+        assert_eq!(rs[0], 0x80);
+        assert_eq!(rs[32], 0x90);
+        assert!(rs[1..32].iter().all(|&b| b == 0));
+        assert!(rs[33..64].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn der_to_rs_pads_short_integers_to_32_bytes() {
+        let der = vec![0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x02];
+        let rs = der_to_rs(&der).unwrap();
+        assert!(rs[..31].iter().all(|&b| b == 0));
+        assert_eq!(rs[31], 0x01);
+        assert!(rs[32..63].iter().all(|&b| b == 0));
+        assert_eq!(rs[63], 0x02);
+    }
+
+    #[test]
+    fn der_to_rs_rejects_non_sequence() {
+        let bad = vec![0x31, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x02];
+        let err = der_to_rs(&bad).expect_err("must reject non-SEQUENCE");
+        match err {
+            SignerError::Kms(m) => assert!(m.contains("SEQUENCE"), "got: {m}"),
+            other => panic!("expected Kms, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn der_to_rs_rejects_truncated_sequence() {
+        let bad = vec![0x30, 70, 0x02, 0x01];
+        let err = der_to_rs(&bad).expect_err("must reject truncated SEQUENCE");
+        match err {
+            SignerError::Kms(m) => {
+                assert!(m.contains("truncated") || m.contains("INTEGER"), "got: {m}")
+            }
+            other => panic!("expected Kms, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn der_to_rs_rejects_wrong_inner_tag() {
+        let bad = vec![0x30, 0x04, 0x04, 0x02, 0x00, 0x01];
+        let err = der_to_rs(&bad).expect_err("must reject non-INTEGER inner");
+        match err {
+            SignerError::Kms(m) => assert!(m.contains("INTEGER"), "got: {m}"),
+            other => panic!("expected Kms, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn der_to_rs_rejects_oversized_integer() {
+        let mut der = Vec::new();
+        der.push(0x30);
+        der.push(70);
+        der.extend_from_slice(&[0x02, 33]);
+        der.extend_from_slice(&[0xFF; 33]);
+        der.extend_from_slice(&[0x02, 33]);
+        der.extend_from_slice(&[0xFF; 33]);
+        let err = der_to_rs(&der).expect_err("must reject oversized integer");
+        match err {
+            SignerError::Kms(m) => assert!(m.contains("32 bytes"), "got: {m}"),
+            other => panic!("expected Kms, got {other:?}"),
+        }
+    }
+
+    /// Build a real-shaped 88-byte secp256k1 SPKI from a SigningKey.
+    fn spki_from(signing: &SigningKey) -> Vec<u8> {
+        let pk = signing.verifying_key().to_encoded_point(false);
+        let pk_bytes = pk.as_bytes();
+        let mut spki = Vec::with_capacity(88);
+        spki.extend_from_slice(&[
+            0x30, 0x56, 0x30, 0x10, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06,
+            0x05, 0x2b, 0x81, 0x04, 0x00, 0x0a, 0x03, 0x42, 0x00,
+        ]);
+        spki.extend_from_slice(pk_bytes);
+        spki
+    }
+
+    #[test]
+    fn parse_spki_returns_correct_pubkey() {
+        let signing = SigningKey::from_bytes((&[0x11u8; 32]).into()).unwrap();
+        let spki = spki_from(&signing);
+        let vk = parse_spki_secp256k1(&spki).unwrap();
+        assert_eq!(&vk, signing.verifying_key());
+    }
+
+    #[test]
+    fn parse_spki_rejects_too_short_input() {
+        let err = parse_spki_secp256k1(&[0x30, 0x00]).expect_err("must reject");
+        match err {
+            SignerError::Kms(m) => assert!(m.contains("too short"), "got: {m}"),
+            other => panic!("expected Kms, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_spki_rejects_garbage() {
+        let err = parse_spki_secp256k1(&[0x42; 100]).expect_err("must reject");
+        match err {
+            SignerError::Kms(m) => assert!(m.contains("not contain"), "got: {m}"),
+            other => panic!("expected Kms, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_spki_handles_88_byte_canonical_secp256k1_form() {
+        let signing = SigningKey::from_bytes((&[0xAAu8; 32]).into()).unwrap();
+        let spki = spki_from(&signing);
+        assert_eq!(spki.len(), 88);
+        let vk = parse_spki_secp256k1(&spki).unwrap();
+        assert_eq!(&vk, signing.verifying_key());
+    }
+
+    #[test]
+    fn der_to_rsv_normalizes_high_s() {
+        let signing = SigningKey::from_bytes((&[0x44u8; 32]).into()).unwrap();
+        let digest = [0x55u8; 32];
+        let (sig, _): (Signature, RecoveryId) = signing.sign_prehash(&digest).unwrap();
+        // Force high-S form by negating s.
+        let s_field = sig.s();
+        let high_s = -*s_field;
+        let mut high_s_bytes = [0u8; 32];
+        high_s_bytes.copy_from_slice(&high_s.to_bytes());
+        let mut hi_sig_bytes = [0u8; 64];
+        hi_sig_bytes[..32].copy_from_slice(&sig.r().to_bytes());
+        hi_sig_bytes[32..].copy_from_slice(&high_s_bytes);
+        let hi_sig = Signature::from_slice(&hi_sig_bytes).unwrap();
+        let der = hi_sig.to_der();
+
+        let rsv = der_to_rsv(der.as_bytes(), &digest, signing.verifying_key()).unwrap();
+        let recovered_sig = Signature::from_slice(&rsv[..64]).unwrap();
+        // Low-S means s <= n/2. The Signature type already enforces
+        // this on the wire via `normalize_s` (called inside der_to_rsv);
+        // the simplest cross-check is "the bytes are <= n/2".
+        let s_bytes: [u8; 32] = recovered_sig.s().to_bytes().into();
+        // n/2 (secp256k1 group order halved):
+        // 7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0
+        let half_n: [u8; 32] = [
+            0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0x5D, 0x57, 0x6E, 0x73, 0x57, 0xA4, 0x50, 0x1D, 0xDF, 0xE9, 0x2F, 0x46,
+            0x68, 0x1B, 0x20, 0xA0,
+        ];
+        assert!(
+            s_bytes <= half_n,
+            "der_to_rsv must normalize to low-S; got s={}",
+            hex::encode(s_bytes)
+        );
+    }
+
+    #[test]
+    fn der_to_rsv_errors_when_pubkey_doesnt_match() {
+        let signing_a = SigningKey::from_bytes((&[0x77u8; 32]).into()).unwrap();
+        let signing_b = SigningKey::from_bytes((&[0x88u8; 32]).into()).unwrap();
+        let digest = [0x66u8; 32];
+        let (sig, _): (Signature, RecoveryId) = signing_a.sign_prehash(&digest).unwrap();
+        let der = sig.to_der().as_bytes().to_vec();
+        let err =
+            der_to_rsv(&der, &digest, signing_b.verifying_key()).expect_err("must not recover");
+        match err {
+            SignerError::Kms(m) => assert!(m.contains("recovery id"), "got: {m}"),
+            other => panic!("expected Kms, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn der_to_rsv_round_trips_normal_signature() {
+        let signing = SigningKey::from_bytes((&[0x33u8; 32]).into()).unwrap();
+        let digest = [0x99u8; 32];
+        let (sig, _): (Signature, RecoveryId) = signing.sign_prehash(&digest).unwrap();
+        let der = sig.to_der().as_bytes().to_vec();
+        let rsv = der_to_rsv(&der, &digest, signing.verifying_key()).unwrap();
+        // Recover from the rsv and check we get back the right pubkey.
+        let recovered_sig = Signature::from_slice(&rsv[..64]).unwrap();
+        let recid = RecoveryId::try_from(rsv[64]).unwrap();
+        let recovered = VerifyingKey::recover_from_prehash(&digest, &recovered_sig, recid).unwrap();
+        assert_eq!(&recovered, signing.verifying_key());
+    }
+
+    #[test]
+    fn address_from_verifying_key_matches_eip55() {
+        // Address should be EIP-55 formatted with leading 0x.
+        let signing = SigningKey::from_bytes((&[0x55u8; 32]).into()).unwrap();
+        let addr = address_from_verifying_key(signing.verifying_key());
+        assert!(addr.starts_with("0x"));
+        assert_eq!(addr.len(), 42);
+    }
+}

--- a/crates/sbo3l-core/src/signers/eth_kms_gcp_live.rs
+++ b/crates/sbo3l-core/src/signers/eth_kms_gcp_live.rs
@@ -1,0 +1,583 @@
+//! `eth_kms_gcp_live` — live GCP KMS [`EthSigner`] backend (R14 P3).
+//!
+//! Compiled only with `--features eth_kms_gcp`. Mirrors the AWS path
+//! shape but goes through `google-cloud-kms` 0.6 + `google-cloud-auth`
+//! 0.17 (the yoshidan family — same module set as the rest of the
+//! Rust GCP ecosystem).
+//!
+//! # Honest status
+//!
+//! No real KMS round-trip has been verified — Daniel does NOT have GCP
+//! creds in this round. Unit tests exercise the response-decoding logic
+//! against synthetic inputs; the gated integration test in
+//! `tests/gcp_kms_live.rs` skips cleanly unless `GCP_KMS_TEST_ENABLED=1`
+//! is set with `GOOGLE_APPLICATION_CREDENTIALS` pointing at a real
+//! service-account JSON. Daniel runs the gated integration test in R15.
+//!
+//! # API differences vs AWS KMS (the gotchas)
+//!
+//! - GCP returns the public key as **PEM** (RFC 7468). We strip the
+//!   `-----BEGIN PUBLIC KEY-----` envelope, base64-decode, then run
+//!   the same SubjectPublicKeyInfo parser the AWS path uses.
+//! - GCP `AsymmetricSign` takes a `Digest { sha256: ... }` field
+//!   rather than a separate `MessageType::Digest` flag. The signature
+//!   bytes are still ASN.1 DER, so the DER-to-rsv path is shared.
+//! - GCP key spec is `EC_SIGN_SECP256K1_SHA256` (algorithm enum 31)
+//!   — we cross-check against the `algorithm` field on the
+//!   `PublicKey` response so a mis-provisioned key fails fast.
+
+use std::sync::OnceLock;
+
+use async_trait::async_trait;
+use google_cloud_googleapis::cloud::kms::v1::{
+    digest::Digest as DigestKind, AsymmetricSignRequest, Digest, GetPublicKeyRequest,
+};
+use google_cloud_kms::client::{Client as GcpKmsClient, ClientConfig};
+use k256::ecdsa::VerifyingKey;
+
+use super::eth_kms_common::{address_from_verifying_key, der_to_rsv, parse_spki_secp256k1};
+use super::{eth::EthSigner, SignerError};
+
+/// `CryptoKeyVersionAlgorithm::EcSignSecp256k1Sha256` (proto enum value
+/// 31). Hardcoded to avoid a re-export through every dependent crate.
+const ALG_EC_SIGN_SECP256K1_SHA256: i32 = 31;
+
+/// Minimal surface this signer needs from GCP KMS. Mirrors the AWS
+/// trait shape — wraps the two RPCs we use so unit tests can fake.
+#[async_trait]
+pub trait GcpClient: Send + Sync {
+    /// `AsymmetricSign` with a SHA-256 digest. Returns DER signature
+    /// bytes.
+    async fn asymmetric_sign(
+        &self,
+        key_name: &str,
+        digest: &[u8; 32],
+    ) -> Result<Vec<u8>, SignerError>;
+
+    /// `GetPublicKey`. Returns the PEM string + algorithm enum value.
+    async fn get_public_key(&self, key_name: &str) -> Result<(String, i32), SignerError>;
+}
+
+/// SDK-backed adapter — wraps a `google_cloud_kms::client::Client`.
+pub struct SdkGcpClient {
+    inner: GcpKmsClient,
+}
+
+impl SdkGcpClient {
+    pub fn new(inner: GcpKmsClient) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl GcpClient for SdkGcpClient {
+    async fn asymmetric_sign(
+        &self,
+        key_name: &str,
+        digest: &[u8; 32],
+    ) -> Result<Vec<u8>, SignerError> {
+        let req = AsymmetricSignRequest {
+            name: key_name.to_string(),
+            digest: Some(Digest {
+                digest: Some(DigestKind::Sha256(digest.to_vec())),
+            }),
+            digest_crc32c: None,
+            data: vec![],
+            data_crc32c: None,
+        };
+        let resp = self
+            .inner
+            .asymmetric_sign(req, None)
+            .await
+            .map_err(|e| SignerError::Kms(format!("gcp kms sign({key_name}): {e}")))?;
+        if resp.signature.is_empty() {
+            return Err(SignerError::Kms(format!(
+                "gcp kms sign({key_name}): empty signature in response"
+            )));
+        }
+        Ok(resp.signature)
+    }
+
+    async fn get_public_key(&self, key_name: &str) -> Result<(String, i32), SignerError> {
+        let req = GetPublicKeyRequest {
+            name: key_name.to_string(),
+        };
+        let resp =
+            self.inner.get_public_key(req, None).await.map_err(|e| {
+                SignerError::Kms(format!("gcp kms get_public_key({key_name}): {e}"))
+            })?;
+        Ok((resp.pem, resp.algorithm))
+    }
+}
+
+/// Live GCP KMS secp256k1 EVM signer.
+pub struct GcpEthKmsLiveSigner {
+    client: Box<dyn GcpClient>,
+    key_name: String,
+    cached_verifying_key: OnceLock<VerifyingKey>,
+    cached_address: OnceLock<String>,
+}
+
+impl std::fmt::Debug for GcpEthKmsLiveSigner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GcpEthKmsLiveSigner")
+            .field("key_name", &self.key_name)
+            .field(
+                "cached_pubkey_present",
+                &self.cached_verifying_key.get().is_some(),
+            )
+            .finish()
+    }
+}
+
+impl GcpEthKmsLiveSigner {
+    /// Construct from env. Reads `SBO3L_ETH_GCP_KMS_KEY_NAME` (the full
+    /// `projects/.../cryptoKeyVersions/N` resource name). Auth is via
+    /// the standard GCP credentials chain (`GOOGLE_APPLICATION_CREDENTIALS`,
+    /// metadata server, gcloud login).
+    pub fn from_env(_role: &str) -> Result<Self, SignerError> {
+        let key_name = std::env::var("SBO3L_ETH_GCP_KMS_KEY_NAME")
+            .map_err(|_| SignerError::MissingEnv("SBO3L_ETH_GCP_KMS_KEY_NAME"))?;
+        if key_name.is_empty() {
+            return Err(SignerError::MissingEnv("SBO3L_ETH_GCP_KMS_KEY_NAME"));
+        }
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| SignerError::Kms(format!("gcp kms: build tokio rt: {e}")))?;
+        let client = rt.block_on(async {
+            let cfg = ClientConfig::default()
+                .with_auth()
+                .await
+                .map_err(|e| SignerError::Kms(format!("gcp kms: auth: {e}")))?;
+            GcpKmsClient::new(cfg)
+                .await
+                .map_err(|e| SignerError::Kms(format!("gcp kms: client: {e}")))
+        })?;
+        Self::with_client(Box::new(SdkGcpClient::new(client)), key_name)
+    }
+
+    /// Construct with an explicit client. Used by unit tests + callers
+    /// that want to share a configured client.
+    pub fn with_client(client: Box<dyn GcpClient>, key_name: String) -> Result<Self, SignerError> {
+        let s = Self {
+            client,
+            key_name,
+            cached_verifying_key: OnceLock::new(),
+            cached_address: OnceLock::new(),
+        };
+        s.address()?;
+        Ok(s)
+    }
+
+    fn block_on<T>(
+        &self,
+        fut: impl std::future::Future<Output = Result<T, SignerError>>,
+    ) -> Result<T, SignerError> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| SignerError::Kms(format!("gcp kms: build tokio rt: {e}")))?;
+        rt.block_on(fut)
+    }
+
+    fn verifying_key(&self) -> Result<&VerifyingKey, SignerError> {
+        if let Some(vk) = self.cached_verifying_key.get() {
+            return Ok(vk);
+        }
+        let key_name = self.key_name.clone();
+        let (pem, algorithm) =
+            self.block_on(async { self.client.get_public_key(&key_name).await })?;
+        if algorithm != 0 && algorithm != ALG_EC_SIGN_SECP256K1_SHA256 {
+            return Err(SignerError::KeySpecMismatch {
+                key_id: self.key_name.clone(),
+                found_spec: format!("CryptoKeyVersionAlgorithm({algorithm})"),
+            });
+        }
+        let der = pem_to_der(&pem)?;
+        let vk = parse_spki_secp256k1(&der)?;
+        let _ = self.cached_verifying_key.set(vk);
+        Ok(self.cached_verifying_key.get().expect("just set"))
+    }
+
+    fn address(&self) -> Result<&str, SignerError> {
+        if let Some(addr) = self.cached_address.get() {
+            return Ok(addr);
+        }
+        let vk = self.verifying_key()?;
+        let addr = address_from_verifying_key(vk);
+        let _ = self.cached_address.set(addr);
+        Ok(self.cached_address.get().expect("just set"))
+    }
+}
+
+impl EthSigner for GcpEthKmsLiveSigner {
+    fn sign_digest_hex(&self, digest: &[u8; 32]) -> Result<String, SignerError> {
+        let key_name = self.key_name.clone();
+        let der = self.block_on(async { self.client.asymmetric_sign(&key_name, digest).await })?;
+        let vk = self.verifying_key()?;
+        let sig_bytes = der_to_rsv(&der, digest, vk)?;
+        Ok(format!("0x{}", hex::encode(sig_bytes)))
+    }
+
+    fn eth_address(&self) -> Result<String, SignerError> {
+        Ok(self.address()?.to_string())
+    }
+
+    fn key_id(&self) -> &str {
+        &self.key_name
+    }
+}
+
+/// Strip a `-----BEGIN PUBLIC KEY-----` PEM envelope to its raw DER
+/// bytes. Tolerant of CRLF / LF line endings + variable header spacing
+/// (real GCP responses use LF; we accept both for robustness when the
+/// PEM travels through a Windows-shaped relay).
+pub fn pem_to_der(pem: &str) -> Result<Vec<u8>, SignerError> {
+    use base64::Engine as _;
+    const BEGIN: &str = "-----BEGIN PUBLIC KEY-----";
+    const END: &str = "-----END PUBLIC KEY-----";
+    let begin = pem
+        .find(BEGIN)
+        .ok_or_else(|| SignerError::Kms("gcp pem: missing BEGIN PUBLIC KEY header".to_string()))?;
+    let after_begin = begin + BEGIN.len();
+    let end = pem
+        .find(END)
+        .ok_or_else(|| SignerError::Kms("gcp pem: missing END PUBLIC KEY footer".to_string()))?;
+    if end <= after_begin {
+        return Err(SignerError::Kms(
+            "gcp pem: footer before header".to_string(),
+        ));
+    }
+    let body: String = pem[after_begin..end]
+        .chars()
+        .filter(|c| !c.is_ascii_whitespace())
+        .collect();
+    base64::engine::general_purpose::STANDARD
+        .decode(body.as_bytes())
+        .map_err(|e| SignerError::Kms(format!("gcp pem: base64 decode: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine as _;
+    use k256::ecdsa::signature::hazmat::PrehashSigner;
+    use k256::ecdsa::{RecoveryId, Signature, SigningKey};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    /// See `eth_kms_aws_live::tests::env_lock` for the rationale —
+    /// env-var tests serialised under one mutex per module to avoid
+    /// the parallel-test race that flips `set_var`/`remove_var`
+    /// between sibling tests.
+    fn env_lock() -> &'static Mutex<()> {
+        static M: std::sync::OnceLock<Mutex<()>> = std::sync::OnceLock::new();
+        M.get_or_init(|| Mutex::new(()))
+    }
+
+    /// Hand-rolled fake. Returns SHA-256-style ECDSA over the digest
+    /// (matching what real KMS would do for an
+    /// EC_SIGN_SECP256K1_SHA256 key).
+    struct FakeGcp {
+        signing: SigningKey,
+        algorithm: i32,
+        pem_override: Option<String>,
+        sign_calls: Arc<AtomicUsize>,
+        get_public_key_calls: Arc<AtomicUsize>,
+        sign_error: Option<String>,
+        get_public_key_error: Option<String>,
+    }
+
+    impl FakeGcp {
+        fn new(secret: [u8; 32]) -> Self {
+            Self {
+                signing: SigningKey::from_bytes((&secret).into()).unwrap(),
+                algorithm: ALG_EC_SIGN_SECP256K1_SHA256,
+                pem_override: None,
+                sign_calls: Arc::new(AtomicUsize::new(0)),
+                get_public_key_calls: Arc::new(AtomicUsize::new(0)),
+                sign_error: None,
+                get_public_key_error: None,
+            }
+        }
+
+        fn pem(&self) -> String {
+            if let Some(p) = &self.pem_override {
+                return p.clone();
+            }
+            // Build the same SPKI shape the AWS fake uses, then base64
+            // wrap it as PEM.
+            let pk = self.signing.verifying_key().to_encoded_point(false);
+            let pk_bytes = pk.as_bytes();
+            let mut spki = Vec::with_capacity(88);
+            spki.extend_from_slice(&[
+                0x30, 0x56, 0x30, 0x10, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06,
+                0x05, 0x2b, 0x81, 0x04, 0x00, 0x0a, 0x03, 0x42, 0x00,
+            ]);
+            spki.extend_from_slice(pk_bytes);
+            let b64 = base64::engine::general_purpose::STANDARD.encode(&spki);
+            // Standard PEM line wrapping at 64 chars.
+            let mut wrapped = String::new();
+            for chunk in b64.as_bytes().chunks(64) {
+                wrapped.push_str(std::str::from_utf8(chunk).unwrap());
+                wrapped.push('\n');
+            }
+            format!("-----BEGIN PUBLIC KEY-----\n{wrapped}-----END PUBLIC KEY-----\n")
+        }
+    }
+
+    #[async_trait]
+    impl GcpClient for FakeGcp {
+        async fn asymmetric_sign(
+            &self,
+            _key_name: &str,
+            digest: &[u8; 32],
+        ) -> Result<Vec<u8>, SignerError> {
+            self.sign_calls.fetch_add(1, Ordering::SeqCst);
+            if let Some(e) = &self.sign_error {
+                return Err(SignerError::Kms(e.clone()));
+            }
+            let (sig, _): (Signature, RecoveryId) = self
+                .signing
+                .sign_prehash(digest)
+                .map_err(|e| SignerError::Kms(format!("fake sign: {e}")))?;
+            Ok(sig.to_der().as_bytes().to_vec())
+        }
+
+        async fn get_public_key(&self, _key_name: &str) -> Result<(String, i32), SignerError> {
+            self.get_public_key_calls.fetch_add(1, Ordering::SeqCst);
+            if let Some(e) = &self.get_public_key_error {
+                return Err(SignerError::Kms(e.clone()));
+            }
+            Ok((self.pem(), self.algorithm))
+        }
+    }
+
+    fn fixed_secret() -> [u8; 32] {
+        [0x22; 32]
+    }
+
+    fn make_signer() -> GcpEthKmsLiveSigner {
+        let fake = FakeGcp::new(fixed_secret());
+        GcpEthKmsLiveSigner::with_client(
+            Box::new(fake),
+            "projects/test/locations/us/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1".to_string(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn constructor_caches_pubkey_with_one_get_public_key_call() {
+        let fake = FakeGcp::new(fixed_secret());
+        let counter = fake.get_public_key_calls.clone();
+        let signer =
+            GcpEthKmsLiveSigner::with_client(Box::new(fake), "test-key".to_string()).unwrap();
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        for _ in 0..5 {
+            let _ = signer.eth_address().unwrap();
+        }
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn sign_digest_hex_round_trip_recovers_signers_address() {
+        let signer = make_signer();
+        let digest = [0xCD; 32];
+        let sig_hex = signer.sign_digest_hex(&digest).unwrap();
+        let raw = hex::decode(sig_hex.strip_prefix("0x").unwrap()).unwrap();
+        let sig = Signature::from_slice(&raw[..64]).unwrap();
+        let recid = RecoveryId::try_from(raw[64]).unwrap();
+        let recovered = VerifyingKey::recover_from_prehash(&digest, &sig, recid).unwrap();
+        let addr = address_from_verifying_key(&recovered);
+        assert_eq!(addr, signer.eth_address().unwrap());
+    }
+
+    #[test]
+    fn pem_to_der_round_trip() {
+        let fake = FakeGcp::new(fixed_secret());
+        let pem = fake.pem();
+        let der = pem_to_der(&pem).unwrap();
+        let vk = parse_spki_secp256k1(&der).unwrap();
+        let local = SigningKey::from_bytes((&fixed_secret()).into()).unwrap();
+        assert_eq!(&vk, local.verifying_key());
+    }
+
+    #[test]
+    fn pem_to_der_handles_crlf_line_endings() {
+        let fake = FakeGcp::new(fixed_secret());
+        let pem = fake.pem().replace('\n', "\r\n");
+        let der = pem_to_der(&pem).unwrap();
+        // SPKI for secp256k1 is exactly 88 bytes.
+        assert_eq!(der.len(), 88);
+    }
+
+    #[test]
+    fn pem_to_der_rejects_missing_begin() {
+        let bad = "no header here\nMFY=\n-----END PUBLIC KEY-----\n";
+        let err = pem_to_der(bad).expect_err("must reject");
+        match err {
+            SignerError::Kms(m) => assert!(m.contains("BEGIN"), "got: {m}"),
+            other => panic!("expected Kms, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pem_to_der_rejects_missing_end() {
+        let bad = "-----BEGIN PUBLIC KEY-----\nMFY=\n";
+        let err = pem_to_der(bad).expect_err("must reject");
+        match err {
+            SignerError::Kms(m) => assert!(m.contains("END"), "got: {m}"),
+            other => panic!("expected Kms, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pem_to_der_rejects_invalid_base64() {
+        let bad = "-----BEGIN PUBLIC KEY-----\nthis is not base64!@#$\n-----END PUBLIC KEY-----\n";
+        let err = pem_to_der(bad).expect_err("must reject");
+        match err {
+            SignerError::Kms(m) => assert!(m.contains("base64"), "got: {m}"),
+            other => panic!("expected Kms, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn constructor_rejects_wrong_algorithm() {
+        let mut fake = FakeGcp::new(fixed_secret());
+        // RSA_SIGN_PSS_2048_SHA256 = enum value 5 (definitely not
+        // secp256k1).
+        fake.algorithm = 5;
+        let err = GcpEthKmsLiveSigner::with_client(Box::new(fake), "test-key".to_string())
+            .expect_err("must reject");
+        match err {
+            SignerError::KeySpecMismatch { found_spec, .. } => {
+                assert!(found_spec.contains("CryptoKeyVersionAlgorithm(5)"));
+            }
+            other => panic!("expected KeySpecMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn constructor_accepts_unspecified_algorithm() {
+        // GCP returns algorithm = 0 (UNSPECIFIED) on some legacy
+        // responses; we accept it rather than fail-closed since the
+        // pubkey parse step still validates the actual point.
+        let mut fake = FakeGcp::new(fixed_secret());
+        fake.algorithm = 0;
+        let signer = GcpEthKmsLiveSigner::with_client(Box::new(fake), "test-key".to_string());
+        assert!(signer.is_ok());
+    }
+
+    #[test]
+    fn constructor_propagates_get_public_key_error() {
+        let mut fake = FakeGcp::new(fixed_secret());
+        fake.get_public_key_error = Some("PermissionDenied".to_string());
+        let err = GcpEthKmsLiveSigner::with_client(Box::new(fake), "test-key".to_string())
+            .expect_err("must propagate");
+        match err {
+            SignerError::Kms(m) => assert!(m.contains("PermissionDenied"), "got: {m}"),
+            other => panic!("expected Kms, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sign_propagates_kms_error() {
+        let fake = FakeGcp::new(fixed_secret());
+        let mut signer =
+            GcpEthKmsLiveSigner::with_client(Box::new(fake), "test-key".to_string()).unwrap();
+        let mut bad = FakeGcp::new(fixed_secret());
+        bad.sign_error = Some("ResourceExhausted".to_string());
+        signer.client = Box::new(bad);
+        let err = signer.sign_digest_hex(&[0u8; 32]).expect_err("must error");
+        match err {
+            SignerError::Kms(m) => assert!(m.contains("ResourceExhausted"), "got: {m}"),
+            other => panic!("expected Kms, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sign_n_times_calls_pubkey_only_once() {
+        let fake = FakeGcp::new(fixed_secret());
+        let sign_counter = fake.sign_calls.clone();
+        let pk_counter = fake.get_public_key_calls.clone();
+        let signer =
+            GcpEthKmsLiveSigner::with_client(Box::new(fake), "test-key".to_string()).unwrap();
+        for _ in 0..3 {
+            signer.sign_digest_hex(&[0xEE; 32]).unwrap();
+        }
+        assert_eq!(sign_counter.load(Ordering::SeqCst), 3);
+        assert_eq!(pk_counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn from_env_missing_var_errors_clearly() {
+        let _guard = env_lock().lock().unwrap();
+        let original = std::env::var("SBO3L_ETH_GCP_KMS_KEY_NAME").ok();
+        unsafe {
+            std::env::remove_var("SBO3L_ETH_GCP_KMS_KEY_NAME");
+        }
+        let err = GcpEthKmsLiveSigner::from_env("audit").expect_err("must error");
+        match err {
+            SignerError::MissingEnv("SBO3L_ETH_GCP_KMS_KEY_NAME") => {}
+            other => panic!("expected MissingEnv, got {other:?}"),
+        }
+        unsafe {
+            if let Some(v) = original {
+                std::env::set_var("SBO3L_ETH_GCP_KMS_KEY_NAME", v);
+            }
+        }
+    }
+
+    #[test]
+    fn key_id_returns_configured_value() {
+        let signer = make_signer();
+        assert!(signer.key_id().contains("cryptoKeyVersions/1"));
+    }
+
+    #[test]
+    fn signature_byte_identical_across_two_calls() {
+        let signer = make_signer();
+        let digest = [0x77; 32];
+        let s1 = signer.sign_digest_hex(&digest).unwrap();
+        let s2 = signer.sign_digest_hex(&digest).unwrap();
+        assert_eq!(s1, s2);
+    }
+
+    #[test]
+    fn signature_address_matches_local_signer() {
+        let signer = make_signer();
+        let local = SigningKey::from_bytes((&fixed_secret()).into()).unwrap();
+        let local_addr = address_from_verifying_key(local.verifying_key());
+        assert_eq!(signer.eth_address().unwrap(), local_addr);
+    }
+
+    #[test]
+    fn sign_returns_65_bytes() {
+        let signer = make_signer();
+        let sig_hex = signer.sign_digest_hex(&[0u8; 32]).unwrap();
+        let raw = hex::decode(sig_hex.strip_prefix("0x").unwrap()).unwrap();
+        assert_eq!(raw.len(), 65);
+        assert!(raw[64] <= 1, "v must be 0 or 1, got {}", raw[64]);
+    }
+
+    #[test]
+    fn empty_key_name_env_treated_as_missing() {
+        let _guard = env_lock().lock().unwrap();
+        let original = std::env::var("SBO3L_ETH_GCP_KMS_KEY_NAME").ok();
+        unsafe {
+            std::env::set_var("SBO3L_ETH_GCP_KMS_KEY_NAME", "");
+        }
+        let err = GcpEthKmsLiveSigner::from_env("audit").expect_err("must reject empty");
+        match err {
+            SignerError::MissingEnv(_) => {}
+            other => panic!("expected MissingEnv, got {other:?}"),
+        }
+        unsafe {
+            std::env::remove_var("SBO3L_ETH_GCP_KMS_KEY_NAME");
+            if let Some(v) = original {
+                std::env::set_var("SBO3L_ETH_GCP_KMS_KEY_NAME", v);
+            }
+        }
+    }
+}

--- a/crates/sbo3l-core/src/signers/mod.rs
+++ b/crates/sbo3l-core/src/signers/mod.rs
@@ -115,6 +115,17 @@ pub mod eth_kms;
 #[cfg(feature = "eth_signer")]
 pub mod eth_local;
 
+// R14 P3 — live cloud-KMS EthSigner backends. Each pulls a vendor SDK
+// only when its feature is enabled. `eth_kms_common` holds the shared
+// SPKI / DER / address helpers; gated to either feature so it's
+// available to whichever backend is active.
+#[cfg(feature = "eth_kms_aws")]
+pub mod eth_kms_aws_live;
+#[cfg(any(feature = "eth_kms_aws", feature = "eth_kms_gcp"))]
+pub mod eth_kms_common;
+#[cfg(feature = "eth_kms_gcp")]
+pub mod eth_kms_gcp_live;
+
 pub use dev::DevSignerLockedDown;
 pub use local_file::{KeyFileFormat, LocalFileSigner};
 
@@ -139,12 +150,22 @@ pub fn eth_signer_from_env(role: &str) -> Result<Box<dyn EthSigner>, SignerError
     match backend.as_str() {
         "local_file" => Ok(Box::new(eth_local::EthLocalFileSigner::from_env(role)?)),
 
+        // R14 P3: live AWS KMS EthSigner is gated behind `eth_kms_aws`.
+        // The older `aws_kms` Ed25519 stub feature still exposes a
+        // compile-only stub via `eth_kms::aws` — kept for callers that
+        // pull the trait but not the SDK.
         "aws_kms" => {
-            #[cfg(feature = "aws_kms")]
+            #[cfg(feature = "eth_kms_aws")]
+            {
+                Ok(Box::new(eth_kms_aws_live::AwsEthKmsLiveSigner::from_env(
+                    role,
+                )?))
+            }
+            #[cfg(all(feature = "aws_kms", not(feature = "eth_kms_aws")))]
             {
                 Ok(Box::new(eth_kms::aws::AwsEthKmsSigner::from_env(role)?))
             }
-            #[cfg(not(feature = "aws_kms"))]
+            #[cfg(not(any(feature = "aws_kms", feature = "eth_kms_aws")))]
             {
                 let _ = role;
                 Err(SignerError::BackendNotCompiled("aws_kms"))
@@ -152,11 +173,17 @@ pub fn eth_signer_from_env(role: &str) -> Result<Box<dyn EthSigner>, SignerError
         }
 
         "gcp_kms" => {
-            #[cfg(feature = "gcp_kms")]
+            #[cfg(feature = "eth_kms_gcp")]
+            {
+                Ok(Box::new(eth_kms_gcp_live::GcpEthKmsLiveSigner::from_env(
+                    role,
+                )?))
+            }
+            #[cfg(all(feature = "gcp_kms", not(feature = "eth_kms_gcp")))]
             {
                 Ok(Box::new(eth_kms::gcp::GcpEthKmsSigner::from_env(role)?))
             }
-            #[cfg(not(feature = "gcp_kms"))]
+            #[cfg(not(any(feature = "gcp_kms", feature = "eth_kms_gcp")))]
             {
                 let _ = role;
                 Err(SignerError::BackendNotCompiled("gcp_kms"))

--- a/crates/sbo3l-core/tests/aws_kms_live.rs
+++ b/crates/sbo3l-core/tests/aws_kms_live.rs
@@ -1,0 +1,81 @@
+//! Live AWS KMS round-trip — gated on `AWS_KMS_TEST_ENABLED=1`.
+//!
+//! Compiled only with `--features eth_kms_aws`. Skips silently when
+//! the gating env var is unset, so default `cargo test` runs (which
+//! never have AWS creds) don't touch the network.
+//!
+//! # How Daniel runs this in R15
+//!
+//! ```text
+//! export AWS_REGION=us-east-1
+//! export AWS_ACCESS_KEY_ID=...
+//! export AWS_SECRET_ACCESS_KEY=...
+//! export SBO3L_ETH_AWS_KMS_KEY_ID=arn:aws:kms:us-east-1:...:key/...
+//! export AWS_KMS_TEST_ENABLED=1
+//! cargo test -p sbo3l-core --features eth_kms_aws --test aws_kms_live -- --nocapture
+//! ```
+//!
+//! Provisioning the key + IAM policy: see `docs/kms-aws-setup.md`.
+
+#![cfg(feature = "eth_kms_aws")]
+
+use sbo3l_core::signers::eth::EthSigner;
+use sbo3l_core::signers::eth_kms_aws_live::AwsEthKmsLiveSigner;
+
+/// Skip helper — returns `true` if the gating env var is set.
+fn live_enabled() -> bool {
+    std::env::var("AWS_KMS_TEST_ENABLED")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+#[test]
+fn live_sign_and_recover_round_trip() {
+    if !live_enabled() {
+        eprintln!(
+            "SKIP: live_sign_and_recover_round_trip — set AWS_KMS_TEST_ENABLED=1 + AWS creds + \
+             SBO3L_ETH_AWS_KMS_KEY_ID to enable."
+        );
+        return;
+    }
+
+    use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
+    use sbo3l_core::signers::eth_kms_common::address_from_verifying_key;
+
+    let signer = AwsEthKmsLiveSigner::from_env("audit").expect("AwsEthKmsLiveSigner::from_env");
+    let claimed_addr = signer.eth_address().expect("eth_address");
+    eprintln!("live AWS KMS signer address = {claimed_addr}");
+
+    let digest = [0xABu8; 32];
+    let sig_hex = signer.sign_digest_hex(&digest).expect("sign_digest_hex");
+    eprintln!("live AWS KMS signature = {sig_hex}");
+
+    // Recover address from sig + digest. Must match `claimed_addr` —
+    // this is the contract every on-chain ecrecover relies on.
+    let raw = hex::decode(sig_hex.strip_prefix("0x").unwrap()).unwrap();
+    assert_eq!(raw.len(), 65);
+    let sig = Signature::from_slice(&raw[..64]).unwrap();
+    let recid = RecoveryId::try_from(raw[64]).unwrap();
+    let recovered = VerifyingKey::recover_from_prehash(&digest, &sig, recid)
+        .expect("recover from live signature");
+    let recovered_addr = address_from_verifying_key(&recovered);
+    assert_eq!(
+        recovered_addr, claimed_addr,
+        "live AWS KMS: ecrecover must match cached address"
+    );
+}
+
+#[test]
+fn live_pubkey_caching_one_round_trip() {
+    if !live_enabled() {
+        eprintln!("SKIP: live_pubkey_caching_one_round_trip");
+        return;
+    }
+    let signer = AwsEthKmsLiveSigner::from_env("audit").expect("from_env");
+    // Two address() calls — the second must be cached (no network).
+    // We can't directly assert "no network" here without wrapping the
+    // SDK client, but we can assert the value is stable.
+    let a1 = signer.eth_address().unwrap();
+    let a2 = signer.eth_address().unwrap();
+    assert_eq!(a1, a2);
+}

--- a/crates/sbo3l-core/tests/gcp_kms_live.rs
+++ b/crates/sbo3l-core/tests/gcp_kms_live.rs
@@ -1,0 +1,72 @@
+//! Live GCP KMS round-trip — gated on `GCP_KMS_TEST_ENABLED=1`.
+//!
+//! Compiled only with `--features eth_kms_gcp`. Skips silently when
+//! the gating env var is unset.
+//!
+//! # How Daniel runs this in R15
+//!
+//! ```text
+//! export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+//! export SBO3L_ETH_GCP_KMS_KEY_NAME=projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1
+//! export GCP_KMS_TEST_ENABLED=1
+//! cargo test -p sbo3l-core --features eth_kms_gcp --test gcp_kms_live -- --nocapture
+//! ```
+//!
+//! Provisioning the key + IAM role: see `docs/kms-gcp-setup.md`.
+
+#![cfg(feature = "eth_kms_gcp")]
+
+use sbo3l_core::signers::eth::EthSigner;
+use sbo3l_core::signers::eth_kms_gcp_live::GcpEthKmsLiveSigner;
+
+fn live_enabled() -> bool {
+    std::env::var("GCP_KMS_TEST_ENABLED")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+#[test]
+fn live_sign_and_recover_round_trip() {
+    if !live_enabled() {
+        eprintln!(
+            "SKIP: live_sign_and_recover_round_trip — set GCP_KMS_TEST_ENABLED=1 + \
+             GOOGLE_APPLICATION_CREDENTIALS + SBO3L_ETH_GCP_KMS_KEY_NAME to enable."
+        );
+        return;
+    }
+
+    use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
+    use sbo3l_core::signers::eth_kms_common::address_from_verifying_key;
+
+    let signer = GcpEthKmsLiveSigner::from_env("audit").expect("from_env");
+    let claimed_addr = signer.eth_address().expect("eth_address");
+    eprintln!("live GCP KMS signer address = {claimed_addr}");
+
+    let digest = [0xCDu8; 32];
+    let sig_hex = signer.sign_digest_hex(&digest).expect("sign_digest_hex");
+    eprintln!("live GCP KMS signature = {sig_hex}");
+
+    let raw = hex::decode(sig_hex.strip_prefix("0x").unwrap()).unwrap();
+    assert_eq!(raw.len(), 65);
+    let sig = Signature::from_slice(&raw[..64]).unwrap();
+    let recid = RecoveryId::try_from(raw[64]).unwrap();
+    let recovered = VerifyingKey::recover_from_prehash(&digest, &sig, recid)
+        .expect("recover from live signature");
+    let recovered_addr = address_from_verifying_key(&recovered);
+    assert_eq!(
+        recovered_addr, claimed_addr,
+        "live GCP KMS: ecrecover must match cached address"
+    );
+}
+
+#[test]
+fn live_pubkey_caching_one_round_trip() {
+    if !live_enabled() {
+        eprintln!("SKIP: live_pubkey_caching_one_round_trip");
+        return;
+    }
+    let signer = GcpEthKmsLiveSigner::from_env("audit").expect("from_env");
+    let a1 = signer.eth_address().unwrap();
+    let a2 = signer.eth_address().unwrap();
+    assert_eq!(a1, a2);
+}

--- a/docs/kms-aws-setup.md
+++ b/docs/kms-aws-setup.md
@@ -1,0 +1,129 @@
+# AWS KMS — secp256k1 EthSigner runbook
+
+How to provision an AWS KMS key for SBO3L's EVM signing path
+(`AwsEthKmsLiveSigner`, feature `eth_kms_aws`), wire credentials, and
+run the gated live integration tests.
+
+## Status
+
+The Rust backend (`crates/sbo3l-core/src/signers/eth_kms_aws_live.rs`)
+is **code-ready** as of R14 P3. No real KMS round-trip has been
+verified yet — Daniel runs the live integration tests (`cargo test
+--test aws_kms_live`) in R15 once the key + creds exist. Until then,
+the unit tests cover all decoding paths against synthetic DER fixtures.
+
+## 1 — Provision the KMS key
+
+```bash
+aws kms create-key \
+  --region us-east-1 \
+  --key-spec ECC_SECG_P256K1 \
+  --key-usage SIGN_VERIFY \
+  --description "SBO3L EVM signer (eth audit/receipt)"
+```
+
+Capture the `KeyId` (UUID) and `Arn` from the response. Optionally
+attach an alias for stable referencing:
+
+```bash
+aws kms create-alias \
+  --alias-name alias/sbo3l-eth-audit \
+  --target-key-id <KeyId>
+```
+
+## 2 — IAM policy for the daemon's role
+
+The role under which the daemon runs (EC2 instance profile / ECS task
+role / lambda execution role) needs:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Sbo3lKmsSign",
+      "Effect": "Allow",
+      "Action": ["kms:Sign", "kms:GetPublicKey"],
+      "Resource": "arn:aws:kms:us-east-1:<account>:key/<key-id>"
+    }
+  ]
+}
+```
+
+Both `kms:Sign` and `kms:GetPublicKey` are required — `GetPublicKey` is
+called once at constructor time to derive the EIP-55 address; `Sign` is
+called per signing operation. Omitting `GetPublicKey` causes
+`AwsEthKmsLiveSigner::with_client` to error with `AccessDenied` at
+startup.
+
+## 3 — Daemon environment
+
+```bash
+# AWS SDK credentials chain — any of:
+#  - AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY env vars
+#  - shared credentials file (~/.aws/credentials)
+#  - EC2 instance metadata service (IMDSv2)
+#  - ECS task role
+export AWS_REGION=us-east-1
+
+# SBO3L wiring:
+export SBO3L_ETH_SIGNER_BACKEND=aws_kms
+export SBO3L_ETH_AWS_KMS_KEY_ID=arn:aws:kms:us-east-1:<account>:key/<key-id>
+# OR (alias to the same value):
+# export SBO3L_ETH_AWS_KMS_KEY_ARN=arn:aws:kms:us-east-1:<account>:key/<key-id>
+
+# Build the daemon with the live backend feature:
+cargo build --release -p sbo3l-server --features sbo3l-core/eth_kms_aws
+```
+
+The factory in `sbo3l_core::signers::eth_signer_from_env` routes to
+`AwsEthKmsLiveSigner::from_env` when both the env var AND the feature
+flag are set. Without the feature flag the factory returns
+`SignerError::BackendNotCompiled("aws_kms")` even with the env var
+present — by design, since the SDK isn't compiled in.
+
+## 4 — Run the gated integration tests
+
+```bash
+export AWS_KMS_TEST_ENABLED=1
+cargo test -p sbo3l-core --features eth_kms_aws --test aws_kms_live -- --nocapture
+```
+
+The tests:
+
+1. Build a real `AwsEthKmsLiveSigner` from env.
+2. Call `eth_address()` — must succeed (one `GetPublicKey` round-trip).
+3. Sign a known 32-byte digest with `sign_digest_hex(&digest)`.
+4. Run `ecrecover` over the resulting 65-byte signature + digest, and
+   assert the recovered EIP-55 address matches `eth_address()`.
+
+If step 4 fails, the bug is one of:
+
+- Wrong key spec (`KeySpec::EccNistP256` instead of `EccSecgP256K1`)
+- The cached pubkey + signed digest don't agree (clock-skew style
+  staleness — extremely unlikely with KMS).
+
+Without `AWS_KMS_TEST_ENABLED=1` the tests print `SKIP:` and return ok.
+Default CI never touches AWS.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `KMSInvalidStateException` | Key is in `PendingDeletion` | `aws kms cancel-key-deletion --key-id <id>` |
+| `AccessDeniedException` on `Sign` | IAM policy missing `kms:Sign` | Add `kms:Sign` to the role's policy. |
+| `KeySpecMismatch { found_spec: "EccNistP256" }` | Key was created with the wrong spec | Provision a new key with `--key-spec ECC_SECG_P256K1`. |
+| Constructor hangs ~30s then errors | Region mismatch (key in `us-west-2`, daemon in `us-east-1`) | Set `AWS_REGION` to the key's region or use a region-qualified ARN. |
+| `SDK config: no credentials` | No creds in chain | Set `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`, attach an instance profile, or run `aws configure`. |
+
+## Why this design
+
+- **Pubkey caching at constructor time** — every `eth_address()` call
+  after the first is a memory read. KMS `GetPublicKey` is rate-limited
+  and bills per call; caching saves both quota and latency.
+- **Recovery byte derived locally** — KMS returns DER `(r, s)` only.
+  We try both recovery ids 0 and 1 and pick the one that recovers the
+  cached pubkey. One ECDSA verify is faster than a second KMS round-trip.
+- **Low-S normalization** — EIP-2 / Bitcoin's malleability fix. KMS
+  may return high-S signatures; the on-chain Solidity ecrecover
+  rejects them. We normalize before returning.

--- a/docs/kms-gcp-setup.md
+++ b/docs/kms-gcp-setup.md
@@ -1,0 +1,139 @@
+# GCP KMS — secp256k1 EthSigner runbook
+
+How to provision a Google Cloud KMS key for SBO3L's EVM signing path
+(`GcpEthKmsLiveSigner`, feature `eth_kms_gcp`), wire credentials, and
+run the gated live integration tests.
+
+## Status
+
+The Rust backend (`crates/sbo3l-core/src/signers/eth_kms_gcp_live.rs`)
+is **code-ready** as of R14 P3. No real KMS round-trip has been
+verified yet — Daniel runs the live integration tests (`cargo test
+--test gcp_kms_live`) in R15 once the key + service-account JSON
+exist. Until then, the unit tests cover all decoding paths against
+synthetic inputs (DER + PEM).
+
+## 1 — Provision the KMS key
+
+```bash
+PROJECT=my-project
+LOCATION=us-east1
+KEYRING=sbo3l-keys
+KEY=eth-audit
+
+# Key ring (one-time per location):
+gcloud kms keyrings create $KEYRING \
+  --location $LOCATION \
+  --project $PROJECT
+
+# secp256k1 ECDSA-SHA256 key:
+gcloud kms keys create $KEY \
+  --keyring $KEYRING \
+  --location $LOCATION \
+  --purpose asymmetric-signing \
+  --default-algorithm ec-sign-secp256k1-sha256 \
+  --project $PROJECT
+```
+
+The full resource name is:
+
+```
+projects/$PROJECT/locations/$LOCATION/keyRings/$KEYRING/cryptoKeys/$KEY/cryptoKeyVersions/1
+```
+
+GCP auto-creates `cryptoKeyVersions/1` on key creation. List versions:
+
+```bash
+gcloud kms keys versions list \
+  --keyring $KEYRING \
+  --key $KEY \
+  --location $LOCATION
+```
+
+## 2 — Service-account IAM role
+
+Create a service account dedicated to the daemon:
+
+```bash
+gcloud iam service-accounts create sbo3l-daemon \
+  --display-name "SBO3L daemon (KMS signing)"
+```
+
+Grant it the minimum role for signing:
+
+```bash
+gcloud kms keys add-iam-policy-binding $KEY \
+  --keyring $KEYRING \
+  --location $LOCATION \
+  --member serviceAccount:sbo3l-daemon@$PROJECT.iam.gserviceaccount.com \
+  --role roles/cloudkms.signerVerifier
+```
+
+`roles/cloudkms.signerVerifier` grants `cloudkms.cryptoKeyVersions.useToSign`
++ `cloudkms.cryptoKeyVersions.viewPublicKey` — exactly the two RPCs
+the backend uses (`AsymmetricSign` + `GetPublicKey`).
+
+Generate a service-account JSON key for non-GCE deployments:
+
+```bash
+gcloud iam service-accounts keys create /secure/sbo3l-daemon.json \
+  --iam-account sbo3l-daemon@$PROJECT.iam.gserviceaccount.com
+```
+
+For GCE / GKE deployments use Workload Identity instead and skip the
+JSON file.
+
+## 3 — Daemon environment
+
+```bash
+# GCP credentials — either:
+export GOOGLE_APPLICATION_CREDENTIALS=/secure/sbo3l-daemon.json
+# OR rely on the metadata server (GCE / GKE Workload Identity).
+
+# SBO3L wiring:
+export SBO3L_ETH_SIGNER_BACKEND=gcp_kms
+export SBO3L_ETH_GCP_KMS_KEY_NAME="projects/$PROJECT/locations/$LOCATION/keyRings/$KEYRING/cryptoKeys/$KEY/cryptoKeyVersions/1"
+
+# Build the daemon with the live backend feature:
+cargo build --release -p sbo3l-server --features sbo3l-core/eth_kms_gcp
+```
+
+## 4 — Run the gated integration tests
+
+```bash
+export GCP_KMS_TEST_ENABLED=1
+cargo test -p sbo3l-core --features eth_kms_gcp --test gcp_kms_live -- --nocapture
+```
+
+Same shape as the AWS gated tests — sign a known digest, ecrecover,
+assert the recovered address matches `eth_address()`. Without
+`GCP_KMS_TEST_ENABLED=1` the tests skip cleanly.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `PermissionDenied` on `GetPublicKey` | IAM role missing | Add `roles/cloudkms.signerVerifier` (or at least `cloudkms.cryptoKeyVersions.viewPublicKey`). |
+| `KeySpecMismatch { found_spec: "CryptoKeyVersionAlgorithm(8)" }` | Wrong algorithm (algorithm 8 = `EC_SIGN_P256_SHA256`) | Recreate the key with `--default-algorithm ec-sign-secp256k1-sha256`. |
+| `gcp pem: missing BEGIN PUBLIC KEY header` | KMS returned an unexpected response shape | Verify the key version exists and is enabled. |
+| `Authentication failed: invalid_grant` | Service-account JSON expired / clock skew | Regenerate the key, check NTP. |
+| Constructor blocks on first call | DNS / firewall blocking `cloudkms.googleapis.com:443` | Confirm egress to GCP from the daemon's network. |
+
+## Why this design
+
+- **Direct gRPC to `cloudkms.googleapis.com`** via `google-cloud-kms`
+  0.6 (the yoshidan family) — bypasses the official `google-cloud-rust`
+  preview, which is still moving. The yoshidan crate is stable, has
+  a clean async API, and avoids pulling `ethers-core` (which the 0.6
+  `eth` feature would).
+- **Algorithm enum cross-check** — we accept both
+  `EC_SIGN_SECP256K1_SHA256` (= 31) and the legacy `UNSPECIFIED`
+  (= 0); a mismatch (e.g. P-256, RSA) errors at constructor time so
+  misconfiguration fails fast.
+- **PEM → DER once, cached** — the public key arrives PEM-armored.
+  We strip the envelope, base64-decode, parse SPKI, derive the
+  EIP-55 address, and cache. Every subsequent `eth_address()` call
+  is a memory read.
+- **Shared decoding helpers with AWS path** — the SPKI + DER signature
+  parser lives in `eth_kms_common.rs` and is exercised by both
+  backends + an independent unit-test surface.


### PR DESCRIPTION
## Summary

Wires AWS KMS and GCP KMS as live secp256k1 `EthSigner` implementations
behind dedicated cargo features (`eth_kms_aws` / `eth_kms_gcp`). The
existing `eth_kms.rs` stubs (gated behind the older Ed25519 `aws_kms`
/ `gcp_kms` features) remain in place; the factory in `signers/mod.rs`
prefers the live backend when its dedicated feature is on.

- AWS path: `aws-sdk-kms` 1.x via a `KmsClient` trait wrapper. Sign
  uses `MessageType::Digest` + `SigningAlgorithmSpec::EcdsaSha256`;
  `GetPublicKey` returns SPKI DER. SPKI parse + DER signature decode
  + low-S normalization + recovery-id derivation all in
  `eth_kms_common.rs` (shared with GCP path).
- GCP path: `google-cloud-kms` 0.6 (yoshidan family) via a `GcpClient`
  trait wrapper. PEM-armored pubkey is stripped + base64-decoded, then
  fed into the same SPKI parser. `AsymmetricSign` with `Digest::Sha256`.
- 53 new unit tests + 4 gated integration tests (skip silently
  without `AWS_KMS_TEST_ENABLED=1` / `GCP_KMS_TEST_ENABLED=1`).
- Runbooks: `docs/kms-aws-setup.md` + `docs/kms-gcp-setup.md`.

## Honest scope — no live KMS round-trip yet

No real KMS round-trip has been verified. Daniel does **not** have
AWS / GCP creds in R14. The gated integration tests at
`tests/aws_kms_live.rs` + `tests/gcp_kms_live.rs` are the truth-tellers;
Daniel runs them in R15 once the keys + creds are provisioned. Until
then, the unit tests cover all decoding paths against synthetic
DER + SPKI fixtures (and against fake clients that round-trip real
secp256k1 signatures via deterministic-k ECDSA).

## Files (10)

- `crates/sbo3l-core/Cargo.toml` — two new features
  (`eth_kms_aws`, `eth_kms_gcp`), each pulling the matching vendor
  SDK only when active.
- `crates/sbo3l-core/src/signers/eth_kms_aws_live.rs` — 700 LOC,
  `AwsEthKmsLiveSigner` + `KmsClient` trait + 22 unit tests.
- `crates/sbo3l-core/src/signers/eth_kms_gcp_live.rs` — 600 LOC,
  `GcpEthKmsLiveSigner` + `GcpClient` trait + 19 unit tests.
- `crates/sbo3l-core/src/signers/eth_kms_common.rs` — 400 LOC, shared
  SPKI / DER / address helpers + 12 unit tests on the decoding logic.
- `crates/sbo3l-core/src/signers/mod.rs` — factory routes
  `aws_kms` / `gcp_kms` to live backend when feature on, falls back
  to existing stub when only legacy feature on.
- `crates/sbo3l-core/tests/aws_kms_live.rs` + `gcp_kms_live.rs` —
  gated integration tests (2 each).
- `docs/kms-aws-setup.md` + `docs/kms-gcp-setup.md` — runbooks.

## Test plan

- [x] `cargo build -p sbo3l-core` (no features) — 125 unit tests
      still pass, no new transitive deps.
- [x] `cargo build -p sbo3l-core --features eth_kms_aws` — clean.
- [x] `cargo build -p sbo3l-core --features eth_kms_gcp` — clean.
- [x] `cargo build -p sbo3l-core --features eth_kms_aws,eth_kms_gcp` — clean.
- [x] `cargo test -p sbo3l-core --features eth_kms_aws,eth_kms_gcp` —
      178 unit + 4 integration + gated live tests skip cleanly.
- [x] `cargo clippy -p sbo3l-core --features eth_kms_aws,eth_kms_gcp --all-targets -- -D warnings` — clean.
- [x] `cargo fmt -p sbo3l-core -- --check` clean on all new files
      (one pre-existing diff in `proptest_invariants.rs` reverted).
- [x] `cargo build --workspace` — clean (no consumer crate breakage).
- [ ] **R15 only — Daniel with creds:** `AWS_KMS_TEST_ENABLED=1
      cargo test -p sbo3l-core --features eth_kms_aws --test aws_kms_live`.
- [ ] **R15 only — Daniel with creds:** `GCP_KMS_TEST_ENABLED=1
      cargo test -p sbo3l-core --features eth_kms_gcp --test gcp_kms_live`.

## What stays gated until R15

| Item | Gate |
| --- | --- |
| AWS KMS live `Sign` round-trip | `AWS_KMS_TEST_ENABLED=1` + AWS creds + `SBO3L_ETH_AWS_KMS_KEY_ID` |
| GCP KMS live `AsymmetricSign` round-trip | `GCP_KMS_TEST_ENABLED=1` + `GOOGLE_APPLICATION_CREDENTIALS` + `SBO3L_ETH_GCP_KMS_KEY_NAME` |
| AWS-side IAM policy (`kms:Sign`, `kms:GetPublicKey`) | Daniel attaches in R15 |
| GCP-side IAM role (`roles/cloudkms.signerVerifier`) | Daniel grants in R15 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)