### PR TITLE
fix(ci): vercel-ai publish — install parent sdks/typescript first

### DIFF
--- a/.github/workflows/integrations-publish.yml
+++ b/.github/workflows/integrations-publish.yml
@@ -230,6 +230,11 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Install parent SDK (for vercel-ai which lives under sdks/typescript/)
+        if: ${{ startsWith(github.ref_name, matrix.tag_prefix) && matrix.id == 'vercel-ai' }}
+        working-directory: sdks/typescript
+        run: npm install --no-audit --no-fund
+
       - name: Install
         if: ${{ startsWith(github.ref_name, matrix.tag_prefix) }}
         working-directory: ${{ matrix.dir }}


### PR DESCRIPTION
tsup walks up to parent config; needs parent node_modules. Add gated install step.