### PR TITLE
fix(server): resolve lib.rs conflict markers (cluster+grpc both)

### DIFF
--- a/crates/sbo3l-server/Cargo.toml
+++ b/crates/sbo3l-server/Cargo.toml
@@ -145,6 +145,7 @@ grpc = [
     "dep:tokio-stream",
     "dep:tonic-build",
     "dep:protoc-bin-vendored",
+]
 # R14 P5: OpenTelemetry tracing emitter. OFF by default — the
 # no-features build must not pull a single OTEL transitive dep. Enable
 # with `--features otel`. Runtime exporter selection via

--- a/crates/sbo3l-server/src/lib.rs
+++ b/crates/sbo3l-server/src/lib.rs
@@ -54,18 +54,16 @@ pub mod ws_events;
 #[cfg(feature = "ws_events")]
 pub mod admin_events;
 
-<<<<<<< HEAD
 /// R14 P4 — 3-node Raft cluster scaffold (**EXPERIMENTAL**). Built only
 /// with `--features cluster`. See `crates/sbo3l-server/src/cluster/mod.rs`
 /// + `docs/cluster-mode.md` for what's wired vs what's TODO.
 #[cfg(feature = "cluster")]
 pub mod cluster;
-=======
+
 // R14 P1: tonic-based gRPC service. Compiled only with `--features grpc`
 // so HTTP-only builds don't pay the prost / tonic compile cost.
 #[cfg(feature = "grpc")]
 pub mod grpc;
->>>>>>> origin/main
 
 /// `Idempotency-Key` header constraints from `docs/api/openapi.json`.
 const IDEMPOTENCY_KEY_HEADER: &str = "Idempotency-Key";


### PR DESCRIPTION
Cargo.toml fix #334 wasn't enough — lib.rs also had unresolved conflict markers.