### PR TITLE
fix(mobile): switch from expo-barcode-scanner to expo-camera (Expo SDK 52)

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -37,7 +37,7 @@
       "expo-router",
       "expo-secure-store",
       ["expo-notifications", { "color": "#4ade80" }],
-      ["expo-barcode-scanner", { "cameraPermission": "Allow $(PRODUCT_NAME) to scan Passport QR codes." }]
+      ["expo-camera", { "cameraPermission": "Allow $(PRODUCT_NAME) to scan Passport QR codes." }]
     ],
     "extra": {
       "eas": { "projectId": "00000000-0000-0000-0000-000000000000" },

--- a/apps/mobile/app/scan.tsx
+++ b/apps/mobile/app/scan.tsx
@@ -1,5 +1,5 @@
-import { BarCodeScanner, BarCodeScannerResult } from "expo-barcode-scanner";
-import { useEffect, useState } from "react";
+import { CameraView, useCameraPermissions } from "expo-camera";
+import { useState } from "react";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useRouter } from "expo-router";
 import { tokens } from "~/theme";
@@ -7,20 +7,30 @@ import { tokens } from "~/theme";
 // Capsule QR scanner. The QR encodes a base64-url Passport capsule
 // payload. We hand it off to the verify route which mounts the WASM
 // verifier (same code path as the hosted-app /demo/3-verify-yourself).
+//
+// Self-review fix (bug 5): switched from expo-barcode-scanner (removed
+// in Expo SDK 52) to expo-camera's built-in barcode scanning.
+// CameraView accepts barcodeScannerSettings directly; no separate
+// package needed.
 
 export default function ScanScreen(): JSX.Element {
-  const [permission, setPermission] = useState<boolean | null>(null);
+  const [permission, requestPermission] = useCameraPermissions();
   const [scanned, setScanned] = useState(false);
   const router = useRouter();
 
-  useEffect(() => {
-    BarCodeScanner.requestPermissionsAsync().then(({ status }) => setPermission(status === "granted"));
-  }, []);
+  if (!permission) return <View style={styles.center}><Text style={styles.muted}>Loading…</Text></View>;
+  if (!permission.granted) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.error}>Camera permission required to scan capsules.</Text>
+        <TouchableOpacity onPress={requestPermission} style={styles.btn}>
+          <Text style={styles.btnText}>Grant permission</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
 
-  if (permission === null) return <View style={styles.center}><Text style={styles.muted}>Requesting camera permission…</Text></View>;
-  if (permission === false) return <View style={styles.center}><Text style={styles.error}>Camera permission denied. Enable in Settings.</Text></View>;
-
-  const onScan = ({ data }: BarCodeScannerResult): void => {
+  const onScan = ({ data }: { data: string }): void => {
     if (scanned) return;
     setScanned(true);
     router.push({ pathname: "/verify", params: { capsule: data } });
@@ -28,7 +38,12 @@ export default function ScanScreen(): JSX.Element {
 
   return (
     <View style={styles.container}>
-      <BarCodeScanner onBarCodeScanned={onScan} style={StyleSheet.absoluteFillObject} />
+      <CameraView
+        style={StyleSheet.absoluteFillObject}
+        facing="back"
+        barcodeScannerSettings={{ barcodeTypes: ["qr"] }}
+        onBarcodeScanned={scanned ? undefined : onScan}
+      />
       <View style={styles.frame}><Text style={styles.frameText}>Align Passport QR inside the frame</Text></View>
       {scanned && (
         <TouchableOpacity onPress={() => setScanned(false)} style={styles.retry}>
@@ -41,9 +56,11 @@ export default function ScanScreen(): JSX.Element {
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: tokens.bg },
-  center: { flex: 1, justifyContent: "center", alignItems: "center", padding: 16 },
+  center: { flex: 1, justifyContent: "center", alignItems: "center", padding: 16, backgroundColor: tokens.bg },
   muted: { color: tokens.muted },
-  error: { color: tokens.deny },
+  error: { color: tokens.deny, marginBottom: 16 },
+  btn: { backgroundColor: tokens.accent, paddingVertical: 12, paddingHorizontal: 24, borderRadius: tokens.rMd },
+  btnText: { color: tokens.bg, fontSize: 15, fontWeight: "700" },
   frame: { position: "absolute", left: 40, right: 40, top: "30%", height: 280, borderColor: tokens.accent, borderWidth: 2, borderRadius: tokens.rLg, justifyContent: "flex-end", padding: 8 },
   frameText: { color: tokens.accent, fontSize: 12, textAlign: "center" },
   retry: { position: "absolute", bottom: 40, alignSelf: "center", padding: 14, backgroundColor: tokens.codeBg, borderRadius: tokens.rMd },

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "expo": "~52.0.0",
     "expo-auth-session": "~6.0.0",
-    "expo-barcode-scanner": "~13.0.0",
+    "expo-camera": "~16.0.0",
     "expo-constants": "~17.0.0",
     "expo-linking": "~7.0.0",
     "expo-local-authentication": "~15.0.0",


### PR DESCRIPTION
## Summary

**Self-review bug 5.** \`apps/mobile\` pinned \`expo: ~52.0.0\` but used \`expo-barcode-scanner: ~13.0.0\` — **removed in Expo SDK 52** in favor of \`expo-camera\`'s built-in barcode scanner. Skeleton would have failed \`eas build\`.

## Changes

- \`package.json\`: \`expo-barcode-scanner ~13.0.0\` → \`expo-camera ~16.0.0\`
- \`app.json\`: plugin entry swapped (cameraPermission string preserved)
- \`app/scan.tsx\`: \`BarCodeScanner\` → \`CameraView\` with \`barcodeScannerSettings={{ barcodeTypes: [\"qr\"] }}\`. Permission API switched to \`useCameraPermissions\` hook (canonical SDK 52). Added \"Grant permission\" button for the previously-denied recovery path.

## Verification

Checked Expo SDK 52 release notes + expo-barcode-scanner deprecation notice (last version 13.0.1 targets SDK 51).

## Test plan

- [ ] \`pnpm --filter @sbo3l/mobile install\` resolves with no peer-dep warnings
- [ ] \`pnpm --filter @sbo3l/mobile test\` passes
- [ ] /scan route works on iOS simulator with QR test image

🤖 Generated with [Claude Code](https://claude.com/claude-code)