### PR TITLE
feat(marketing): /playground mock engine + 8 scenarios (R16 Wave 3 P7)

### DIFF
--- a/apps/marketing/src/lib/playground/mock-engine.ts
+++ b/apps/marketing/src/lib/playground/mock-engine.ts
@@ -1,0 +1,280 @@
+// Mock decision engine — TS reimplementation that mimics real
+// sbo3l-core behaviour for teaching purposes only.
+//
+// LOAD-BEARING DISCLAIMER. Mock capsules CANNOT pass the real
+// strict-mode WASM verifier because:
+//   1. They lack an Ed25519 signature (we have no private key in
+//      the browser to sign with — and putting one there would be
+//      a security incident waiting to happen)
+//   2. They use a distinct schema string ("sbo3l.playground_mock.v1")
+//      so the real verifier rejects them as schema-mismatched
+//   3. The hashes are computed by browser SubtleCrypto, deterministic
+//      but the verifier expects them to be signed
+//
+// A visitor can verify the boundary holds: paste a mock capsule into
+// /proof and watch the strict-mode verifier reject it.
+//
+// Real decisions: /playground/live (Vercel-hosted real daemon).
+
+export interface MockDecision {
+  outcome: "allow" | "deny" | "require_human";
+  deny_code?: string;
+  matched_rule?: string;
+  request_hash: string;     // sha256("mock:" + canonical APRP)
+  policy_hash: string;      // sha256("mock:" + policy TOML bytes)
+  audit_event_id: string;   // ulid-shaped (mock)
+  mock_capsule: MockCapsule;
+}
+
+export interface MockCapsule {
+  schema: "sbo3l.playground_mock.v1";
+  policy_receipt: {
+    request_hash: string;
+    outcome: "allow" | "deny" | "require_human";
+    deny_code?: string;
+    matched_rule?: string;
+    policy_hash: string;
+    audit_event_id: string;
+    signature: "MOCK_NOT_SIGNED";
+    verifier_pubkey: "MOCK_NO_KEY";
+  };
+  evidence: {
+    aprp_canonical: string;
+    policy_canonical: string;
+    decision_input_summary: string;
+  };
+  notice: "This capsule was produced by the in-browser mock engine. It is not cryptographically real and will be rejected by the strict-mode WASM verifier. For real signed receipts, use /playground/live.";
+}
+
+interface AprpEnvelope {
+  schema_version?: number;
+  agent_id?: string;
+  intent?: Record<string, unknown> & { kind?: string };
+  attestations?: unknown[];
+  nonce?: string;
+  timestamp_ms?: number;
+}
+
+// Browser-side SHA-256 via SubtleCrypto. Returns hex string with the
+// "0x" prefix to match the on-chain anchor format.
+async function sha256Hex(input: string): Promise<string> {
+  const bytes = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  const hex = Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return "0x" + hex;
+}
+
+// Best-effort canonical JSON. Real sbo3l uses RFC 8785 JCS; this mock
+// uses JSON.stringify with sorted keys, which produces the same result
+// for the simple shapes the playground deals with. Visitor sees the
+// canonical form in the capsule's `evidence` field.
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return "[" + value.map(canonicalJson).join(",") + "]";
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  const entries = keys.map((k) => JSON.stringify(k) + ":" + canonicalJson((value as Record<string, unknown>)[k]));
+  return "{" + entries.join(",") + "}";
+}
+
+// Mock ULID — month-stable id derived from the inputs so the same
+// scenario produces the same audit_event_id every time the visitor
+// re-runs it. Real ULIDs come from the daemon's monotonic clock.
+async function mockUlid(seed: string): Promise<string> {
+  const h = await sha256Hex(seed);
+  return "01HZRG-MOCK-" + h.slice(2, 16).toUpperCase();
+}
+
+interface PolicyParseResult {
+  tenant?: string;
+  intents: Array<{
+    kind?: string;
+    where?: Record<string, unknown>;
+    require?: Array<Record<string, unknown>>;
+  }>;
+}
+
+// Sub-set TOML parser — handles the policy shapes the playground uses.
+// Not a general TOML parser. If the visitor writes something exotic,
+// we fall back to a single-rule "allow everything" interpretation
+// rather than throw, so the playground stays interactive even with
+// malformed input.
+function parsePolicyToml(toml: string): PolicyParseResult {
+  const result: PolicyParseResult = { intents: [] };
+  const lines = toml.split("\n").map((l) => l.trim()).filter((l) => l && !l.startsWith("#"));
+
+  let currentIntent: PolicyParseResult["intents"][0] | null = null;
+  for (const line of lines) {
+    if (line === "[[intents]]") {
+      if (currentIntent) result.intents.push(currentIntent);
+      currentIntent = { where: {}, require: [] };
+      continue;
+    }
+    if (line.startsWith("tenant")) {
+      const m = /tenant\s*=\s*"([^"]*)"/.exec(line);
+      if (m) result.tenant = m[1];
+      continue;
+    }
+    if (currentIntent) {
+      const kindM = /^kind\s*=\s*"([^"]*)"/.exec(line);
+      if (kindM) {
+        currentIntent.kind = kindM[1];
+        continue;
+      }
+      const whereM = /^where\.([\w.]+)\s*=\s*(.+)$/.exec(line);
+      if (whereM && currentIntent.where) {
+        currentIntent.where[whereM[1]] = whereM[2];
+        continue;
+      }
+      const reqM = /^require\s*=\s*\[(.*)\]$/.exec(line);
+      if (reqM && currentIntent.require) {
+        currentIntent.require.push({ raw: reqM[1] });
+      }
+    }
+  }
+  if (currentIntent) result.intents.push(currentIntent);
+  return result;
+}
+
+// The actual decision logic. Pattern-matches against the 8 known
+// scenarios; for unknown shapes, defaults to allow with a synthetic
+// rule id so the playground always returns *something*.
+function evalDecision(aprp: AprpEnvelope, policy: PolicyParseResult): { outcome: MockDecision["outcome"]; deny_code?: string; matched_rule?: string } {
+  const intent = aprp.intent ?? {};
+  const kind = typeof intent.kind === "string" ? intent.kind : "unknown";
+
+  // Replay nonce — flagged by suffix in the mock fixtures.
+  if (typeof aprp.nonce === "string" && aprp.nonce.endsWith("REPLAY")) {
+    return { outcome: "deny", deny_code: "protocol.nonce_replay" };
+  }
+
+  // Expired APRP — 60-second skew tolerance.
+  if (typeof aprp.timestamp_ms === "number" && aprp.timestamp_ms < (1714565000000 - 60_000)) {
+    return { outcome: "deny", deny_code: "protocol.aprp_expired" };
+  }
+
+  // MEV slippage breach.
+  if (kind === "uniswap.swap" && typeof intent.slippage_bps === "number") {
+    const cap = policy.intents.find((i) => i.kind === "uniswap.swap")?.where?.["slippage_bps"];
+    if (typeof cap === "string" && /lte\s*=\s*(\d+)/.exec(cap)) {
+      const limit = parseInt(/lte\s*=\s*(\d+)/.exec(cap)![1]!, 10);
+      if (intent.slippage_bps > limit) {
+        return { outcome: "deny", deny_code: "policy.deny_mev_slippage", matched_rule: "uniswap.swap-slippage" };
+      }
+    }
+  }
+
+  // Provider allowlist.
+  if (kind === "erc20.transfer") {
+    const provider = typeof intent.provider === "string" ? intent.provider : "unknown";
+    const allowlistRaw = policy.intents.find((i) => i.kind === "erc20.transfer")?.where?.["provider"];
+    if (typeof allowlistRaw === "string") {
+      const m = /allowlist\s*=\s*\[(.*)\]/.exec(allowlistRaw);
+      if (m) {
+        const allowed = m[1]!.split(",").map((s) => s.trim().replace(/^"|"$/g, ""));
+        if (!allowed.includes(provider)) {
+          return { outcome: "deny", deny_code: "policy.deny_unknown_provider", matched_rule: "erc20.transfer-provider" };
+        }
+      }
+    }
+  }
+
+  // Token gate — APRP needs to claim an attestation.
+  if (kind === "compute.train") {
+    const requires = policy.intents.find((i) => i.kind === "compute.train")?.require ?? [];
+    const wantsTokenGate = requires.some((r) => typeof r.raw === "string" && r.raw.includes("token_gate"));
+    const claimed = Array.isArray(aprp.attestations) && aprp.attestations.length > 0;
+    if (wantsTokenGate && !claimed) {
+      return { outcome: "deny", deny_code: "policy.deny_token_gate_missing", matched_rule: "compute.train-token-gate" };
+    }
+  }
+
+  // Human-2FA threshold.
+  if (kind === "erc20.transfer" && typeof intent.amount === "number") {
+    const requires = policy.intents.find((i) => i.kind === "erc20.transfer")?.require ?? [];
+    const human2fa = requires.find((r) => typeof r.raw === "string" && r.raw.includes("human_2fa"));
+    if (human2fa) {
+      const m = /amount\s*=\s*\{\s*gt\s*=\s*(\d+)/.exec(human2fa.raw as string);
+      const threshold = m ? parseInt(m[1]!, 10) : 10000;
+      if (intent.amount > threshold) {
+        return { outcome: "require_human", matched_rule: "erc20.transfer-human-2fa" };
+      }
+    }
+  }
+
+  // Default allow with a synthetic matched_rule so the result panel
+  // has something to show.
+  return { outcome: "allow", matched_rule: `${kind}-default-allow` };
+}
+
+export interface DecideError {
+  kind: "schema" | "json" | "internal";
+  message: string;
+}
+
+export async function decideMock(aprpRaw: string, policyToml: string): Promise<{ ok: true; decision: MockDecision } | { ok: false; error: DecideError }> {
+  let aprp: AprpEnvelope;
+  try {
+    aprp = JSON.parse(aprpRaw) as AprpEnvelope;
+  } catch (e) {
+    return { ok: false, error: { kind: "json", message: `APRP is not valid JSON: ${(e as Error).message}` } };
+  }
+
+  // Lightweight schema validation — real schema lives at
+  // schemas/aprp-envelope.v1.json. We check the load-bearing fields.
+  if (typeof aprp.schema_version !== "number") {
+    return { ok: false, error: { kind: "schema", message: "APRP missing schema_version (number)" } };
+  }
+  if (typeof aprp.agent_id !== "string") {
+    return { ok: false, error: { kind: "schema", message: "APRP missing agent_id (string)" } };
+  }
+  if (!aprp.intent || typeof aprp.intent !== "object") {
+    return { ok: false, error: { kind: "schema", message: "APRP missing intent (object)" } };
+  }
+
+  const policy = parsePolicyToml(policyToml);
+  const verdict = evalDecision(aprp, policy);
+
+  const aprpCanonical = canonicalJson(aprp);
+  const policyCanonical = policyToml;
+
+  const requestHash = await sha256Hex("mock:" + aprpCanonical);
+  const policyHash = await sha256Hex("mock:" + policyCanonical);
+  const auditEventId = await mockUlid(requestHash + policyHash);
+
+  const summary = `${verdict.outcome.toUpperCase()}${verdict.deny_code ? ` · ${verdict.deny_code}` : ""}${verdict.matched_rule ? ` · matched ${verdict.matched_rule}` : ""}`;
+
+  const capsule: MockCapsule = {
+    schema: "sbo3l.playground_mock.v1",
+    policy_receipt: {
+      request_hash: requestHash,
+      outcome: verdict.outcome,
+      deny_code: verdict.deny_code,
+      matched_rule: verdict.matched_rule,
+      policy_hash: policyHash,
+      audit_event_id: auditEventId,
+      signature: "MOCK_NOT_SIGNED",
+      verifier_pubkey: "MOCK_NO_KEY",
+    },
+    evidence: {
+      aprp_canonical: aprpCanonical,
+      policy_canonical: policyCanonical,
+      decision_input_summary: summary,
+    },
+    notice: "This capsule was produced by the in-browser mock engine. It is not cryptographically real and will be rejected by the strict-mode WASM verifier. For real signed receipts, use /playground/live.",
+  };
+
+  return {
+    ok: true,
+    decision: {
+      outcome: verdict.outcome,
+      deny_code: verdict.deny_code,
+      matched_rule: verdict.matched_rule,
+      request_hash: requestHash,
+      policy_hash: policyHash,
+      audit_event_id: auditEventId,
+      mock_capsule: capsule,
+    },
+  };
+}

--- a/apps/marketing/src/lib/playground/scenarios.ts
+++ b/apps/marketing/src/lib/playground/scenarios.ts
@@ -1,0 +1,200 @@
+// 8 pre-loaded scenarios for the mock playground. Each entry contains
+// a starter APRP envelope + policy override that produces a known
+// outcome when fed through `decideMock()`. The visitor edits these
+// freely — the mock engine evaluates whatever they end up with.
+
+export interface PlaygroundScenario {
+  id: string;
+  label: string;
+  outcome_emoji: string;
+  outcome_word: "allow" | "deny" | "human";
+  blurb: string;
+  aprp: string;
+  policy: string;
+}
+
+const ts = (offset_seconds = 0): number => 1714565000000 + offset_seconds * 1000;
+
+export const SCENARIOS: PlaygroundScenario[] = [
+  {
+    id: "allow-small-swap",
+    label: "Allow small swap",
+    outcome_emoji: "✅",
+    outcome_word: "allow",
+    blurb: "Happy path. $50 USDC swap routed through KeeperHub workflow — under all caps, allowlisted provider.",
+    aprp: JSON.stringify({
+      schema_version: 1,
+      agent_id: "research-01",
+      intent: { kind: "erc20.transfer", to: "kh-treasury", token: "USDC", amount: 50, provider: "keeperhub" },
+      nonce: "01HZRG-7e8dC1ALLOW001",
+      timestamp_ms: ts(0),
+    }, null, 2),
+    policy: `# acme.sbo3lagent.eth — allow small swaps via KH
+schema_version = 1
+tenant = "acme"
+
+[[intents]]
+kind = "erc20.transfer"
+where.provider = { allowlist = ["keeperhub", "uniswap"] }
+where.amount = { lte_per_24h = 1000 }
+`,
+  },
+
+  {
+    id: "deny-unknown-provider",
+    label: "Deny unknown provider",
+    outcome_emoji: "❌",
+    outcome_word: "deny",
+    blurb: "Same intent, but provider is not in the allowlist. Daemon denies with policy.deny_unknown_provider.",
+    aprp: JSON.stringify({
+      schema_version: 1,
+      agent_id: "research-01",
+      intent: { kind: "erc20.transfer", to: "0xabc", token: "USDC", amount: 50, provider: "unknown.dex.io" },
+      nonce: "01HZRG-7e8dC1PROV001",
+      timestamp_ms: ts(0),
+    }, null, 2),
+    policy: `schema_version = 1
+tenant = "acme"
+
+[[intents]]
+kind = "erc20.transfer"
+where.provider = { allowlist = ["keeperhub", "uniswap"] }
+`,
+  },
+
+  {
+    id: "deny-mev-slippage",
+    label: "MEV slippage breach",
+    outcome_emoji: "❌",
+    outcome_word: "deny",
+    blurb: "Swap with 25% slippage — way above the 1% policy cap. Denies before the swap can execute.",
+    aprp: JSON.stringify({
+      schema_version: 1,
+      agent_id: "trader-02",
+      intent: { kind: "uniswap.swap", tokenIn: "USDC", tokenOut: "WETH", amountIn: 5000, slippage_bps: 2500 },
+      nonce: "01HZRG-7e8dC1MEV001",
+      timestamp_ms: ts(0),
+    }, null, 2),
+    policy: `schema_version = 1
+tenant = "ops"
+
+[[intents]]
+kind = "uniswap.swap"
+where.slippage_bps = { lte = 100 }
+`,
+  },
+
+  {
+    id: "deny-token-gate",
+    label: "Token gate (NFT not held)",
+    outcome_emoji: "❌",
+    outcome_word: "deny",
+    blurb: "Policy requires the agent's wallet to hold a specific NFT. APRP doesn't claim it; deny.",
+    aprp: JSON.stringify({
+      schema_version: 1,
+      agent_id: "research-01",
+      intent: { kind: "compute.train", model: "llama-3-8b", duration_minutes: 60 },
+      attestations: [],
+      nonce: "01HZRG-7e8dC1NFT001",
+      timestamp_ms: ts(0),
+    }, null, 2),
+    policy: `schema_version = 1
+tenant = "research"
+
+[[intents]]
+kind = "compute.train"
+require = [{ token_gate = "0xCONTRACT/123" }]
+`,
+  },
+
+  {
+    id: "deny-aprp-expired",
+    label: "APRP expired (>60s)",
+    outcome_emoji: "❌",
+    outcome_word: "deny",
+    blurb: "Timestamp is 5 minutes in the past. Daemon's clock skew tolerance is 60 seconds. protocol.aprp_expired.",
+    aprp: JSON.stringify({
+      schema_version: 1,
+      agent_id: "research-01",
+      intent: { kind: "erc20.transfer", to: "kh-treasury", token: "USDC", amount: 50 },
+      nonce: "01HZRG-7e8dC1EXP001",
+      timestamp_ms: ts(-300),
+    }, null, 2),
+    policy: `schema_version = 1
+tenant = "acme"
+
+[[intents]]
+kind = "erc20.transfer"
+`,
+  },
+
+  {
+    id: "deny-nonce-replay",
+    label: "Nonce replay",
+    outcome_emoji: "❌",
+    outcome_word: "deny",
+    blurb: "Nonce ends in REPLAY — the mock engine treats this as a known-seen value. protocol.nonce_replay.",
+    aprp: JSON.stringify({
+      schema_version: 1,
+      agent_id: "research-01",
+      intent: { kind: "erc20.transfer", to: "kh-treasury", token: "USDC", amount: 50 },
+      nonce: "01HZRG-7e8dC1-REPLAY",
+      timestamp_ms: ts(0),
+    }, null, 2),
+    policy: `schema_version = 1
+tenant = "acme"
+
+[[intents]]
+kind = "erc20.transfer"
+`,
+  },
+
+  {
+    id: "require-human",
+    label: "Requires human approval",
+    outcome_emoji: "⚠️",
+    outcome_word: "human",
+    blurb: "$15K transfer crosses the human_2fa threshold. Outcome is `require_human` — daemon waits for the admin to confirm before signing.",
+    aprp: JSON.stringify({
+      schema_version: 1,
+      agent_id: "trader-02",
+      intent: { kind: "erc20.transfer", to: "kh-treasury", token: "USDC", amount: 15000, provider: "keeperhub" },
+      nonce: "01HZRG-7e8dC1HUM001",
+      timestamp_ms: ts(0),
+    }, null, 2),
+    policy: `schema_version = 1
+tenant = "acme"
+
+[[intents]]
+kind = "erc20.transfer"
+where.provider = { allowlist = ["keeperhub", "uniswap"] }
+require = [{ human_2fa = true, when = { amount = { gt = 10000 } } }]
+`,
+  },
+
+  {
+    id: "tampered-capsule",
+    label: "Tampered capsule",
+    outcome_emoji: "🔴",
+    outcome_word: "deny",
+    blurb: "This isn't a decision input — paste the resulting mock-capsule into /proof and modify a byte to see strict-mode reject it.",
+    aprp: JSON.stringify({
+      schema_version: 1,
+      agent_id: "research-01",
+      intent: { kind: "erc20.transfer", to: "kh-treasury", token: "USDC", amount: 50, provider: "keeperhub" },
+      nonce: "01HZRG-7e8dC1TAMP001",
+      timestamp_ms: ts(0),
+    }, null, 2),
+    policy: `schema_version = 1
+tenant = "acme"
+
+[[intents]]
+kind = "erc20.transfer"
+where.provider = { allowlist = ["keeperhub", "uniswap"] }
+`,
+  },
+];
+
+export function findScenario(id: string): PlaygroundScenario | undefined {
+  return SCENARIOS.find((s) => s.id === id);
+}

--- a/apps/marketing/src/pages/playground.astro
+++ b/apps/marketing/src/pages/playground.astro
@@ -1,0 +1,384 @@
+---
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import { SCENARIOS } from "~/lib/playground/scenarios";
+
+const githubBaseUrl = "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026";
+const mockEngineUrl = `${githubBaseUrl}/blob/main/apps/marketing/src/lib/playground/mock-engine.ts`;
+const realEngineUrl = `${githubBaseUrl}/tree/main/crates/sbo3l-core`;
+---
+<BaseLayout
+  title="SBO3L mock playground — edit a policy, see the decision"
+  description="Browser-side mock decision engine. Edit an APRP + policy, see the verdict. Mock-signed capsules; for real cryptography use /playground/live."
+>
+  <article class="playground">
+    <!-- Banner: persistent MOCK warning -->
+    <div role="alert" class="mock-banner">
+      <strong>⚠️ MOCK PLAYGROUND.</strong>
+      Decisions here are computed by a TypeScript reimplementation in your browser — <em>not</em> the real <code>sbo3l-core</code> engine. Mock capsules are <strong>not cryptographically signed</strong> and will be rejected by the strict-mode verifier.
+      <span class="banner-actions">
+        <a href={mockEngineUrl} rel="noopener">View mock source</a>
+        <a href="/learn/tier-architecture">Why mock?</a>
+        <a href="/playground/live" class="emphasis">Run on real daemon →</a>
+      </span>
+    </div>
+
+    <header>
+      <h1>Mock playground</h1>
+      <p class="lede">
+        Pick a scenario, edit the APRP + policy, hit Decide. The mock engine evaluates the inputs against pattern-matching rules and produces a synthetic capsule with deterministic hashes — useful for understanding what flows through the daemon in production.
+      </p>
+    </header>
+
+    <!-- Scenario tabs -->
+    <nav class="scenarios" aria-label="Pre-loaded scenarios">
+      {SCENARIOS.map((s, i) => (
+        <button
+          type="button"
+          class={`scenario-tab ${i === 0 ? "active" : ""}`}
+          data-scenario={s.id}
+          aria-pressed={i === 0 ? "true" : "false"}
+          title={s.blurb}
+        >
+          <span class="emoji" aria-hidden="true">{s.outcome_emoji}</span>
+          <span class="label">{s.label}</span>
+        </button>
+      ))}
+    </nav>
+
+    <p class="scenario-blurb" id="scenario-blurb" data-default={SCENARIOS[0]!.blurb}>{SCENARIOS[0]!.blurb}</p>
+
+    <!-- Editors + result panel -->
+    <div class="grid">
+      <section class="pane">
+        <header>
+          <span class="pane-title">APRP REQUEST</span>
+          <span class="pane-meta">JSON</span>
+        </header>
+        <textarea
+          id="aprp-input"
+          aria-label="APRP request envelope"
+          spellcheck="false"
+          autocapitalize="off"
+          autocomplete="off"
+          autocorrect="off"
+        >{SCENARIOS[0]!.aprp}</textarea>
+      </section>
+
+      <section class="pane">
+        <header>
+          <span class="pane-title">POLICY OVERRIDE</span>
+          <span class="pane-meta">TOML</span>
+        </header>
+        <textarea
+          id="policy-input"
+          aria-label="Policy TOML"
+          spellcheck="false"
+          autocapitalize="off"
+          autocomplete="off"
+          autocorrect="off"
+        >{SCENARIOS[0]!.policy}</textarea>
+      </section>
+    </div>
+
+    <div class="actions">
+      <button type="button" id="decide-btn" class="btn primary">▶ Decide (mock)</button>
+      <button type="button" id="copy-capsule-btn" class="btn ghost" disabled>📋 Copy capsule</button>
+      <button type="button" id="reset-btn" class="btn ghost">🔄 Reset to scenario</button>
+    </div>
+
+    <!-- Decision panel -->
+    <section class="result" id="result-panel" aria-live="polite">
+      <header>
+        <span class="result-title">MOCK DECISION RESULT</span>
+        <span class="result-meta">Click <em>Decide (mock)</em> to compute</span>
+      </header>
+      <div class="result-body" id="result-body">
+        <p class="muted">No decision yet — edit the inputs above and click <strong>Decide (mock)</strong>.</p>
+      </div>
+    </section>
+
+    <!-- Right rail teaching -->
+    <aside class="teaching">
+      <h2>Concepts</h2>
+      <ul>
+        <li><a href="/learn/audit-chain">What is APRP?</a></li>
+        <li><a href="/learn/audit-chain">What is a policy hash?</a></li>
+        <li><a href="/learn/tier-architecture">Why mock-only here?</a></li>
+        <li><a href="/playground/live">Run this on the real daemon →</a></li>
+      </ul>
+
+      <h2>Source</h2>
+      <ul>
+        <li><a href={mockEngineUrl} rel="noopener">View mock engine source</a></li>
+        <li><a href={realEngineUrl} rel="noopener">View real engine (Rust)</a></li>
+      </ul>
+    </aside>
+  </article>
+</BaseLayout>
+
+<script>
+  import { SCENARIOS, findScenario } from "~/lib/playground/scenarios";
+  import { decideMock } from "~/lib/playground/mock-engine";
+
+  // Astro bundles this as a static file under _astro/, served from
+  // same-origin so strict CSP (script-src 'self') passes.
+
+  const aprpInput = document.getElementById("aprp-input") as HTMLTextAreaElement | null;
+  const policyInput = document.getElementById("policy-input") as HTMLTextAreaElement | null;
+  const decideBtn = document.getElementById("decide-btn");
+  const copyBtn = document.getElementById("copy-capsule-btn") as HTMLButtonElement | null;
+  const resetBtn = document.getElementById("reset-btn");
+  const resultBody = document.getElementById("result-body");
+  const blurbEl = document.getElementById("scenario-blurb");
+  const tabs = document.querySelectorAll<HTMLButtonElement>(".scenario-tab");
+
+  let currentScenarioId = SCENARIOS[0]?.id ?? "";
+  let lastCapsuleJson: string | null = null;
+
+  function loadScenario(id: string): void {
+    const s = findScenario(id);
+    if (!s || !aprpInput || !policyInput) return;
+    aprpInput.value = s.aprp;
+    policyInput.value = s.policy;
+    if (blurbEl) blurbEl.textContent = s.blurb;
+    currentScenarioId = id;
+    tabs.forEach((t) => {
+      const active = t.dataset.scenario === id;
+      t.classList.toggle("active", active);
+      t.setAttribute("aria-pressed", active ? "true" : "false");
+    });
+    if (resultBody) resultBody.innerHTML = '<p class="muted">Inputs reset. Click <strong>Decide (mock)</strong>.</p>';
+    if (copyBtn) copyBtn.disabled = true;
+  }
+
+  tabs.forEach((tab) => {
+    tab.addEventListener("click", () => {
+      const id = tab.dataset.scenario;
+      if (id) loadScenario(id);
+    });
+  });
+
+  resetBtn?.addEventListener("click", () => loadScenario(currentScenarioId));
+
+  decideBtn?.addEventListener("click", async () => {
+    if (!aprpInput || !policyInput || !resultBody) return;
+    resultBody.innerHTML = '<p class="muted">Computing…</p>';
+    if (copyBtn) copyBtn.disabled = true;
+    const result = await decideMock(aprpInput.value, policyInput.value);
+    if (!result.ok) {
+      resultBody.innerHTML = `<p class="error"><strong>Error (${escape(result.error.kind)}):</strong> ${escape(result.error.message)}</p>`;
+      lastCapsuleJson = null;
+      return;
+    }
+    const d = result.decision;
+    const outcomeClass = d.outcome === "allow" ? "allow" : d.outcome === "require_human" ? "human" : "deny";
+    const outcomeIcon = d.outcome === "allow" ? "✅" : d.outcome === "require_human" ? "⚠️" : "❌";
+    lastCapsuleJson = JSON.stringify(d.mock_capsule, null, 2);
+    if (copyBtn) copyBtn.disabled = false;
+    resultBody.innerHTML = `
+      <p class="outcome ${outcomeClass}">${outcomeIcon} <strong>${escape(d.outcome.toUpperCase())}</strong>${d.deny_code ? ' · <code>' + escape(d.deny_code) + '</code>' : ''}</p>
+      <dl class="kv">
+        <dt>matched_rule</dt><dd><code>${escape(d.matched_rule ?? "—")}</code></dd>
+        <dt>request_hash</dt><dd><code>${escape(d.request_hash)}</code></dd>
+        <dt>policy_hash</dt><dd><code>${escape(d.policy_hash)}</code></dd>
+        <dt>audit_event_id</dt><dd><code>${escape(d.audit_event_id)}</code></dd>
+        <dt>capsule_signed</dt><dd><strong class="warn">NO (mock has no key)</strong></dd>
+      </dl>
+      <details>
+        <summary>Show generated mock capsule</summary>
+        <pre class="capsule-json">${escape(lastCapsuleJson)}</pre>
+      </details>
+      <p class="next">
+        ↗ <a href="/playground/live">Run this same APRP + policy on /playground/live</a> for a real signed receipt.
+      </p>
+    `;
+  });
+
+  copyBtn?.addEventListener("click", async () => {
+    if (!lastCapsuleJson) return;
+    try {
+      await navigator.clipboard.writeText(lastCapsuleJson);
+      copyBtn.textContent = "✓ Copied";
+      setTimeout(() => { if (copyBtn) copyBtn.textContent = "📋 Copy capsule"; }, 1500);
+    } catch {
+      copyBtn.textContent = "Clipboard blocked";
+    }
+  });
+
+  function escape(s: string): string {
+    return s.replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]!));
+  }
+</script>
+
+<style>
+  .playground {
+    max-width: var(--max);
+    margin: 2em auto 4em;
+    padding: 0 1.5em;
+    display: grid;
+    grid-template-columns: 1fr 280px;
+    grid-template-areas:
+      "banner banner"
+      "header header"
+      "scenarios scenarios"
+      "blurb blurb"
+      "grid teaching"
+      "actions teaching"
+      "result teaching";
+    gap: 1.5em;
+  }
+
+  .mock-banner {
+    grid-area: banner;
+    padding: 0.85em 1.1em;
+    background: rgba(248, 113, 113, 0.08);
+    border: 1px solid rgba(248, 113, 113, 0.4);
+    border-left: 4px solid #f87171;
+    border-radius: var(--r-md);
+    color: var(--fg);
+    font-size: 0.92em;
+    line-height: 1.5;
+  }
+  .mock-banner code { background: var(--code-bg); padding: 0.05em 0.3em; border-radius: 3px; }
+  .banner-actions { display: inline-block; margin-left: 0.5em; }
+  .banner-actions a { margin-right: 0.8em; color: var(--accent); }
+  .banner-actions a.emphasis { font-weight: 600; }
+
+  .playground header { grid-area: header; }
+  .playground h1 { font-size: var(--fs-3); font-weight: 700; margin: 0 0 0.4em; }
+  .playground .lede { color: var(--muted); margin: 0; max-width: 760px; }
+
+  .scenarios {
+    grid-area: scenarios;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4em;
+  }
+  .scenario-tab {
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    color: var(--fg);
+    padding: 0.45em 0.8em;
+    border-radius: var(--r-sm);
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4em;
+    transition: border-color 0.15s, background 0.15s;
+  }
+  .scenario-tab:hover { border-color: var(--accent); }
+  .scenario-tab.active { border-color: var(--accent); background: rgba(74, 222, 128, 0.08); color: var(--accent); }
+
+  .scenario-blurb { grid-area: blurb; color: var(--muted); margin: 0; font-size: 0.95em; }
+
+  .grid {
+    grid-area: grid;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1em;
+  }
+  .pane {
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+  .pane header { padding: 0.5em 0.9em; border-bottom: 1px solid var(--border); display: flex; justify-content: space-between; }
+  .pane-title { color: var(--accent); font-family: var(--font-mono); font-size: 0.78em; letter-spacing: 0.06em; }
+  .pane-meta { color: var(--muted); font-family: var(--font-mono); font-size: 0.78em; }
+  .pane textarea {
+    flex: 1;
+    width: 100%;
+    min-height: 280px;
+    border: 0;
+    background: transparent;
+    color: var(--fg);
+    padding: 0.9em 1em;
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    line-height: 1.55;
+    resize: vertical;
+    outline: none;
+  }
+  .pane textarea:focus { outline: 2px solid var(--accent); outline-offset: -2px; }
+
+  .actions {
+    grid-area: actions;
+    display: flex;
+    gap: 0.6em;
+    flex-wrap: wrap;
+  }
+
+  .result {
+    grid-area: result;
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    overflow: hidden;
+  }
+  .result header { padding: 0.6em 1em; border-bottom: 1px solid var(--border); display: flex; justify-content: space-between; align-items: baseline; }
+  .result-title { color: var(--accent); font-family: var(--font-mono); font-size: 0.82em; letter-spacing: 0.06em; }
+  .result-meta { color: var(--muted); font-size: 0.85em; }
+  .result-body { padding: 1em 1.2em; }
+  .result-body .muted { color: var(--muted); }
+  .result-body .error { color: #f87171; }
+  .result-body .outcome { font-size: 1.2em; margin: 0 0 0.8em; }
+  .result-body .outcome.allow { color: var(--accent); }
+  .result-body .outcome.deny { color: #f87171; }
+  .result-body .outcome.human { color: #ffce5c; }
+  .result-body .outcome code { background: rgba(248, 113, 113, 0.1); padding: 0.1em 0.4em; border-radius: 3px; font-size: 0.8em; }
+  .kv {
+    display: grid;
+    grid-template-columns: 11em 1fr;
+    gap: 0.3em 1em;
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.84em;
+  }
+  .kv dt { color: var(--muted); }
+  .kv dd { margin: 0; word-break: break-all; }
+  .kv .warn { color: #ffce5c; }
+  details { margin-top: 1em; }
+  details summary { cursor: pointer; color: var(--muted); font-size: 0.88em; }
+  details[open] summary { color: var(--fg); margin-bottom: 0.5em; }
+  .capsule-json { background: var(--bg); border: 1px solid var(--border); border-radius: var(--r-sm); padding: 0.8em 1em; font-family: var(--font-mono); font-size: 0.8em; line-height: 1.5; overflow-x: auto; max-height: 400px; }
+  .next { margin-top: 1em; font-size: 0.92em; }
+  .next a { color: var(--accent); }
+
+  .teaching {
+    grid-area: teaching;
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    padding: 1em 1.2em;
+    align-self: start;
+    position: sticky;
+    top: 1.5em;
+  }
+  .teaching h2 { font-size: 0.85em; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; margin: 0 0 0.6em; }
+  .teaching h2:not(:first-child) { margin-top: 1.4em; }
+  .teaching ul { list-style: none; padding: 0; margin: 0; }
+  .teaching li { margin-bottom: 0.4em; }
+  .teaching a { color: var(--accent); font-size: 0.9em; }
+
+  @media (max-width: 900px) {
+    .playground {
+      grid-template-columns: 1fr;
+      grid-template-areas:
+        "banner"
+        "header"
+        "scenarios"
+        "blurb"
+        "grid"
+        "actions"
+        "result"
+        "teaching";
+    }
+    .grid { grid-template-columns: 1fr; }
+    .teaching { position: static; }
+  }
+</style>


### PR DESCRIPTION
## Summary

**Tier 2** of the 3-tier playground. Browser-side mock decision engine with explicit MOCK badge — no theater.

### Components

- \`lib/playground/scenarios.ts\` — 8 pre-loaded scenarios (allow-small / deny-provider / deny-mev / deny-token-gate / deny-expired / deny-replay / require-human / tampered-starter)
- \`lib/playground/mock-engine.ts\` — \`decideMock(aprpJson, policyToml)\`. Real APRP shape validation, mock pattern-match policy eval, real SHA-256 over canonical inputs (hashes prefixed \`\"mock:\"\` so they can't collide with daemon's). Capsule schema = \`sbo3l.playground_mock.v1\` (distinct from real). Signature = \`\"MOCK_NOT_SIGNED\"\`.
- \`pages/playground.astro\` — 3-area layout, persistent MOCK banner, scenario tabs, two textarea editors, decision panel with mock-capsule disclosure, sticky teaching rail.

### Why textarea, not Monaco

Adding \`@astrojs/react\` for Monaco would ship ~140 KB of React + scheduler hydration. Marketing site is Astro static specifically to avoid that. Monaco also pulls from jsdelivr CDN, requiring CSP relaxation. Styled monospace textarea preserves functional behavior + visual fidelity at 0 KB JS overhead.

### Boundary verification

Visitor can paste a mock capsule into \`/proof\` and watch strict-mode WASM verifier reject it (schema mismatch + missing signature). The MOCK badge is honest; the system enforces it.

## Test plan

- [ ] /playground loads, all 8 scenarios pre-fill editors when clicked
- [ ] Decide produces deterministic outcome for each scenario
- [ ] Mock capsule pasted into /proof → rejected (schema + signature)
- [ ] No CSP violations in browser console
- [ ] Mobile (<900px) collapses to single column

🤖 Generated with [Claude Code](https://claude.com/claude-code)