### PR TITLE
feat(deploy): Helm chart skeleton for sbo3l-server (R14 P6)

### DIFF
--- a/deploy/helm/sbo3l/.helmignore
+++ b/deploy/helm/sbo3l/.helmignore
@@ -1,0 +1,30 @@
+# Patterns to ignore when building Helm packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# OWNERS / project-management files
+OWNERS
+.helmignore
+# Test render artifacts
+ci/
+tests/
+*.tgz

--- a/deploy/helm/sbo3l/Chart.lock
+++ b/deploy/helm/sbo3l/Chart.lock
@@ -1,0 +1,3 @@
+dependencies: []
+digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+generated: "2026-05-02T00:00:00Z"

--- a/deploy/helm/sbo3l/Chart.yaml
+++ b/deploy/helm/sbo3l/Chart.yaml
@@ -1,0 +1,35 @@
+apiVersion: v2
+name: sbo3l
+description: |
+  EXPERIMENTAL chart skeleton for the SBO3L server (cryptographically
+  verifiable trust layer for autonomous AI agents). Lints clean and
+  templates clean; NOT yet validated against a live cluster. Operators
+  forking this chart should review every default before deploying to
+  production. CRDs (SBO3LPolicy, SBO3LCluster) and multi-replica Raft
+  cluster mode are deliberately out of scope and will ship as a
+  separate operator chart.
+type: application
+# Chart version is independent of appVersion; bumped on chart-shape
+# changes (template additions, value-key renames). Start at 0.1.0
+# while the chart is experimental — first stable release will be 1.0.0.
+version: 0.1.0
+# appVersion tracks the workspace package version of the sbo3l-server
+# binary baked into the default `image.tag`.
+appVersion: "1.2.0"
+kubeVersion: ">=1.27.0-0"
+keywords:
+  - sbo3l
+  - agents
+  - audit
+  - eth
+  - mandate
+home: https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026
+sources:
+  - https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026
+maintainers:
+  - name: B2JK Industry
+    url: https://github.com/B2JK-Industry
+icon: https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/icon.png
+annotations:
+  category: Security
+  licenses: Apache-2.0

