### PR TITLE
feat(marketing): /quickstart hub + 5 stack-specific guides (R16 P3)

### DIFF
--- a/apps/marketing/src/data/quickstarts.ts
+++ b/apps/marketing/src/data/quickstarts.ts
@@ -1,0 +1,269 @@
+// Quickstart guides — one per integration target. Static content
+// rendered at build time by /quickstart/[slug].astro. Each guide
+// follows the same shape: install → configure → first decision →
+// verify the capsule → next steps. Code blocks are intentionally
+// copy-pasteable (no placeholder you-must-fill-in markers); env
+// vars are documented with safe fallbacks.
+
+export interface QuickstartStep {
+  title: string;
+  description: string;
+  code?: string;
+  language?: "sh" | "ts" | "py" | "rs" | "yaml" | "toml" | "json";
+  output?: string;
+}
+
+export interface Quickstart {
+  slug: string;
+  title: string;
+  audience: string;
+  duration_min: number;
+  prereqs: string[];
+  steps: QuickstartStep[];
+  next_steps: { label: string; href: string }[];
+}
+
+export const QUICKSTARTS: Quickstart[] = [
+  {
+    slug: "nodejs",
+    title: "Node.js — first signed decision in 5 minutes",
+    audience: "Backend devs adding policy guardrails to an existing Node service",
+    duration_min: 5,
+    prereqs: ["Node.js 20+", "Docker (for the daemon)"],
+    steps: [
+      {
+        title: "Install the SDK",
+        description: "TypeScript + ESM bundle, ~14 KB gzipped, no native deps.",
+        code: "pnpm add @sbo3l/sdk",
+        language: "sh",
+      },
+      {
+        title: "Start the daemon",
+        description: "SQLite-backed local daemon. Auth bypassed by default for dev.",
+        code: "docker compose up sbo3l -d\ncurl -fsS http://localhost:8730/v1/healthz",
+        language: "sh",
+        output: '{"status":"ok"}',
+      },
+      {
+        title: "Issue your first decision",
+        description: "Wraps tool-use intent in an APRP envelope, daemon decides + signs the receipt.",
+        code: `import { Sbo3lClient } from "@sbo3l/sdk";
+
+const sbo3l = new Sbo3lClient({ url: "http://localhost:8730" });
+
+const decision = await sbo3l.decide({
+  agent_id: "research-01",
+  intent: { kind: "erc20.transfer", to: "0xabc...", token: "USDC", amount: 100 },
+});
+
+console.log(decision.outcome, decision.receipt.signature.slice(0, 16) + "...");`,
+        language: "ts",
+        output: 'allow ed25519:9aF3-2bC7-8eD1-...',
+      },
+      {
+        title: "Verify the capsule offline",
+        description: "WASM verifier — same Rust code as the daemon, runs in Node + browser.",
+        code: `import { verifyCapsule } from "@sbo3l/wasm-verifier";
+
+const ok = verifyCapsule(decision.capsule);
+console.log(ok ? "✓ all 6 strict-mode checks passed" : "✗ rejected");`,
+        language: "ts",
+        output: "✓ all 6 strict-mode checks passed",
+      },
+    ],
+    next_steps: [
+      { label: "Add MEV slippage guard for swap intents", href: "/learn/mev-guard" },
+      { label: "Wire to LangChain via @sbo3l/langchain", href: "/quickstart/langchain" },
+      { label: "Anchor your audit chain on Sepolia", href: "/learn/onchain-anchor" },
+    ],
+  },
+
+  {
+    slug: "python",
+    title: "Python — first signed decision in 5 minutes",
+    audience: "ML engineers + data scientists wiring SBO3L into existing Python pipelines",
+    duration_min: 5,
+    prereqs: ["Python 3.10+", "Docker (for the daemon)"],
+    steps: [
+      {
+        title: "Install",
+        description: "Type-stubs included; works with mypy strict.",
+        code: "pip install sbo3l-sdk",
+        language: "sh",
+      },
+      {
+        title: "Start daemon",
+        description: "Same Docker image as the Node quickstart.",
+        code: "docker compose up sbo3l -d",
+        language: "sh",
+      },
+      {
+        title: "First decision",
+        description: "AsyncIO-friendly client; the sync flavour is `Sbo3lClientSync` if asyncio doesn't fit your stack.",
+        code: `from sbo3l import Sbo3lClient
+
+async def main():
+    sbo3l = Sbo3lClient(url="http://localhost:8730")
+    decision = await sbo3l.decide(
+        agent_id="research-01",
+        intent={"kind": "erc20.transfer", "to": "0xabc...", "token": "USDC", "amount": 100},
+    )
+    print(decision.outcome, decision.receipt.signature[:16] + "...")
+
+import asyncio; asyncio.run(main())`,
+        language: "py",
+        output: "allow ed25519:9aF3-2bC7-8e...",
+      },
+      {
+        title: "Verify offline",
+        description: "Pure-Python verifier (no FFI); accepts capsule as dict or JSON string.",
+        code: `from sbo3l.verify import verify_capsule
+
+ok = verify_capsule(decision.capsule)
+print("✓" if ok else "✗", "strict-mode")`,
+        language: "py",
+      },
+    ],
+    next_steps: [
+      { label: "LangChain integration", href: "/quickstart/langchain" },
+      { label: "Claude tool-use receipts", href: "/quickstart/claude" },
+      { label: "How the audit chain prevents tampering", href: "/learn/audit-chain" },
+    ],
+  },
+
+  {
+    slug: "langchain",
+    title: "LangChain — sign every tool-use decision",
+    audience: "LangChain devs who want every chain step audit-grade",
+    duration_min: 7,
+    prereqs: ["LangChain 0.3+ (TS or Python)", "running SBO3L daemon"],
+    steps: [
+      {
+        title: "Install the LangChain adapter",
+        description: "Drop-in callback handler — no chain code changes.",
+        code: "pnpm add @sbo3l/langchain  # or: pip install sbo3l-langchain",
+        language: "sh",
+      },
+      {
+        title: "Add the callback handler",
+        description: "Every tool invocation flows through the SBO3L policy boundary first.",
+        code: `import { Sbo3lCallbackHandler } from "@sbo3l/langchain";
+
+const handler = new Sbo3lCallbackHandler({
+  url: "http://localhost:8730",
+  agentId: "research-01",
+  onDeny: (reason) => console.warn("policy deny:", reason),
+});
+
+const result = await chain.invoke({ input }, { callbacks: [handler] });`,
+        language: "ts",
+      },
+      {
+        title: "Inspect the receipts",
+        description: "Each tool call writes a receipt. Pull them all from the chain context.",
+        code: `const receipts = handler.receipts;
+console.log(receipts.length, "tool calls,", receipts.filter(r => r.outcome === "deny").length, "denied");`,
+        language: "ts",
+      },
+    ],
+    next_steps: [
+      { label: "Same flow on Python LangChain", href: "/learn/langchain-python" },
+      { label: "AutoGen + CrewAI adapters", href: "/learn/multi-framework" },
+    ],
+  },
+
+  {
+    slug: "claude",
+    title: "Claude tool-use — receipts for every API call",
+    audience: "Anthropic API users wanting audit-grade tool-use logs",
+    duration_min: 6,
+    prereqs: ["@anthropic-ai/sdk", "ANTHROPIC_API_KEY in env"],
+    steps: [
+      {
+        title: "Install the Anthropic adapter",
+        description: "Wraps `@anthropic-ai/sdk` to intercept every `tool_use` block.",
+        code: "pnpm add @sbo3l/anthropic",
+        language: "sh",
+      },
+      {
+        title: "Wrap your client",
+        description: "API surface unchanged — just hand the SBO3L-wrapped client to your existing code.",
+        code: `import Anthropic from "@anthropic-ai/sdk";
+import { wrapAnthropic } from "@sbo3l/anthropic";
+
+const raw = new Anthropic();
+const claude = wrapAnthropic(raw, {
+  sbo3lUrl: "http://localhost:8730",
+  agentId: "research-01",
+});
+
+const reply = await claude.messages.create({
+  model: "claude-sonnet-4-6",
+  max_tokens: 1024,
+  tools: [/* ... */],
+  messages: [{ role: "user", content: "Send 100 USDC to 0xabc" }],
+});`,
+        language: "ts",
+      },
+      {
+        title: "What changed",
+        description: "Every `tool_use` block in the response now has an attached `_sbo3l_receipt` — signed, hash-chained, capsule-verifiable. Denials surface as a `tool_result` block with the deny code.",
+      },
+    ],
+    next_steps: [
+      { label: "MCP tool integration", href: "/quickstart/mcp" },
+      { label: "Token gate for high-value ops", href: "/learn/token-gates" },
+    ],
+  },
+
+  {
+    slug: "keeperhub",
+    title: "KeeperHub cron — audit-grade scheduled automation",
+    audience: "Web3 ops running KH workflows with policy boundaries",
+    duration_min: 8,
+    prereqs: ["KeeperHub workflow ID", "Sepolia RPC URL"],
+    steps: [
+      {
+        title: "Install the KeeperHub adapter",
+        description: "CLI wraps `kh run` so every workflow tick produces a signed receipt.",
+        code: "cargo install sbo3l-keeperhub-adapter",
+        language: "sh",
+      },
+      {
+        title: "Configure your policy",
+        description: "Allow the KH workflow ID, set max gas, set max amount per tick.",
+        code: `# policy.toml
+schema_version = 1
+tenant = "ops"
+
+[[intents]]
+kind = "keeperhub.tick"
+where.workflow_id = "m4t4cnpmhv8qquce3bv3c"
+where.max_gas_gwei = 50
+where.max_amount_usd = 1000`,
+        language: "toml",
+      },
+      {
+        title: "Run a tick under the policy boundary",
+        description: "Adapter produces signed receipt + uploads to KH's compliance dashboard.",
+        code: "sbo3l-keeperhub run --workflow m4t4cnpmhv8qquce3bv3c --policy policy.toml",
+        language: "sh",
+        output: "allow → execution_ref=kh-tx-0x9c8...  receipt=cap_01HZYRG...",
+      },
+      {
+        title: "Verify the receipt offline",
+        description: "Same WASM verifier as the SDK quickstarts. KH archives the capsule for 90 days.",
+        code: "sbo3l verify cap_01HZYRG... --strict",
+        language: "sh",
+      },
+    ],
+    next_steps: [
+      { label: "Anchor each KH tick on Sepolia", href: "/learn/onchain-anchor" },
+      { label: "MEV slippage guard", href: "/learn/mev-guard" },
+    ],
+  },
+];
+
+export function getQuickstart(slug: string): Quickstart | undefined {
+  return QUICKSTARTS.find((q) => q.slug === slug);
+}

