### PR TITLE
fix(codex): batch 3 — docs alignment with shipped CLI + PG design correctness

### DIFF
--- a/docs/compliance/audit-log-as-evidence.md
+++ b/docs/compliance/audit-log-as-evidence.md
@@ -73,56 +73,75 @@
 
 ## Auditor walkthrough script
 
-This is the script we recommend an external auditor follow when validating SBO3L's audit posture for any of the four frameworks.
+This is the script we recommend an external auditor follow when validating SBO3L's audit posture for any of the four frameworks. Every command below maps to a real subcommand on the shipped `sbo3l` CLI (run `sbo3l --help` for the full surface).
 
 ### 1. Verify chain by construction
 
+The daemon stores its audit chain in a SQLite file plus exposes a JSONL export. To verify the entire chain:
+
 ```bash
-# Take any production daemon's audit DB (or the demo capsule)
-sbo3l verify-audit --strict-hash --db /path/to/sbo3l.db
-# Expected: exit 0; no errors; "verified N events, last chain_hash=..."
+# Step A: ask the daemon for a JSONL dump of the chain (or use a saved one)
+sbo3l audit export \
+  --receipt /path/to/some-receipt.json \
+  --db /path/to/sbo3l.db \
+  --receipt-pubkey <hex32> \
+  --audit-pubkey <hex32> \
+  --out /tmp/chain.jsonl-bundle.json
+
+# Step B: re-verify the bundle
+sbo3l audit verify-bundle --path /tmp/chain.jsonl-bundle.json
+# Expected: exit 0
 ```
 
-If verification fails, EITHER:
+Or for a standalone JSONL file (one `SignedAuditEvent` per line):
+
+```bash
+sbo3l verify-audit --path /path/to/chain.jsonl --pubkey <hex32>
+# Expected: exit 0
+```
+
+If verification fails:
 - The DB has been tampered with (cause for incident response), OR
 - A bug exists in the verifier (cause for `SECURITY.md` report)
 
 ### 2. Verify by spot-check
 
+The CLI does not currently expose a single-row inspector — `sbo3l audit show` and `sbo3l audit canonical-hash` are NOT shipped subcommands (verified in `crates/sbo3l-cli/src/main.rs::AuditCmd`). To spot-check one event:
+
 ```bash
-# Pick any audit row
-sbo3l audit show --seq 42 --db /path/to/sbo3l.db
-# Re-derive the payload_hash from the JSON
-echo "$payload_json" | sbo3l audit canonical-hash
-# Compare to the stored payload_hash — must match byte-for-byte
+# Use sqlite to read one row directly
+sqlite3 /path/to/sbo3l.db \
+  "SELECT seq, payload, chain_hash_v2 FROM audit_events WHERE seq = 42"
+# Then re-export the bundle prefix containing that seq via
+# sbo3l audit export and run sbo3l audit verify-bundle on it.
 ```
+
+A single-row CLI inspector + canonical-hash printer is on the
+roadmap in [`docs/dev3/scope-cut-report.md`](../dev3/scope-cut-report.md).
 
 ### 3. Verify by external proof
 
 ```bash
 # Drop the corresponding capsule into the /proof page WASM verifier
-# (https://sbo3l.dev/proof or local equivalent)
-# Confirm 6/6 ✅ checks pass
+# (https://sbo3l-marketing.vercel.app/proof or local equivalent)
+# Confirm all strict-mode checks pass
 ```
+
+The capsule itself is produced by `sbo3l passport run` and verified offline by `sbo3l passport verify --strict --receipt-pubkey <hex> --audit-bundle <bundle.json> --policy <policy.json>`.
 
 ### 4. Verify the policy boundary
 
 ```bash
-# Re-derive the policy hash from the live policy file
-sbo3l policy current --hash
-# Compare to the ENS text record on the agent's ENS name
-# Confirm byte-for-byte match
+# Re-derive the policy hash from a snapshot
+sbo3l audit export ... --out /tmp/bundle.json
+# Inspect bundle.policy.policy_hash; compare to ENS text record
 ```
+
+`sbo3l policy current` is not a shipped subcommand. The bundle exported in step 1 carries the active policy hash inline; that is the canonical surface.
 
 ### 5. Verify chain Ed25519 signature
 
-```bash
-# Extract the daemon's pubkey from sbo3l-identity
-sbo3l identity export-pubkey
-# Verify the chain_hash_v2 signature against this pubkey for any row
-sbo3l audit verify-row --seq 42 --pubkey <hex>
-# Expected: "valid"
-```
+`sbo3l verify-audit --pubkey <hex>` from step 1 already verifies every event's signature. There is no `sbo3l audit verify-row` subcommand.
 
 ### 6. Verify chain Ed25519 cannot be forged without the key
 

--- a/docs/compliance/gdpr-posture.md
+++ b/docs/compliance/gdpr-posture.md
@@ -53,11 +53,11 @@ SBO3L's design **minimizes** personal data — the capsule schema is structurall
 
 | Right | SBO3L support | Notes |
 |---|---|---|
