### PR TITLE
fix(codex): batch 1 — marketing i18n fallback + OG twitter:image + mobile fixes

### DIFF
--- a/apps/marketing/astro.config.mjs
+++ b/apps/marketing/astro.config.mjs
@@ -26,8 +26,24 @@ export default defineConfig({
       'de', 'fr', 'it', 'es', 'pt-br', 'pl', 'cs', 'hu',
       'ar', 'he', 'zh-cn', 'zh-tw', 'ru', 'uk', 'tr', 'hi', 'th',
     ],
+    // Codex review fix (PR #284 + #296): we declared 17 locales in
+    // the array but only `sk/` and `ko/` page directories exist on
+    // disk. Without a fallback mapping, navigating to /de/, /ja/,
+    // /ar/, etc. via the LocaleSwitcher would 404. Fall back to EN
+    // content so the URLs resolve; i18n strings still pull from
+    // each locale's JSON via the `t()` helper in src/i18n/index.ts,
+    // so headers + CTAs translate even when the page body itself
+    // is the English file.
+    fallback: {
+      sk: 'en', ko: 'en', ja: 'en',
+      de: 'en', fr: 'en', it: 'en', es: 'en', 'pt-br': 'en',
+      pl: 'en', cs: 'en', hu: 'en',
+      ar: 'en', he: 'en', 'zh-cn': 'en', 'zh-tw': 'en',
+      ru: 'en', uk: 'en', tr: 'en', hi: 'en', th: 'en',
+    },
     routing: {
       prefixDefaultLocale: false,
+      fallbackType: 'redirect',
     },
   },
   build: {

--- a/apps/marketing/src/layouts/BaseLayout.astro
+++ b/apps/marketing/src/layouts/BaseLayout.astro
@@ -40,10 +40,17 @@ const dir = isRtlLocale(currentLocale) ? "rtl" : "ltr";
     <meta property="og:image:alt" content="SBO3L — the cryptographically verifiable trust layer for autonomous AI agents." />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta name="twitter:card" content="summary_large_image" />
+    {/*
+      Codex review fix (PR #291): X/Twitter cards do not render SVG, so the
+      previous twitter:image pointing at og-default.svg produced cards
+      without preview imagery. summary_large_image card stays declared —
+      Twitter falls back to a no-image card variant which renders the
+      title + description correctly. When a PNG hero asset ships,
+      restore twitter:image pointing at the PNG.
+    */}
+    <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content={ogTitle} />
     <meta name="twitter:description" content="Don't give your agent a wallet. Give it a mandate." />
-    <meta name="twitter:image" content="/og-default.svg" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
   </head>
   <body>

--- a/apps/marketing/src/lib/playground/mock-engine.ts
+++ b/apps/marketing/src/lib/playground/mock-engine.ts
@@ -150,8 +150,22 @@ function evalDecision(aprp: AprpEnvelope, policy: PolicyParseResult): { outcome:
   }
 
   // Expired APRP — 60-second skew tolerance.
-  if (typeof aprp.timestamp_ms === "number" && aprp.timestamp_ms < (1714565000000 - 60_000)) {
-    return { outcome: "deny", deny_code: "protocol.aprp_expired" };
+  // Codex review fix (PR #353): the previous bound was hard-coded to
+  // 1714565000000 - 60_000 (the fixed scenario timestamp), so any APRP
+  // edited in 2026+ would always pass the expiry check. Use Date.now()
+  // so the 60s tolerance behaves like the real daemon. The seeded
+  // scenarios deliberately include `deny-aprp-expired` with a
+  // ts_ms 5 minutes in the past relative to the same fixed reference
+  // point, so it still denies via the path below for that scenario.
+  const SKEW_TOLERANCE_MS = 60_000;
+  const SCENARIO_REF_MS = 1714565000000;
+  if (typeof aprp.timestamp_ms === "number") {
+    const now = Date.now();
+    const isFromSeededScenario = Math.abs(aprp.timestamp_ms - SCENARIO_REF_MS) < 24 * 60 * 60 * 1000;
+    const baseline = isFromSeededScenario ? SCENARIO_REF_MS : now;
+    if (aprp.timestamp_ms < baseline - SKEW_TOLERANCE_MS) {
+      return { outcome: "deny", deny_code: "protocol.aprp_expired" };
+    }
   }
 
   // MEV slippage breach.

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -4,12 +4,10 @@
     "slug": "sbo3l-mobile",
     "version": "0.0.1",
     "orientation": "portrait",
-    "icon": "./assets/icon.png",
     "scheme": "sbo3l",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "splash": {
-      "image": "./assets/splash.png",
       "resizeMode": "contain",
       "backgroundColor": "#0a0e1a"
     },
@@ -25,7 +23,6 @@
       "package": "dev.sbo3l.mobile",
       "permissions": ["CAMERA", "USE_BIOMETRIC"],
       "adaptiveIcon": {
-        "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#0a0e1a"
       }
     },

--- a/apps/mobile/app/verify.tsx
+++ b/apps/mobile/app/verify.tsx
@@ -1,0 +1,163 @@
+import { useLocalSearchParams } from "expo-router";
+import { useEffect, useMemo, useState } from "react";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+import { tokens } from "~/theme";
+
+// Capsule verify screen — destination of the QR scanner from app/scan.tsx.
+// Codex review fix (PR #309): scan.tsx pushed users to /verify but no
+// /verify route existed, breaking the scanner handoff.
+//
+// Real WASM verifier integration is gated on the same wasm32-wasi build
+// of sbo3l-core that the playground API depends on (see
+// apps/sbo3l-playground-api/lib/wasm-loader.ts). Until that lands, we
+// run the structural checks the mock playground does on the web —
+// schema string + presence of the load-bearing fields. The user can
+// share the capsule via the system share sheet to reach the marketing
+// /proof page where a more thorough check happens.
+
+interface CapsulePolicyReceipt {
+  request_hash?: string;
+  outcome?: "allow" | "deny" | "require_human";
+  signature?: string;
+}
+
+interface MaybeCapsule {
+  schema?: string;
+  policy_receipt?: CapsulePolicyReceipt;
+}
+
+interface StructuralCheck {
+  label: string;
+  passed: boolean;
+  detail?: string;
+}
+
+function runStructuralChecks(raw: string): { capsule?: MaybeCapsule; checks: StructuralCheck[]; parseError?: string } {
+  let parsed: MaybeCapsule;
+  try {
+    parsed = JSON.parse(raw) as MaybeCapsule;
+  } catch (e) {
+    return { checks: [], parseError: (e as Error).message };
+  }
+
+  const schema = typeof parsed.schema === "string" ? parsed.schema : "";
+  const isMock = schema === "sbo3l.playground_mock.v1";
+  const isReal = schema.startsWith("sbo3l.passport_capsule.");
+
+  const checks: StructuralCheck[] = [
+    {
+      label: "Schema string present",
+      passed: schema.length > 0,
+      detail: schema || "missing",
+    },
+    {
+      label: "Schema is a recognized capsule version",
+      passed: isMock || isReal,
+      detail: isMock ? "MOCK (sbo3l.playground_mock.v1)" : isReal ? `real (${schema})` : `unknown: ${schema}`,
+    },
+    {
+      label: "Has policy_receipt object",
+      passed: typeof parsed.policy_receipt === "object" && parsed.policy_receipt !== null,
+    },
+    {
+      label: "Has request_hash",
+      passed: typeof parsed.policy_receipt?.request_hash === "string",
+      detail: parsed.policy_receipt?.request_hash?.slice(0, 18) ?? "—",
+    },
+    {
+      label: "Has outcome (allow/deny/require_human)",
+      passed: ["allow", "deny", "require_human"].includes(parsed.policy_receipt?.outcome ?? ""),
+      detail: parsed.policy_receipt?.outcome ?? "—",
+    },
+    {
+      label: "Has signature (if real schema)",
+      passed: !isReal || (typeof parsed.policy_receipt?.signature === "string" && parsed.policy_receipt.signature !== "MOCK_NOT_SIGNED"),
+      detail: parsed.policy_receipt?.signature === "MOCK_NOT_SIGNED" ? "MOCK_NOT_SIGNED (Tier-2 capsule)" : (parsed.policy_receipt?.signature?.slice(0, 18) ?? "—"),
+    },
+  ];
+
+  return { capsule: parsed, checks };
+}
+
+export default function VerifyScreen(): JSX.Element {
+  const params = useLocalSearchParams<{ capsule?: string }>();
+  const [decoded, setDecoded] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof params.capsule === "string" && params.capsule.length > 0) {
+      // QR payloads are usually url-safe base64 of the JSON. Try
+      // decoding; fall back to the raw value if it parses already.
+      try {
+        const decodedB64 = atob(params.capsule.replace(/-/g, "+").replace(/_/g, "/"));
+        JSON.parse(decodedB64);
+        setDecoded(decodedB64);
+      } catch {
+        setDecoded(params.capsule);
+      }
+    }
+  }, [params.capsule]);
+
+  const result = useMemo(() => decoded ? runStructuralChecks(decoded) : null, [decoded]);
+
+  if (!decoded) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.muted}>No capsule supplied. Open this screen via /scan.</Text>
+      </View>
+    );
+  }
+
+  if (result?.parseError) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.error}>Capsule isn't valid JSON.</Text>
+        <Text style={styles.muted}>{result.parseError}</Text>
+      </View>
+    );
+  }
+
+  const passed = result?.checks.every((c) => c.passed) ?? false;
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={[styles.headline, passed ? styles.allow : styles.deny]}>
+        {passed ? "✓ Structural checks passed" : "✗ Capsule failed structural checks"}
+      </Text>
+      <Text style={styles.note}>
+        Mobile verifier runs structural checks only. For full strict-mode WASM
+        cryptographic verification, share this capsule to the /proof page on
+        sbo3l-marketing.vercel.app (link below).
+      </Text>
+      <View style={styles.checks}>
+        {result?.checks.map((c, i) => (
+          <View key={i} style={styles.check}>
+            <Text style={[styles.checkMark, c.passed ? styles.allow : styles.deny]}>
+              {c.passed ? "✓" : "✗"}
+            </Text>
+            <View style={styles.checkBody}>
+              <Text style={styles.checkLabel}>{c.label}</Text>
+              {c.detail && <Text style={styles.checkDetail}>{c.detail}</Text>}
+            </View>
+          </View>
+        ))}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 16, backgroundColor: tokens.bg, minHeight: "100%" },
+  center: { flex: 1, justifyContent: "center", alignItems: "center", padding: 16, backgroundColor: tokens.bg },
+  muted: { color: tokens.muted, textAlign: "center" },
+  error: { color: tokens.deny, marginBottom: 12, fontWeight: "700" },
+  headline: { fontSize: 18, fontWeight: "700", marginBottom: 8 },
+  allow: { color: tokens.accent },
+  deny: { color: tokens.deny },
+  note: { color: tokens.muted, fontSize: 13, marginBottom: 16, lineHeight: 19 },
+  checks: { gap: 6 },
+  check: { flexDirection: "row", gap: 10, padding: 10, backgroundColor: tokens.codeBg, borderColor: tokens.border, borderWidth: 1, borderRadius: tokens.rSm },
+  checkMark: { fontSize: 16, fontWeight: "700", width: 20 },
+  checkBody: { flex: 1 },
+  checkLabel: { color: tokens.fg, fontSize: 14 },
+  checkDetail: { color: tokens.muted, fontSize: 12, marginTop: 2, fontFamily: tokens.fontMono },
+});

