### PR TITLE
ci+docs: supply-chain workflow + CODE_OF_CONDUCT + CONTRIBUTING

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,138 @@
+name: Supply chain security
+
+# R14 follow-up — closes self-scan checklist gaps from
+# docs/compliance/scan-readiness.md:
+#   - cargo audit (Rust dep CVEs)
+#   - npm audit (TS dep CVEs across SDKs + integrations)
+#   - SBOM generation (cargo-cyclonedx + syft for npm/PyPI)
+#   - gitleaks (secret scanning)
+#
+# Runs on every push to main + every PR + nightly.
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  schedule:
+    # 03:00 UTC nightly — picks up newly-disclosed CVEs in already-merged
+    # dependency versions.
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  cargo-audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git
+            ~/.cargo/bin
+          key: cargo-audit-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+      - name: Install cargo-audit
+        run: |
+          if ! command -v cargo-audit > /dev/null; then
+            cargo install cargo-audit --version "^0.21" --locked
+          fi
+      - name: Run cargo audit
+        # We allow `--deny warnings` so any new advisory is loud.
+        # Configurable via `audit.toml` if a specific finding needs an
+        # acknowledged exception.
+        run: cargo audit --deny warnings
+
+  npm-audit:
+    name: npm audit (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - sdks/typescript
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: npm install
+        working-directory: ${{ matrix.target }}
+        run: npm install --no-audit --no-fund
+      - name: npm audit
+        working-directory: ${{ matrix.target }}
+        # `--audit-level=high` to avoid noise from low-severity advisories.
+        # Lockfile-only audit (no install side effects).
+        run: npm audit --audit-level=high
+
+  sbom-cargo:
+    name: SBOM (cargo-cyclonedx)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-cyclonedx
+        run: |
+          if ! command -v cargo-cyclonedx > /dev/null; then
+            cargo install cargo-cyclonedx --version "^0.5" --locked
+          fi
+      - name: Generate workspace SBOM (CycloneDX 1.5)
+        run: cargo cyclonedx --format json --spec-version 1.5 --target-in-filename
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-cargo
+          # cargo-cyclonedx writes per-package files; pick them all up.
+          path: |
+            **/sbo3l-*.cdx.json
+            **/bom.json
+          if-no-files-found: warn
+
+  sbom-syft:
+    name: SBOM (syft — npm + PyPI)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install syft
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | \
+            sh -s -- -b /usr/local/bin
+      - name: Generate SBOM for sdks/typescript
+        run: |
+          syft sdks/typescript -o cyclonedx-json=sbom-sdk-ts.json
+      - name: Generate SBOM for sdks/python
+        run: |
+          syft sdks/python -o cyclonedx-json=sbom-sdk-py.json
+      - name: Upload SBOM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-syft
+          path: |
+            sbom-sdk-ts.json
+            sbom-sdk-py.json
+          if-no-files-found: warn
+
+  gitleaks:
+    name: gitleaks (secret scanning)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # gitleaks scans full history; need it.
+          fetch-depth: 0
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # No org license needed for OSS; the action upgrades to lic if set.
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,60 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in
+the SBO3L community a harassment-free experience for everyone, regardless of
+age, body size, visible or invisible disability, ethnicity, sex characteristics,
+gender identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing standards of
+acceptable behavior, and will take appropriate and fair corrective action in
+response to any behavior they deem inappropriate, threatening, offensive, or
+harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to `conduct@sbo3l.dev`. All complaints will be reviewed and
+investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,163 @@
+# Contributing to SBO3L
+
+Thanks for considering a contribution. This doc covers what to expect.
+
+## TL;DR
+
+1. Read [`SECURITY.md`](SECURITY.md) before reporting a vulnerability — do **NOT** open public issues for security findings.
+2. For features / bugs / docs: open a GitHub issue first to discuss; PRs without prior discussion may be closed.
+3. PRs must pass all CI checks (regression-on-main, supply-chain, proptest, fuzz, mutation testing, benchmarks).
+4. Sign your commits (recommended) and add a `Co-Authored-By` trailer if AI-assisted.
+
+## Repo layout
+
+| Path | What |
+|---|---|
+| `crates/sbo3l-{core,storage,policy,identity,execution,server,mcp,cli,...}/` | Rust workspace |
+| `sdks/typescript/` | `@sbo3l/sdk` + per-framework `@sbo3l/*` integrations |
+| `sdks/python/` | `sbo3l-sdk` + `sbo3l-{langchain,crewai,llamaindex,langgraph}` |
+| `apps/{marketing,hosted-app,trust-dns-viz,observability,mobile}/` | User-facing surfaces |
+| `contracts/` | Solidity (AnchorRegistry, OffchainResolver, ReputationBond, SubnameAuction, ReputationRegistry) |
+| `fuzz/` | cargo-fuzz harnesses (5 targets) |
+| `benchmarks/competitive/` | Criterion benchmark suite |
+| `scripts/` | Operator scripts (run-competitive-benchmarks, build-wasm-verifier, etc.) |
+| `docs/` | Submission package, compliance, security, win-backlog (Phase 1/2/3 ACs) |
+
+## Local dev
+
+### Rust
+
+```bash
+cargo check --workspace
+cargo test --workspace --tests --no-fail-fast
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+### TypeScript SDK
+
+```bash
+cd sdks/typescript
+npm install --no-audit --no-fund
+npm run build
+npm test
+```
+
+### Python SDK
+
+```bash
+cd sdks/python
+python -m pip install -e ".[dev]"
+ruff check .
+ruff format --check .
+mypy --strict sbo3l_sdk
+pytest -q
+```
+
+### Marketing site
+
+```bash
+cd apps/marketing
+npm install
+npm run dev   # http://localhost:4321
+```
+
+### Daemon
+
+```bash
+cargo run --bin sbo3l-server
+# Default listens on 127.0.0.1:18731
+# Set SBO3L_ALLOW_UNAUTHENTICATED=1 to skip auth (DEV ONLY — banner-warned)
+```
+
+## PR conventions
+
+### Commit messages
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+type(scope): one-line summary
+
+Optional body explaining the why.
+
+Fixes #123
+Co-Authored-By: AI Assistant Name <noreply@example.com>
+```
+
+Common types: `feat`, `fix`, `docs`, `test`, `perf`, `refactor`, `chore`, `ci`, `build`.
+
+Common scopes: `core`, `policy`, `server`, `cli`, `identity`, `execution`, `marketing`, `hosted-app`, `submission`, `compliance`, `security`, `bench`, `fuzz`.
+
+### Branch naming
+
+```
+agent/<name>/<task-id>           # e.g. agent/dev1/T-3-1
+agent/qa/<task-name>             # QA agent (Heidi)
+fix/<short-desc>                 # Hotfixes
+docs/<short-desc>                # Doc-only changes
+chore/<short-desc>
+```
+
+### PR scope
+
+- Keep PRs small and reviewable. Default target: < 500 LoC change.
+- One logical concern per PR. Don't bundle a refactor + new feature.
+- If the PR closes a Phase 1/2/3 ticket, link it: `Closes T-3-5`.
+
+### CI checks
+
+Every PR runs:
+
+- `regression-on-main.yml` — full Rust workspace test + clippy + fmt
+- `supply-chain.yml` — cargo-audit + npm-audit + SBOM + gitleaks
+- `proptest.yml` — 4 invariants × 256 cases
+- `fuzz.yml` — _scheduled only_ (nightly cron)
+- `mutation-testing.yml` — _scheduled only_ (weekly cron)
+- `multi-framework-smoke.yml` — Docker compose end-to-end
+- `lighthouse.yml` — marketing site performance + a11y
+- `codex-review.yml` — automated PR review with severity tags
+
+PRs cannot merge if any required check is red. Branch protection on `main` enforces this.
+
+### Security
+
+If your change touches:
+- Auth (`crates/sbo3l-server/src/auth.rs`)
+- Signing (`crates/sbo3l-identity/`)
+- Capsule format (`crates/sbo3l-core/src/passport.rs`)
+- Audit chain (`crates/sbo3l-core/src/audit.rs`)
+- Policy enforcement (`crates/sbo3l-policy/`)
+
+…then ping a maintainer for an extra security review. These touch the trust boundary.
+
+## Reporting a security issue
+
+**Do NOT open a public GitHub issue.**
+
+Use the channels in [`SECURITY.md`](SECURITY.md):
+- GitHub Security Advisory (preferred; encrypted)
+- `security@sbo3l.dev` email
+- HackerOne (when live; see `docs/security/bounty-platform-integration.md`)
+- Immunefi for crypto bugs (when live)
+
+We pay bounties: $1K-5K Critical / $250-1K High / $50-250 Medium / swag Low.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant 2.1](CODE_OF_CONDUCT.md). Report
+violations to `conduct@sbo3l.dev`.
+
+## License
+
+Apache-2.0. By contributing, you agree your contributions are licensed under
+the same terms.
+
+## Thanks
+
+If your contribution surfaces a security issue, you're added to the Hall of
+Fame in [`SECURITY.md`](SECURITY.md).
+
+If your contribution lands a feature, we cite you in the release notes
+([`CHANGELOG.md`](CHANGELOG.md)) and (if you're OK with it) the GitHub Release
+page.


### PR DESCRIPTION
## Summary

Closes self-scan checklist gaps from \`docs/compliance/scan-readiness.md\` + ships missing governance docs.

**\`.github/workflows/supply-chain.yml\`:**
- \`cargo audit\` — Rust dep CVEs
- \`npm audit\` — sdks/typescript at --audit-level=high
- SBOM (\`cargo-cyclonedx\`) — Rust workspace
- SBOM (\`syft\`) — TS + Py SDKs
- \`gitleaks\` — secret scanning on full history
- Triggers: push to main, PR, nightly cron, manual dispatch

**\`CODE_OF_CONDUCT.md\`:** Contributor Covenant 2.1 (satisfies SOC 2 CC1.1).

**\`CONTRIBUTING.md\`:** repo layout, local dev for Rust/TS/Py/marketing/daemon, PR conventions, CI checklist, security flag for trust-boundary changes.

## Test plan
- [x] Workflow YAML lints
- [x] Conventional Commits format in CONTRIBUTING reflects actual project usage
- [ ] First CI run validates 5 supply-chain jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)