--- a/deploy/helm/sbo3l/README.md
+++ b/deploy/helm/sbo3l/README.md
@@ -1,0 +1,272 @@
+# sbo3l — Helm chart
+
+> **EXPERIMENTAL — chart skeleton.** Lints clean, templates clean, **NOT
+> validated on a live cluster.** This chart is a SCAFFOLD operators can
+> fork. Every default in `values.yaml` should be reviewed before any
+> production rollout. CRDs (`SBO3LPolicy`, `SBO3LCluster`) and the
+> multi-replica Raft cluster mode are deliberately out of scope here —
+> see "What's NOT in this chart" below.
+
+Deploys a single SBO3L server instance (the `sbo3l-server` daemon —
+cryptographically verifiable trust layer for autonomous AI agents) as
+a Kubernetes `Deployment` + `Service`. The chart is intended for
+operators who want to run one daemon behind their existing ingress +
+monitoring stack.
+
+## Versions
+
+| chart `version` | chart `appVersion` | image tag default |
+| ---             | ---                | ---               |
+| `0.1.0`         | `1.2.0`            | `sbo3l/server:1.2.0` |
+
+`appVersion` tracks the workspace package version; the chart `version`
+is bumped independently on chart-shape changes.
+
+## Prerequisites
+
+- Kubernetes `>= 1.27.0` (matches `Chart.yaml#kubeVersion`).
+- Helm `>= 3.10`.
+- A container registry that mirrors `sbo3l/server` (or override
+  `image.repository` to point at your own).
+- (Optional) Prometheus Operator CRDs in-cluster if you enable
+  `serviceMonitor.enabled=true`.
+- (Optional) An IngressClass installed if you enable `ingress.enabled=true`.
+
+## Quickstart — local smoke test
+
+> **Danger:** the flags below enable the dev bypasses. NEVER use them
+> in production.
+
+```bash
+helm install sbo3l ./deploy/helm/sbo3l \
+  --set env.allowUnauthenticated=true \
+  --set env.devOnlySigner=true
+
+kubectl port-forward svc/sbo3l 8730:8730
+curl http://127.0.0.1:8730/v1/healthz
+```
+
+The two `--set` flags above:
+
+- `env.allowUnauthenticated=true` flips the F-1 auth bypass on. Without
+  it, the server defaults to deny-all on `POST /v1/payment-requests`.
+- `env.devOnlySigner=true` is the F-5 signer gate — the binary refuses
+  to start with `signer.backend=dev` unless this flag is also set.
+
+For any non-trivial deployment, leave both off and configure a
+production signer backend (see "KMS backends" below).
+
+## Common overrides
+
+### Production-shaped install (single replica, KMS, ingress, monitoring)
+
+```bash
+helm install sbo3l ./deploy/helm/sbo3l \
+  --set image.tag=1.2.0 \
+  --set replicaCount=1 \
+  --set persistence.enabled=true \
+  --set persistence.size=10Gi \
+  --set signer.backend=aws_kms \
+  --set signer.awsKmsKeyArn=arn:aws:kms:us-east-1:111111111111:key/aaaa-bbbb-cccc \
+  --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::111111111111:role/sbo3l-kms \
+  --set existingSecret=sbo3l-prod-creds \
+  --set serviceMonitor.enabled=true \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set 'ingress.hosts[0].host=sbo3l.example.com' \
+  --set 'ingress.hosts[0].paths[0].path=/' \
+  --set 'ingress.hosts[0].paths[0].pathType=Prefix' \
+  --set 'ingress.tls[0].secretName=sbo3l-tls' \
+  --set 'ingress.tls[0].hosts[0]=sbo3l.example.com'
+```
+
+> The current binary refuses to start with a non-`dev` signer backend
+> until the F-5 AppState refactor lands (see
+> `crates/sbo3l-server/src/main.rs`). The chart accepts the production
+> values now so operator config can be staged ahead of the runtime
+> change.
+
+### KMS backends
+
+The chart exposes three signer backend strings:
+
+| `signer.backend` | extra env wired by chart           | auth supplied by operator                              |
+| ---              | ---                                | ---                                                    |
+| `dev`            | (no extra env)                     | none — uses public dev seeds                           |
+| `aws_kms`        | `SBO3L_AWS_KMS_KEY_ARN`            | IRSA on the ServiceAccount, or `AWS_*` env vars        |
+| `gcp_kms`        | `SBO3L_GCP_KMS_KEY_NAME`           | Workload Identity, or `GOOGLE_APPLICATION_CREDENTIALS` |
+
+For `aws_kms` IRSA, annotate the ServiceAccount in your overrides:
+
+```yaml
+serviceAccount:
+  create: true
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::111111111111:role/sbo3l-kms
+```
+
+For `gcp_kms` Workload Identity, annotate similarly:
+
+```yaml
+serviceAccount:
+  create: true
+  annotations:
+    iam.gke.io/gcp-service-account: sbo3l-kms@my-project.iam.gserviceaccount.com
+```
+
+### Secrets
+
+Two patterns are supported:
+
+1. **`existingSecret` (recommended).** Manage the Secret out-of-band
+   (External Secrets Operator, sealed-secrets, sops-flux, …) and tell
+   the chart its name:
+
+   ```yaml
+   existingSecret: sbo3l-prod-creds
+   ```
+
+   The chart will `envFrom: secretRef: name: sbo3l-prod-creds` so any
+   keys in that Secret become environment variables in the daemon.
+
+2. **`secret.create: true` (chart-managed placeholder).** Useful for
+   GitOps repos that prefer all manifests live in one place. Set
+   `secret.data` to a map; values are b64-encoded automatically:
+
+   ```yaml
+   secret:
+     create: true
+     data:
+       SBO3L_BEARER_TOKEN_HASH: "$2b$12$..."
+       SBO3L_JWT_PUBKEY_HEX: "0x..."
+   ```
+
+   **Do not** check plaintext secrets into Git. Use sops, sealed-secrets,
+   or any other transport encryption.
+
+### Persistence
+
+The daemon writes a SQLite database at `/var/lib/sbo3l/sbo3l.db` (the
+container image's `VOLUME`). With `persistence.enabled=false` (default),
+the chart mounts an `emptyDir` — fine for ephemeral demos but the audit
+chain is lost on pod restart. For real use:
+
+```yaml
+persistence:
+  enabled: true
+  size: 10Gi
+  storageClass: gp3
+```
+
+When persistence is on, the chart automatically forces
+`spec.strategy.type=Recreate` because `ReadWriteOnce` PVCs cannot be
+attached to two pods during a rolling update.
+
+### Resources
+
+The defaults (100m CPU request, 128Mi memory request, no limits) are
+sized for a low-traffic single-tenant deployment. Profile under your
+own workload before going to production.
+
+### Pod security
+
+The chart ships with a hardened pod by default:
+
+- `runAsNonRoot: true`, `runAsUser: 65532` (matches the distroless image)
+- `readOnlyRootFilesystem: true` (a writable `emptyDir` is mounted at
+  `/tmp` for tracing-subscriber + tokio scratch)
+- `allowPrivilegeEscalation: false`
+- All Linux capabilities dropped
+- `seccompProfile: RuntimeDefault`
+
+Adjust via `podSecurityContext` and `securityContext` in your overrides
+if your environment requires different settings (e.g. PSA-baseline
+clusters can flip `seccompProfile.type` to `Unconfined`, but you
+should not).
+
+## Publishing to Artifact Hub
+
+This chart is `experimental` while in `0.x.y`. To graduate:
+
+1. Bump `Chart.yaml#version` to `1.0.0` and remove the EXPERIMENTAL
+   banner from `Chart.yaml#description` and from `values.yaml`'s top
+   comment.
+2. Run `helm package deploy/helm/sbo3l`.
+3. Sign the chart (`helm package --sign --key '<key>'`).
+4. Push to your OCI registry (`helm push sbo3l-1.0.0.tgz oci://...`)
+   or to a static repo index (`helm repo index --url <url> .`).
+5. Submit to Artifact Hub via a `artifacthub-repo.yml` in the repo
+   root pointing at the chart directory; see
+   <https://artifacthub.io/docs/topics/repositories/helm-charts/>.
+
+Until then, the chart is consumed via `helm install … ./deploy/helm/sbo3l`
+from a checkout of the repo.
+
+## Verification
+
+This chart's release artifacts are validated with:
+
+```bash
+# Lint pass (must be clean):
+helm lint deploy/helm/sbo3l
+helm lint --strict deploy/helm/sbo3l
+
+# Default render:
+helm template test deploy/helm/sbo3l
+
+# Full feature render (every optional template enabled):
+helm template test deploy/helm/sbo3l \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set 'ingress.hosts[0].host=sbo3l.example.com' \
+  --set 'ingress.hosts[0].paths[0].path=/' \
+  --set 'ingress.hosts[0].paths[0].pathType=Prefix' \
+  --set serviceMonitor.enabled=true \
+  --set signer.backend=aws_kms \
+  --set 'signer.awsKmsKeyArn=arn:aws:kms:us-east-1:111:key/abc' \
+  --set persistence.enabled=true \
+  --set secret.create=true \
+  --set podDisruptionBudget.enabled=true \
+  --set startupProbe.enabled=true
+```
+
+These were the only validations performed at chart authoring time. **No
+live cluster apply was attempted.** The first operator to deploy this
+chart should expect to debug at least one issue (image-pull permissions,
+PVC storageClass mismatch, ingress class typo, KMS auth, …) — that's
+the cost of "scaffold, not validated".
+
+## What's NOT in this chart yet
+
+This is a deliberate scope cut. The following are out of scope for the
+0.x line and tracked separately:
+
+- **Multi-replica with shared storage.** The audit chain is single-writer;
+  multi-replica without coordination silently corrupts the chain. The
+  experimental Raft cluster scaffold is in `docker-compose-cluster.yml`
+  at repo root; the corresponding Helm chart will be a separate
+  `sbo3l-cluster` chart that builds on this one.
+- **CRDs (`SBO3LPolicy`, `SBO3LCluster`).** CRDs without an operator are
+  inert. The operator + its CRDs will live in a separate `sbo3l-operator`
+  chart project.
+- **Live mTLS between sidecars.** Deferred to service-mesh integration
+  (Linkerd / Istio / cilium-mesh take this off the chart's plate).
+- **Backup / restore automation for the SQLite DB.** Use Velero or a
+  scheduled `kubectl exec` cronjob — the chart does not opine.
+- **Horizontal Pod Autoscaler.** Pointless until multi-replica works.
+- **Live-cluster smoke test in CI.** The chart is render-tested only.
+
+## Comparison
+
+| Use case                                      | Use this chart? |
+| ---                                           | ---             |
+| Deploy a single SBO3L instance behind ingress | yes             |
+| Run the experimental Raft cluster (3+ nodes)  | no — see `docker-compose-cluster.yml` or wait for `sbo3l-cluster` |
+| Deploy CRDs + an operator that reconciles them | no — wait for `sbo3l-operator` |
+| Local dev with docker-compose                 | no — use `docker-compose.yml` at repo root |
+| Bare-metal install without Kubernetes         | no — use the binary directly per `docs/cli/docker.md` |
+
+## Source + license
+
+- Source: <https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026>
+- License: Apache-2.0 (matches the workspace LICENSE)

--- a/deploy/helm/sbo3l/templates/NOTES.txt
+++ b/deploy/helm/sbo3l/templates/NOTES.txt
@@ -1,0 +1,67 @@
+SBO3L server has been installed (chart version {{ .Chart.Version }}, app version {{ .Chart.AppVersion }}).
+
+⚠ EXPERIMENTAL CHART ⚠
+This chart is a SCAFFOLD. It lints and templates clean, but has not been
+validated end-to-end on a live cluster. Operators should review every
+default in values.yaml before deploying to production.
+
+1. Service URL inside the cluster:
+{{- if contains "ClusterIP" .Values.service.type }}
+   sbo3l.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+   (Service type is ClusterIP — not reachable from outside the cluster.
+    Use port-forward or enable ingress to expose externally.)
+{{- else if contains "NodePort" .Values.service.type }}
+   Run:
+     kubectl get svc -n {{ .Release.Namespace }} {{ include "sbo3l.fullname" . }} -o jsonpath='{.spec.ports[0].nodePort}'
+{{- else if contains "LoadBalancer" .Values.service.type }}
+   Run (may take a minute for the LB to provision):
+     kubectl get svc -n {{ .Release.Namespace }} {{ include "sbo3l.fullname" . }} -w
+{{- end }}
+
+2. Port-forward for local smoke test:
+   kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "sbo3l.fullname" . }} 8730:{{ .Values.service.port }}
+   curl http://127.0.0.1:8730/v1/healthz
+
+3. Health endpoints exposed by the daemon:
+   GET /v1/health    → "ok" (plaintext)
+   GET /v1/healthz   → structured JSON (used by liveness/readiness probes)
+   GET /v1/metrics   → Prometheus text exposition
+
+{{- if .Values.env.allowUnauthenticated }}
+
+⚠ DEV BYPASS ENABLED ⚠
+   env.allowUnauthenticated=true → POST /v1/payment-requests will accept
+   unauthenticated requests. NEVER use this in production. Disable by
+   removing the override or setting env.allowUnauthenticated=false.
+{{- end }}
+
+{{- if .Values.env.devOnlySigner }}
+
+⚠ DEV SIGNER ENABLED ⚠
+   env.devOnlySigner=true → audit + receipt signatures are produced
+   with a publicly-known dev seed. NEVER use this in production. Pair
+   with signer.backend=aws_kms (or gcp_kms / phala_tee) and set
+   env.devOnlySigner=false once the F-5 trait refactor is wired.
+{{- end }}
+
+{{- if eq .Values.signer.backend "dev" }}
+{{- if not .Values.env.devOnlySigner }}
+
+NOTE: signer.backend=dev REQUIRES env.devOnlySigner=true. The daemon
+will refuse to start until both are set together (or you switch to a
+production backend). See crates/sbo3l-server/src/main.rs for the
+startup gate.
+{{- end }}
+{{- end }}
+
+{{- if and (ne .Values.signer.backend "dev") (not (or .Values.signer.awsKmsKeyArn .Values.signer.gcpKmsKeyName)) }}
+
+WARNING: signer.backend={{ .Values.signer.backend }} but no KMS key reference is
+configured (signer.awsKmsKeyArn / signer.gcpKmsKeyName). The current
+binary refuses to start with a non-dev backend until the F-5 AppState
+refactor lands; expect CrashLoopBackOff until that ships or until you
+flip back to signer.backend=dev.
+{{- end }}
+
+4. For KMS, ingress, monitoring, and persistence configuration, see:
+     deploy/helm/sbo3l/README.md