--- a/apps/mobile/assets/README.md
+++ b/apps/mobile/assets/README.md
@@ -1,0 +1,44 @@
+# SBO3L mobile — assets
+
+This directory holds icon + splash + adaptive-icon assets for Expo
+build. Currently empty so Expo uses its built-in defaults rather than
+pointing `app.json` at files that don't exist (Codex review fix on
+PR #309 — broken file references would have failed `eas build`).
+
+## Required files (when branded assets are ready)
+
+| File | Resolution | Used by |
+|---|---|---|
+| `icon.png` | 1024×1024 PNG | iOS app icon source (Expo derives all sizes) |
+| `adaptive-icon.png` | 1024×1024 PNG, transparent BG | Android adaptive icon foreground |
+| `splash.png` | 1242×2436 PNG, transparent or `#0a0e1a` BG | iOS + Android splash |
+
+## How to wire them back into `app.json`
+
+Once committed, restore the references in `app.json`:
+
+```json
+{
+  "expo": {
+    "icon": "./assets/icon.png",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#0a0e1a"
+    },
+    "android": {
+      "adaptiveIcon": {
+        "foregroundImage": "./assets/adaptive-icon.png",
+        "backgroundColor": "#0a0e1a"
+      }
+    }
+  }
+}
+```
+
+## Brand reference
+
+The marketing site OG image at `apps/marketing/public/og-default.svg`
+shows the visual brand (wallet→mandate tagline, accent green
+`#4ade80`, dark bg `#0a0e1a`). A designer can derive the mobile
+assets from it.

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -37,6 +37,7 @@
     "@babel/core": "^7.25.0",
     "@types/jest": "^29.5.0",
     "@types/react": "~18.3.0",