--- a/apps/marketing/src/pages/quickstart/[slug].astro
+++ b/apps/marketing/src/pages/quickstart/[slug].astro
@@ -1,0 +1,120 @@
+---
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import { QUICKSTARTS, getQuickstart } from "~/data/quickstarts";
+
+export function getStaticPaths() {
+  return QUICKSTARTS.map((q) => ({ params: { slug: q.slug } }));
+}
+
+const { slug } = Astro.params;
+const guide = slug ? getQuickstart(slug) : undefined;
+if (!guide) {
+  return Astro.redirect("/quickstart");
+}
+---
+<BaseLayout
+  title={`${guide.title} — SBO3L quickstart`}
+  description={`${guide.audience}. ${guide.duration_min}-minute first-decision walkthrough.`}
+>
+  <article class="quickstart">
+    <header class="qs-header">
+      <p class="audience">For: {guide.audience}</p>
+      <h1>{guide.title}</h1>
+      <p class="meta">
+        <strong>~{guide.duration_min} min</strong>
+        <span> · prereqs: </span>
+        {guide.prereqs.join(" · ")}
+      </p>
+    </header>
+
+    <ol class="steps">
+      {guide.steps.map((step, i) => (
+        <li class="step">
+          <header>
+            <span class="step-number">{i + 1}</span>
+            <h2>{step.title}</h2>
+          </header>
+          <p>{step.description}</p>
+          {step.code && (
+            <pre class="code"><code class={`language-${step.language ?? "sh"}`}>{step.code}</code></pre>
+          )}
+          {step.output && (
+            <pre class="output"><code>{step.output}</code></pre>
+          )}
+        </li>
+      ))}
+    </ol>
+
+    <footer class="next-steps">
+      <h2>Next steps</h2>
+      <ul>
+        {guide.next_steps.map((n) => (
+          <li><a href={n.href}>{n.label} →</a></li>
+        ))}
+      </ul>
+    </footer>
+  </article>
+</BaseLayout>
+
+<style>
+  .quickstart { max-width: 760px; margin: 3em auto 4em; padding: 0 1.5em; }
+
+  .qs-header { margin-bottom: 2.5em; padding-bottom: 1.5em; border-bottom: 1px solid var(--border); }
+  .audience { color: var(--accent); font-size: 0.85em; letter-spacing: 0.06em; text-transform: uppercase; margin: 0 0 0.5em; }
+  .qs-header h1 { font-size: var(--fs-4); font-weight: 700; line-height: 1.2; margin: 0 0 0.5em; }
+  .meta { color: var(--muted); font-family: var(--font-mono); font-size: 0.9em; }
+
+  .steps { list-style: none; padding: 0; margin: 0; counter-reset: step; }
+  .step {
+    margin-bottom: 2.5em;
+    padding-left: 0;
+  }
+  .step header {
+    display: flex;
+    align-items: center;
+    gap: 0.8em;
+    margin-bottom: 0.6em;
+  }
+  .step-number {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2em;
+    height: 2em;
+    background: var(--accent);
+    color: var(--bg);
+    border-radius: 50%;
+    font-weight: 700;
+    font-family: var(--font-mono);
+    flex-shrink: 0;
+  }
+  .step h2 { margin: 0; font-size: 1.3em; font-weight: 600; }
+  .step p { color: var(--muted); margin: 0 0 0.8em; max-width: 65ch; }
+
+  .code, .output {
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    padding: 0.9em 1.1em;
+    margin: 0.5em 0;
+    font-family: var(--font-mono);
+    font-size: 0.86em;
+    line-height: 1.55;
+    overflow-x: auto;
+  }
+  .output {
+    border-left: 3px solid var(--accent);
+    color: var(--muted);
+  }
+  .output::before {
+    content: "→ ";
+    color: var(--accent);
+    font-weight: 700;
+  }
+
+  .next-steps { margin-top: 3em; padding-top: 2em; border-top: 1px solid var(--border); }
+  .next-steps h2 { font-size: 1.1em; font-weight: 600; margin: 0 0 0.7em; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; }
+  .next-steps ul { list-style: none; padding: 0; margin: 0; }
+  .next-steps li { margin-bottom: 0.4em; }
+  .next-steps a { color: var(--accent); }
+</style>

