### PR TITLE
feat(playground): real decide_aprp_wasm + build_capsule_wasm exports (R17 P1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,3 +112,43 @@ jobs:
             echo "::error::WASM size $wasm_size > 5 MiB; investigate"
             exit 1
           fi
+
+  wasm-playground-build:
+    name: WASM playground build (R17 marketing /playground)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain (with wasm32 target)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: |
+          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build WASM playground bundle
+        run: bash scripts/build-wasm-playground.sh
+
+      - name: Assert artefacts exist
+        run: |
+          set -euo pipefail
+          for f in sbo3l_playground.js sbo3l_playground_bg.wasm sbo3l_playground.d.ts package.json; do
+            if [ ! -f "apps/marketing/public/wasm/$f" ]; then
+              echo "::error::missing apps/marketing/public/wasm/$f"
+              exit 1
+            fi
+          done
+          wasm_size=$(wc -c <apps/marketing/public/wasm/sbo3l_playground_bg.wasm | tr -d ' ')
+          echo "WASM playground size: $wasm_size bytes"
+          # The playground bundle pulls sbo3l-policy + jsonschema +
+          # serde_yaml + frost-ed25519 (transitively) so it's larger
+          # than the verifier-only bundle. Honest budget: 6 MiB raw.
+          # The brief targeted 250 KB gzipped — we currently land at
+          # ~1 MB gzipped; documented in docs/dev1/wasm-playground.md.
+          if [ "$wasm_size" -gt 6291456 ]; then
+            echo "::error::WASM playground size $wasm_size > 6 MiB; investigate"
+            exit 1
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5643,6 +5643,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sbo3l-playground"
+version = "1.2.0"
+dependencies = [
+ "chrono",
+ "getrandom 0.3.4",
+ "hex",
+ "sbo3l-core",
+ "sbo3l-policy",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "serde_json_canonicalizer",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "sbo3l-policy"
 version = "1.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/sbo3l-cli",
     "crates/sbo3l-server",
     "crates/sbo3l-anchor",
+    "crates/sbo3l-playground",
     "demo-agents/research-agent",
 ]
 
@@ -85,7 +86,13 @@ url = "2"
 # (`crates/sbo3l-keeperhub-adapter`) needs `sbo3l-core` to be
 # publishable, which means the version must be declared here.
 sbo3l-core = { path = "crates/sbo3l-core", version = "1.2.0" }
-sbo3l-policy = { path = "crates/sbo3l-policy", version = "1.2.0" }
+# Workspace dep declares `default-features = false` so per-member
+# `features = […]` and `default-features = false/true` overrides take
+# effect. Most members opt-in to the `budget` feature explicitly via
+# `features = ["budget"]` (server, cli, mcp, identity, research-agent);
+# the wasm-target playground crate uses default-off to skip the
+# rusqlite-backed budget tracker. R17 P1.
+sbo3l-policy = { path = "crates/sbo3l-policy", version = "1.2.0", default-features = false }
 sbo3l-storage = { path = "crates/sbo3l-storage", version = "1.2.0" }
 sbo3l-identity = { path = "crates/sbo3l-identity", version = "1.2.0" }
 sbo3l-execution = { path = "crates/sbo3l-execution", version = "1.2.0" }
@@ -94,6 +101,7 @@ sbo3l-mcp = { path = "crates/sbo3l-mcp", version = "1.2.0" }
 sbo3l-cli = { path = "crates/sbo3l-cli", version = "1.2.0" }
 sbo3l-server = { path = "crates/sbo3l-server", version = "1.2.0" }
 sbo3l-anchor = { path = "crates/sbo3l-anchor", version = "1.2.0" }
+sbo3l-playground = { path = "crates/sbo3l-playground", version = "1.2.0" }
 
 [profile.release]
 lto = "thin"

--- a/crates/sbo3l-cli/Cargo.toml
+++ b/crates/sbo3l-cli/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 sbo3l-core = { workspace = true }
-sbo3l-policy = { workspace = true }
+sbo3l-policy = { workspace = true, features = ["budget"] }
 sbo3l-storage = { workspace = true }
 # Passport P2.1: `sbo3l passport run` orchestrates the existing
 # `POST /v1/payment-requests` pipeline in-process (research-agent

--- a/crates/sbo3l-identity/Cargo.toml
+++ b/crates/sbo3l-identity/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["api-bindings"]
 sbo3l-core = { workspace = true }
 # T-4-6 reputation publisher: depends on policy::reputation::compute_reputation_v2.
 # No cycle (sbo3l-policy depends on sbo3l-core; identity also depends on core).
-sbo3l-policy = { workspace = true }
+sbo3l-policy = { workspace = true, features = ["budget"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 # T-3-4 cross-agent: JCS canonicalisation for the signed-challenge

--- a/crates/sbo3l-mcp/Cargo.toml
+++ b/crates/sbo3l-mcp/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 # No new logic: validate_aprp / verify_capsule / build / verify in sbo3l-core,
 # AppState + router in sbo3l-server, executor mocks in sbo3l-execution.
 sbo3l-core = { workspace = true }
-sbo3l-policy = { workspace = true }
+sbo3l-policy = { workspace = true, features = ["budget"] }
 sbo3l-storage = { workspace = true }
 sbo3l-identity = { workspace = true }
 sbo3l-execution = { workspace = true }

--- a/crates/sbo3l-playground/Cargo.toml
+++ b/crates/sbo3l-playground/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "sbo3l-playground"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+readme.workspace = true
+description = "SBO3L browser playground — wasm-pack bundle exposing decide_aprp_wasm + build_capsule_wasm + verify_capsule_strict for the marketing site /playground page."
+keywords = ["sbo3l", "wasm", "policy", "playground"]
+categories = ["wasm", "web-programming"]
+
+[lib]
+# wasm-pack consumes cdylib; rlib is kept so the workspace's native
+# unit tests can exercise the offline capsule builder directly (no
+# wasm-pack-test round-trip required for the structural / strict
+# verifier coverage).
+crate-type = ["cdylib", "rlib"]
+
+# wasm-pack bundled wasm-opt rejects rustc's bulk-memory ops; disable
+# the post-processing step. Same trade-off the existing /proof
+# verifier bundle made (sbo3l-core's wasm32 build).
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+
+[dependencies]
+sbo3l-core = { workspace = true }
+# R17 P1: real `decide_aprp_wasm` calls policy::decide. Pull
+# sbo3l-policy with `default-features = false` so we skip the `budget`
+# feature (which transitively pulls sbo3l-storage's rusqlite native
+# FFI — does NOT build for wasm).
+sbo3l-policy = { workspace = true, default-features = false }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_json_canonicalizer = { workspace = true }
+chrono = { workspace = true }
+hex = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# wasm-pack JS bridge. Pinned to the same versions sbo3l-core uses for
+# the /proof verifier so both bundles share the same wasm-bindgen ABI.
+wasm-bindgen = "0.2"
+serde-wasm-bindgen = "0.6"
+# Browser entropy source for any `OsRng`-style code path — sbo3l-core's
+# wasm32 build pins the same. We avoid randomness in the playground
+# (everything is deterministic per inputs), but the dep tree pulls
+# `getrandom` transitively; declare here so feature resolution lines up.
+getrandom = { version = "0.3", features = ["wasm_js"] }

--- a/crates/sbo3l-playground/src/lib.rs
+++ b/crates/sbo3l-playground/src/lib.rs
@@ -1,0 +1,37 @@
+//! SBO3L browser playground bundle (R17 P1).
+//!
+//! Sister crate to `sbo3l-core`'s wasm verifier (#110). Where the
+//! verifier is read-only ("does this capsule pass?"), the playground
+//! is an *engine* — given an APRP and a policy, it returns a decision
+//! and (optionally) builds a fully self-contained
+//! `sbo3l.passport_capsule.v2` capsule whose 6-check strict verifier
+//! passes with no auxiliary input.
+//!
+//! Bundle path on the marketing site:
+//! `apps/marketing/public/wasm/sbo3l_playground_bg.wasm` plus
+//! `sbo3l_playground.js`. The JS surface is exported via wasm-bindgen.
+//!
+//! # Why a separate crate
+//!
+//! `sbo3l-policy` already depends on `sbo3l-core`. A direct
+//! `sbo3l-core → sbo3l-policy` dep edge would create a cycle even on
+//! wasm32-only targets (cargo's resolver doesn't gate on
+//! `cfg(target_arch)`). This crate sits below both: it depends on
+//! both crates, calls `sbo3l_policy::decide`, and wraps the result in
+//! a v2 capsule built via `passport_offline`. No native crate has
+//! to depend on `sbo3l-playground`; only the wasm-pack pipeline does.
+//!
+//! # Public surface
+//!
+//! - [`passport_offline::build_capsule_v2_self_contained`] — pure
+//!   Rust (no wasm-bindgen) builder. Native unit tests exercise the
+//!   strict verifier against its output.
+//! - [`wasm::decide_aprp_wasm`] (wasm32-only) — JS-callable real
+//!   policy engine.
+//! - [`wasm::build_capsule_wasm`] (wasm32-only) — JS-callable
+//!   capsule builder using a caller-supplied Ed25519 seed.
+
+pub mod passport_offline;
+
+#[cfg(target_arch = "wasm32")]
+pub mod wasm;

--- a/crates/sbo3l-playground/src/passport_offline.rs
+++ b/crates/sbo3l-playground/src/passport_offline.rs
@@ -1,0 +1,498 @@
+//! R17 P1 — offline capsule builder for the browser playground.
+//!
+//! Native-callable (no wasm-bindgen) so unit tests can exercise the
+//! builder + strict verifier directly. The wasm-bindgen wrapper in
+//! [`crate::wasm::build_capsule_wasm`] is a thin shim around
+//! [`build_capsule_v2_self_contained`].
+//!
+//! # What this builds
+//!
+//! A fully self-contained `sbo3l.passport_capsule.v2` capsule whose
+//! strict verifier ([`sbo3l_core::passport::verify_capsule_strict`])
+//! passes ALL 6 checks WITHOUT auxiliary input:
+//!
+//! - **structural** — schema + cross-field invariants (request_hash
+//!   agreement, decision agreement, etc.).
+//! - **request_hash_recompute** — JCS+SHA-256 over `request.aprp`.
+//! - **policy_hash_recompute** — JCS+SHA-256 over the embedded
+//!   `policy.policy_snapshot`.
+//! - **receipt_signature** — Ed25519 verify under the embedded
+//!   audit bundle's `verification_keys.receipt_signer_pubkey_hex`.
+//! - **audit_chain** — single-event chain (seq=1, prev=ZERO_HASH)
+//!   walked under `verification_keys.audit_signer_pubkey_hex`.
+//! - **audit_event_link** — `decision.audit_event_id` matches the
+//!   chain's lone signed event.
+//!
+//! The audit + receipt signers are the SAME caller-supplied seed —
+//! a single key keeps the embedded `verification_keys` block honest
+//! (no risk of pubkey drift between roles in the playground).
+//!
+//! # Determinism
+//!
+//! - Audit event id is `evt-` + Crockford-Base32 string derived from
+//!   `sha256(canonical_aprp || canonical_policy || decision_str)`,
+//!   masked to fit `^[0-7][0-9A-HJKMNP-TV-Z]{25}$`.
+//! - Wall-clock fields take the caller-supplied `issued_at`. Same
+//!   inputs → byte-identical output capsule (test pin in
+//!   `deterministic_byte_for_byte_across_runs`).
+
+use chrono::{DateTime, Utc};
+use serde_json::{json, Map, Value};
+
+use sbo3l_core::aprp::PaymentRequest;
+use sbo3l_core::audit::{AuditEvent, SignedAuditEvent, ZERO_HASH};
+use sbo3l_core::audit_bundle::{AuditBundle, BundleSummary, BundleType, VerificationKeys};
+use sbo3l_core::error::{CoreError, Result};
+use sbo3l_core::hashing::{request_hash, sha256_hex};
+use sbo3l_core::receipt::{Decision, UnsignedReceipt};
+use sbo3l_core::signer::DevSigner;
+
+/// Inputs the playground builder accepts. All `Value`-shaped so the
+/// browser side can pass straight from `JSON.parse`.
+#[derive(Debug, Clone)]
+pub struct OfflineBuildArgs {
+    pub aprp: PaymentRequest,
+    pub decision: Decision,
+    pub matched_rule_id: Option<String>,
+    pub deny_code: Option<String>,
+    /// Canonical policy JSON (the *same* JSON `Policy::parse_json`
+    /// accepts). Embedded under `policy.policy_snapshot` so the
+    /// strict verifier can recompute `policy_hash` without aux input.
+    pub policy_json: Value,
+    /// 32-byte Ed25519 seed (raw bytes). The builder derives a
+    /// `DevSigner` from this and uses it to sign BOTH the audit event
+    /// and the receipt — single-key keeps the embedded
+    /// `verification_keys` block honest.
+    pub signing_seed: [u8; 32],
+    /// Stable key-id label embedded in signatures.
+    pub key_id: String,
+    /// Wall-clock the capsule + audit event get stamped with.
+    pub issued_at: DateTime<Utc>,
+}
+
+/// Build a fully self-contained `sbo3l.passport_capsule.v2` JSON
+/// value. Returns the capsule as a `Value` so callers can either
+/// re-serialise it or pass straight back as a JS object.
+///
+/// On `Decision::RequiresHuman` returns `Err` — the capsule's
+/// `decision.result` enum is `{allow, deny}` only.
+pub fn build_capsule_v2_self_contained(args: OfflineBuildArgs) -> Result<Value> {
+    if matches!(args.decision, Decision::RequiresHuman) {
+        return Err(CoreError::Schema(sbo3l_core::SchemaError::InvalidRoot {
+            detail:
+                "capsule.requires_human: decision.requires_human cannot be embedded in a passport capsule"
+                    .to_string(),
+        }));
+    }
+
+    let signer = DevSigner::from_seed(args.key_id.clone(), args.signing_seed);
+    let verifying_key_hex = signer.verifying_key_hex();
+
+    // 1. APRP serialised + request_hash.
+    let aprp_value = serde_json::to_value(&args.aprp).map_err(CoreError::Json)?;
+    let req_hash = request_hash(&aprp_value)?;
+
+    // 2. Canonical policy snapshot + JCS+SHA-256 hash.
+    let policy_canonical_bytes =
+        serde_json_canonicalizer::to_string(&args.policy_json).map_err(CoreError::Json)?;
+    let policy_hash = sha256_hex(policy_canonical_bytes.as_bytes());
+
+    // 3. Synthesise the audit event (single-event chain, genesis prev_hash).
+    let event_id = derive_audit_event_id(&aprp_value, &policy_canonical_bytes, &args.decision);
+    let mut metadata = Map::new();
+    metadata.insert(
+        "decision".into(),
+        Value::String(decision_str(&args.decision).to_string()),
+    );
+    if let Some(rule) = &args.matched_rule_id {
+        metadata.insert("matched_rule".into(), Value::String(rule.clone()));
+    }
+    if let Some(code) = &args.deny_code {
+        metadata.insert("deny_code".into(), Value::String(code.clone()));
+    }
+    let audit_event = AuditEvent {
+        version: 1,
+        seq: 1,
+        id: event_id.clone(),
+        ts: args.issued_at,
+        event_type: "policy_decided".to_string(),
+        actor: "playground".to_string(),
+        subject_id: format!("pr-{}", &event_id[4..]),
+        payload_hash: req_hash.clone(),
+        metadata,
+        policy_version: Some(1),
+        policy_hash: Some(policy_hash.clone()),
+        attestation_ref: None,
+        prev_event_hash: ZERO_HASH.to_string(),
+    };
+    let signed_event = SignedAuditEvent::sign(audit_event, &signer)?;
+
+    // 4. Build + sign the policy receipt.
+    let receipt = UnsignedReceipt {
+        agent_id: args.aprp.agent_id.clone(),
+        decision: args.decision.clone(),
+        deny_code: args.deny_code.clone(),
+        request_hash: req_hash.clone(),
+        policy_hash: policy_hash.clone(),
+        policy_version: Some(1),
+        audit_event_id: event_id.clone(),
+        execution_ref: None,
+        issued_at: args.issued_at,
+        expires_at: None,
+    }
+    .sign(&signer)?;
+
+    // 5. Wrap into the AuditBundle the strict verifier consumes.
+    // `audit_chain_root` is the FIRST event's event_hash (NOT ZERO_HASH —
+    // ZERO_HASH is the genesis prev_event_hash, a different sentinel).
+    // Single-event chain → root == latest.
+    let chain_root = signed_event.event_hash.clone();
+    let chain_latest = signed_event.event_hash.clone();
+    let bundle_summary = BundleSummary {
+        decision: args.decision.clone(),
+        deny_code: args.deny_code.clone(),
+        request_hash: req_hash.clone(),
+        policy_hash: policy_hash.clone(),
+        audit_event_id: event_id.clone(),
+        audit_event_hash: signed_event.event_hash.clone(),
+        audit_chain_root: chain_root,
+        audit_chain_latest: chain_latest,
+    };
+    let bundle = AuditBundle {
+        bundle_type: BundleType::AuditBundleV1,
+        version: 1,
+        exported_at: args.issued_at,
+        receipt: receipt.clone(),
+        audit_event: signed_event.clone(),
+        audit_chain_segment: vec![signed_event.clone()],
+        verification_keys: VerificationKeys {
+            receipt_signer_pubkey_hex: verifying_key_hex.clone(),
+            audit_signer_pubkey_hex: verifying_key_hex.clone(),
+        },
+        summary: bundle_summary,
+    };
+
+    // 6. Assemble the v2 capsule.
+    let receipt_value = serde_json::to_value(&receipt).map_err(CoreError::Json)?;
+    let receipt_signature_hex = receipt.signature.signature_hex.clone();
+
+    let agent_block = json!({
+        "agent_id": args.aprp.agent_id,
+        "ens_name": "playground.local",
+        // Schema enum: {"offline-fixture", "live-ens"}. We're the
+        // offline browser playground so "offline-fixture" is the
+        // honest value (we have NO ENS resolver attached).
+        "resolver": "offline-fixture",
+        "records": {
+            "sbo3l:policy_hash": policy_hash,
+            "sbo3l:audit_root": signed_event.event_hash,
+            "sbo3l:passport_schema": "sbo3l.passport_capsule.v2",
+        }
+    });
+    let request_block = json!({
+        "aprp": aprp_value,
+        "request_hash": req_hash,
+        "idempotency_key": Value::Null,
+        "nonce": args.aprp.nonce,
+    });
+    let policy_block = json!({
+        "policy_hash": policy_hash,
+        "policy_version": 1,
+        "activated_at": args.issued_at.to_rfc3339(),
+        "source": "playground-input",
+        "policy_snapshot": args.policy_json,
+    });
+    let decision_block = json!({
+        "result": decision_str(&args.decision),
+        "matched_rule": args.matched_rule_id,
+        "deny_code": args.deny_code,
+        "receipt": receipt_value,
+        "receipt_signature": receipt_signature_hex,
+    });
+    let execution_block = if matches!(args.decision, Decision::Deny) {
+        json!({
+            "executor": "none",
+            "mode": "mock",
+            "status": "not_called",
+            "sponsor_payload_hash": null,
+            "live_evidence": null,
+        })
+    } else {
+        json!({
+            "executor": "none",
+            "mode": "mock",
+            "execution_ref": format!("pg-{}", &event_id[4..]),
+            "status": "submitted",
+            "sponsor_payload_hash": null,
+            "live_evidence": null,
+        })
+    };
+    let bundle_value = serde_json::to_value(&bundle).map_err(CoreError::Json)?;
+    // checkpoint.mock_anchor_ref must match `^local-mock-anchor-[0-9a-f]{16}$`
+    // per `schemas/sbo3l.passport_capsule.v2.json`. Derive from the
+    // first 16 hex chars of the event hash so it's deterministic +
+    // unique per capsule.
+    let mock_anchor_ref = format!("local-mock-anchor-{}", &signed_event.event_hash[..16]);
+    let audit_block = json!({
+        "audit_event_id": event_id,
+        "prev_event_hash": ZERO_HASH,
+        "event_hash": signed_event.event_hash,
+        "bundle_ref": "sbo3l.audit_bundle.v1",
+        "audit_segment": bundle_value,
+        "checkpoint": {
+            "schema": "sbo3l.audit_checkpoint.v1",
+            "sequence": 1u64,
+            "latest_event_id": event_id,
+            "latest_event_hash": signed_event.event_hash,
+            "chain_digest": signed_event.event_hash,
+            "mock_anchor": true,
+            "mock_anchor_ref": mock_anchor_ref,
+            "created_at": args.issued_at.to_rfc3339(),
+        }
+    });
+
+    let verification_block = json!({
+        "doctor_status": "ok",
+        "offline_verifiable": true,
+        "live_claims": [],
+    });
+
+    Ok(json!({
+        "schema": "sbo3l.passport_capsule.v2",
+        "generated_at": args.issued_at.to_rfc3339(),
+        "agent": agent_block,
+        "request": request_block,
+        "policy": policy_block,
+        "decision": decision_block,
+        "execution": execution_block,
+        "audit": audit_block,
+        "verification": verification_block,
+    }))
+}
+
+fn decision_str(d: &Decision) -> &'static str {
+    match d {
+        Decision::Allow => "allow",
+        Decision::Deny => "deny",
+        Decision::RequiresHuman => "requires_human",
+    }
+}
+
+/// Derive a Crockford-Base32-shaped `evt-…` id deterministically from
+/// the inputs. Format matches the schema regex
+/// `^evt-[0-7][0-9A-HJKMNP-TV-Z]{25}$`.
+fn derive_audit_event_id(aprp: &Value, policy_canon: &str, decision: &Decision) -> String {
+    let mut buf = Vec::with_capacity(512);
+    if let Ok(s) = serde_json_canonicalizer::to_string(aprp) {
+        buf.extend_from_slice(s.as_bytes());
+    }
+    buf.extend_from_slice(b"|");
+    buf.extend_from_slice(policy_canon.as_bytes());
+    buf.extend_from_slice(b"|");
+    buf.extend_from_slice(decision_str(decision).as_bytes());
+    let digest_hex = sha256_hex(&buf);
+    encode_crockford_ulid_shape(&digest_hex[..32])
+}
+
+const CROCKFORD: &[u8] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+fn encode_crockford_ulid_shape(hex32: &str) -> String {
+    let mut bytes = [0u8; 16];
+    for (i, byte) in bytes.iter_mut().enumerate() {
+        let off = i * 2;
+        *byte = u8::from_str_radix(&hex32[off..off + 2], 16).unwrap_or(0);
+    }
+    let mut value: u128 = 0;
+    for b in &bytes {
+        value = (value << 8) | (*b as u128);
+    }
+    let mut out = [0u8; 26];
+    for slot in out.iter_mut().rev() {
+        *slot = CROCKFORD[(value & 0x1f) as usize];
+        value >>= 5;
+    }
+    // First char must be 0-7 (3-bit head).
+    let head_idx = (out[0] as char).to_digit(36).unwrap_or(0) & 0x7;
+    out[0] = CROCKFORD[head_idx as usize];
+    format!("evt-{}", std::str::from_utf8(&out).unwrap_or(""))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sbo3l_core::aprp::{
+        Currency, Destination, HttpMethod, Intent, Money, PaymentProtocol, PaymentRequest,
+        RiskClass,
+    };
+    use sbo3l_core::passport::{verify_capsule, verify_capsule_strict, StrictVerifyOpts};
+
+    fn fixture_aprp() -> PaymentRequest {
+        PaymentRequest {
+            agent_id: "research-agent-01".to_string(),
+            task_id: "demo-task".to_string(),
+            intent: Intent::PurchaseApiCall,
+            amount: Money {
+                value: "0.05".to_string(),
+                currency: Currency::USD,
+            },
+            token: "USDC".to_string(),
+            destination: Destination::X402Endpoint {
+                url: "https://api.example.com/v1/inference".to_string(),
+                method: HttpMethod::Post,
+                expected_recipient: Some("0x1111111111111111111111111111111111111111".to_string()),
+            },
+            payment_protocol: PaymentProtocol::X402,
+            chain: "base".to_string(),
+            provider_url: "https://api.example.com".to_string(),
+            x402_payload: None,
+            expiry: chrono::DateTime::parse_from_rfc3339("2099-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            nonce: "01HTAWX5K3R8YV9NQB7C6P2DGM".to_string(),
+            expected_result: None,
+            risk_class: RiskClass::Low,
+        }
+    }
+
+    fn fixture_args(decision: Decision) -> OfflineBuildArgs {
+        OfflineBuildArgs {
+            aprp: fixture_aprp(),
+            decision,
+            matched_rule_id: Some("allow-low-risk-x402".to_string()),
+            deny_code: None,
+            policy_json: serde_json::json!({
+                "version": 1,
+                "default_decision": "deny",
+                "agents": [{"agent_id": "research-agent-01", "status": "active"}],
+                "providers": [],
+                "recipients": [],
+                "rules": [
+                    {"id": "allow-low-risk-x402", "when": "request.risk_class == \"low\"", "effect": "allow"}
+                ]
+            }),
+            signing_seed: [42u8; 32],
+            key_id: "playground-mock-v1".to_string(),
+            issued_at: chrono::DateTime::parse_from_rfc3339("2026-05-02T17:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        }
+    }
+
+    #[test]
+    fn allow_capsule_passes_structural_verify() {
+        let capsule =
+            build_capsule_v2_self_contained(fixture_args(Decision::Allow)).expect("allow build");
+        verify_capsule(&capsule).expect("structural verify");
+    }
+
+    #[test]
+    fn deny_capsule_passes_structural_verify() {
+        let mut args = fixture_args(Decision::Deny);
+        args.deny_code = Some("policy.unknown_provider".to_string());
+        args.matched_rule_id = Some("deny-default".to_string());
+        let capsule = build_capsule_v2_self_contained(args).expect("deny build");
+        verify_capsule(&capsule).expect("structural verify");
+    }
+
+    #[test]
+    fn requires_human_is_rejected() {
+        let err = build_capsule_v2_self_contained(fixture_args(Decision::RequiresHuman))
+            .expect_err("requires_human must reject");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("requires_human") || msg.contains("capsule.requires_human"),
+            "error must name the cause; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn allow_capsule_passes_strict_self_contained() {
+        let capsule =
+            build_capsule_v2_self_contained(fixture_args(Decision::Allow)).expect("allow build");
+        let report = verify_capsule_strict(&capsule, &StrictVerifyOpts::default());
+        assert!(
+            report.is_fully_ok(),
+            "all 6 strict checks must PASS without aux input; report = {report:?}"
+        );
+    }
+
+    #[test]
+    fn deny_capsule_passes_strict_self_contained() {
+        let mut args = fixture_args(Decision::Deny);
+        args.deny_code = Some("policy.unknown_provider".to_string());
+        args.matched_rule_id = Some("deny-default".to_string());
+        let capsule = build_capsule_v2_self_contained(args).expect("deny build");
+        let report = verify_capsule_strict(&capsule, &StrictVerifyOpts::default());
+        assert!(
+            report.is_fully_ok(),
+            "deny capsule strict must fully pass; report = {report:?}"
+        );
+    }
+
+    #[test]
+    fn deterministic_byte_for_byte_across_runs() {
+        let a =
+            build_capsule_v2_self_contained(fixture_args(Decision::Allow)).expect("first build");
+        let b =
+            build_capsule_v2_self_contained(fixture_args(Decision::Allow)).expect("second build");
+        let a_bytes = serde_json::to_vec(&a).unwrap();
+        let b_bytes = serde_json::to_vec(&b).unwrap();
+        assert_eq!(a_bytes, b_bytes);
+    }
+
+    #[test]
+    fn different_aprp_produces_different_audit_event_id() {
+        let a =
+            build_capsule_v2_self_contained(fixture_args(Decision::Allow)).expect("first build");
+        let mut args2 = fixture_args(Decision::Allow);
+        args2.aprp.task_id = "demo-task-different".to_string();
+        let b = build_capsule_v2_self_contained(args2).expect("second build");
+        let id_a = a["audit"]["audit_event_id"].as_str().unwrap();
+        let id_b = b["audit"]["audit_event_id"].as_str().unwrap();
+        assert_ne!(id_a, id_b);
+    }
+
+    #[test]
+    fn audit_event_id_matches_crockford_ulid_shape() {
+        let capsule =
+            build_capsule_v2_self_contained(fixture_args(Decision::Allow)).expect("build");
+        let id = capsule["audit"]["audit_event_id"].as_str().unwrap();
+        assert!(id.starts_with("evt-"));
+        let body = &id[4..];
+        assert_eq!(body.len(), 26);
+        let head = body.chars().next().unwrap();
+        assert!(('0'..='7').contains(&head), "head must be 0-7: {head}");
+        for c in body.chars().skip(1) {
+            assert!(
+                !matches!(c, 'I' | 'L' | 'O' | 'U'),
+                "Crockford forbids I/L/O/U; got {c} in {id}"
+            );
+        }
+    }
+
+    #[test]
+    fn tampered_request_hash_fails_structural() {
+        let mut capsule =
+            build_capsule_v2_self_contained(fixture_args(Decision::Allow)).expect("build");
+        capsule["request"]["request_hash"] = Value::String("0".repeat(64));
+        verify_capsule(&capsule).expect_err("tamper must fail");
+    }
+
+    #[test]
+    fn tampered_policy_snapshot_fails_strict() {
+        // Mutate one field in the embedded policy_snapshot. The
+        // strict verifier's policy_hash_recompute should FAIL because
+        // the recomputed JCS hash no longer matches policy.policy_hash.
+        let mut capsule =
+            build_capsule_v2_self_contained(fixture_args(Decision::Allow)).expect("build");
+        if let Some(snap) = capsule["policy"]["policy_snapshot"].as_object_mut() {
+            snap.insert("malicious_field".into(), Value::Bool(true));
+        }
+        let report = verify_capsule_strict(&capsule, &StrictVerifyOpts::default());
+        assert!(
+            report.policy_hash_recompute.is_failed(),
+            "policy_hash_recompute must FAIL on tampered snapshot; got {:?}",
+            report.policy_hash_recompute
+        );
+    }
+}

--- a/crates/sbo3l-playground/src/wasm.rs
+++ b/crates/sbo3l-playground/src/wasm.rs
@@ -1,0 +1,199 @@
+//! R17 P1 — wasm-bindgen JS bridge for the playground bundle.
+//!
+//! Compiled only on `target_arch = "wasm32"`. Native sbo3l-playground
+//! builds skip this module and don't pull `wasm-bindgen` /
+//! `serde-wasm-bindgen` (kept as wasm-only deps in `Cargo.toml`).
+//!
+//! # Surface
+//!
+//! Three functions, all consumed by `apps/marketing/`'s `/playground`
+//! page after `wasm-pack build --target web` runs:
+//!
+//! - [`decide_aprp_wasm`] — runs the REAL policy decide engine
+//!   (`sbo3l_policy::decide`) over caller-supplied APRP + policy JSON.
+//!   Returns a `{ decision, matched_rule, deny_code, policy_hash }`
+//!   object. No mock — same engine sbo3l-server runs in production.
+//! - [`build_capsule_wasm`] — synthesises a fully self-contained
+//!   `sbo3l.passport_capsule.v2` capsule signed with a caller-supplied
+//!   Ed25519 seed. The capsule passes the 6-check strict verifier
+//!   *with no auxiliary input*. Same audit + receipt key (mock
+//!   playground key) so the embedded `verification_keys` block stays
+//!   honest.
+//! - [`sbo3l_playground_version_js`] — crate version exposed to JS so
+//!   the playground UI can show "engine built from sbo3l-playground
+//!   v1.2.0" honestly.
+//!
+//! # Why not just expose `verify_capsule_strict_json`
+//!
+//! `sbo3l-core`'s wasm bundle (#110) already exposes that. The
+//! playground page imports both bundles: this one for engine +
+//! capsule build, the verifier bundle for the in-browser strict
+//! verify. Keeping them separate avoids forcing every /proof page
+//! visitor to download `sbo3l-policy`'s ~150KB even though they only
+//! verify (no decide).
+
+use serde::Serialize;
+use serde_json::Value;
+use wasm_bindgen::prelude::*;
+
+use sbo3l_core::aprp::PaymentRequest;
+use sbo3l_core::receipt::Decision as ReceiptDecision;
+use sbo3l_policy::{decide as policy_decide, Decision as EngineDecision, Policy};
+
+use crate::passport_offline::{build_capsule_v2_self_contained, OfflineBuildArgs};
+
+/// JS-visible decision response. Field names match the brief's
+/// `DecisionResponse JSON` contract.
+#[derive(Serialize)]
+struct WasmDecisionResponse {
+    /// `"allow" | "deny" | "requires_human"`.
+    decision: &'static str,
+    /// Rule id whose `when` clause fired, or `null` for the default
+    /// fall-through.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    matched_rule: Option<String>,
+    /// Deny code, populated only when decision == "deny".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    deny_code: Option<String>,
+    /// JCS+SHA-256 of the canonical policy JSON. Useful for the
+    /// playground UI to display alongside the decision so users can
+    /// tell two policies apart at a glance.
+    policy_hash: String,
+}
+
+/// Run the real policy decide engine in the browser.
+///
+/// JS side calls `decide_aprp_wasm(aprpJson, policyJson)` and gets
+/// back a plain object with `{ decision, matched_rule, deny_code,
+/// policy_hash }`. Both inputs are JSON strings — `policyJson` accepts
+/// the same shape `Policy::parse_json` does on the daemon side.
+///
+/// **Determinism:** no time, no randomness. Same inputs → same
+/// output. The only state is the parsed Policy + APRP.
+#[wasm_bindgen(js_name = decide_aprp_wasm)]
+pub fn decide_aprp_wasm(aprp_json: &str, policy_json: &str) -> Result<JsValue, JsValue> {
+    let aprp_value: Value = serde_json::from_str(aprp_json)
+        .map_err(|e| JsValue::from_str(&format!("aprp.parse_error: {e}")))?;
+    let aprp: PaymentRequest = serde_json::from_value(aprp_value)
+        .map_err(|e| JsValue::from_str(&format!("aprp.schema_error: {e}")))?;
+    let policy = Policy::parse_json(policy_json)
+        .map_err(|e| JsValue::from_str(&format!("policy.parse_error: {e}")))?;
+
+    let outcome = policy_decide(&policy, &aprp)
+        .map_err(|e| JsValue::from_str(&format!("policy.decide_error: {e}")))?;
+
+    let decision_str = match outcome.decision {
+        EngineDecision::Allow => "allow",
+        EngineDecision::Deny => "deny",
+        EngineDecision::RequiresHuman => "requires_human",
+    };
+    let response = WasmDecisionResponse {
+        decision: decision_str,
+        matched_rule: outcome.matched_rule_id,
+        deny_code: outcome.deny_code,
+        policy_hash: outcome.policy_hash,
+    };
+    serde_wasm_bindgen::to_value(&response)
+        .map_err(|e| JsValue::from_str(&format!("serialize_response: {e}")))
+}
+
+/// Build a self-contained `sbo3l.passport_capsule.v2` capsule from
+/// the caller-supplied APRP + decision response + Ed25519 seed.
+///
+/// `signing_seed_hex` MUST be exactly 32 bytes (64 hex chars). The
+/// builder uses the same seed for both the audit-event signer and the
+/// receipt signer — keeping the embedded `verification_keys` block
+/// honest (audit_signer_pubkey == receipt_signer_pubkey).
+///
+/// Returns the capsule as a plain JS object (NOT a JSON string —
+/// callers can re-stringify via `JSON.stringify(capsule)` if they
+/// need the canonical bytes).
+///
+/// On `decision == "requires_human"` returns a JS error — the v2
+/// capsule's `decision.result` enum is `{allow, deny}` only. The
+/// daemon rejects this case upstream; the playground does the same.
+#[wasm_bindgen(js_name = build_capsule_wasm)]
+pub fn build_capsule_wasm(
+    aprp_json: &str,
+    decision_response_json: &str,
+    policy_json: &str,
+    signing_seed_hex: &str,
+    issued_at_rfc3339: &str,
+) -> Result<JsValue, JsValue> {
+    let aprp_value: Value = serde_json::from_str(aprp_json)
+        .map_err(|e| JsValue::from_str(&format!("aprp.parse_error: {e}")))?;
+    let aprp: PaymentRequest = serde_json::from_value(aprp_value)
+        .map_err(|e| JsValue::from_str(&format!("aprp.schema_error: {e}")))?;
+
+    let decision_response: Value = serde_json::from_str(decision_response_json)
+        .map_err(|e| JsValue::from_str(&format!("decision.parse_error: {e}")))?;
+    let decision_str = decision_response
+        .get("decision")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| JsValue::from_str("decision.missing_decision"))?;
+    let decision = match decision_str {
+        "allow" => ReceiptDecision::Allow,
+        "deny" => ReceiptDecision::Deny,
+        "requires_human" => ReceiptDecision::RequiresHuman,
+        other => {
+            return Err(JsValue::from_str(&format!(
+                "decision.unknown: `{other}` (expected allow|deny|requires_human)"
+            )))
+        }
+    };
+    let matched_rule_id = decision_response
+        .get("matched_rule")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let deny_code = decision_response
+        .get("deny_code")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+
+    let policy_value: Value = serde_json::from_str(policy_json)
+        .map_err(|e| JsValue::from_str(&format!("policy.parse_error: {e}")))?;
+
+    let signing_seed = parse_seed_hex(signing_seed_hex)?;
+    let issued_at = chrono::DateTime::parse_from_rfc3339(issued_at_rfc3339)
+        .map_err(|e| JsValue::from_str(&format!("issued_at.parse_error: {e}")))?
+        .with_timezone(&chrono::Utc);
+
+    let capsule = build_capsule_v2_self_contained(OfflineBuildArgs {
+        aprp,
+        decision,
+        matched_rule_id,
+        deny_code,
+        policy_json: policy_value,
+        signing_seed,
+        key_id: "playground-mock-v1".to_string(),
+        issued_at,
+    })
+    .map_err(|e| JsValue::from_str(&format!("capsule.build_error: {e}")))?;
+
+    serde_wasm_bindgen::to_value(&capsule)
+        .map_err(|e| JsValue::from_str(&format!("serialize_capsule: {e}")))
+}
+
+/// Crate version exposed to JS so the playground UI can show
+/// "engine built from sbo3l-playground v1.2.0" honestly.
+#[wasm_bindgen(js_name = sbo3l_playground_version)]
+pub fn sbo3l_playground_version_js() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
+fn parse_seed_hex(s: &str) -> Result<[u8; 32], JsValue> {
+    let bytes = hex::decode(s).map_err(|e| {
+        JsValue::from_str(&format!(
+            "signing_seed.hex_decode_error: {e} (expected 64 hex chars)"
+        ))
+    })?;
+    if bytes.len() != 32 {
+        return Err(JsValue::from_str(&format!(
+            "signing_seed.length_error: expected 32 bytes, got {}",
+            bytes.len()
+        )));
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes);
+    Ok(out)
+}

--- a/crates/sbo3l-policy/Cargo.toml
+++ b/crates/sbo3l-policy/Cargo.toml
@@ -14,7 +14,14 @@ categories = ["config", "parser-implementations"]
 
 [dependencies]
 sbo3l-core = { workspace = true }
-sbo3l-storage = { workspace = true }
+# R17 P2: sbo3l-storage uses rusqlite (native sqlite3 FFI) and does
+# NOT build for `wasm32-unknown-unknown`. The budget module is the
+# only consumer; gate it behind the default-on `budget` feature so
+# `cargo build -p sbo3l-policy --no-default-features` produces a
+# wasm-clean library that exposes engine + model + expr + reputation
+# only. Workspace consumers (server, cli) keep the default features
+# and see no behaviour change.
+sbo3l-storage = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
@@ -24,6 +31,13 @@ sha2 = { workspace = true }
 hex = { workspace = true }
 serde_json_canonicalizer = { workspace = true }
 chrono = { workspace = true }
+
+[features]
+default = ["budget"]
+# Compiles the persistent budget tracker that wraps sbo3l-storage
+# transactions. Disable for wasm targets — storage's rusqlite dep
+# pulls native sqlite3 FFI that doesn't build for wasm32.
+budget = ["dep:sbo3l-storage"]
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/sbo3l-policy/src/lib.rs
+++ b/crates/sbo3l-policy/src/lib.rs
@@ -1,5 +1,6 @@
 //! SBO3L policy: YAML/JSON policy parsing and rule evaluation.
 
+#[cfg(feature = "budget")]
 pub mod budget;
 pub mod cross_chain_reputation;
 pub mod engine;
@@ -15,6 +16,7 @@ pub use cross_chain_reputation::{
 };
 pub use reputation::{compute_reputation, Reputation, ReputationRow};
 
+#[cfg(feature = "budget")]
 pub use budget::{BudgetDeny, BudgetTracker};
 pub use engine::{decide, Decision, EngineError, Outcome};
 pub use mev_guard::{

--- a/crates/sbo3l-server/Cargo.toml
+++ b/crates/sbo3l-server/Cargo.toml
@@ -32,7 +32,7 @@ required-features = ["grpc"]
 
 [dependencies]
 sbo3l-core = { workspace = true }
-sbo3l-policy = { workspace = true }
+sbo3l-policy = { workspace = true, features = ["budget"] }
 sbo3l-storage = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/sbo3l-storage/src/audit_store.rs
+++ b/crates/sbo3l-storage/src/audit_store.rs
@@ -512,7 +512,7 @@ mod tests {
         // Seed a 5-event chain (seq 1..=5).
         for i in 0..5 {
             s.audit_append(
-                NewAuditEvent::now("policy_decided", "policy_engine", &format!("pr-{i}")),
+                NewAuditEvent::now("policy_decided", "policy_engine", format!("pr-{i}")),
                 &signer,
             )
             .unwrap();

--- a/demo-agents/research-agent/Cargo.toml
+++ b/demo-agents/research-agent/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 sbo3l-core = { workspace = true }
-sbo3l-policy = { workspace = true }
+sbo3l-policy = { workspace = true, features = ["budget"] }
 sbo3l-storage = { workspace = true }
 sbo3l-server = { path = "../../crates/sbo3l-server" }
 sbo3l-identity = { workspace = true }

--- a/scripts/build-wasm-playground.sh
+++ b/scripts/build-wasm-playground.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Build the SBO3L browser playground WASM bundle (R17 P1).
+#
+# Output:
+#   apps/marketing/public/wasm/sbo3l_playground.js
+#   apps/marketing/public/wasm/sbo3l_playground_bg.wasm
+#   apps/marketing/public/wasm/sbo3l_playground.d.ts
+#   apps/marketing/public/wasm/package.json
+#
+# The marketing site's `/playground` page imports
+# `sbo3l_playground.js` and calls:
+#   - `decide_aprp_wasm(aprpJson, policyJson)` — real policy engine
+#   - `build_capsule_wasm(aprpJson, decisionJson, policyJson, seedHex, issuedAtRfc3339)`
+#     → fully self-contained sbo3l.passport_capsule.v2 (passes the
+#     6-check strict verifier with no aux input)
+#
+# Re-run this script whenever `crates/sbo3l-playground/src/*.rs` or
+# any of its transitive deps (sbo3l-core, sbo3l-policy) change.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+if ! command -v wasm-pack >/dev/null 2>&1; then
+  echo "::error::wasm-pack not found. Install via:"
+  echo "  cargo install wasm-pack"
+  echo "  # or: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh"
+  exit 1
+fi
+
+rustup target add wasm32-unknown-unknown >/dev/null 2>&1 || true
+
+OUT_DIR="apps/marketing/public/wasm"
+mkdir -p "$OUT_DIR"
+
+echo "Building sbo3l-playground WASM bundle (target=web, out=$OUT_DIR) ..."
+wasm-pack build --target web crates/sbo3l-playground --out-dir "../../$OUT_DIR"
+
+for f in sbo3l_playground.js sbo3l_playground_bg.wasm sbo3l_playground.d.ts package.json; do
+  if [ ! -f "$OUT_DIR/$f" ]; then
+    echo "::error::wasm-pack output missing: $OUT_DIR/$f"
+    exit 1
+  fi
+done
+
+# Honest size report — R17 brief targets ≤250KB gzipped; current
+# realistic ceiling is ~1MB gzipped because policy + jsonschema +
+# serde_yaml + frost-ed25519 land in the bundle. Surface the number
+# rather than fudge it.
+WASM_RAW_BYTES=$(wc -c <"$OUT_DIR/sbo3l_playground_bg.wasm")
+WASM_GZ_BYTES=$(gzip -9 <"$OUT_DIR/sbo3l_playground_bg.wasm" | wc -c)
+echo
+echo "✓ sbo3l_playground bundle:"
+printf "  raw:   %'d bytes (%.1f MB)\n" "$WASM_RAW_BYTES" "$(echo "scale=1; $WASM_RAW_BYTES/1048576" | bc)"
+printf "  gzip:  %'d bytes (%.0f KB)\n" "$WASM_GZ_BYTES" "$(echo "scale=0; $WASM_GZ_BYTES/1024" | bc)"


### PR DESCRIPTION
## Summary

New crate **`sbo3l-playground`** with three wasm-bindgen exports for the marketing-site `/playground` page:

- **`decide_aprp_wasm(aprp_json, policy_json) → DecisionResponse`** — REAL `sbo3l_policy::decide` engine in the browser. Same engine sbo3l-server runs in production. **No mock.**
- **`build_capsule_wasm(aprp_json, decision_json, policy_json, signing_seed_hex, issued_at_rfc3339) → Capsule`** — synthesises a fully self-contained `sbo3l.passport_capsule.v2` capsule that passes the **6-check strict verifier WITHOUT any auxiliary input** (policy_snapshot embedded → policy_hash_recompute PASSES; single-event audit_segment with verification_keys → audit_chain + audit_event_link + receipt_signature all PASS).
- **`sbo3l_playground_version() → string`**

Single signing seed used for both audit + receipt sigs so the embedded `verification_keys.{audit,receipt}_signer_pubkey_hex` stays honest (no key drift between roles).

## Why a separate crate

`sbo3l-policy` already depends on `sbo3l-core`. Adding sbo3l-policy to sbo3l-core's wasm32 deps creates a cycle (cargo's resolver doesn't gate on `cfg(target_arch)`). The new crate sits below both: depends on both, calls `sbo3l_policy::decide`, wraps via `passport_offline::build_capsule_v2_self_contained`.

The marketing site will import both bundles:
- `/proof`: `sbo3l_core.js` (verifier-only, 150 KB gz)
- `/playground`: `sbo3l_playground.js` (engine + capsule build)

## Workspace plumbing

- New **`sbo3l-policy/budget`** cargo feature gates the rusqlite-backed budget tracker (storage uses native sqlite3 FFI; doesn't build for wasm32). Workspace dep declares `default-features = false`; consumers needing budget (server/cli/mcp/identity/research-agent) opt-in via `features = [\"budget\"]`. The playground skips it.
- `passport_offline.rs` is `pub mod` (NOT wasm32-gated) so **10 native unit tests** exercise the builder + strict verifier directly. Round-trip pinned: deterministic byte-for-byte across runs, allow + deny capsules pass all 6 strict checks, tampered `policy_snapshot` FAILs `policy_hash_recompute`, `requires_human` rejected upstream.
- `scripts/build-wasm-playground.sh` mirrors `build-wasm-verifier.sh`.
- New CI job `wasm-playground-build` asserts artefacts + size < 6 MiB raw.

## Honest scope cuts vs the brief

- **Bundle size**: brief targeted ≤250 KB gzipped; reality is **~1 MB gzipped** because policy + jsonschema + serde_yaml + frost-ed25519 land in the bundle. Numbers reported faithfully by the build script. Tree-shaking (replace serde_yaml, prune jsonschema, drop frost-ed25519 from sbo3l-core's wasm target) is a separate optimisation pass.
- **8 wasm-pack tests** (brief): shipping **10 native unit tests** instead — same coverage scenarios via direct `passport_offline` API. wasm-pack-test integration would re-prove what the native tests prove, against the wasm-bindgen ABI. Follow-up; doesn't block the demo path.
- **Bundled file in `apps/marketing/public/wasm/`**: ships from CI rather than committed (matches the existing /proof verifier pattern — `apps/marketing/public/wasm/.gitignore = *`).

## Test plan

- [x] `cargo test --workspace --tests --no-fail-fast` → all green
- [x] `cargo test -p sbo3l-playground --lib passport_offline` → 10/10 green (incl. all-6-checks-pass + tampered-snapshot-fails)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` → clean (also fixed pre-existing `&format!()` warning in sbo3l-storage from PR #346)
- [x] `cargo fmt --all -- --check` → clean
- [x] `cargo build -p sbo3l-playground --target wasm32-unknown-unknown` → clean (release + dev)

## Coordination

Dev 3 ships Tier 2 with TS mock + \"MOCK\" badge. When this lands:
- Swap `mock-engine.ts` for `import { decide_aprp_wasm, build_capsule_wasm } from '/wasm/sbo3l_playground.js'`
- Remove the \"MOCK\" badge
- Add \"Real engine. Verify in browser.\" callout

Closes round 17 P1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)