+    "babel-plugin-module-resolver": "^5.0.2",
     "jest": "^29.7.0",
     "jest-expo": "~52.0.0",
     "typescript": "~5.5.0"

--- a/docs/proof/lighthouse-final.md
+++ b/docs/proof/lighthouse-final.md
@@ -12,16 +12,18 @@ the numbers were representative of historical runs, not freshly
 measured. Caught during self-review and corrected here.
 
 Why budget targets are still useful: the marketing site has had a
-Lighthouse CI workflow ([`.github/workflows/lighthouse.yml`](../../.github/workflows/lighthouse.yml))
-running on every merge for months. Historical runs have hit ≥90 on
-every axis except `/proof` mobile (WASM bundle weight). The targets
-below are the bar we hold against; **a real run before submission
-must produce numbers in the same neighborhood or any regression
-needs investigation.**
+Lighthouse CI workflow ([`.github/workflows/lighthouse.yml`](../../.github/workflows/lighthouse.yml)).
+The workflow is triggered by `workflow_dispatch` (manual run) plus a
+weekly cron at Mon 06:00 UTC — **not automatically on every merge.**
+Historical weekly runs have hit ≥90 on every axis except `/proof`
+mobile (WASM bundle weight). The targets below are the bar we hold
+against; **a real run before submission must produce numbers in the
+same neighborhood or any regression needs investigation.**
 
 Daniel: run before submission via either
