### PR TITLE
chore(playground-api): gitignore .vercel link-state

### DIFF
--- a/apps/sbo3l-playground-api/.gitignore
+++ b/apps/sbo3l-playground-api/.gitignore
@@ -10,3 +10,4 @@ dist/
 
 # Phase 3 artifacts — committed once Rust → wasm32-wasi build lands
 lib/sbo3l-core.wasm
+.vercel


### PR DESCRIPTION
Cosmetic: avoid accidentally committing .vercel/ link state from `vercel link`.