### PR TITLE
fix(codex): batch 2 — hosted-app — WS reconnect, dirty state, hydration, event-kind alignment

### DIFF
--- a/apps/hosted-app/__tests__/audit-exports.test.ts
+++ b/apps/hosted-app/__tests__/audit-exports.test.ts
@@ -3,10 +3,45 @@ import { eventsToCsv, eventsToJsonl } from "../app/admin/audit/exports";
 import { eventMatchesFilters, EMPTY_FILTERS } from "../app/admin/audit/AuditFilters";
 import type { TimelineEvent } from "../app/admin/audit/audit-types";
 
+// Codex review fix (PR #317): test sample updated to match the actual
+// admin_events wire format (`decision` / `operational` kinds), not the
+// dotted-kind union the previous test used. Field shape mirrors
+// crates/sbo3l-server/src/admin_events.rs::AdminEvent.
+
 const sample: TimelineEvent[] = [
-  { kind: "decision.made", agent_id: "research-01", decision: "allow", ts_ms: 1714564961000, intent: "erc20.transfer" },
-  { kind: "decision.made", agent_id: "trader-02",   decision: "deny",  deny_code: "policy.budget_exceeded", ts_ms: 1714565000000 },
-  { kind: "audit.checkpoint", agent_id: "research-01", chain_length: 42, root_hash: "0xabcdef1234567890abc", ts_ms: 1714565100000 },
+  {
+    kind: "decision",
+    id: 1,
+    tenant_id: "default",
+    agent_id: "research-01",
+    decision: "allow",
+    deny_code: null,
+    severity: "info",
+    audit_event_hash: "0xa1b2c3d4e5f60718",
+    chain_seq: 17,
+    ts_ms: 1714564961000,
+  },
+  {
+    kind: "decision",
+    id: 2,
+    tenant_id: "default",
+    agent_id: "trader-02",
+    decision: "deny",
+    deny_code: "policy.budget_exceeded",
+    severity: "warn",
+    audit_event_hash: "0xb2c3d4e5f6071829",
+    chain_seq: 18,
+    ts_ms: 1714565000000,
+  },
+  {
+    kind: "operational",
+    id: 3,
+    tenant_id: "default",
+    op_kind: "signer.rotate",
+    message: "rotated to key v3",
+    severity: "info",
+    ts_ms: 1714565100000,
+  },
 ];
 
 describe("eventsToCsv", () => {
@@ -19,14 +54,18 @@ describe("eventsToCsv", () => {
 
   it("escapes commas + quotes in description fields", () => {
     const tricky: TimelineEvent[] = [{
-      kind: "agent.discovered",
-      agent_id: "test",
-      ens_name: "weird,name\"quoted.eth",
-      pubkey_b58: "ed25519:abc",
+      kind: "operational",
+      id: 99,
+      tenant_id: "default",
+      op_kind: "test.export",
+      message: 'weird,name"quoted',
+      severity: "info",
       ts_ms: 1,
     }];
     const csv = eventsToCsv(tricky);
-    expect(csv).toContain('"test (weird,name""quoted.eth)"');
+    // describe() builds "test.export: weird,name\"quoted" — has both
+    // a comma and a doubled quote, so RFC4180 wraps + doubles.
+    expect(csv).toContain('"test.export: weird,name""quoted"');
   });
 });
 
@@ -44,15 +83,21 @@ describe("eventMatchesFilters", () => {
     for (const e of sample) expect(eventMatchesFilters(e, EMPTY_FILTERS)).toBe(true);
   });
 
-  it("decision filter narrows to allow/deny", () => {
+  it("decision filter narrows to allow", () => {
     const allowOnly = sample.filter((e) => eventMatchesFilters(e, { ...EMPTY_FILTERS, decision: "allow" }));
     expect(allowOnly).toHaveLength(1);
-    expect(allowOnly[0].kind).toBe("decision.made");
+    expect(allowOnly[0]?.kind).toBe("decision");
   });
 
-  it("agent substring matches across kinds", () => {
+  it("kind filter narrows to operational", () => {
+    const opOnly = sample.filter((e) => eventMatchesFilters(e, { ...EMPTY_FILTERS, kind: "operational" }));
+    expect(opOnly).toHaveLength(1);
+  });
+
+  it("agent substring matches decision events only", () => {
     const matched = sample.filter((e) => eventMatchesFilters(e, { ...EMPTY_FILTERS, agentSubstring: "research" }));
-    expect(matched).toHaveLength(2);
+    expect(matched).toHaveLength(1);
+    expect(matched[0]?.kind).toBe("decision");
   });
 
   it("date range filters inclusive", () => {

--- a/apps/hosted-app/app/admin/audit/AuditFilters.tsx
+++ b/apps/hosted-app/app/admin/audit/AuditFilters.tsx
@@ -35,13 +35,26 @@ const inputStyle = {
   fontSize: "0.85em",
 } as const;
 
+// Codex review fix (PR #317): `<input type="datetime-local">` displays
+// values as the user's local wall-clock time, but `toISOString()` always
+// renders UTC. Slicing to YYYY-MM-DDTHH:MM gave the input a timestamp
+// that looks like local time but is actually UTC, shifting the apparent
+// hour by the user's offset. Format the local-clock fields by hand so
+// the input shows the same time the user picked.
+function pad(n: number): string { return n.toString().padStart(2, "0"); }
+
 function tsToInputValue(ts: number | null): string {
   if (ts === null) return "";
-  return new Date(ts).toISOString().slice(0, 16);
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return "";
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
 function inputValueToTs(s: string): number | null {
   if (!s) return null;
+  // datetime-local strings are local time without offset; Date.parse on
+  // a string of the form "YYYY-MM-DDTHH:MM" interprets as local time on
+  // every modern engine, so this is the correct inverse of tsToInputValue.
   const t = Date.parse(s);
   return Number.isFinite(t) ? t : null;
 }
@@ -87,12 +100,8 @@ export function AuditFilters({ value, onChange, matchedCount, totalCount }: Prop
           style={inputStyle}
         >
           <option value="">all kinds</option>
-          <option value="decision.made">decision.made</option>
-          <option value="execution.confirmed">execution.confirmed</option>
-          <option value="audit.checkpoint">audit.checkpoint</option>
-          <option value="flag.changed">flag.changed</option>
-          <option value="agent.discovered">agent.discovered</option>
-          <option value="attestation.signed">attestation.signed</option>
+          <option value="decision">decision</option>
+          <option value="operational">operational</option>
         </select>
         <input
           aria-label="From timestamp"
@@ -115,15 +124,17 @@ export function AuditFilters({ value, onChange, matchedCount, totalCount }: Prop
 
 export function eventMatchesFilters(e: TimelineEvent, f: FilterState): boolean {
   if (f.kind && e.kind !== f.kind) return false;
-  if (f.decision && (e.kind !== "decision.made" || e.decision !== f.decision)) return false;
+  if (f.decision && (e.kind !== "decision" || e.decision !== f.decision)) return false;
   if (f.fromTs !== null && e.ts_ms < f.fromTs) return false;
   if (f.toTs !== null && e.ts_ms > f.toTs) return false;
   if (f.agentSubstring) {
     const needle = f.agentSubstring.toLowerCase();
-    const haystacks: string[] = [];
-    if ("agent_id" in e && e.agent_id) haystacks.push(e.agent_id.toLowerCase());
-    if (e.kind === "attestation.signed") haystacks.push(e.from.toLowerCase(), e.to.toLowerCase());
-    if (!haystacks.some((s) => s.includes(needle))) return false;
+    if (e.kind === "decision") {
+      if (!e.agent_id.toLowerCase().includes(needle)) return false;
+    } else {
+      // Operational events have no agent_id; agent-filter excludes them.
+      return false;
+    }
   }
   return true;
 }

--- a/apps/hosted-app/app/admin/audit/AuditTimeline.tsx
+++ b/apps/hosted-app/app/admin/audit/AuditTimeline.tsx
@@ -105,7 +105,7 @@ export function AuditTimeline({ wsUrl }: Props): JSX.Element {
             }}
           >
             <code style={{ color: "var(--muted)" }}>{new Date(e.ts_ms).toLocaleTimeString()}</code>
-            <code style={{ color: kindColor(e.kind) }}>{e.kind}</code>
+            <code style={{ color: kindColor(e) }}>{e.kind}</code>
             <span>{describe(e)}</span>
           </li>
         ))}
@@ -115,22 +115,16 @@ export function AuditTimeline({ wsUrl }: Props): JSX.Element {
 }
 
 function describe(e: TimelineEvent): string {
-  switch (e.kind) {
-    case "agent.discovered":    return `${e.agent_id} (${e.ens_name})`;
-    case "attestation.signed":  return `${e.from} → ${e.to}  ${e.attestation_id}`;
-    case "decision.made":       return `${e.agent_id}  ${e.decision}${e.deny_code ? ` (${e.deny_code})` : ""}${e.intent ? ` · ${e.intent}` : ""}`;
-    case "audit.checkpoint":    return `${e.agent_id}  chain_length=${e.chain_length}  root=${e.root_hash.slice(0, 14)}…`;
-    case "execution.confirmed": return `${e.agent_id} → ${e.sponsor}  ref=${e.execution_ref}`;
-    case "flag.changed":        return `${e.flag_name} → ${e.enabled ? "on" : "off"} (by ${e.changed_by})`;
+  if (e.kind === "decision") {
+    const tail = e.deny_code ? ` (${e.deny_code})` : "";
+    return `${e.agent_id}  ${e.decision}${tail}  chain_seq=${e.chain_seq}`;
   }
+  return `${e.op_kind}  ${e.message}`;
 }
 
-function kindColor(kind: TimelineEvent["kind"]): string {
-  switch (kind) {
-    case "decision.made":       return "var(--accent)";
-    case "execution.confirmed": return "var(--accent)";
-    case "flag.changed":        return "#ffce5c";
-    case "audit.checkpoint":    return "var(--muted)";
-    default:                    return "var(--fg)";
-  }
+function kindColor(e: TimelineEvent): string {
+  if (e.kind === "operational") return "#ffce5c";
+  if (e.severity === "warn") return "#ffce5c";
+  if (e.severity === "error") return "#f87171";
+  return e.decision === "deny" ? "#f87171" : "var(--accent)";
 }

--- a/apps/hosted-app/app/admin/audit/DecisionChart.tsx
+++ b/apps/hosted-app/app/admin/audit/DecisionChart.tsx
@@ -22,14 +22,22 @@ export function DecisionChart({ wsUrl }: Props): JSX.Element {
   const reconnectTimer = useRef<number | null>(null);
 
   useEffect(() => {
+    // Codex review fix (PR #288): the previous close handler scheduled
+    // a reconnect unconditionally, including when the component
+    // unmounted or wsUrl changed. That left a background reconnect
+    // loop after unmount and re-opened sockets to stale URLs after
+    // prop changes. `shouldReconnect` flag gates reconnects to
+    // unexpected disconnects only.
+    let shouldReconnect = true;
     const connect = (): void => {
+      if (!shouldReconnect) return;
       setState("connecting");
       let ws: WebSocket;
       try {
         ws = new WebSocket(wsUrl);
       } catch {
         setState("offline");
-        reconnectTimer.current = window.setTimeout(connect, 3000);
+        if (shouldReconnect) reconnectTimer.current = window.setTimeout(connect, 3000);
         return;
       }
       wsRef.current = ws;
@@ -42,6 +50,7 @@ export function DecisionChart({ wsUrl }: Props): JSX.Element {
         } catch { /* ignore malformed */ }
       });
       ws.addEventListener("close", () => {
+        if (!shouldReconnect) return;
         setState("offline");
         reconnectTimer.current = window.setTimeout(connect, 3000);
       });
@@ -49,6 +58,7 @@ export function DecisionChart({ wsUrl }: Props): JSX.Element {
     };
     connect();
     return () => {
+      shouldReconnect = false;
       if (reconnectTimer.current !== null) window.clearTimeout(reconnectTimer.current);
       wsRef.current?.close();
     };
@@ -57,7 +67,7 @@ export function DecisionChart({ wsUrl }: Props): JSX.Element {
   const decisionData = useMemo(() => {
     let allow = 0, deny = 0;
     for (const e of events) {
-      if (e.kind !== "decision.made") continue;
+      if (e.kind !== "decision") continue;
       if (e.decision === "allow") allow += 1;
       else deny += 1;
     }
@@ -70,7 +80,7 @@ export function DecisionChart({ wsUrl }: Props): JSX.Element {
   const denyCodeData = useMemo(() => {
     const counts = new Map<string, number>();
     for (const e of events) {
-      if (e.kind !== "decision.made" || e.decision !== "deny" || !e.deny_code) continue;
+      if (e.kind !== "decision" || e.decision !== "deny" || !e.deny_code) continue;
       counts.set(e.deny_code, (counts.get(e.deny_code) ?? 0) + 1);
     }
     return [...counts.entries()]

--- a/apps/hosted-app/app/admin/audit/audit-types.ts
+++ b/apps/hosted-app/app/admin/audit/audit-types.ts
@@ -1,29 +1,61 @@
-// Shared types + WS plumbing for the audit page.
-// Both <AuditTimeline> (textual feed) and <DecisionChart> (recharts viz)
-// consume the same /v1/events shape. Keeping the union in one place
-// avoids drift when Dev 1 ships new event kinds.
+// Shared types for the /admin/audit page. Both <AuditTimeline> (textual
+// feed) and <DecisionChart> (recharts viz) consume `/v1/admin/events`,
+// emitted by crate::sbo3l_server::admin_events::AdminEvent.
+//
+// Codex review fix (PR #317): the previous union used dotted kinds
+// (`decision.made`, `execution.confirmed`, …) which never match
+// AdminEvent's serde-tagged kinds (`decision`, `operational`). Result:
+// every incoming WS frame failed `isTimelineEvent` and the timeline /
+// chart stayed empty even when the socket was live.
+//
+// Wire format anchor: crates/sbo3l-server/src/admin_events.rs defines
+// `#[serde(tag = "kind")] enum AdminEvent { Decision {...}, Operational {...} }`.
 
-export type TimelineEvent =
-  | { kind: "agent.discovered";    agent_id: string; ens_name: string; pubkey_b58: string; ts_ms: number }
-  | { kind: "attestation.signed";  from: string; to: string; attestation_id: string; ts_ms: number }
-  | { kind: "decision.made";       agent_id: string; decision: "allow" | "deny"; deny_code?: string; ts_ms: number; intent?: string }
-  | { kind: "audit.checkpoint";    agent_id: string; chain_length: number; root_hash: string; ts_ms: number }
-  | { kind: "execution.confirmed"; agent_id: string; execution_ref: string; sponsor: string; ts_ms: number }
-  | { kind: "flag.changed";        flag_name: string; enabled: boolean; changed_by: string; ts_ms: number };
+export interface DecisionEvent {
+  kind: "decision";
+  id: number;
+  tenant_id: string;
+  agent_id: string;
+  decision: "allow" | "deny";
+  deny_code: string | null;
+  severity: "info" | "warn" | "error";
+  audit_event_hash: string;
+  chain_seq: number;
+  ts_ms: number;
+}
+
+export interface OperationalEvent {
+  kind: "operational";
+  id: number;
+  tenant_id: string;
+  op_kind: string;
+  message: string;
+  severity: "info" | "warn" | "error";
+  ts_ms: number;
+}
+
+export type TimelineEvent = DecisionEvent | OperationalEvent;
 
 export type ConnState = "connecting" | "live" | "offline";
 
 export const KIND_LABEL: Record<TimelineEvent["kind"], string> = {
-  "agent.discovered":    "agent.discovered",
-  "attestation.signed":  "attestation.signed",
-  "decision.made":       "decision.made",
-  "audit.checkpoint":    "audit.checkpoint",
-  "execution.confirmed": "execution.confirmed",
-  "flag.changed":        "flag.changed",
+  decision: "decision",
+  operational: "operational",
 };
 
 export function isTimelineEvent(value: unknown): value is TimelineEvent {
   if (typeof value !== "object" || value === null) return false;
-  const v = value as { kind?: unknown };
-  return typeof v.kind === "string" && v.kind in KIND_LABEL;
+  const v = value as Record<string, unknown>;
+  if (typeof v.kind !== "string") return false;
+  if (typeof v.ts_ms !== "number") return false;
+  if (typeof v.tenant_id !== "string") return false;
+  if (typeof v.id !== "number") return false;
+  if (v.kind === "decision") {
+    return typeof v.agent_id === "string"
+      && (v.decision === "allow" || v.decision === "deny");
+  }
+  if (v.kind === "operational") {
+    return typeof v.op_kind === "string" && typeof v.message === "string";
+  }
+  return false;
 }

--- a/apps/hosted-app/app/admin/audit/exports.ts
+++ b/apps/hosted-app/app/admin/audit/exports.ts
@@ -17,14 +17,10 @@ const CSV_HEADERS = [
 ] as const;
 
 function describe(e: TimelineEvent): string {
-  switch (e.kind) {
-    case "agent.discovered":    return `${e.agent_id} (${e.ens_name})`;
-    case "attestation.signed":  return `${e.from} → ${e.to} ${e.attestation_id}`;
-    case "decision.made":       return e.intent ?? "";
-    case "audit.checkpoint":    return `chain_length=${e.chain_length} root=${e.root_hash.slice(0, 14)}…`;
-    case "execution.confirmed": return `→ ${e.sponsor} ref=${e.execution_ref}`;
-    case "flag.changed":        return `${e.flag_name} → ${e.enabled ? "on" : "off"} (by ${e.changed_by})`;
+  if (e.kind === "decision") {
+    return `chain_seq=${e.chain_seq} hash=${e.audit_event_hash.slice(0, 14)}…`;
   }
+  return `${e.op_kind}: ${e.message}`;
 }
 
 function escapeCsvField(value: string): string {
@@ -36,9 +32,9 @@ function escapeCsvField(value: string): string {
 
 export function eventsToCsv(events: TimelineEvent[]): string {
   const rows = events.map((e) => {
-    const agentId = "agent_id" in e ? e.agent_id : e.kind === "attestation.signed" ? `${e.from}→${e.to}` : "";
-    const decision = e.kind === "decision.made" ? e.decision : "";
-    const denyCode = e.kind === "decision.made" ? e.deny_code ?? "" : "";
+    const agentId = e.kind === "decision" ? e.agent_id : "";
+    const decision = e.kind === "decision" ? e.decision : "";
+    const denyCode = e.kind === "decision" ? (e.deny_code ?? "") : "";
     return [
       new Date(e.ts_ms).toISOString(),
       String(e.ts_ms),

--- a/apps/hosted-app/app/admin/audit/page.tsx
+++ b/apps/hosted-app/app/admin/audit/page.tsx
@@ -19,12 +19,14 @@ export default function AdminAuditPage() {
         </nav>
       </header>
       <p style={{ color: "var(--muted)", marginBottom: "1.5em", maxWidth: 760 }}>
-        Live tail of the daemon's <code>/v1/events</code> WebSocket bus.
-        Every <code>policy.decision</code>, <code>execution.confirmed</code>,
-        <code>flag.changed</code>, and <code>audit.checkpoint</code> appears here in
-        real time. Filter inline; export the buffered window as JSONL for
-        post-hoc analysis. Buffered window holds the last 200 events; older
-        events scroll off (full chain remains in the daemon's audit DB).
+        Live tail of the daemon's <code>/v1/admin/events</code> WebSocket bus.
+        Each <code>kind: "decision"</code> frame carries the agent's
+        decision, deny code (if any), severity, audit-event hash, and
+        chain seq; <code>kind: "operational"</code> covers signer rotations
+        + flag changes. Filter inline; export the buffered window as
+        JSONL or CSV for post-hoc analysis. Buffered window holds the
+        last 500 events; older events scroll off (full chain remains in
+        the daemon's audit DB).
       </p>
 
       <DecisionChart wsUrl={wsUrl} />

--- a/apps/hosted-app/app/api/billing/webhook/route.ts
+++ b/apps/hosted-app/app/api/billing/webhook/route.ts
@@ -41,11 +41,20 @@ export async function POST(req: Request): Promise<NextResponse> {
   }
 }
 
+// Codex review fix (PR #311): the previous handlers returned HTTP 400
+// when tenant_uuid metadata was missing, which makes Stripe retry the
+// event up to ~3 days. Real subscriptions created outside our exact
+// Checkout flow (manual ones, legacy ones, ones from a different
+// app sharing the Stripe account) lack our metadata and would loop
+// indefinitely. Treat missing metadata as "ignored" with a 2xx so
+// Stripe drops the event from its retry queue instead.
+
 async function handleCheckoutCompleted(session: Stripe.Checkout.Session): Promise<NextResponse> {
   const tenantUuid = session.metadata?.tenant_uuid;
   const targetTier = session.metadata?.target_tier;
   if (!tenantUuid || !targetTier) {
-    return NextResponse.json({ error: "missing_metadata" }, { status: 400 });
+    console.warn("[stripe] checkout.session.completed missing metadata — ignored", { sessionId: session.id });
+    return NextResponse.json({ received: true, ignored: true, reason: "missing_metadata" });
   }
   // TODO: POST to daemon /v1/tenants/<uuid>/billing with
   // { tier: targetTier, stripe_customer: session.customer, stripe_subscription: session.subscription }
@@ -56,17 +65,26 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session): Promis
 
 async function handleSubscriptionChange(sub: Stripe.Subscription): Promise<NextResponse> {
   const tenantUuid = sub.metadata?.tenant_uuid;
-  if (!tenantUuid) return NextResponse.json({ error: "missing_tenant_metadata" }, { status: 400 });
+  if (!tenantUuid) {
+    console.warn("[stripe] subscription change missing tenant_uuid metadata — ignored", { subId: sub.id });
+    return NextResponse.json({ received: true, ignored: true, reason: "missing_tenant_metadata" });
+  }
   const priceId = sub.items.data[0]?.price.id;
   const tier = priceId ? tierFromPriceId(priceId) : null;
-  if (!tier) return NextResponse.json({ error: "unknown_price", priceId }, { status: 400 });
+  if (!tier) {
+    console.warn("[stripe] subscription change with unknown price — ignored", { tenantUuid, priceId });
+    return NextResponse.json({ received: true, ignored: true, reason: "unknown_price", priceId });
+  }
   console.log("[stripe] subscription.changed", { tenantUuid, tier, status: sub.status });
   return NextResponse.json({ received: true, tenant: tenantUuid, tier });
 }
 
 async function handleSubscriptionDeleted(sub: Stripe.Subscription): Promise<NextResponse> {
   const tenantUuid = sub.metadata?.tenant_uuid;
-  if (!tenantUuid) return NextResponse.json({ error: "missing_tenant_metadata" }, { status: 400 });
+  if (!tenantUuid) {
+    console.warn("[stripe] subscription.deleted missing tenant_uuid metadata — ignored", { subId: sub.id });
+    return NextResponse.json({ received: true, ignored: true, reason: "missing_tenant_metadata" });
+  }
   // Downgrade to free on deletion. Daemon enforces the new quota
   // immediately; if the user reactivates, the next subscription.created
   // event upgrades them back.

--- a/apps/hosted-app/app/t/[tenant]/admin/billing/page.tsx
+++ b/apps/hosted-app/app/t/[tenant]/admin/billing/page.tsx
@@ -9,6 +9,22 @@ interface Props { params: Promise<{ tenant: string }> }
 
 export const dynamic = "force-dynamic";
 
+// Codex review fix (PR #297): formatting an ISO date string with
+// `new Date(...).toLocaleDateString()` interprets bare YYYY-MM-DD
+// as UTC midnight and then displays in the runtime's local timezone.
+// On a server in negative UTC offset (Pacific time, etc.) this
+// shows the day BEFORE the stored date. Use a fixed UTC formatter
+// so the displayed invoice date matches the stored value byte-for-byte.
+function formatStableDate(iso: string): string {
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return new Intl.DateTimeFormat("en-CA", { timeZone: "UTC", year: "numeric", month: "2-digit", day: "2-digit" }).format(d);
+  } catch {
+    return iso;
+  }
+}
+
 export default async function TenantBillingPage({ params }: Props): Promise<JSX.Element> {
   const { tenant: slug } = await params;
   const tenant = tenantBySlug(slug);
@@ -42,7 +58,7 @@ export default async function TenantBillingPage({ params }: Props): Promise<JSX.
       <header style={{ marginBottom: "1.5em" }}>
         <h1 style={{ marginBottom: "0.2em" }}>Billing — {tenant.display_name}</h1>
         <p style={{ color: "var(--muted)", margin: 0, maxWidth: 760 }}>
-          Tier <code>{billing.tier}</code>{billing.next_invoice_at && <> · next invoice {new Date(billing.next_invoice_at).toLocaleDateString()}</>}
+          Tier <code>{billing.tier}</code>{billing.next_invoice_at && <> · next invoice {formatStableDate(billing.next_invoice_at)}</>}
           {billing.payment_method && <> · {billing.payment_method}</>}.
         </p>
       </header>
@@ -78,16 +94,29 @@ export default async function TenantBillingPage({ params }: Props): Promise<JSX.
                 <li>· {limits.support_sla}</li>
               </ul>
               <div style={{ marginTop: "0.8em" }}>
+                {/*
+                  Codex review fix (PR #311): the previous "Downgrade"
+                  button hit /api/billing/checkout which creates a NEW
+                  Stripe subscription line item. For an
+                  enterprise → pro downgrade that produced a duplicate
+                  active subscription instead of changing the existing
+                  plan. Downgrades must use the Customer Portal
+                  (Stripe-hosted, lets the user pick the new plan from
+                  their existing subscription). Upgrades remain on
+                  Checkout where new-subscription semantics are correct.
+                */}
                 {isCurrent ? (
                   <span style={{ fontSize: "0.85em", color: "var(--accent)" }}>● current plan</span>
-                ) : tier === "free" ? (
-                  <span style={{ fontSize: "0.75em", color: "var(--muted)" }}>Downgrade via Customer Portal</span>
+                ) : limits.monthly_usd < TIER_LIMITS[billing.tier].monthly_usd ? (
+                  <span style={{ fontSize: "0.78em", color: "var(--muted)" }}>
+                    Downgrade via Customer Portal
+                  </span>
                 ) : (
                   <UpgradeButton
                     tenantSlug={slug}
                     targetTier={tier as "pro" | "enterprise"}
-                    isUpgrade={limits.monthly_usd > TIER_LIMITS[billing.tier].monthly_usd}
-                    label={limits.monthly_usd > TIER_LIMITS[billing.tier].monthly_usd ? "Upgrade" : "Downgrade"}
+                    isUpgrade={true}
+                    label="Upgrade"
                   />
                 )}
               </div>

--- a/apps/hosted-app/app/t/[tenant]/admin/policy/edit/PolicyEditor.tsx
+++ b/apps/hosted-app/app/t/[tenant]/admin/policy/edit/PolicyEditor.tsx
@@ -21,11 +21,34 @@ interface Props {
 
 type SaveState = "idle" | "validating" | "saving" | "saved" | "error";
 
+// Codex review fix (PR #290): formatting an ISO timestamp with
+// `new Date(...).toLocaleDateString()` during render produces different
+// output between server pre-render (server's locale/timezone) and browser
+// hydration (user's locale/timezone), which causes hydration mismatches
+// and date text flicker. Format on the server with a fixed locale +
+// UTC timezone so the initial client render matches the SSR HTML byte
+// for byte.
+function formatStableDate(iso: string): string {
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return new Intl.DateTimeFormat("en-CA", { timeZone: "UTC", year: "numeric", month: "2-digit", day: "2-digit" }).format(d);
+  } catch {
+    return iso;
+  }
+}
+
 export function PolicyEditor({ initialYaml, version, signedBy, updatedAt, tenantSlug }: Props): JSX.Element {
   const [yaml, setYaml] = useState(initialYaml);
+  // Codex review fix (PR #290): the previous `dirty = yaml !== initialYaml`
+  // computed against the immutable prop, so the UI kept showing
+  // "unsaved changes" + an enabled Save button even after a successful
+  // save told the user the draft persisted. After save we advance the
+  // baseline + version so the dirty state reflects reality.
+  const [savedBaseline, setSavedBaseline] = useState({ yaml: initialYaml, version });
   const [state, setState] = useState<SaveState>("idle");
   const [errorMsg, setErrorMsg] = useState("");
-  const dirty = yaml !== initialYaml;
+  const dirty = yaml !== savedBaseline.yaml;
 
   const onValidate = (): void => {
     setState("validating");
@@ -49,8 +72,10 @@ export function PolicyEditor({ initialYaml, version, signedBy, updatedAt, tenant
     // Mock save. Real impl: POST /v1/tenants/<slug>/policy with the
     // YAML body + If-Match: <version> for optimistic concurrency.
     setTimeout(() => {
+      const newVersion = savedBaseline.version + 1;
+      setSavedBaseline({ yaml, version: newVersion });
       setState("saved");
-      setErrorMsg(`Saved as draft v${version + 1} (mock — daemon round-trip pending P3.5).`);
+      setErrorMsg(`Saved as draft v${newVersion} (mock — daemon round-trip pending P3.5).`);
     }, 600);
   };
 
@@ -58,7 +83,7 @@ export function PolicyEditor({ initialYaml, version, signedBy, updatedAt, tenant
     <div style={{ display: "grid", gap: "1em" }}>
       <header style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", flexWrap: "wrap", gap: "0.6em" }}>
         <span style={{ color: "var(--muted)", fontSize: "0.9em", fontFamily: "var(--font-mono)" }}>
-          {tenantSlug} · v{version} · signed by <code>{signedBy}</code> · updated {new Date(updatedAt).toLocaleDateString()}
+          {tenantSlug} · v{savedBaseline.version} · signed by <code>{signedBy}</code> · updated {formatStableDate(updatedAt)}
         </span>
         <span style={{ fontSize: "0.85em", color: dirty ? "var(--accent)" : "var(--muted)" }}>
           {dirty ? "● unsaved changes" : "○ no changes"}


### PR DESCRIPTION
## Summary

Eight bugs flagged by Codex review on PRs **#288, #290, #297, #311, #317**.

| Original PR | Severity | Fix |
|---|---|---|
| #288 | P1 | \`DecisionChart\` reconnect timer no longer fires after intentional close (shouldReconnect flag) |
| #290 | P2 | \`PolicyEditor\` dirty baseline advances on save; \`updatedAt\` formatted with UTC + en-CA to fix SSR hydration mismatch |
| #297 | P2 | Billing page \`next_invoice_at\` formatted with same stable UTC formatter |
| #311 | P1 | \"Downgrade\" button switched to Customer Portal copy (Checkout creates duplicate subs); webhook returns 2xx + \`ignored: true\` on missing metadata to stop Stripe retry storms |
| #317 | P1 | \`audit-types\` realigned to actual \`/v1/admin/events\` wire format (\`decision\` / \`operational\` kinds, not \`decision.made\` etc.) — previously \`isTimelineEvent\` rejected every frame and the timeline stayed empty |
| #317 | P2 | \`tsToInputValue\` formats local wall-clock manually instead of via \`toISOString()\` slice (UTC drift) |

Tests in \`__tests__/audit-exports.test.ts\` rewritten to match the new wire shape.

## Test plan

- [ ] \`pnpm --filter @sbo3l/hosted-app typecheck\` clean
- [ ] \`pnpm --filter @sbo3l/hosted-app test\` passes
- [ ] /admin/audit shows live frames after the daemon's \`/v1/admin/events\` is reachable
- [ ] Stripe CLI replay of \`customer.subscription.updated\` without our metadata returns 200 + ignored
- [ ] Policy editor save flow clears the dirty indicator + advances the version

🤖 Generated with [Claude Code](https://claude.com/claude-code)