### PR TITLE
fix(integrations): drop unused noqa BLE001 directives

### DIFF
--- a/integrations/llamaindex/sbo3l_llamaindex/tool.py
+++ b/integrations/llamaindex/sbo3l_llamaindex/tool.py
@@ -121,7 +121,7 @@ def sbo3l_tool(
                 if callable(close):
                     try:
                         close()
-                    except Exception:  # noqa: BLE001
+                    except Exception:
                         # Closing a half-started coroutine can raise;
                         # we have no recovery path and the caller already
                         # gets a structured error envelope, so swallow.

--- a/sdks/python/integrations/langgraph/sbo3l_langgraph/guard.py
+++ b/sdks/python/integrations/langgraph/sbo3l_langgraph/guard.py
@@ -139,9 +139,10 @@ class PolicyGuardNode:
                 if callable(close):
                     try:
                         close()
-                    except Exception:  # noqa: BLE001 — closing a half-started
-                        # coroutine can raise; we have no recovery and the
-                        # caller already gets a structured deny envelope.
+                    except Exception:
+                        # Closing a half-started coroutine can raise; we have
+                        # no recovery and the caller already gets a structured
+                        # deny envelope.
                         pass
                 return {
                     "deny_reason": {


### PR DESCRIPTION
Unblocks Integrations publish workflow. RUF100 was failing because the project's ruff config doesn't enable BLE001; the noqa was suppressing nothing.