-| Right of access (Art. 15) | ✅ via `sbo3l audit query --agent-id <id>` | Returns full audit history for that agent |
+| Right of access (Art. 15) | ⚠️ **roadmap** — no shipped CLI today; auditors query via direct SQLite (`SELECT … FROM audit_events WHERE agent_id = …`) or via `sbo3l audit export --receipt <r>` for the bundle around a specific receipt | A dedicated `sbo3l audit query --agent-id <id>` subcommand is on the roadmap (see `docs/dev3/scope-cut-report.md`) |
 | Right to rectification (Art. 16) | ⚠️ **structurally limited** — audit chain is append-only by design | Corrections appended as new audit rows referencing the prior; original NOT deleted (audit integrity) |
 | Right to erasure (Art. 17) | ⚠️ **structurally limited** — see "Right to be forgotten" below | |
 | Right to restriction (Art. 18) | ✅ — per-agent disable via PolicyReceipt revocation | |
-| Right to portability (Art. 20) | ✅ — capsule export via `sbo3l passport export` | JSON format; trivially portable |
+| Right to portability (Art. 20) | ✅ — capsule export via `sbo3l passport run` (which writes a `sbo3l.passport_capsule.v1` JSON for any past APRP), plus `sbo3l audit export` for the audit bundle | JSON format; trivially portable. There is no shipped `sbo3l passport export` subcommand — `passport run` produces the capsule + `audit export` packages the chain. |
 | Right to object (Art. 21) | ✅ via API access revocation | |
 | Automated decision-making (Art. 22) | ✅ — every policy decision is human-readable + appealable | The PolicyReceipt itself is the explanation; deny-codes are categorized |
 

--- a/docs/dev3/production/01-postgres-rls-migration.md
+++ b/docs/dev3/production/01-postgres-rls-migration.md
@@ -62,9 +62,13 @@ CREATE TABLE audit_events (
   ts_ms         BIGINT NOT NULL,
   kind          TEXT NOT NULL,
   agent_id      TEXT,
-  payload_jsonb JSONB NOT NULL,
-  INDEX idx_audit_tenant_ts (tenant_uuid, ts_ms DESC)
+  payload_jsonb JSONB NOT NULL
 );
+-- Postgres takes indexes as separate statements (the inline INDEX
+-- clause above is MySQL-style and will fail to parse on PG). The
+-- shipped migration in V020__postgres_init.sql already does this
+-- correctly; this doc snippet is the example any engineer would copy.
+CREATE INDEX idx_audit_tenant_ts ON audit_events (tenant_uuid, ts_ms DESC);
 
 CREATE TABLE capsules (
   capsule_id    TEXT PRIMARY KEY,
@@ -99,8 +103,31 @@ Daemon sets the GUC at the start of every transaction:
 SET LOCAL app.tenant_uuid = '<resolved-from-jwt>';
 ```
 
-A bug in the daemon that leaks the wrong UUID is contained by the RLS
-fence; misconfiguration shows up as empty results, not data leakage.
+RLS contains the failure mode where the daemon **forgets to set**
+`app.tenant_uuid` at all — `current_setting` errors out (or, with the
+`missing_ok = true` form, returns NULL), and the policy denies. That
+case shows up as empty result sets, not data leakage.
+
+**RLS does NOT contain the failure mode where the daemon sets the
+GUC to the wrong tenant's UUID** (e.g. via a JWT-claim mix-up). The
+policy then evaluates true for that other tenant's rows and serves
+them. Defence requires an explicit *application-layer* membership
+check before setting the GUC, e.g.:
+
+```rust
+let user_id = jwt.sub;
+let claimed_tenant = jwt.tenant;
+let allowed = memberships
+    .has(user_id, claimed_tenant)
+    .await?;                               // explicit auth check
+if !allowed { return Err(Forbidden); }
+sqlx::raw_sql(&format!(
+    "SET LOCAL app.tenant_uuid = '{}'", claimed_tenant
+)).execute(&mut *tx).await?;
+```
+
+Treat the GUC as a *consequence* of an authorization decision the
+application has already made, not a substitute for one.
 
 ## Migration steps
 


### PR DESCRIPTION
## Summary

Four bugs flagged by Codex review on PRs **#287, #294** — all in design / compliance docs.

| Original PR | Severity | Fix |
|---|---|---|
| #287 | P2 | \`audit-log-as-evidence.md\` 6-step walkthrough rewritten — every command now matches the shipped \`sbo3l-cli\` surface (\`verify-audit --path …\`, \`audit { export, verify-bundle, anchor, … }\`, \`passport { verify, run, explain }\`). Removed references to \`audit show\`, \`audit canonical-hash\`, \`audit verify-row\`, \`policy current\` — none exist. |
| #287 | P2 | \`gdpr-posture.md\` DSAR table corrected — \`audit query\` not shipped (Art. 15 marked roadmap with actual SQLite workaround); \`passport export\` not shipped (Art. 20 flow is \`passport run\` + \`audit export\`). |
| #294 | P1 | Postgres design doc CREATE TABLE used MySQL inline-INDEX syntax. PG rejects that at parse time. Pulled into separate CREATE INDEX statement matching what \`V020__postgres_init.sql\` already does. |
| #294 | P1 | RLS section claimed wrong-UUID failure mode shows up as empty results — false. Empty results only happen when the GUC is **unset**; if the daemon sets it to ANOTHER valid tenant's UUID, RLS happily returns that tenant's rows. Rewrote with the precise distinction + example membership-check code. |

## Test plan

- [ ] Every command in the auditor walkthrough is runnable on a fresh checkout (`sbo3l --help` confirms each subcommand exists)
- [ ] Postgres design doc CREATE TABLE block parses against `psql --syntax-check`
- [ ] RLS section accurately distinguishes the two failure modes (unset GUC vs wrong UUID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)