--- a/apps/marketing/src/pages/quickstart/index.astro
+++ b/apps/marketing/src/pages/quickstart/index.astro
@@ -1,0 +1,78 @@
+---
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import { QUICKSTARTS } from "~/data/quickstarts";
+---
+<BaseLayout
+  title="SBO3L quickstarts — pick your stack"
+  description="5-minute walkthroughs to first signed decision: Node.js, Python, LangChain, Claude tool-use, KeeperHub cron."
+>
+  <section class="hero-strip">
+    <h1>Pick your quickstart</h1>
+    <p class="lede">
+      Each guide takes you from <code>install</code> to <strong>first
+      signed decision + offline-verified capsule</strong> in under 10
+      minutes. No credit card, no API key signup, no daemon to host —
+      everything runs locally via Docker.
+    </p>
+  </section>
+
+  <section class="grid">
+    {QUICKSTARTS.map((q) => (
+      <a href={`/quickstart/${q.slug}`} class="card">
+        <header>
+          <h2>{q.title.split(" — ")[0]}</h2>
+          <span class="duration">{q.duration_min} min</span>
+        </header>
+        <p class="audience">{q.audience}</p>
+        <p class="prereqs">
+          <strong>Needs:</strong> {q.prereqs.join(", ")}
+        </p>
+      </a>
+    ))}
+  </section>
+
+  <aside class="footer-note">
+    Don't see your stack? The <a href="https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/tree/main/integrations">framework adapter directory</a> covers 16+ frameworks. PRs for new adapters welcome.
+  </aside>
+</BaseLayout>
+
+<style>
+  .hero-strip { max-width: var(--max); margin: 4em auto 2em; padding: 0 1.5em; }
+  .hero-strip h1 { font-size: var(--fs-4); font-weight: 700; margin-bottom: 0.4em; }
+  .lede { color: var(--muted); font-size: var(--fs-2); max-width: 700px; margin: 0; }
+
+  .grid {
+    max-width: var(--max);
+    margin: 2em auto;
+    padding: 0 1.5em;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1em;
+  }
+
+  .card {
+    display: block;
+    padding: 1.4em 1.5em;
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    color: var(--fg);
+    text-decoration: none;
+    transition: border-color 0.15s, transform 0.15s;
+  }
+  .card:hover { border-color: var(--accent); transform: translateY(-2px); text-decoration: none; }
+  .card header { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 0.5em; gap: 1em; }
+  .card h2 { font-size: 1.15em; font-weight: 600; margin: 0; }
+  .card .duration { color: var(--accent); font-family: var(--font-mono); font-size: 0.85em; flex-shrink: 0; }
+  .card .audience { color: var(--muted); font-size: 0.92em; margin: 0 0 0.6em; line-height: 1.5; }
+  .card .prereqs { color: var(--muted); font-size: 0.82em; font-family: var(--font-mono); margin: 0; }
+
+  .footer-note {
+    max-width: var(--max);
+    margin: 3em auto 4em;
+    padding: 0 1.5em;
+    color: var(--muted);
+    text-align: center;
+    font-size: 0.95em;
+  }
+</style>


### PR DESCRIPTION
## Summary

Five quickstart walkthroughs from R16 P3, plus a card-grid hub page:

- \`/quickstart/nodejs\` — 5min, TypeScript SDK
- \`/quickstart/python\` — 5min, async client
- \`/quickstart/langchain\` — 7min, drop-in callback handler
- \`/quickstart/claude\` — 6min, \`wrapAnthropic()\` for tool-use receipts
- \`/quickstart/keeperhub\` — 8min, Rust adapter + policy.toml

## Architecture

- \`src/data/quickstarts.ts\` owns the content as typed TS data (not MDX) — build-time validation catches missing fields
- \`pages/quickstart/[slug].astro\` uses \`getStaticPaths\` to pre-render one page per guide
- \`pages/quickstart/index.astro\` is the card-grid hub

## Test plan

- [ ] \`pnpm --filter @sbo3l/marketing build\` produces 5 \`/quickstart/<slug>/\` routes + the index
- [ ] Each guide renders with numbered step cards + code blocks
- [ ] Cross-links between guides resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)