### PR TITLE
chore: bump anthropic + openai-assistants to 1.2.0

### DIFF
--- a/sdks/typescript/integrations/anthropic/package.json
+++ b/sdks/typescript/integrations/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sbo3l/anthropic",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Anthropic tool-use adapter for SBO3L — wrap an APRP submit as a `messages.create({ tools: [...] })` Tool with zod-validated input.",
   "license": "MIT",
   "author": "Daniel Babjak <babjak_daniel@hotmail.com>",

--- a/sdks/typescript/integrations/openai-assistants/package.json
+++ b/sdks/typescript/integrations/openai-assistants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sbo3l/openai-assistants",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "OpenAI Assistants API adapter for SBO3L — wrap an APRP submit as an Assistants `function` tool.",
   "license": "MIT",
   "author": "Daniel Babjak <babjak_daniel@hotmail.com>",


### PR DESCRIPTION
Both packages were at 1.0.0; bumped to align with rest of @sbo3l/* @ 1.2.0. Driver-published already.