### PR TITLE
fix(playground-api): JSX.Element → ReactElement (Next 15 build fix)

### DIFF
--- a/apps/sbo3l-playground-api/app/layout.tsx
+++ b/apps/sbo3l-playground-api/app/layout.tsx
@@ -1,12 +1,14 @@
 // API-only project; root layout is required by Next.js App Router
 // even when no pages exist. Keeps the bundle minimal.
 
+import type { ReactElement, ReactNode } from "react";
+
 export const metadata = {
   title: "SBO3L Playground API",
   description: "Tier-3 hosted daemon for the SBO3L playground.",
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }): JSX.Element {
+export default function RootLayout({ children }: { children: ReactNode }): ReactElement {
   return (
     <html lang="en">
       <body>{children}</body>


### PR DESCRIPTION
Vercel build was failing on layout.tsx due to JSX namespace. Local build green after fix.