### PR TITLE
fix(dev4): 16 codex review feedback bugs across R9-R14 PRs

### DIFF
--- a/.github/workflows/ccip-gateway.yml
+++ b/.github/workflows/ccip-gateway.yml
@@ -68,7 +68,11 @@ jobs:
 
   deploy-preview:
     name: Vercel preview deploy
-    if: github.event_name == 'pull_request'
+    # Skip on fork PRs and Dependabot — they don't get repo secrets, so
+    # the `vercel pull/build/deploy` calls would receive empty
+    # credentials and fail the check spuriously. Only run when the PR
+    # head ref lives in this repo.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     needs: typecheck
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/apps/ccip-gateway/src/app/api/[sender]/[data]/route.ts
+++ b/apps/ccip-gateway/src/app/api/[sender]/[data]/route.ts
@@ -24,6 +24,7 @@ import type { Hex } from "viem";
 import { decodeResolverCall } from "@/lib/ens";
 import { lookupByNode } from "@/lib/records";
 import {
+  encodeAddressResult,
   encodeEmptyStringResult,
   encodeStringResult,
   signGatewayResponse,
@@ -97,10 +98,12 @@ export async function GET(_req: Request, { params }: RouteParams) {
     const value = agent.records[decoded.key] ?? "";
     resultBytes = encodeStringResult(value);
   } else {
-    // addr(node) — for now, return zero address. Agents don't have
-    // their own EVM addresses bound at the resolver level in T-4-1;
-    // T-4-2 ERC-8004 entry carries the address.
-    resultBytes = encodeStringResult("");
+    // addr(node) — return zero address. Agents don't have their own
+    // EVM addresses bound at the resolver level in T-4-1; T-4-2
+    // ERC-8004 entry carries the address. MUST encode as ABI-encoded
+    // address (32-byte word), NOT as `string`, or viem.getEnsAddress
+    // mis-decodes the (offset, length) header as an address.
+    resultBytes = encodeAddressResult("0x0000000000000000000000000000000000000000");
   }
 
   try {

--- a/crates/sbo3l-cli/src/agent_reputation_broadcast.rs
+++ b/crates/sbo3l-cli/src/agent_reputation_broadcast.rs
@@ -154,6 +154,25 @@ pub async fn cmd_broadcast(args: ReputationPublishArgs, network: EnsNetwork) -> 
     };
     println!("  chain_id:       {chain_id}");
 
+    // Refuse if RPC chain id doesn't match `--network`. Otherwise an
+    // operator passing `--network sepolia` with a mainnet RPC silently
+    // sends `setText` to the wrong chain (with the right resolver
+    // address shape, since ENS Public Resolvers live at different
+    // mainnet/Sepolia addresses but EOAs may collide on chain).
+    let expected_chain_id = match network {
+        EnsNetwork::Mainnet => 1u64,
+        EnsNetwork::Sepolia => 11_155_111u64,
+    };
+    if chain_id != expected_chain_id {
+        eprintln!(
+            "sbo3l agent reputation-publish --broadcast: --network {} expects chain_id {}, but RPC reports {}. Refusing to broadcast against mismatched chain.",
+            network.as_str(),
+            expected_chain_id,
+            chain_id
+        );
+        return ExitCode::from(2);
+    }
+
     let resolver_addr: Address = resolver.into();
     let tx = TransactionRequest::default()
         .with_to(resolver_addr)

--- a/crates/sbo3l-identity/contracts/AnchorRegistry.sol
+++ b/crates/sbo3l-identity/contracts/AnchorRegistry.sol
@@ -70,6 +70,10 @@ error InvalidAuditRoot();
 error CallerNotTenantOwner(address caller, address expected);
 error TenantAlreadyClaimed(bytes32 tenantId, address existingOwner);
 error TenantNotClaimed(bytes32 tenantId);
+error CallerNotAdmin(address caller, address expected);
+error TenantHasAnchors(bytes32 tenantId, uint256 anchorCount);
+
+event TenantOwnerReassigned(bytes32 indexed tenantId, address indexed previousOwner, address indexed newOwner);
 
 contract AnchorRegistry {
     /// @notice One anchor record. Stored verbatim in `_anchors[tenantId][sequence]`.
@@ -105,6 +109,27 @@ contract AnchorRegistry {
     ///         written at sequence position `sequence`.
     mapping(bytes32 => mapping(uint256 => Anchor)) internal _anchors;
 
+    /// @notice Admin address with the limited power to reassign a
+    ///         tenant *that has not yet published any anchors*. This
+    ///         exists to mitigate the front-running squat attack
+    ///         (a mempool watcher submits the same `claimTenant` with
+    ///         higher gas to lock out the legitimate operator).
+    ///
+    ///         The admin CANNOT reassign a tenant once any anchor has
+    ///         been published — that would be retroactive history
+    ///         tampering, which the append-only invariant forbids.
+    ///         The admin is therefore strictly weaker than tenant
+    ///         ownership: it can only undo squats, not rewrite truth.
+    ///
+    ///         Production deployments should bind this to a multi-sig
+    ///         (or to address(0) for fully trustless operation, in
+    ///         which case the squat-recovery path becomes a redeploy).
+    address public immutable admin;
+
+    constructor(address admin_) {
+        admin = admin_;
+    }
+
     /// @notice Claim a tenant_id. The first caller becomes the
     ///         permanent owner; subsequent calls revert with
     ///         `TenantAlreadyClaimed`. Tenants are identified by
@@ -117,6 +142,25 @@ contract AnchorRegistry {
         address existing = tenantOwner[tenantId];
         if (existing != address(0)) revert TenantAlreadyClaimed(tenantId, existing);
         tenantOwner[tenantId] = msg.sender;
+    }
+
+    /// @notice Admin-only: reassign a tenant whose owner squatted via
+    ///         front-running. Strictly bounded: ONLY callable by
+    ///         `admin`, and ONLY when the tenant has not yet
+    ///         published any anchors (`nextSequence == 0`). This
+    ///         preserves the append-only / no-retroactive-tampering
+    ///         invariant: a tenant with even one anchor is
+    ///         immutable forever.
+    /// @param  tenantId   Tenant to reassign.
+    /// @param  newOwner   Address that becomes the new owner.
+    function reassignTenant(bytes32 tenantId, address newOwner) external {
+        if (msg.sender != admin) revert CallerNotAdmin(msg.sender, admin);
+        if (tenantId == bytes32(0)) revert InvalidTenantId();
+        uint256 anchors = nextSequence[tenantId];
+        if (anchors != 0) revert TenantHasAnchors(tenantId, anchors);
+        address prev = tenantOwner[tenantId];
+        tenantOwner[tenantId] = newOwner;
+        emit TenantOwnerReassigned(tenantId, prev, newOwner);
     }
 
     /// @notice Publish an anchor under a claimed tenant. Caller MUST

--- a/crates/sbo3l-identity/contracts/SBO3LReputationRegistry.sol
+++ b/crates/sbo3l-identity/contracts/SBO3LReputationRegistry.sol
@@ -37,7 +37,12 @@ pragma solidity ^0.8.24;
 ///      bound to the registry contract — sigs from a copy of this
 ///      contract on a different address don't validate (the
 ///      contract address is part of the digest).
-bytes32 constant DOMAIN = keccak256("SBO3L-Reputation-Registry-v1");
+// v2 bumps the digest to bind block.chainid alongside address(this).
+// Without chainid, an EOA deploying the same bytecode at the same
+// nonce on Sepolia + mainnet produces collidable contract addresses,
+// and a signature crafted for one chain replays on the other. v2
+// closes that. v1 was the deployed Sepolia version (immutable).
+bytes32 constant DOMAIN = keccak256("SBO3L-Reputation-Registry-v2");
 
 event ReputationWritten(
     bytes32 indexed tenantId,
@@ -208,12 +213,13 @@ contract SBO3LReputationRegistry {
 
     /// @dev Internal digest builder. Binds tenantId + agent + score
     ///      + chainHeadBlock + sequence + DOMAIN + this contract
-    ///      address into one 32-byte hash. Signers signing this
-    ///      hash can't have their sigs replayed across:
+    ///      address + block.chainid into one 32-byte hash. Signers
+    ///      signing this hash can't have their sigs replayed across:
     ///      - different sequence positions (sequence in payload)
     ///      - different agents (agent in payload)
     ///      - different scores (score in payload)
     ///      - different contracts (address(this) in payload)
+    ///      - different chains (block.chainid in payload — v2)
     ///      - different schemes (DOMAIN constant in payload)
     function _digestFor(
         bytes32 tenantId,
@@ -226,6 +232,7 @@ contract SBO3LReputationRegistry {
             abi.encodePacked(
                 hex"1900",
                 address(this),
+                block.chainid,
                 DOMAIN,
                 tenantId,
                 agent,

--- a/crates/sbo3l-identity/contracts/SBO3LSubnameAuction.sol
+++ b/crates/sbo3l-identity/contracts/SBO3LSubnameAuction.sol
@@ -51,6 +51,7 @@ error CallerNotOperator(address caller, address expected);
 error NoRefundOwed(address bidder, uint256 id);
 error RefundFailed(uint256 amount);
 error PayoutFailed(uint256 amount);
+error NoOperatorProceedsOwed(address operator);
 
 event AuctionCreated(
     uint256 indexed id,
@@ -78,6 +79,10 @@ event AuctionSettled(
 event AuctionUnsold(uint256 indexed id, string label);
 
 event RefundWithdrawn(uint256 indexed id, address indexed bidder, uint256 amount);
+
+event OperatorProceedsAccrued(uint256 indexed id, address indexed operator, uint256 amount);
+
+event OperatorProceedsWithdrawn(address indexed operator, uint256 amount);
 
 contract SBO3LSubnameAuction {
     /// @notice Minimum bid increment over the current high bid, in
@@ -114,6 +119,15 @@ contract SBO3LSubnameAuction {
     ///         can't lock the auction with a revert-on-receive
     ///         contract.
     mapping(uint256 => mapping(address => uint256)) internal _refundsOwed;
+
+    /// @notice Per-operator settled-auction proceeds. After `settle`
+    ///         credits the winning bid here, the operator pulls via
+    ///         `withdrawOperatorProceeds`. Pull-pattern protects
+    ///         settlement from a misconfigured operator address (e.g.
+    ///         a contract with a reverting `receive`) — without this,
+    ///         a push-style transfer in `settle` would brick the
+    ///         auction permanently.
+    mapping(address => uint256) internal _operatorProceeds;
 
     /// @notice Create an auction. Caller becomes the operator entitled
     ///         to the winning bid on settlement.
@@ -170,7 +184,15 @@ contract SBO3LSubnameAuction {
             if (msg.value < a.reserve) revert BidBelowReserve(msg.value, a.reserve);
         } else {
             // Subsequent bid — must beat current high by min increment.
-            uint256 minRequired = a.highBid + (a.highBid * MIN_INCREMENT_BPS) / 10_000;
+            // Floor the increment at 1 wei so tiny bids (highBid <
+            // 10_000 / MIN_INCREMENT_BPS) can't be replaced by an
+            // equal bid; otherwise integer truncation makes the
+            // computed increment 0 and `minRequired == highBid`.
+            uint256 increment = (a.highBid * MIN_INCREMENT_BPS) / 10_000;
+            if (increment == 0) {
+                increment = 1;
+            }
+            uint256 minRequired = a.highBid + increment;
             if (msg.value < minRequired) {
                 revert BidIncrementTooSmall(msg.value, minRequired);
             }
@@ -223,8 +245,23 @@ contract SBO3LSubnameAuction {
         uint256 winningBid = a.highBid;
         emit AuctionSettled(id, a.highBidder, a.label, winningBid);
 
-        (bool ok, ) = payable(a.operator).call{value: winningBid}("");
-        if (!ok) revert PayoutFailed(winningBid);
+        // Pull-pattern proceeds — settle is permissionless ("anyone can
+        // call after end time") so a push transfer to a contract-typed
+        // operator with a reverting `receive` would otherwise brick the
+        // settle path forever and trap the winning bid in this contract.
+        _operatorProceeds[a.operator] += winningBid;
+        emit OperatorProceedsAccrued(id, a.operator, winningBid);
+    }
+
+    /// @notice Withdraw queued settlement proceeds for the calling
+    ///         operator. Pull-pattern; mirrors `withdrawRefund`.
+    function withdrawOperatorProceeds() external returns (uint256 amount) {
+        amount = _operatorProceeds[msg.sender];
+        if (amount == 0) revert NoOperatorProceedsOwed(msg.sender);
+        _operatorProceeds[msg.sender] = 0;
+        (bool ok, ) = payable(msg.sender).call{value: amount}("");
+        if (!ok) revert PayoutFailed(amount);
+        emit OperatorProceedsWithdrawn(msg.sender, amount);
     }
 
     /// @notice Read an auction's full state. Returns the zero-shape
@@ -236,6 +273,13 @@ contract SBO3LSubnameAuction {
     /// @notice Read the queued refund balance for (auction, bidder).
     function refundOwed(uint256 id, address bidder) external view returns (uint256) {
         return _refundsOwed[id][bidder];
+    }
+
+    /// @notice Read the queued settlement-proceeds balance for an
+    ///         operator. Pull-pattern; operator calls
+    ///         `withdrawOperatorProceeds` to claim.
+    function operatorProceeds(address operator) external view returns (uint256) {
+        return _operatorProceeds[operator];
     }
 
     /// @notice ERC-165 advertisement. Currently advertises only IERC165;

--- a/crates/sbo3l-identity/contracts/test/AnchorRegistry.t.sol
+++ b/crates/sbo3l-identity/contracts/test/AnchorRegistry.t.sol
@@ -18,11 +18,13 @@ contract AnchorRegistryTest is Test {
 
     address internal alice;
     address internal bob;
+    address internal admin;
     bytes32 internal tenantA;
     bytes32 internal tenantB;
 
     function setUp() public {
-        registry = new AnchorRegistry();
+        admin = vm.addr(uint256(keccak256("admin")));
+        registry = new AnchorRegistry(admin);
         alice = vm.addr(uint256(keccak256("alice")));
         bob = vm.addr(uint256(keccak256("bob")));
         tenantA = keccak256("sbo3lagent.eth");
@@ -220,7 +222,11 @@ contract AnchorRegistryFuzzTest is Test {
     address internal owner;
 
     function setUp() public {
-        registry = new AnchorRegistry();
+        // Fuzz suite uses admin = address(0) to mean "no admin / fully
+        // trustless"; the squat-recovery path is unreachable here,
+        // which is appropriate for the append-only invariants under
+        // test.
+        registry = new AnchorRegistry(address(0));
         owner = vm.addr(uint256(keccak256("fuzz-owner")));
     }
 

--- a/crates/sbo3l-identity/contracts/test/SBO3LSubnameAuction.t.sol
+++ b/crates/sbo3l-identity/contracts/test/SBO3LSubnameAuction.t.sol
@@ -260,7 +260,7 @@ contract SBO3LSubnameAuctionTest is Test {
     // settle
     // ============================================================
 
-    function test_settle_withWinnerPaysOperator() public {
+    function test_settle_withWinnerCreditsOperatorProceeds() public {
         uint256 id = _create();
         vm.prank(alice);
         auction.bid{value: 1 ether}(id);
@@ -268,12 +268,22 @@ contract SBO3LSubnameAuctionTest is Test {
         auction.bid{value: 2 ether}(id);
 
         vm.warp(block.timestamp + 1 days + 1);
-        uint256 opBefore = operator.balance;
+        // Pull-pattern proceeds — settle credits the operator's
+        // proceeds balance, operator pulls via withdrawOperatorProceeds.
+        // (Pre-fix this was a push transfer that bricked settle if the
+        // operator was a contract with a reverting `receive`.)
+        assertEq(auction.operatorProceeds(operator), 0);
         vm.expectEmit(true, true, false, true);
         emit AuctionSettled(id, bob, "premium-trader", 2 ether);
         auction.settle(id);
-        assertEq(operator.balance, opBefore + 2 ether);
+        assertEq(auction.operatorProceeds(operator), 2 ether);
         assertTrue(auction.getAuction(id).settled);
+
+        uint256 opBefore = operator.balance;
+        vm.prank(operator);
+        auction.withdrawOperatorProceeds();
+        assertEq(operator.balance, opBefore + 2 ether);
+        assertEq(auction.operatorProceeds(operator), 0);
     }
 
     function test_settle_withoutWinnerEmitsUnsold() public {

--- a/crates/sbo3l-identity/src/name_wrapper.rs
+++ b/crates/sbo3l-identity/src/name_wrapper.rs
@@ -115,14 +115,23 @@ impl Fuse {
 /// Operator-controlled fuses (the ones in the `ownerControlledFuses`
 /// uint16 arg of `wrapETH2LD` and `setFuses`) live in the low 16
 /// bits. Parent-controlled fuses (`PARENT_CANNOT_CONTROL`,
-/// `IS_DOT_ETH`, `CAN_EXTEND_EXPIRY`) live in the high bits and
-/// pass through `setSubnodeRecord`'s `fuses` uint32 arg instead.
-pub fn fuses_bitmask(fuses: &[Fuse]) -> u32 {
+/// `CAN_EXTEND_EXPIRY`) live in the high bits and pass through
+/// `setSubnodeRecord`'s `fuses` uint32 arg instead.
+///
+/// `IS_DOT_ETH` is a NameWrapper-internal fuse — the contract sets
+/// it itself when a `.eth` 2LD is wrapped, and it is NOT in
+/// `USER_SETTABLE_FUSES`. Calls that include this bit revert at
+/// broadcast. We therefore reject it at calldata construction time
+/// rather than letting an operator discover the revert on chain.
+pub fn fuses_bitmask(fuses: &[Fuse]) -> Result<u32, NameWrapperError> {
     let mut out = 0u32;
     for f in fuses {
+        if matches!(f, Fuse::IS_DOT_ETH) {
+            return Err(NameWrapperError::InternalFuseNotSettable("IS_DOT_ETH"));
+        }
         out |= f.bit();
     }
-    out
+    Ok(out)
 }
 
 /// NameWrapper-side errors. Mirrors `AnchorError` shape so callers
@@ -135,6 +144,8 @@ pub enum NameWrapperError {
     LabelTooLong(usize),
     #[error("operator-controlled fuses must fit in uint16")]
     OwnerFusesOverflow,
+    #[error("fuse {0} is NameWrapper-internal and not user-settable; calldata including it would revert at broadcast")]
+    InternalFuseNotSettable(&'static str),
     #[error(transparent)]
     Anchor(#[from] AnchorError),
 }
@@ -339,18 +350,24 @@ mod tests {
 
     #[test]
     fn fuses_bitmask_combines_correctly() {
-        let bits = fuses_bitmask(&[Fuse::CANNOT_UNWRAP, Fuse::CANNOT_TRANSFER]);
+        let bits = fuses_bitmask(&[Fuse::CANNOT_UNWRAP, Fuse::CANNOT_TRANSFER]).unwrap();
         assert_eq!(bits, 0x0001 | 0x0004);
     }
 
     #[test]
     fn fuses_bitmask_handles_parent_fuses() {
-        let bits = fuses_bitmask(&[
-            Fuse::CANNOT_UNWRAP,
-            Fuse::PARENT_CANNOT_CONTROL,
-            Fuse::IS_DOT_ETH,
-        ]);
-        assert_eq!(bits, 0x0001 | 0x10000 | 0x20000);
+        let bits =
+            fuses_bitmask(&[Fuse::CANNOT_UNWRAP, Fuse::PARENT_CANNOT_CONTROL]).unwrap();
+        assert_eq!(bits, 0x0001 | 0x10000);
+    }
+
+    #[test]
+    fn fuses_bitmask_rejects_is_dot_eth() {
+        // IS_DOT_ETH is NameWrapper-internal — calldata containing it
+        // reverts at broadcast. We surface the rejection at calldata
+        // build time so misuse is caught before any tx is sent.
+        let err = fuses_bitmask(&[Fuse::CANNOT_UNWRAP, Fuse::IS_DOT_ETH]).unwrap_err();
+        assert!(matches!(err, NameWrapperError::InternalFuseNotSettable("IS_DOT_ETH")));
     }
 
     #[test]
@@ -358,7 +375,7 @@ mod tests {
         let cd = wrap_eth_2ld_calldata(
             "sbo3lagent",
             "0xdc7EFA6b4Bd77d1a406DE4727F0DF567e597D231",
-            fuses_bitmask(&[Fuse::CANNOT_UNWRAP]),
+            fuses_bitmask(&[Fuse::CANNOT_UNWRAP]).unwrap(),
             "0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63",
         )
         .unwrap();
@@ -397,7 +414,7 @@ mod tests {
     fn set_fuses_happy_path() {
         let cd = set_fuses_calldata(
             "sbo3lagent.eth",
-            fuses_bitmask(&[Fuse::CANNOT_UNWRAP, Fuse::CANNOT_BURN_FUSES]),
+            fuses_bitmask(&[Fuse::CANNOT_UNWRAP, Fuse::CANNOT_BURN_FUSES]).unwrap(),
         )
         .unwrap();
         assert_eq!(&cd[..4], &SET_FUSES_SELECTOR);
@@ -430,7 +447,7 @@ mod tests {
             0,
             // Issue with PARENT_CANNOT_CONTROL + CANNOT_UNWRAP →
             // child sovereign.
-            fuses_bitmask(&[Fuse::CANNOT_UNWRAP, Fuse::PARENT_CANNOT_CONTROL]),
+            fuses_bitmask(&[Fuse::CANNOT_UNWRAP, Fuse::PARENT_CANNOT_CONTROL]).unwrap(),
             // Expiry = max-ish (year 2200ish).
             7_000_000_000,
         )

--- a/crates/sbo3l-identity/src/token_gate.rs
+++ b/crates/sbo3l-identity/src/token_gate.rs
@@ -325,6 +325,7 @@ impl AllOfGates {
 impl TokenGate for AllOfGates {
     fn check(&self, owner: &str) -> Result<GateResult, GateError> {
         let mut summaries: Vec<String> = Vec::with_capacity(self.gates.len());
+        let mut contracts: Vec<String> = Vec::with_capacity(self.gates.len());
         let mut owner_normalised = owner.to_string();
         for gate in &self.gates {
             let r = gate.check(owner)?;
@@ -338,13 +339,20 @@ impl TokenGate for AllOfGates {
                     evidence: r.evidence,
                 });
             }
+            if !r.contract.is_empty() {
+                contracts.push(r.contract.clone());
+            }
             summaries.push(format!("{}: {}", r.gate_label, r.evidence));
         }
         Ok(GateResult {
             passed: true,
             gate_label: format!("{} ({} branches all passed)", self.label, self.gates.len()),
             owner: owner_normalised,
-            contract: String::new(),
+            // Aggregate every queried contract address so auditors
+            // re-verifying a high-risk multi-contract decision can see
+            // exactly which contracts were checked. Failure path
+            // already preserves the failing branch's contract above.
+            contract: contracts.join(", "),
             evidence: summaries.join("; "),
         })
     }

--- a/crates/sbo3l-identity/tests/erc8004_live.rs
+++ b/crates/sbo3l-identity/tests/erc8004_live.rs
@@ -139,6 +139,25 @@ fn live_register_agent_calldata_targets_real_contract() {
         "expected `result` or `error` from eth_call; got {json}"
     );
 
+    if has_result {
+        // `eth_call` returns `"0x"` (zero bytes) when the target
+        // address has no code at all (EOA) or when a contract returns
+        // an empty payload. Treating that as success is a false
+        // positive — it lets a misconfigured `SBO3L_ERC8004_ADDR`
+        // pointing at an EOA pass the test. Require the result to be
+        // a non-empty hex string. ABI-encoded returns are 32-byte
+        // aligned, so we accept any length ≥ 2 (the "0x" prefix) +
+        // 64 hex chars = 66, but in practice anything > 2 indicates
+        // real contract execution.
+        let result_str = json["result"]
+            .as_str()
+            .expect("`result` field is a string per JSON-RPC spec");
+        assert!(
+            result_str.len() > 2 && result_str.starts_with("0x"),
+            "`eth_call` returned empty `\"0x\"` — target at {registry_hex} has no code or returned empty. Did SBO3L_ERC8004_ADDR get pointed at an EOA?"
+        );
+    }
+
     if let Some(err) = json.get("error") {
         let msg = err.get("message").and_then(|m| m.as_str()).unwrap_or("");
         assert!(

--- a/crates/sbo3l-policy/src/reputation.rs
+++ b/crates/sbo3l-policy/src/reputation.rs
@@ -156,12 +156,25 @@ where
     let mut total: u64 = 0;
 
     for event in events {
-        total += 1;
         match event.decision.as_str() {
-            "allow" if event.executor_confirmed => clean_count += 1,
-            "allow" => allow_unconfirmed += 1,
-            "deny" => deny_weighted += age_weight(event.age),
-            _ => {} // unknown decisions ignored — don't punish them
+            "allow" if event.executor_confirmed => {
+                clean_count += 1;
+                total += 1;
+            }
+            "allow" => {
+                allow_unconfirmed += 1;
+                total += 1;
+            }
+            "deny" => {
+                deny_weighted += age_weight(event.age);
+                total += 1;
+            }
+            // Unknown decisions are ignored — they MUST NOT contribute
+            // to `total` either, otherwise clean_ratio and
+            // weighted_deny_ratio shrink for callers whose history
+            // happens to contain unknown-kind events (silently
+            // depressing scores for clean agents).
+            _ => {}
         }
     }
 
@@ -335,16 +348,41 @@ mod tests {
 
     #[test]
     fn v2_unknown_decisions_are_ignored() {
-        // Unknown decisions don't count for or against.
+        // Unknown decisions MUST NOT contribute to the denominator —
+        // otherwise an agent that happens to have queue/rate_limit
+        // events in its history is silently penalised below an
+        // identical clean agent. Pre-2026-05-02 this test asserted
+        // 55 (the buggy diluted output); the fix to compute_reputation_v2
+        // restores the documented "don't punish them" semantic.
         let r = compute_reputation_v2(vec![
             ev("allow", true, 0),
             ev("queue", false, 0),
             ev("rate_limited", false, 0),
         ]);
-        // total=3, clean=1 (1/3 ≈ 0.333), no denies, confirm=1/1=1.0,
-        // stability_bonus = 0.03.
-        // 60 * 0.333 + 20 * 1.0 + 15 * 1.0 + 5 * 0.03 = 55.15 → 55
-        assert_eq!(r.as_u8(), 55);
+        // total=1 (only the allow counts), clean=1, confirm=1/1=1.0,
+        // stability_bonus = 1/100 = 0.01.
+        // 60 * 1.0 + 20 * 1.0 + 15 * 1.0 + 5 * 0.01 = 95.05 → 95
+        assert_eq!(r.as_u8(), 95);
+    }
+
+    #[test]
+    fn v2_unknown_decisions_dont_dilute_clean_score() {
+        // Regression test for the diluted-denominator bug. An agent
+        // with 10 clean events should score the same as the same agent
+        // with 10 clean + 100 unknown events — the unknowns should
+        // not pull the score down at all.
+        let clean: Vec<_> = (0..10).map(|_| ev("allow", true, 0)).collect();
+        let baseline = compute_reputation_v2(clean.clone());
+
+        let mut mixed = clean;
+        mixed.extend((0..100).map(|_| ev("queue", false, 0)));
+        let mixed_score = compute_reputation_v2(mixed);
+
+        assert_eq!(
+            baseline.as_u8(),
+            mixed_score.as_u8(),
+            "unknown-decision events must not dilute clean scores"
+        );
     }
 
     #[test]

--- a/docs/dev4/known-issues-v1-deploys.md
+++ b/docs/dev4/known-issues-v1-deploys.md
@@ -1,0 +1,144 @@
+# Known issues — live Sepolia v1 deploys
+
+> **Audience:** judges + auditors + future maintainers.
+> **Outcome:** an explicit, honest map of bugs that were found in the
+> live Sepolia deployments after they shipped, alongside what changed
+> in the source on `main` and how to roll them out (redeploy paths).
+>
+> All four deployed addresses are pinned in
+> [`contracts.rs`](../../crates/sbo3l-identity/src/contracts.rs)
+> and remain the canonical Sepolia targets for the live demo. The
+> source on `main` has been bumped beyond their bytecode in places
+> noted below; a v2 redeploy would carry the fixes.
+
+## Posture
+
+These bugs were caught by a self-review pass on Codex's line-anchored
+PR comments after the corresponding PRs had merged. The deployed
+contracts are immutable. The honest move is:
+
+1. Fix in source, with a clear comment in the relevant file.
+2. Bump the version constant where the on-chain digest depends on it
+   (so a v2 redeploy mints sigs that aren't ambiguous with v1).
+3. Document each bug here so a future redeploy knows what to flip.
+
+Live demo paths still work — these are mostly edge cases (small bids,
+contract operators, cross-chain replay risk) that the demo doesn't
+exercise.
+
+## Per-contract status
+
+### `AnchorRegistry` — `0x4C302ba8349129bd5963A22e3c7a38a246E8f4Ac`
+
+**Live v1 bug — first-come tenant squat.** `claimTenant(bytes32)` is
+first-come-first-served with no ENS ownership binding. A mempool
+watcher can front-run a legitimate operator's claim with higher gas
+and permanently lock the tenant id.
+
+**Source on `main` — v1 → v1.1 (constructor change).** Added an
+`admin` immutable parameter and a `reassignTenant(bytes32, address)`
+function. Strictly bounded:
+
+- ONLY callable by `admin`.
+- ONLY when the tenant has not yet published any anchors
+  (`nextSequence == 0`).
+
+This preserves the append-only invariant: a tenant with even one
+anchor is immutable forever — the admin can only undo a *bare squat*,
+not rewrite history. Production deployments should bind `admin` to a
+multi-sig (or to `address(0)` for fully trustless operation).
+
+**Redeploy needed:** yes — constructor signature changed
+(`AnchorRegistry(address admin)`).
+
+### `SubnameAuction` — `0x5dE75E64739A95701367F3Ad592e0b674b22114B`
+
+**Live v1 bug 1 — equal-bid replacement on tiny bids.** For a
+high-bid below `10_000 / MIN_INCREMENT_BPS` (i.e. ≤ 19 wei with a 5%
+increment), the integer-truncated minimum increment is 0, so a new
+bidder can replace the incumbent with an equal bid.
+
+**Live v1 bug 2 — push-pattern operator payout can brick `settle`.**
+`settle` push-transfers the winning bid to the operator. If the
+operator is a contract with a reverting `receive` (or a misconfigured
+multi-sig with no payable fallback), `settle` reverts forever and
+the winning bid is trapped.
+
+**Source on `main` — v1 → v1.1 (additive ABI extension).**
+
+- Bid: increment is now `max(1, highBid * MIN_INCREMENT_BPS / 10_000)`.
+  Equal-bid replacement no longer possible at any high-bid value.
+- Settle: pull-pattern proceeds. `settle` credits
+  `_operatorProceeds[a.operator]` and emits
+  `OperatorProceedsAccrued(id, operator, amount)`. A new external
+  function `withdrawOperatorProceeds()` returns the credit. New error
+  `NoOperatorProceedsOwed`. New view `operatorProceeds(address)`.
+
+**Redeploy needed:** yes if a production demo depends on
+contract-typed operators or wants the increment-floor guarantee.
+Live Sepolia is fine for read-only verification + unit-stress demo.
+
+### `ReputationBond` — `0x75072217B43960414047c362198A428f0E9793dA`
+
+No bugs flagged actionable by self-review. The "bond holder can
+publish during lock window" behaviour was acknowledged in the inline
+NatSpec ("lock prevents withdrawal, not publishing") and is intended.
+
+### `ReputationRegistry` — `0x6aA95d8126B6221607245c068483fa5008F36dc2`
+
+**Live v1 bug — cross-chain replay.** The signed digest binds
+`address(this)` but NOT `block.chainid`. An EOA deploying the same
+bytecode at the same nonce on Sepolia + mainnet produces colliding
+contract addresses, so a sig crafted for one chain replays on the
+other.
+
+**Source on `main` — v1 → v2 (digest schema change).**
+
+- `_digestFor` now packs `block.chainid` between `address(this)` and
+  `DOMAIN`.
+- `DOMAIN` constant bumped:
+  `keccak256("SBO3L-Reputation-Registry-v2")`.
+
+The version bump in `DOMAIN` is what makes the change unambiguous:
+sigs minted under v1 will not verify under v2, so the digest-schema
+fork is loud, not silent.
+
+**Redeploy needed:** yes — the v2 digest is binary-incompatible with
+v1 sigs. v1 bytecode on Sepolia will continue to verify v1 sigs (and
+remain replay-vulnerable across-chain); a v2 redeploy is replay-safe.
+
+## Why we did not redeploy at hackathon close
+
+1. **Live demo continuity.** Judges have the v1 addresses pinned in
+   [`docs/proof/etherscan-link-pack.md`](../proof/etherscan-link-pack.md).
+   Re-pinning + re-verifying mid-judging window costs more than it
+   buys.
+2. **Test coverage already proves the v2 source.** 127 foundry tests +
+   207 sbo3l-identity Rust tests + 85 sbo3l-policy Rust tests + 64
+   sbo3l-cli Rust tests pass on `main` HEAD post-fix. The v2 source
+   *is* a known-good drop-in for the v1 deployments.
+3. **None of the bugs are exploitable in the demo flow.** AnchorRegistry
+   squat is a future-tenant problem, not a today-demo problem.
+   Auction tiny-bid + bricked-settle require ≤ 19-wei reserves or a
+   contract operator. ReputationRegistry cross-chain replay needs a
+   second chain deployment we explicitly chose not to do (per
+   [`docs/dev4/closeout-status.md`](closeout-status.md#3-multi-chain-l2-deploys)).
+
+## When to redeploy
+
+If any of:
+
+- **A judge asks for v2 evidence.** All four redeploys are turnkey
+  via the existing scripts (`scripts/deploy-*.sh`); ~2 minutes per
+  contract.
+- **A multi-chain L2 push happens** (per closeout deferred item #3).
+  The ReputationRegistry v2 chainid binding is required *before*
+  shipping to a second chain.
+- **The Sepolia AnchorRegistry actually gets squatted.** Documented
+  recovery: deploy v1.1 with admin bound to Daniel's multi-sig.
+
+After redeploy: flip the addresses in `contracts.rs` and update
+[`docs/proof/etherscan-link-pack.md`](../proof/etherscan-link-pack.md)
++ [`docs/proof/contracts-live-test.md`](../proof/contracts-live-test.md)
++ [`docs/dev4/closeout-status.md`](closeout-status.md). The
+`every_pin_is_canonical_form` test catches typos.

--- a/docs/proof/ens-pitch.md
+++ b/docs/proof/ens-pitch.md
@@ -11,8 +11,8 @@ load-bearing for runtime authentication, policy enforcement, and
 audit-chain integrity.
 
 `sbo3lagent.eth` (mainnet, owned) carries seven `sbo3l:*` text
-records: `agent_id`, `endpoint`, `pubkey_ed25519`, `policy_url`,
-`policy_hash`, `audit_root`, `proof_uri`, `capabilities`. `policy_hash`
+records: `agent_id`, `endpoint`, `pubkey_ed25519`, `policy_hash`,
+`audit_root`, `proof_uri`, `capabilities`. `policy_hash`
 is the JCS+SHA-256 of the agent's active policy snapshot; any judge
 holding the ENS record and the daemon's `/v1/policy` endpoint can
 re-hash and prove non-drift independently. `audit_root` pins the

--- a/examples/t-4-1-viem-e2e/src/index.ts
+++ b/examples/t-4-1-viem-e2e/src/index.ts
@@ -34,7 +34,7 @@
  * judge-facing, not test-suite-load-bearing.
  */
 
-import { createPublicClient, http, namehash } from 'viem';
+import { createPublicClient, encodeFunctionData, http, namehash } from 'viem';
 import { sepolia } from 'viem/chains';
 
 // Mirrors `sbo3l-identity::contracts::OFFCHAIN_RESOLVER_SEPOLIA`.
@@ -178,11 +178,17 @@ function dnsEncode(name: string): Uint8Array {
   const out: number[] = [];
   for (const label of name.split('.')) {
     if (!label) continue;
-    if (label.length > 63) {
-      throw new Error(`label too long: ${label.length} bytes`);
+    // DNS wire format prefixes each label with its UTF-8 *byte*
+    // length, NOT JavaScript's UTF-16 code-unit count. For non-ASCII
+    // labels (emoji, accents) the JS `.length` is smaller than the
+    // encoded byte count, which produces malformed names. Encode
+    // first, then prefix with the encoded length.
+    const encoded = new TextEncoder().encode(label);
+    if (encoded.length > 63) {
+      throw new Error(`label too long: ${encoded.length} bytes`);
     }
-    out.push(label.length);
-    for (const c of new TextEncoder().encode(label)) out.push(c);
+    out.push(encoded.length);
+    for (const c of encoded) out.push(c);
   }
   out.push(0);
   return new Uint8Array(out);
@@ -193,12 +199,9 @@ function encodeFunctionDataInline(
   abi: readonly { name: string; type: string; inputs: readonly { name: string; type: string }[] }[],
   args: readonly unknown[]
 ): `0x${string}` {
-  // Tiny shim around viem's encodeFunctionData. Imported lazily so
-  // a viem version that prefers the newer named-export API still
-  // works.
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { encodeFunctionData } = require('viem');
-  // Cast because TS wants the strict viem ABI typing.
+  // Thin wrapper around viem's encodeFunctionData. Imported as a
+  // standard ESM named import — `require()` is undefined in this
+  // file's runtime (package.json has `"type": "module"`).
   return encodeFunctionData({
     abi: abi as never,
     functionName: fn as never,

--- a/scripts/deploy-offchain-resolver.sh
+++ b/scripts/deploy-offchain-resolver.sh
@@ -134,8 +134,7 @@ echo "  2. Set the resolver on sbo3lagent.eth so subnames inherit it:"
 echo
 echo "     cast send 0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e \\"
 echo "       \"setResolver(bytes32,address)\" \\"
-echo "       \$(cast call 0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e \\"
-echo "           \"resolver(bytes32)\" \$(cast namehash sbo3lagent.eth)) \\"
+echo "       \$(cast namehash sbo3lagent.eth) \\"
 echo "       $DEPLOYED_ADDRESS \\"
 echo "       --rpc-url \$RPC_URL --private-key \$SBO3L_DEPLOYER_PRIVATE_KEY"
 echo

--- a/scripts/deploy-reputation-registry.sh
+++ b/scripts/deploy-reputation-registry.sh
@@ -140,7 +140,7 @@ DEPLOY_OUTPUT="$(
     --rpc-url "$RPC_URL" \
     --broadcast \
     --json \
-    --silent \
+    --quiet \
     2>&1
 )" || {
   echo "$DEPLOY_OUTPUT" >&2


### PR DESCRIPTION
## Summary

Self-review of line-anchored Codex review comments on **27 merged Dev 4 PRs** surfaced **16 actionable bugs**. All fixed in this PR. 11 already-fixed-by-subsequent-PR + 9 won't-fix entries were classified during the audit and not touched.

Triage method: pulled review-thread comments via `gh api`, filtered out github-actions / Codex-usage-limit noise, then for each substantive Codex flag opened the file at `main` HEAD and verified the bug *still* existed before classifying it ACTIONABLE.

## Categories

### P0 — judge-facing visible (4)
- **Bug 8** — `ens-pitch.md` claimed "seven" records but listed eight. Dropped `policy_url` (it's a per-subname record, not on the apex). PR #168.
- **Bug 7** — `deploy-offchain-resolver.sh` post-deploy `cast send` template passed a *resolver address* as the `setResolver` namehash arg. Replaced with `cast namehash sbo3lagent.eth` directly. PR #130.
- **Bug 6** — `deploy-reputation-registry.sh` used `forge script --silent` (not a Foundry flag); renamed to `--quiet`. PR #272.
- **Bug 9** — `ccip-gateway.yml` `deploy-preview` ran on every PR, failing fork PRs / Dependabot with empty Vercel secrets; added `head.repo == base.repo` guard. PR #121.

### P1 — pure-additive logic (8)
- **Bug 1** — CCIP gateway `addr(node)` encoded as `encodeStringResult("")` instead of `encodeAddressResult(zero)`; viem mis-decoded. PR #124.
- **Bug 2** — `compute_reputation_v2` incremented `total` *before* matching the decision, silently diluting clean ratios for unknown-kind events. Moved `total += 1` into each known arm. Added regression test that 10 clean events score the same with or without 100 unknown events appended. PR #126.
- **Bug 10** — `AllOfGates::check` dropped contract addresses on success path. Aggregated all branches' contracts. PR #237.
- **Bug 11** — `agent reputation-publish --broadcast` didn't validate RPC chain id matched `--network`. Added hard-fail (mainnet=1, sepolia=11155111). PR #250.
- **Bug 12** — `fuses_bitmask` accepted `IS_DOT_ETH` (NameWrapper-internal, always reverts at broadcast). Now returns `Result<_, NameWrapperError>` with `InternalFuseNotSettable`. PR #292.
- **Bug 14** — `erc8004_live.rs` accepted `"result":"0x"` (empty bytecode) as success. Added hex non-empty assertion. PR #132.
- **Bug 15+16** — viem-e2e example used `require('viem')` in ESM (`require` undefined) AND used `label.length` (UTF-16 units) for DNS wire prefix instead of UTF-8 byte length. Switched to static ESM import + encode-then-prefix-by-byte-length. PR #232.

### P2 — contracts (4)
The four Sepolia deployments at the addresses pinned in `contracts.rs` are immutable v1; fixes ship in source for a future redeploy. See [`docs/dev4/known-issues-v1-deploys.md`](docs/dev4/known-issues-v1-deploys.md).

- **Bug 3** — `SBO3LReputationRegistry` digest didn't bind `block.chainid`; sigs replay across chains. Added chainid + bumped DOMAIN to v2 (so v1 sigs can't accidentally verify under v2). PR #257.
- **Bug 4** — `SBO3LSubnameAuction` minimum-increment was 0 for tiny bids (≤19 wei). Floored to 1 wei. PR #283.
- **Bug 5** — `SBO3LSubnameAuction.settle` push-transferred to operator; reverting `receive` bricked settle forever. Converted to pull-pattern via `_operatorProceeds` + `withdrawOperatorProceeds()`. PR #283.
- **Bug 13** — `AnchorRegistry.claimTenant` first-come squat. Added `admin` immutable + `reassignTenant` admin-only function bounded to tenants with no anchors yet (preserves append-only invariant). Constructor signature changed. PR #245.

## Test results at HEAD

| Suite | Pass | Notes |
|---|---|---|
| `forge test` | 127/127 | All foundry suites incl. updated AnchorRegistry ctor + new pull-pattern test + new IS_DOT_ETH rejection test |
| `sbo3l-identity --lib` | 207/207 | |
| `sbo3l-policy --lib` | 85/85 | Incl. new `v2_unknown_decisions_dont_dilute_clean_score` regression |
| `sbo3l-cli --bin sbo3l` | 64/64 | |
| **Total** | **483** | |

## Triage classification (full audit, for transparency)

- **Actionable (16)**: Bugs 1-16 above.
- **Already fixed by subsequent PR (11)**: PRs #313, #302, #201, #182, #167, #163, #173, #141, #138, #177, #168, #232 contained Codex flags that subsequent PRs had already addressed; verified at HEAD.
- **Won't fix (9)**: 5 contracts (PRs #285 hasActiveBond intentional + #257/#245 TenantNotClaimed-on-empty acknowledged in NatSpec + #240 `|| true` slither intentional + #163 case-insensitive pubkey symmetry + #201 reputation key naming false-positive) + 1 cli-test serialization (PR #116) + 3 dead-code post-refactor (PR #313 zero-threshold, #302 aggregate_partials).

## Test plan

- [x] `forge test --no-match-contract "Live|.*Mainnet"` — 127/127 pass.
- [x] `cargo test -p sbo3l-identity --lib` — 207/207 pass.
- [x] `cargo test -p sbo3l-policy --lib` — 85/85 pass.
- [x] `cargo test -p sbo3l-cli --bin sbo3l` — 64/64 pass.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)