### PR TITLE
fix(server): close grpc feature array — broken from #322 + #330 cascade merge

### DIFF
--- a/crates/sbo3l-server/Cargo.toml
+++ b/crates/sbo3l-server/Cargo.toml
@@ -145,6 +145,7 @@ grpc = [
     "dep:tokio-stream",
     "dep:tonic-build",
     "dep:protoc-bin-vendored",
+]
 # R14 P5: OpenTelemetry tracing emitter. OFF by default — the
 # no-features build must not pull a single OTEL transitive dep. Enable
 # with `--features otel`. Runtime exporter selection via


### PR DESCRIPTION
Cargo.toml had grpc feature array with no closing bracket. cargo check fails on workspace until fixed.