### PR TITLE
docs(submission): refresh npm counts to 25/25 (post driver mass-publish)

### DIFF
--- a/docs/submission/PHASE-3-FINAL-STATUS.md
+++ b/docs/submission/PHASE-3-FINAL-STATUS.md
@@ -120,14 +120,14 @@
 
 | Surface | Status |
 |---|---|
-| **Crates (9)** | 9/9 ✅ at 1.2.0 on crates.io |
+| **Crates (10)** | 10/10 ✅ at 1.2.0 on crates.io (incl. sbo3l-anchor) |
 | **PyPI (top-5)** | 5/5 ✅ at 1.2.0 (sdk + langchain + crewai + llamaindex + langgraph) |
-| **npm core (3)** | ✅ langchain + autogen + elizaos at 1.2.0 |
-| **npm SDK base** | 🟡 @sbo3l/sdk still at 1.0.0 |
-| **Sepolia contracts** | 6/6 ✅ deployed (OffchainResolver, AnchorRegistry, SubnameAuction, ReputationBond, ReputationRegistry, + read-side QuoterV2) |
+| **npm (25)** | **25/25 ✅ at 1.2.0** — sdk + marketplace + 23 framework adapters (langchain, autogen, elizaos, vercel-ai, anthropic, anthropic-computer-use, openai-assistants, mastra, vellum, inngest, langflow, letta, superagi, autogpt, babyagi, cohere-tools, together, perplexity, replicate, modal, e2b, agentforce, copilot-studio) |
+| **npm internal** | @sbo3l/design-tokens — intentionally PRIVATE (workspace-internal, not published) |
+| **Sepolia contracts** | 5/5 ✅ deployed (OffchainResolver, AnchorRegistry, SubnameAuction, ReputationBond, ReputationRegistry) |
 | **Mainnet ENS** | ✅ `sbo3lagent.eth` with 5 records on chain |
 | **Web surfaces** | 11/12 ✅ on Vercel (only trust-dns-viz 404; deploy gated on Daniel) |
-| **Tests** | ✅ 777/777 on main |
+| **Tests** | ✅ 868/868 on main |
 | **Chaos** | ✅ 5/5 PASS |
 | **GitHub Release** | ✅ v1.2.0 as Latest |
 

--- a/docs/submission/READY.md
+++ b/docs/submission/READY.md
@@ -30,8 +30,8 @@
 | Priority | Item | Status |
 |---|---|---|
 | P1 | GitHub Release v1.2.0 page | ✅ live (Latest) at https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/releases/tag/v1.2.0 |
-| P2 | npm publishes (5 integrations + sdk @ 1.2.0) | 🔴 **Daniel-gated**: `NPM_TOKEN` not provisioned |
-| P3 | `sbo3l-langgraph` PyPI 1.2.0 | 🔴 **Daniel-gated**: PyPI trusted-publisher provisioning |
+| P2 | npm publishes (25 packages @ 1.2.0) | ✅ **25/25 LIVE** — sdk + marketplace + 23 framework adapters (driver-published 2026-05-02 evening) |
+| P3 | `sbo3l-langgraph` PyPI 1.2.0 | ✅ **LIVE** — Trusted Publisher provisioned, workflow auto-published |
 | P4 | Pre-submission rehearsal walkthrough | ✅ static walk PASS; 6 hands-on steps DELEGATED |
 | P5 | Live URL inventory final pass | ✅ |
 | P6 | This doc | ✅ |
@@ -100,8 +100,8 @@
 
 | Gap | Severity | Daniel action | Mitigation if not closed |
 |---|---|---|---|
-| `@sbo3l/sdk` still at 1.0.0 (not 1.2.0) on npm | 🟢 Low | Bump npm dist-tag (3 framework integrations already at 1.2.0) | Python SDK + CLI at 1.2.0 cover full install path |
-| Peripheral npm packages 404 (`@sbo3l/{vercel-ai,design-tokens,marketplace,anthropic,openai-assistants,...}`) | 🟢 Low | Push remaining publish tags | 3 core integrations live (langchain, autogen, elizaos) |
+| ~~`@sbo3l/sdk` still at 1.0.0~~ | ✅ RESOLVED | Bumped + republished at 1.2.0 (driver) | All 25 @sbo3l/* packages aligned at 1.2.0 |
+| ~~Peripheral npm packages 404~~ | ✅ RESOLVED | Driver published all 22 missing packages locally with new NPM_TOKEN (2FA bypass enabled) on 2026-05-02 evening | All 25 @sbo3l/* npm packages now @ 1.2.0 (only intentionally-private @sbo3l/design-tokens stays unpublished) |
 | Newer PyPI integrations 404 (`sbo3l-{agno,pydantic-ai,...}`) | 🟢 Low | Provision additional PyPI publishers | Top-5 Python integrations all live |
 | `sbo3l-trust-dns-viz` Vercel 404 | 🟢 Low | Deploy `apps/trust-dns-viz/` to Vercel | Source verifiable; canvas works locally |
 | Custom domains DNS not pointed | 🟢 Low | (Optional, post-submission) point CTI-3-1 DNS | Vercel previews are canonical |


### PR DESCRIPTION
Driver published all 22 missing npm packages tonight. Heidi's docs reflected pre-publish state. Catch them up.