-- The Lighthouse CI workflow (auto-runs on every main merge,
-  artifacts stored 90 days)
+- Manually trigger the Lighthouse CI workflow (Actions tab →
+  Lighthouse → "Run workflow"); artifacts stored 90 days
+- Wait for the next Monday 06:00 UTC weekly run
 - PageSpeed Insights at https://pagespeed.web.dev/ against
   `https://sbo3l-marketing.vercel.app` and each route below
 - Local: `pnpm --filter @sbo3l/marketing build && pnpm preview`,


### PR DESCRIPTION
## Summary

Six bugs flagged by Codex review on PRs **#284, #291, #296, #309, #332, #353**. Each fix matches the comment thread on the original PR.

| Original PR | Severity | Fix |
|---|---|---|
| #284 + #296 | P1 | \`astro.config.mjs\` adds \`i18n.fallback\` mapping every locale to \`en\` + \`fallbackType: 'redirect'\`; previously /de//ja//ar/ etc. 404'd. |
| #291 | P1 | Drop \`twitter:image\` SVG (X doesn't render SVG); switch twitter:card to \`summary\`; keep og:image SVG for Discord/LinkedIn. |
| #309 | P1 | Add \`babel-plugin-module-resolver\` dep; add \`app/verify.tsx\` route (scanner pushed there but it didn't exist); remove asset path references so Expo uses defaults; document required asset resolutions. |
| #332 | P2 | \`lighthouse-final.md\` corrected — workflow is workflow_dispatch + weekly cron, not every merge. |
| #353 | P2 | mock-engine APRP expiry uses \`Date.now()\` for edited inputs; preserves deny path for the seeded scenario via ±24h baseline detection. |

## What this does NOT cover

Two follow-up batches:
- **Batch 2** (hosted-app): WS reconnect on intentional close, dirty state after save, hydration mismatch, timezone drift, datetime-local UTC, Stripe downgrade flow, webhook retry storm, event kind mismatch
- **Batch 3** (docs): PG design doc inline-INDEX MySQL syntax + RLS empty-results claim, compliance docs CLI command alignment

## Test plan

- [ ] \`pnpm --filter @sbo3l/marketing build\` — i18n routes generate without 404s
- [ ] LocaleSwitcher click on /de or /ja resolves
- [ ] Twitter Card Validator on the deployed URL returns a clean summary card
- [ ] \`pnpm --filter @sbo3l/mobile install\` resolves with babel-plugin-module-resolver
- [ ] Mobile QR scan navigates to /verify and runs structural checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)