--- a/deploy/helm/sbo3l/templates/_helpers.tpl
+++ b/deploy/helm/sbo3l/templates/_helpers.tpl
@@ -1,0 +1,108 @@
+{{/*
+=========================================================================
+EXPERIMENTAL — chart skeleton.
+This chart deploys the SBO3L daemon as a single Deployment + Service.
+CRDs (SBO3LPolicy, SBO3LCluster) are intentionally NOT shipped here:
+they require a controller to act on them, and a controller without an
+operator pod is inert. Multi-replica with shared storage / Raft is
+deferred to a separate operator-chart project.
+=========================================================================
+*/}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sbo3l.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited
+to this (by the DNS naming spec).
+*/}}
+{{- define "sbo3l.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sbo3l.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels — applied to every rendered resource.
+*/}}
+{{- define "sbo3l.labels" -}}
+helm.sh/chart: {{ include "sbo3l.chart" . }}
+{{ include "sbo3l.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: sbo3l
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels — these are used in Service / Deployment selectors and
+must be stable across upgrades. Do NOT add release-specific labels here.
+*/}}
+{{- define "sbo3l.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "sbo3l.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Common annotations.
+*/}}
+{{- define "sbo3l.annotations" -}}
+{{- with .Values.commonAnnotations }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Service account name to use.
+*/}}
+{{- define "sbo3l.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "sbo3l.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Image reference (repository:tag).
+*/}}
+{{- define "sbo3l.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end }}
+
+{{/*
+Secret name resolution: if `existingSecret` is set, reference that;
+otherwise, if we render our own Secret, reference its name; otherwise
+emit an empty string (which downstream conditionals must guard).
+*/}}
+{{- define "sbo3l.secretName" -}}
+{{- if .Values.existingSecret -}}
+{{ .Values.existingSecret }}
+{{- else if .Values.secret.create -}}
+{{ include "sbo3l.fullname" . }}
+{{- end -}}
+{{- end }}

--- a/deploy/helm/sbo3l/templates/configmap.yaml
+++ b/deploy/helm/sbo3l/templates/configmap.yaml
@@ -1,0 +1,23 @@
+{{- /*
+Non-secret config (e.g. policy JSON content). Most operators will leave
+``configMap.create`` off and either:
+  * use the embedded reference policy (default), OR
+  * mount their own external ConfigMap / Secret and point ``env.policy``
+    at the mounted path.
+
+Rendered only when ``configMap.create: true`` AND ``configMap.data`` is
+non-empty — an empty ConfigMap is harmless but noisy.
+*/ -}}
+{{- if and .Values.configMap.create .Values.configMap.data -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sbo3l.fullname" . }}
+  labels:
+    {{- include "sbo3l.labels" . | nindent 4 }}
+data:
+  {{- range $k, $v := .Values.configMap.data }}
+  {{ $k }}: |-
+    {{- $v | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/sbo3l/templates/deployment.yaml
+++ b/deploy/helm/sbo3l/templates/deployment.yaml
@@ -1,0 +1,175 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sbo3l.fullname" . }}
+  labels:
+    {{- include "sbo3l.labels" . | nindent 4 }}
+  {{- with (include "sbo3l.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    {{- if and .Values.persistence.enabled (eq .Values.updateStrategy.type "RollingUpdate") }}
+    # PVC is RWO; rolling update would deadlock attaching the volume to
+    # two pods. Force Recreate when persistence is on.
+    type: Recreate
+    {{- else }}
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+    {{- end }}
+  selector:
+    matchLabels:
+      {{- include "sbo3l.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "sbo3l.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "sbo3l.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      containers:
+        - name: sbo3l-server
+          image: {{ include "sbo3l.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 8730
+              protocol: TCP
+          env:
+            - name: SBO3L_LISTEN
+              value: {{ .Values.env.listen | quote }}
+            - name: SBO3L_DB
+              value: {{ .Values.env.db | quote }}
+            - name: SBO3L_SIGNER_BACKEND
+              value: {{ .Values.signer.backend | quote }}
+            {{- if .Values.env.allowUnauthenticated }}
+            - name: SBO3L_ALLOW_UNAUTHENTICATED
+              value: "1"
+            {{- end }}
+            {{- if .Values.env.devOnlySigner }}
+            - name: SBO3L_DEV_ONLY_SIGNER
+              value: "1"
+            {{- end }}
+            {{- if not (kindIs "invalid" .Values.env.allowUnsafePublicBind) }}
+            - name: SBO3L_ALLOW_UNSAFE_PUBLIC_BIND
+              value: {{ .Values.env.allowUnsafePublicBind | quote }}
+            {{- end }}
+            {{- if .Values.env.policy }}
+            - name: SBO3L_POLICY
+              value: {{ .Values.env.policy | quote }}
+            {{- end }}
+            {{- if eq .Values.signer.backend "aws_kms" }}
+            - name: SBO3L_AWS_KMS_KEY_ARN
+              value: {{ .Values.signer.awsKmsKeyArn | quote }}
+            {{- end }}
+            {{- if eq .Values.signer.backend "gcp_kms" }}
+            - name: SBO3L_GCP_KMS_KEY_NAME
+              value: {{ .Values.signer.gcpKmsKeyName | quote }}
+            {{- end }}
+            {{- range $k, $v := .Values.env.extra }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          {{- $secretName := include "sbo3l.secretName" . }}
+          {{- if $secretName }}
+          envFrom:
+            - secretRef:
+                name: {{ $secretName }}
+          {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              {{- toYaml .Values.startupProbe.httpGet | nindent 14 }}
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/sbo3l
+            {{- if .Values.configMap.create }}
+            - name: config
+              mountPath: /etc/sbo3l
+              readOnly: true
+            {{- end }}
+            # readOnlyRootFilesystem requires writable scratch space for
+            # tracing-subscriber temp files + tokio runtime artifacts.
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "sbo3l.fullname" . }}-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- if .Values.configMap.create }}
+        - name: config
+          configMap:
+            name: {{ include "sbo3l.fullname" . }}
+        {{- end }}
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- if .Values.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "sbo3l.fullname" . }}-data
+  labels:
+    {{- include "sbo3l.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/deploy/helm/sbo3l/templates/ingress.yaml
+++ b/deploy/helm/sbo3l/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "sbo3l.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "sbo3l.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/sbo3l/templates/poddisruptionbudget.yaml
+++ b/deploy/helm/sbo3l/templates/poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "sbo3l.fullname" . }}
+  labels:
+    {{- include "sbo3l.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "sbo3l.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/sbo3l/templates/secret.yaml
+++ b/deploy/helm/sbo3l/templates/secret.yaml
@@ -1,0 +1,35 @@
+{{- /*
+Placeholder Secret for sensitive env vars. Default OFF — operators are
+strongly encouraged to use ``existingSecret`` and manage Secret material
+out-of-band (External Secrets Operator, sealed-secrets, sops-flux, etc).
+
+Typical keys an operator would put here when migrating from a flat
+.env file:
+  SBO3L_BEARER_TOKEN_HASH
+  SBO3L_ADMIN_BEARER_HASH
+  SBO3L_JWT_PUBKEY_HEX
+  SBO3L_EXECUTOR_CALLBACK_PUBKEY_<SCOPE>
+
+These are loaded into the daemon's environment via ``envFrom`` (see
+deployment.yaml) so the binary picks them up the same way it does
+under docker-compose.
+*/ -}}
+{{- if .Values.secret.create -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "sbo3l.fullname" . }}
+  labels:
+    {{- include "sbo3l.labels" . | nindent 4 }}
+type: Opaque
+{{- if .Values.secret.data }}
+data:
+  {{- range $k, $v := .Values.secret.data }}
+  {{ $k }}: {{ $v | b64enc | quote }}
+  {{- end }}
+{{- else }}
+# Empty placeholder. Populate ``secret.data`` in your values override
+# (or migrate to ``existingSecret``) before deploying to production.
+data: {}
+{{- end }}
+{{- end }}

--- a/deploy/helm/sbo3l/templates/service.yaml
+++ b/deploy/helm/sbo3l/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sbo3l.fullname" . }}
+  labels:
+    {{- include "sbo3l.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "sbo3l.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/sbo3l/templates/serviceaccount.yaml
+++ b/deploy/helm/sbo3l/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sbo3l.serviceAccountName" . }}
+  labels:
+    {{- include "sbo3l.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/deploy/helm/sbo3l/templates/servicemonitor.yaml
+++ b/deploy/helm/sbo3l/templates/servicemonitor.yaml
@@ -1,0 +1,33 @@
+{{- /*
+Prometheus Operator ServiceMonitor — points at /v1/metrics. Requires
+the ``monitoring.coreos.com/v1`` CRD installed in-cluster (kube-prometheus-stack
+or upstream prometheus-operator). Off by default.
+*/ -}}
+{{- if .Values.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "sbo3l.fullname" . }}
+  labels:
+    {{- include "sbo3l.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "sbo3l.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /v1/metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/helm/sbo3l/values.yaml
+++ b/deploy/helm/sbo3l/values.yaml
@@ -1,0 +1,272 @@
+# =====================================================================
+# EXPERIMENTAL — chart skeleton.
+# Operator deploying to production should review every default below.
+# Multi-replica + Raft cluster mode are NOT in this chart; see
+# `docs/cluster-mode.md` (or `docker-compose-cluster.yml` at repo root)
+# for the experimental cluster scaffold. CRDs (SBO3LPolicy /
+# SBO3LCluster) are deferred to a separate operator-chart project; this
+# chart only deploys the daemon.
+# =====================================================================
+
+# -- Override the chart name. Defaults to ``.Chart.Name``.
+nameOverride: ""
+# -- Override the fullname (release-name + chart-name).
+fullnameOverride: ""
+
+image:
+  # -- Container image repository. Default tracks the published Docker
+  # image that the repo's top-level Dockerfile produces.
+  repository: sbo3l/server
+  # -- Image tag. Defaults to the workspace ``appVersion`` baked into
+  # ``Chart.yaml`` if left empty.
+  tag: "1.2.0"
+  pullPolicy: IfNotPresent
+  # -- Pull secrets passed through to the Pod spec (list of names).
+  pullSecrets: []
+
+# -- Number of daemon replicas. Defaults to 1 because the audit chain
+# is single-writer; multi-replica without the Raft scaffold means
+# silent data loss. Operators running the experimental cluster mode
+# must override BOTH this value AND configure shared storage / Raft
+# peer discovery — see the cluster-mode doc.
+replicaCount: 1
+
+service:
+  type: ClusterIP
+  # -- Service port. Container always listens on 8730 (matches
+  # ``SBO3L_LISTEN`` default in the binary).
+  port: 8730
+  annotations: {}
+
+ingress:
+  # -- Ingress is OFF by default. Enable + configure ``className`` +
+  # ``hosts`` + ``tls`` per your environment.
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts: []
+  # Example:
+  # hosts:
+  #   - host: sbo3l.example.com
+  #     paths:
+  #       - path: /
+  #         pathType: Prefix
+  tls: []
+  # Example:
+  # tls:
+  #   - secretName: sbo3l-tls
+  #     hosts:
+  #       - sbo3l.example.com
+
+env:
+  # -- F-1 dev bypass: accept unauthenticated requests on
+  # ``POST /v1/payment-requests``. SAFE DEFAULT is OFF — operators
+  # opt in per environment, ideally only for local smoke tests.
+  allowUnauthenticated: false
+  # -- F-5 dev signer flag. SAFE DEFAULT is OFF — operators opt in
+  # only when paired with ``signer.backend=dev`` for development.
+  # The binary refuses to start with a non-dev backend label until
+  # the AppState refactor lands; see `docs/cli/docker.md` and
+  # `crates/sbo3l-server/src/main.rs`.
+  devOnlySigner: false
+  # -- F-4 unsafe public-bind flag. The container image ships with
+  # this set to "1" (because public bind is the entire point inside
+  # a container) — Helm value here ONLY overrides the env if you
+  # deliberately want to flip it back to "0" for a sidecar-only
+  # mesh deployment. Normally leave as `null` to keep image default.
+  allowUnsafePublicBind: null
+  # -- Listen address inside the container. Default matches the
+  # Dockerfile's ENV (`0.0.0.0:8730`). Override if you need IPv6 or
+  # a different port.
+  listen: "0.0.0.0:8730"
+  # -- Path inside the container where the SQLite DB lives. The image
+  # also defaults to this; override if you mount the volume elsewhere.
+  db: "/var/lib/sbo3l/sbo3l.db"
+  # -- Optional ``SBO3L_POLICY`` path (mount your policy via a
+  # ConfigMap or Secret and point this at the mounted file path).
+  # Leave empty to use the embedded reference policy.
+  policy: ""
+  # -- Free-form environment variables passed to the container.
+  # Useful for bearer-token hashes, JWT pubkey hex, Prometheus
+  # OTLP endpoints, RUST_LOG overrides, etc. Avoid putting secrets
+  # here — use ``existingSecret`` instead.
+  extra: {}
+  # Example:
+  # extra:
+  #   RUST_LOG: "info,sbo3l_server=debug"
+
+signer:
+  # -- Signer backend identifier. Today only "dev" is functionally
+  # wired through ``AppState`` — the binary refuses to start with a
+  # non-dev backend until the F-5 trait refactor lands. KMS values
+  # are accepted by the chart so operator configs can be drafted
+  # ahead of the runtime change.
+  backend: dev
+  # -- AWS KMS key ARN (used only when ``backend: aws_kms``). Stored
+  # as a plain env var; the actual auth happens via IRSA / instance
+  # role / static AWS_* env vars supplied separately.
+  awsKmsKeyArn: ""
+  # -- GCP KMS key resource name (used only when ``backend: gcp_kms``).
+  # Auth happens via Workload Identity / GOOGLE_APPLICATION_CREDENTIALS
+  # supplied separately.
+  gcpKmsKeyName: ""
+
+# -- Reference an externally managed Secret rather than rendering
+# one from this chart. Recommended for bearer-token hashes,
+# JWT pubkey hex, and KMS auth material. Leave empty to disable;
+# set ``secret.create: true`` to render an empty placeholder Secret.
+existingSecret: ""
+
+secret:
+  # -- Render a placeholder Secret resource (empty by default — used
+  # as the env-from source if you want a single point of override
+  # without managing a separate Secret resource). Most operators
+  # should leave this off and use ``existingSecret``.
+  create: false
+  # -- Map of secret keys → values. Values are templated through
+  # ``b64enc`` automatically. Examples: ``SBO3L_BEARER_TOKEN_HASH``,
+  # ``SBO3L_JWT_PUBKEY_HEX``, ``SBO3L_ADMIN_BEARER_HASH``.
+  data: {}
+
+# -- Render a ConfigMap with non-secret config (policy JSON, log
+# config). When ``data`` is non-empty the ConfigMap is mounted at
+# ``/etc/sbo3l/`` and you can point ``env.policy`` at e.g.
+# ``/etc/sbo3l/policy.json``.
+configMap:
+  create: false
+  data: {}
+  # Example:
+  # data:
+  #   policy.json: |
+  #     { "rules": [] }
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits: {}
+  # Example:
+  # limits:
+  #   cpu: 1000m
+  #   memory: 512Mi
+
+# -- Persistent volume for the SQLite DB. The image's ``VOLUME`` is
+# ``/var/lib/sbo3l``; this chart mounts a PVC there when enabled.
+persistence:
+  enabled: false
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 1Gi
+  annotations: {}
+
+serviceAccount:
+  # -- If ``true``, render a dedicated ServiceAccount.
+  create: true
+  # -- Override the ServiceAccount name (defaults to the chart
+  # fullname when ``create: true``, otherwise ``"default"``).
+  name: ""
+  annotations: {}
+  automount: true
+
+# -- Pod-level securityContext. Defaults match the distroless image's
+# nonroot UID (65532) and lock down filesystem + privilege escalation.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Container-level securityContext. Defaults to a hardened profile
+# (drop all caps, no privilege escalation, read-only root FS). The
+# data dir mounts as a writable PVC (or emptyDir) so SQLite still
+# works.
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  capabilities:
+    drop:
+      - ALL
+
+# -- Liveness + readiness probes target ``/v1/healthz`` (structured
+# JSON) on the container port. The simpler ``/v1/health`` returns a
+# bare ``"ok"`` and is also valid; ``/v1/healthz`` is preferred
+# because Kubernetes can surface the JSON body in describe output.
+livenessProbe:
+  httpGet:
+    path: /v1/healthz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /v1/healthz
+    port: http
+  initialDelaySeconds: 2
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+startupProbe:
+  enabled: false
+  httpGet:
+    path: /v1/healthz
+    port: http
+  initialDelaySeconds: 0
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 30
+
+# -- Prometheus Operator integration. OFF by default. When enabled,
+# renders a ``ServiceMonitor`` that scrapes ``/v1/metrics`` (the
+# daemon exposes the Prometheus text format there).
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  labels: {}
+  # Example:
+  # labels:
+  #   release: kube-prometheus-stack
+  metricRelabelings: []
+  relabelings: []
+
+# -- PodDisruptionBudget. OFF by default because ``replicaCount: 1``
+# makes a PDB pointless (and noisy in cluster-autoscaler logs).
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1
+
+# -- Pod-level scheduling controls.
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+
+# -- Extra labels and annotations applied to all rendered resources.
+commonLabels: {}
+commonAnnotations: {}
+
+# -- Pod-only annotations (e.g. for sidecar opt-in / opt-out).
+podAnnotations: {}
+podLabels: {}
+
+# -- Update strategy for the Deployment. ``Recreate`` is recommended
+# when ``persistence.enabled: true`` because the SQLite volume is
+# RWO and the rolling strategy will deadlock on attach.
+updateStrategy:
+  type: RollingUpdate
+
+# -- Termination grace period. The daemon is mostly stateless on the
+# request path (writes commit-or-abort), but in-flight Raft AppendEntries
+# RPCs benefit from a few seconds.
+terminationGracePeriodSeconds: 30


### PR DESCRIPTION
## EXPERIMENTAL — chart skeleton

> Lints clean, templates clean, **NOT validated on a live cluster.**
> Operators forking this chart should review every default before
> deploying to production. CRDs and multi-replica Raft cluster mode
> are deliberately out of scope here.

## Scope cuts (deliberate)

- **No CRDs.** `SBO3LPolicy` / `SBO3LCluster` require a controller pod
  to reconcile them; without an operator they are inert. Deferred to a
  separate `sbo3l-operator` chart project.
- **No multi-replica defaults.** `replicaCount: 1`. The audit chain is
  single-writer; multi-replica without the Raft scaffold silently
  corrupts state. The cluster chart will be a separate
  `sbo3l-cluster` chart that depends on this one.
- **No live cluster deploy attempt.** No Argo / Flux / minikube smoke.
- **No live mTLS.** Service-mesh integration takes that off the chart's
  plate.

## Ships

```
deploy/helm/sbo3l/
├── Chart.yaml          (version 0.1.0, appVersion 1.2.0, kubeVersion >=1.27)
├── Chart.lock
├── README.md           (operator docs, KMS guide, "what's NOT in this chart")
├── .helmignore
├── values.yaml         (safe defaults; EXPERIMENTAL banner; per-key docs)
└── templates/
    ├── _helpers.tpl                 (sbo3l.fullname/labels/selectorLabels/etc)
    ├── deployment.yaml              (+ PVC when persistence.enabled)
    ├── service.yaml
    ├── ingress.yaml                 (guarded)
    ├── configmap.yaml               (guarded)
    ├── secret.yaml                  (guarded)
    ├── serviceaccount.yaml          (guarded)
    ├── servicemonitor.yaml          (Prometheus Operator; guarded)
    ├── poddisruptionbudget.yaml     (guarded; off by default — replicas=1)
    └── NOTES.txt                    (port-forward + dev-bypass warnings)
```

## Verification gates (all green)

```text
$ helm lint deploy/helm/sbo3l
==> Linting deploy/helm/sbo3l
1 chart(s) linted, 0 chart(s) failed

$ helm lint --strict deploy/helm/sbo3l
==> Linting deploy/helm/sbo3l
1 chart(s) linted, 0 chart(s) failed

$ helm template test deploy/helm/sbo3l
# renders 3 docs: ServiceAccount, Service, Deployment

$ helm template test deploy/helm/sbo3l \
    --set ingress.enabled=true \
    --set 'ingress.hosts[0].host=sbo3l.example.com' \
    --set 'ingress.hosts[0].paths[0].path=/' \
    --set 'ingress.hosts[0].paths[0].pathType=Prefix' \
    --set serviceMonitor.enabled=true \
    --set signer.backend=aws_kms \
    --set 'signer.awsKmsKeyArn=arn:aws:kms:us-east-1:111:key/abc' \
    --set persistence.enabled=true \
    --set secret.create=true \
    --set podDisruptionBudget.enabled=true \
    --set startupProbe.enabled=true
# renders 8 docs: PDB, ServiceAccount, Secret, PVC, Service,
#                 Deployment, Ingress, ServiceMonitor

$ python3 -c "import yaml; list(yaml.safe_load_all(open('rendered.yaml')))"
# both renders parse cleanly
```

`kubectl apply --dry-run=client` requires a live API server for
OpenAPI validation (pulls schema from `localhost:8080/openapi/v2`);
the offline pyyaml parse is the substitute. **The first operator to
deploy this chart live should expect at least one issue to debug**
(image-pull permissions, storageClass mismatch, ingress class typo,
KMS auth, …) — that is the cost of "scaffold, not validated".

## Env-var contract (from `crates/sbo3l-server/src/main.rs`)

| values key                       | env var                              | default |
| ---                              | ---                                  | ---     |
| `env.listen`                     | `SBO3L_LISTEN`                       | `0.0.0.0:8730` |
| `env.db`                         | `SBO3L_DB`                           | `/var/lib/sbo3l/sbo3l.db` |
| `signer.backend`                 | `SBO3L_SIGNER_BACKEND`               | `dev` |
| `env.allowUnauthenticated`       | `SBO3L_ALLOW_UNAUTHENTICATED`        | unset (deny) |
| `env.devOnlySigner`              | `SBO3L_DEV_ONLY_SIGNER`              | unset |
| `env.allowUnsafePublicBind`      | `SBO3L_ALLOW_UNSAFE_PUBLIC_BIND`     | unset (image sets `1`) |
| `env.policy`                     | `SBO3L_POLICY`                       | unset (embedded) |
| `signer.awsKmsKeyArn`            | `SBO3L_AWS_KMS_KEY_ARN`              | (when `aws_kms`) |
| `signer.gcpKmsKeyName`           | `SBO3L_GCP_KMS_KEY_NAME`             | (when `gcp_kms`) |
| `existingSecret`                 | `envFrom: secretRef`                 | bearer/JWT/admin hashes go here |
| `env.extra`                      | (free-form k=v map)                  | `RUST_LOG`, etc |

## Test plan

- [x] `helm lint` clean (default + `--strict`)
- [x] `helm template test deploy/helm/sbo3l` renders without error
- [x] Full-feature render (ingress + servicemonitor + KMS + PVC + secret + PDB + startup probe) renders without error
- [x] Both renders parse cleanly through `python3 yaml.safe_load_all`
- [ ] Live cluster apply (deferred — no cluster in scope for R14 P6)
- [ ] First operator runs `helm install` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)