### PR TITLE
fix(marketing): /submission/<slug> 404s — Astro 5 schema + build pipeline + missing source

### DIFF
--- a/apps/marketing/.gitignore
+++ b/apps/marketing/.gitignore
@@ -6,6 +6,9 @@ node_modules/
 *.tsbuildinfo
 
 # Materialised at prebuild from docs/submission/bounty-*.md by
-# scripts/copy-bounty-pages.mjs — regenerated on every build, so
-# don't commit.
-src/content/submissions/
+# scripts/copy-bounty-pages.mjs. Files ARE committed: Vercel's build
+# rootDirectory is apps/marketing/, so docs/submission/ isn't visible
+# during its build → the script produces 0 pages on Vercel. Commit
+# the generated output so Vercel renders /submission/<slug> pages.
+# Re-run the script locally and commit any diff when bounty-*.md
+# sources change.

--- a/apps/marketing/scripts/copy-bounty-pages.mjs
+++ b/apps/marketing/scripts/copy-bounty-pages.mjs
@@ -50,10 +50,13 @@ async function main() {
     const title = bountyTitle(body);
     const audience = bountyAudience(body);
 
+    // Note: `slug` is reserved in Astro 5 (auto-derived from filename);
+    // do NOT include it in frontmatter or the content schema validation
+    // fails with InvalidContentEntryDataError. The output filename below
+    // (`<slug>.md`) becomes the auto-derived slug.
     const frontmatter =
       `---\n` +
       `title: "${escapeYaml(title)}"\n` +
-      `slug: ${slug}\n` +
       (audience ? `audience: "${escapeYaml(audience)}"\n` : "") +
       `source_file: docs/submission/${file}\n` +
       `---\n\n`;

--- a/apps/marketing/src/components/SponsorLogos.astro
+++ b/apps/marketing/src/components/SponsorLogos.astro
@@ -9,10 +9,10 @@
 // docs/submission/PHASE-3-FINAL-STATUS.md and not surfaced here to avoid
 // implying false coverage.
 const sponsors = [
-  { name: "KeeperHub",  href: "/submission/keeperhub", role: "Live workflow + signed receipts" },
-  { name: "ENS",        href: "/submission/ens",       role: "sbo3lagent.eth + 5 Sepolia subnames" },
-  { name: "Uniswap",    href: "/submission/uniswap",   role: "Sepolia QuoterV2 + MEV guard" },
-  { name: "Anthropic",  href: "/submission/anthropic", role: "Claude tool-use receipts" },
+  { name: "KeeperHub",  href: "/submission/keeperhub",         role: "Live workflow + signed receipts" },
+  { name: "ENS",        href: "/submission/ens-most-creative", role: "sbo3lagent.eth + Trust DNS" },
+  { name: "Uniswap",    href: "/submission/uniswap",           role: "Sepolia QuoterV2 + MEV guard" },
+  { name: "Anthropic",  href: "/submission/anthropic",         role: "Claude tool-use receipts" },
 ];
 ---
 <section class="sponsors" aria-label="ETHGlobal Open Agents 2026 sponsor tracks">

--- a/apps/marketing/src/content/config.ts
+++ b/apps/marketing/src/content/config.ts
@@ -24,11 +24,15 @@ const blog = defineCollection({
 // prebuild. The source-of-truth lives in docs/submission/ alongside the
 // rest of the submission pack; the marketing site mirrors them so the
 // content site can render via Astro's content pipeline.
+//
+// NOTE: `slug` is a reserved field in Astro 5 — auto-derived from the
+// entry filename. Do NOT add it to the schema (causes
+// InvalidContentEntryDataError). The dynamic route [bounty].astro
+// uses `entry.id` (or `entry.slug`) to compute the URL.
 const submissions = defineCollection({
   type: "content",
   schema: z.object({
     title: z.string().min(1),
-    slug: z.string().min(1),
     audience: z.string().optional(),
     source_file: z.string().min(1),
   }),

--- a/apps/marketing/src/content/submissions/anthropic.md
+++ b/apps/marketing/src/content/submissions/anthropic.md
@@ -1,0 +1,85 @@
+---
+title: "SBO3L → Anthropic Claude tool-use"
+audience: "Anthropic ecosystem reviewers + judges evaluating the SBO3L coverage of the dominant agent runtime"
+source_file: docs/submission/bounty-anthropic.md
+---
+
+# SBO3L → Anthropic Claude tool-use
+
+> **Audience:** Anthropic ecosystem reviewers + judges evaluating the SBO3L coverage of the dominant agent runtime.
+> **Length:** ~500 words. Implementation in
+> [`integrations/anthropic/`](../../integrations/anthropic) +
+> [`examples/anthropic-research-agent/`](../../examples/anthropic-research-agent).
+
+## Hero claim
+
+**Claude tool-use is the dominant interface for autonomous agents in 2026.
+SBO3L wraps it with a policy boundary that emits signed receipts for every
+tool call.** No prompt re-engineering, no model swap, no SDK fork. The
+adapter is a Claude `Tool` definition + a one-line dispatcher.
+
+## Why this surface matters
+
+The bulk of agent-economy traffic in 2026 is Claude `messages.create` with
+`tool_use` blocks — and most of those tools are fire-and-forget execution
+shells with no policy gate, no audit trail, and no portable proof of what
+the agent actually did. SBO3L treats the daemon's HTTP surface as a Claude
+tool, so the agent's *intent* (the `tool_use` block) and the policy's
+*decision* (the signed `PolicyReceipt`) live in the same conversation
+turn.
+
+Result: every Claude-driven payment, swap, or workflow trigger is gated
+upstream of the model's hallucination surface. Malformed tool inputs are
+caught locally by Zod *before* the daemon round trip and surfaced back to
+Claude as a `tool_result` with `is_error: true`, so the model can
+self-correct without a network call.
+
+## Technical depth
+
+The `@sbo3l/anthropic` npm package (LIVE on npmjs.com under the
+`@sbo3l/*` scope) ships:
+
+| Export | Shape |
+|---|---|
+| `sbo3lTool` | Anthropic `Tool` definition with the APRP v1 input schema baked in |
+| `runSbo3lToolUse(tool, block, opts)` | Converts a `tool_use` content block → `tool_result` block ready to push back into the next `messages.create` call |
+| `runSbo3lToolUseLoop(client, opts)` | Drives a multi-turn conversation, dispatching `tool_use` blocks through SBO3L until Claude returns `stop_reason: "end_turn"` |
+
+Local Zod validation runs *before* the daemon HTTP call, so malformed
+inputs never consume daemon nonces or pollute the audit log. Daemon
+responses (allow signed receipt OR deny envelope) become the
+`tool_result` content — the model sees the structured outcome and can
+narrate or recover.
+
+## Live verification (judges click these)
+
+- npm: <https://www.npmjs.com/package/@sbo3l/anthropic> — published
+- Demo: `cd examples/anthropic-research-agent && npm install && npm run smoke`
+  — runs deterministic synthetic `tool_use` dispatch with no Anthropic
+  API key required (uses CI-safe mock)
+- Full Claude-driven run: `ANTHROPIC_API_KEY=sk-ant-… npm run agent`
+  — real `messages.create` calls; every tool dispatch produces a signed
+  capsule
+- Source: [`integrations/anthropic/src/`](../../integrations/anthropic/src/)
+  — TypeScript, MIT-licensed, ~250 LoC
+
+## Why this is more than "another tool"
+
+The `@sbo3l/*` namespace ships **25 npm packages** covering every major
+agent runtime: LangChain, LlamaIndex, AutoGen, CrewAI, LangGraph, Agno,
+plus low-level SDKs and 6 framework integrations. Claude tool-use is the
+*highest-traffic* surface but not the *only* surface — the same daemon,
+the same Passport capsule, the same audit chain back every adapter.
+
+A judge picking up `@sbo3l/anthropic` for the first time gets a working
+Claude agent with policy gating in **5 minutes**:
+
+```bash
+npm install @sbo3l/anthropic @anthropic-ai/sdk
+cargo install sbo3l-cli && sbo3l-server &     # the daemon
+node -e "import('./demo.mjs').then(m => m.run())"
+```
+
+That's the bar SBO3L holds itself to across every adapter: no fork, no
+SDK rewrite, real signed receipts in the same turn the model decided to
+act.

--- a/apps/marketing/src/content/submissions/ens-ai-agents.md
+++ b/apps/marketing/src/content/submissions/ens-ai-agents.md
@@ -1,0 +1,54 @@
+---
+title: "SBO3L → ENS AI Agents"
+audience: "ENS bounty judges (Best ENS Integration for AI Agents track)"
+source_file: docs/submission/bounty-ens-ai-agents.md
+---
+
+# SBO3L → ENS AI Agents
+
+> **Audience:** ENS bounty judges (Best ENS Integration for AI Agents track).
+> **Length:** ~500 words.
+
+## Hero claim
+
+**Identity (ENS) + dynamic state (ENSIP-25 CCIP-Read) + global registry (ERC-8004) — composed into a single agent trust profile any other agent can verify.** Three ENS-ecosystem standards, one cryptographically-coherent agent identity surface.
+
+## Why this bounty
+
+The "AI Agents" track rewards depth in ENS-as-agent-infrastructure, not just naming. Our submission stacks three independent ENS-aligned standards into a single trust profile:
+
+1. **ENS text records (mainnet)** — static identity (`agent_id`, `endpoint`, `policy_hash`, `audit_root`, `proof_uri`)
+2. **ENSIP-25 CCIP-Read gateway** — dynamic state (current `audit_root`, fresh `capability`, computed `reputation`) without burning gas on every update
+3. **ERC-8004 Identity Registry** — global agent identity anchor on mainnet, linking the ENS subname to a verifiable canonical pubkey
+
+Each layer is independently useful. Stacked, they answer every question an autonomous agent needs to ask before trusting another autonomous agent: *who are you, what are you allowed to do, what's your current reputation, and is your identity globally verifiable?*
+
+## Technical depth
+
+### CCIP-Read gateway (T-4-1, end-to-end live)
+
+ENSIP-25 / EIP-3668 off-chain resolution. SBO3L's gateway at https://ccip.sbo3l.dev (preview alias of https://sbo3l-ccip.vercel.app) is consumed automatically by `viem.getEnsText`, `ethers.js`, and any ENSIP-10-aware client. **No SBO3L-specific code on the client side.** A client resolving `research-agent.sbo3lagent.eth` text record `sbo3l:reputation` follows the OffchainResolver redirect to our gateway, which computes the current 4-criteria reputation score from the live audit chain and returns a signed envelope verified against the OffchainResolver contract.
+
+- **OffchainResolver contract:** [`crates/sbo3l-identity/contracts/OffchainResolver.sol`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/crates/sbo3l-identity/contracts/OffchainResolver.sol) — Foundry test suite at [`crates/sbo3l-identity/contracts/test/OffchainResolver.t.sol`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/crates/sbo3l-identity/contracts/test/OffchainResolver.t.sol); deploy via [`scripts/deploy-offchain-resolver.sh`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/scripts/deploy-offchain-resolver.sh) — Sepolia deployed
+- **Gateway endpoint:** `GET /api/{sender}/{data}.json` (Next.js dynamic route)
+- **Rust client decoder:** `crates/sbo3l-identity` — ENSIP-25 wire-format decoder for clients that don't use viem/ethers
+- **Uptime probe:** [`.github/workflows/ccip-gateway-uptime.yml`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/.github/workflows/ccip-gateway-uptime.yml)
+
+### ERC-8004 Identity Registry
+
+T-4-2 — agents register their `agent_id` + canonical pubkey in the ERC-8004 Identity Registry on mainnet, anchoring the ENS subname to a global identity. Calldata builders + dry-run path land in the upcoming PR (#125 + #132).
+
+### Cross-agent reputation (T-4-3 ✅ shipped at v1.2.0)
+
+`sbo3l:reputation` text record computed from the audit chain via 4-criteria scoring (success rate, deny rate, recency, consensus-with-peers). The reputation is dynamic — the live record reflects the agent's current state, not an init-time snapshot. CCIP-Read makes this practical without per-update gas.
+
+## Live verification
+
+- **CCIP gateway:** https://sbo3l-ccip.vercel.app/ + smoke fail-mode `/api/0xdeadbeef/0x12345678.json` returns 400 (correct rejection of invalid sender) per [`docs/submission/url-evidence.md`](url-evidence.md)
+- **CLI resolve dynamic record:** `sbo3l agent verify-ens research-agent.sbo3lagent.eth --rpc-url https://ethereum-rpc.publicnode.com` — gateway hit, signed response verified
+- **Mainnet apex byte-match:** `sbo3l-identity` CI test asserts the on-chain `policy_hash` byte-matches the offline fixture (no drift)
+- **Reputation 4-criteria scoring tests:** `crates/sbo3l-policy/src/reputation.rs` + integration test fleet (PR #126 ✅)
+
+## Sponsor-specific value prop
+
+Most "agent identity" projects pick *one* layer of the ENS-ecosystem stack. We pick three, and we make them compose. A judge who wants to know "is this agent trustworthy?" gets back: ENS text records (static commitments), CCIP-Read (current state), ERC-8004 (global identity anchor) — all verified cryptographically end-to-end, all consumable by any standard ENS client without SBO3L-specific tooling. **This is what an agent-grade ENS integration looks like at v1.**

--- a/apps/marketing/src/content/submissions/ens-most-creative-final.md
+++ b/apps/marketing/src/content/submissions/ens-most-creative-final.md
@@ -1,0 +1,389 @@
+---
+title: "SBO3L → ENS Most Creative — final submission"
+audience: "ENS bounty judges (Most Creative track)"
+source_file: docs/submission/bounty-ens-most-creative-final.md
+---
+
+# SBO3L → ENS Most Creative — final submission
+
+> **Audience:** ENS bounty judges (Most Creative track).
+> **Outcome in 60 seconds:** ENS is the *only* thing two SBO3L agents need
+> to share to authenticate each other. Every claim below has a code
+> reference + a live mainnet record + a one-line verification command.
+>
+> **Replaces:** [`bounty-ens-most-creative.md`](bounty-ens-most-creative.md)
+> (the draft submission). This file is the closeout version that pins
+> every Phase-2 + R10/R11/R12 ENS deliverable.
+>
+> **Updated (R12):** added the multi-chain reputation pipeline,
+> ENS DNS gateway codec, broader ENSIP-N draft, time-window token
+> gate, and the mainnet OffchainResolver skip rationale. **14
+> framework adapters** (LangChain, LangGraph, CrewAI, AutoGen,
+> ElizaOS, LlamaIndex, Vercel AI, OpenAI Assistants, Anthropic,
+> + 5 more) consume ENS-resolved agent identity through this stack
+> today.
+
+## Hero claim
+
+**ENS is not the integration. ENS is the trust DNS.** SBO3L doesn't
+*use* ENS as a feature; SBO3L turns ENS into the load-bearing
+identity layer for autonomous AI agents. Two agents who only know
+each other's ENS name can authenticate, attest, and refuse each
+other — without a CA, an enrolment server, or a shared session
+token.
+
+The hero artefact: `sbo3lagent.eth` resolves seven canonical
+`sbo3l:*` text records on Ethereum mainnet today, owned by
+[`0xdc7EFA…D231`](https://etherscan.io/address/0xdc7EFA6b4Bd77d1a406DE4727F0DF567e597D231).
+A judge with a public RPC and `cast` can independently verify
+every record. The same name's subnames are served via a deployed
+ENSIP-25 / EIP-3668 OffchainResolver
+([`0x7c6913…aCA8c3`](https://sepolia.etherscan.io/address/0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3))
+on Sepolia, with the gateway live at `sbo3l-ccip.vercel.app`.
+
+## Why this bounty
+
+The "Most Creative" framing rewards using ENS for something
+*only ENS makes possible*. Our argument: a global,
+censorship-resistant, cryptographically-anchored namespace that
+maps human-meaningful agent names to a complete trust profile —
+Ed25519 pubkey, policy hash, audit root, capability set, dynamic
+reputation. ENS isn't standing in for an alternative; ENS **is**
+the design choice that makes the rest of the protocol
+cryptographically grounded without us running any infrastructure.
+
+We didn't build a SBO3L registry. We built SBO3L *on top of* the
+registry that's already there.
+
+## What shipped (Phase 2 ENS Track)
+
+Eight tickets, eleven merged PRs, one closed PR (superseded), three
+in-flight (auto-merge queued).
+
+| Ticket | What it ships | PR(s) | Status |
+|---|---|---|---|
+| **T-3-1** | `sbo3l agent register --broadcast` direct ENS Registry path (Durin dropped) | #169 | Merged |
+| **T-3-2** | `sbo3l agent verify-ens` CLI + live mainnet test | #163 | Merged |
+| **T-3-3** | 5-agent named-role fleet config + register-fleet.sh + manifest schema | #138 | Merged |
+| **T-3-4** | Cross-agent verification protocol (Ed25519 challenges over ENS-resolved pubkey) | #167 | Merged |
+| **T-3-4** | 60-agent constellation generator + viz hand-off | #141 | Merged |
+| **T-3-4** | TS port of cross-agent protocol (cross-language parity) | #182 | Merged |
+| **T-3-6** | Trust DNS essay — "ENS as identity, not just naming" | #210 | Merged |
+| **T-3-6** | ENS technical deep-dive paper (3000-word, ENS Labs audience) | #215 | Auto-merge queued |
+| **T-3-7** | ENS Most Creative bounty narrative + pitch + tweets | #177 | Merged |
+| **T-3-8** | Cross-chain agent identity — EIP-712 attestations across 6 chains | #197 | Auto-merge queued |
+| **T-3-9** | Cross-chain reputation aggregation (weighted multi-chain score) | #222 | Auto-merge queued |
+| **T-4-1** | OffchainResolver Solidity + CCIP-Read gateway + Rust client decoder | (merged earlier) | Live on Sepolia |
+| **T-4-1** | viem E2E example (judge-runnable, no SBO3L client code) | #232 | Auto-merge queued |
+| **T-4-1** | OffchainResolver fuzz suite (10K runs × 11 properties) | #198 | Merged |
+| **T-4-2** | ERC-8004 Identity Registry calldata + dry-run | #125 | Merged |
+| **T-4-2** | Live AC wiring (gated on Daniel's deploy address) | #132 | DRAFT (gated) |
+| **T-4-5** | ENS Universal Resolver migration (360 → 60 RPC reduction on 60-agent fleet) | #194 | Merged |
+| **T-4-6** | Reputation publisher CLI — `sbo3l agent reputation-publish` | #201 | Merged |
+| **ENSIP** | Pre-submission draft for `reputation_score` text-record convention | #222 | Merged |
+| **Pin** | Canonical contracts.rs single-source-of-truth for deployed addresses | #232 | Merged |
+
+### R10 / R11 / R12 deliverables (added since the round-9 closeout)
+
+| Ticket | What it ships | PR(s) | Status |
+|---|---|---|---|
+| **R10 P1 / T-4-7** | `--broadcast` for reputation publish (alloy harness shared with T-3-1) | #250 | Merged |
+| **R10 P2** | ENSIP-upstream submission packet (cover letter for Dhaiwat) | #251 | Merged |
+| **R10 P3** | ENS DNS gateway scaffold (Vercel/Next.js, RFC 8484 DoH) | #251 | Merged |
+| **R11 P1** | `SBO3LReputationRegistry.sol` — narrowly-scoped on-chain reputation log + 23 tests at 10K fuzz | #257 | Merged |
+| **R11 P2** | Multi-chain reputation broadcast CLI — `--multi-chain sepolia,optimism-sepolia,base-sepolia` | #267 | Merged |
+| **R11 P3** | ENS DNS gateway codec finish — DoH wire codec wired (16 vitest tests) | #262 | Merged |
+| **R11 P4** | Broader ENSIP-N draft — 7 `sbo3l:*` keys, ~2200 words for ENS Labs | #264 | Merged |
+| **R11 P5** | Time-window token gate (UTC range / business hours / DST workaround) — 14 tests | #263 | Merged |
+| **R12** | Deploy runbook, `aggregate` CLI, mainnet skip rationale, bounty finalize | (this PR) | Pending |
+
+## Live verification per claim
+
+Every claim that follows is independently verifiable from a public
+RPC. Pasted commands assume `cast` is on PATH; substitute your own
+mainnet RPC for `--rpc-url`.
+
+### Hero claim — `sbo3lagent.eth` resolves the canonical seven records
+
+```bash
+SBO3L_ENS_RPC_URL=https://ethereum-rpc.publicnode.com \
+  sbo3l agent verify-ens sbo3lagent.eth --network mainnet
+```
+
+OR, without the SBO3L binary, raw `cast`:
+
+```bash
+RESOLVER=0xF29100983E058B709F3D539b0c765937B804AC15
+NODE=$(cast namehash sbo3lagent.eth)
+for KEY in sbo3l:agent_id sbo3l:endpoint sbo3l:policy_hash sbo3l:audit_root sbo3l:proof_uri; do
+  echo -n "$KEY = "
+  cast call "$RESOLVER" "text(bytes32,string)(string)" "$NODE" "$KEY" \
+    --rpc-url https://ethereum-rpc.publicnode.com
+done
+```
+
+| Property        | Value                                                                                                                         |
+|-----------------|-------------------------------------------------------------------------------------------------------------------------------|
+| Owner           | [`0xdc7EFA6b4Bd77d1a406DE4727F0DF567e597D231`](https://etherscan.io/address/0xdc7EFA6b4Bd77d1a406DE4727F0DF567e597D231)        |
+| ENS Registry    | [`0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e`](https://etherscan.io/address/0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e)         |
+| Resolver        | [`0xF29100983E058B709F3D539b0c765937B804AC15`](https://etherscan.io/address/0xF29100983E058B709F3D539b0c765937B804AC15)        |
+| ENS App page    | [https://app.ens.domains/sbo3lagent.eth](https://app.ens.domains/sbo3lagent.eth)                                              |
+
+### CCIP-Read gateway is real
+
+```bash
+# 1. Bytecode at the Sepolia OffchainResolver
+cast code 0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3 \
+  --rpc-url https://ethereum-sepolia-rpc.publicnode.com | head -c 200
+
+# 2. Run the viem E2E example (no SBO3L Rust dependency).
+cd examples/t-4-1-viem-e2e && pnpm install && pnpm start
+```
+
+### Cross-agent protocol works (no shared state, just ENS)
+
+```bash
+cargo test -p sbo3l-identity --lib cross_agent
+# 14 tests, all green. Verifies: resolve peer's pubkey from ENS,
+# verify Ed25519 signature on the challenge, emit signed receipt.
+```
+
+### Cross-chain attestations survive a 4-chain consistency check
+
+```bash
+cargo test -p sbo3l-identity --lib cross_chain
+# 26 tests. Includes: sign on 4 chains, verify_consistency emits
+# ConsistencyReport, tampered chain_id rejected.
+```
+
+### Reputation publisher is dry-run-stable
+
+```bash
+echo '[
+  {"decision":"allow","executor_confirmed":true,"age_secs":0},
+  {"decision":"deny","executor_confirmed":false,"age_secs":86400}
+]' > /tmp/events.json
+
+sbo3l agent reputation-publish \
+  --fqdn research-agent.sbo3lagent.eth \
+  --events /tmp/events.json
+# Emits the setText envelope for sbo3l:reputation_score.
+```
+
+### Universal Resolver win is reproducible
+
+```bash
+cargo test -p sbo3l-identity --lib universal
+# 13 tests including hand-built canned response → decoded EnsRecords.
+```
+
+### Multi-chain reputation aggregator works on synthetic inputs (no chain access required)
+
+```bash
+cat > /tmp/snapshots.json <<'EOF'
+{
+  "now_secs": 2000000000,
+  "snapshots": [
+    {"chain_id": 1,    "fqdn": "x", "score": 90, "observed_at": 1999999940},
+    {"chain_id": 10,   "fqdn": "x", "score": 80, "observed_at": 1999999940},
+    {"chain_id": 137,  "fqdn": "x", "score": 70, "observed_at": 1999999940}
+  ]
+}
+EOF
+sbo3l agent reputation-aggregate --input /tmp/snapshots.json
+# → aggregate_score: 82 (mainnet 90 × 1.0 + Optimism 80 × 0.8 +
+#   Polygon 70 × 0.6 = 196; weight sum 2.4; 196/2.4 = 81.67 → 82).
+# Pinned in sbo3l-policy::cross_chain_reputation::tests.
+```
+
+### ENS DNS gateway codec passes 16 vitest cases
+
+```bash
+cd apps/ens-dns-gateway
+npm install
+npm test
+# 16 tests across 5 mock ENS names + edge cases (trailing-dot, IPv6,
+# missing endpoint, partial records, non-ENS rejection).
+```
+
+### Time-window token gate composes with ERC-721 / ERC-1155 gates
+
+```bash
+cargo test -p sbo3l-identity --lib time_window_gate
+# 14 tests including DST workaround via AnyOf two BusinessHours gates.
+```
+
+## Evidence inventory
+
+Every PR above lands artefacts that survive the hackathon. The
+single index a reviewer can walk through in 10 minutes:
+
+| Artefact                                                                                                            | Purpose                                                       |
+|---------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|
+| [`docs/proof/ens-narrative.md`](../proof/ens-narrative.md)                                                          | Long-form judge walkthrough with live mainnet receipts        |
+| [`docs/concepts/trust-dns-essay.md`](../concepts/trust-dns-essay.md)                                                | Conceptual framing — "ENS as trust DNS" (1500 words)          |
+| [`docs/proof/ens-technical-paper.md`](../proof/ens-technical-paper.md)                                              | ENS Labs / ENSIP-author audience (3000 words, deeper)         |
+| [`docs/proof/ensip-draft-reputation.md`](../proof/ensip-draft-reputation.md)                                        | Pre-submission ENSIP for `reputation_score`                   |
+| [`docs/proof/etherscan-link-pack.md`](../proof/etherscan-link-pack.md)                                              | One-page Etherscan index of every on-chain claim              |
+| [`docs/proof/ens-fleet-agents-5-2026-05-01.json`](../proof/ens-fleet-agents-5-2026-05-01.json)                      | 5-agent named-role fleet manifest                             |
+| [`docs/proof/ens-fleet-agents-60-2026-05-01.json`](../proof/ens-fleet-agents-60-2026-05-01.json)                    | 60-agent constellation manifest                               |
+| [`docs/cli/ens-fleet-sepolia.md`](../cli/ens-fleet-sepolia.md)                                                      | Sepolia apex decision (Path A vs Path B for fleet broadcast)  |
+| [`crates/sbo3l-identity/`](../../crates/sbo3l-identity/)                                                            | The Rust identity surface (resolvers, anchors, cross-agent)   |
+| [`crates/sbo3l-identity/contracts/OffchainResolver.sol`](../../crates/sbo3l-identity/contracts/OffchainResolver.sol)| Solidity source of the deployed Sepolia contract              |
+| [`apps/ccip-gateway/`](../../apps/ccip-gateway/)                                                                    | TypeScript / Vercel CCIP-Read gateway                         |
+| [`examples/t-4-1-viem-e2e/`](../../examples/t-4-1-viem-e2e/)                                                        | Judge-runnable viem E2E test                                  |
+
+## Screenshot inventory (for the demo deck)
+
+| Screenshot                                       | Captures                                                                  |
+|--------------------------------------------------|---------------------------------------------------------------------------|
+| `app.ens.domains-sbo3lagent.eth.png`             | The mainnet apex showing all seven `sbo3l:*` records side by side          |
+| `etherscan-owner-page.png`                       | Daniel's wallet listed as owner of `sbo3lagent.eth` on Etherscan          |
+| `sbo3l-agent-verify-ens-output.png`              | CLI output showing live record fetch + verdict PASS                       |
+| `sepolia-offchain-resolver-etherscan.png`        | Sepolia Etherscan page for the deployed OffchainResolver contract         |
+| `viem-e2e-paste-output.png`                      | The terminal output of `pnpm start` with all three steps green            |
+| `trust-dns-viz-bench.png`                        | The 60-agent constellation rendering in `apps/trust-dns-viz/bench.html`   |
+| `cross-agent-receipt-json.png`                   | A signed `sbo3l.cross_agent_trust.v1` receipt with peer FQDN + pubkey     |
+
+The screenshots live under `docs/proof/screenshots/` (alongside the
+`ens-narrative.md`) and are included in the demo video at
+`demo-scripts/demo-video-script.md`.
+
+## Honest scope — what this submission does *not* claim
+
+Three explicit limitations:
+
+1. **Sybil resistance.** Anyone can register an ENS name and
+   publish `sbo3l:*` records. The trust-DNS framing solves "is
+   this the agent that signed this receipt?", not "is this agent
+   a real person?". For Sybil resistance, layer ERC-8004
+   reputation registries on top — T-4-2 (#125) ships the calldata
+   path; #132 lights up the live AC once the registry is pinned.
+
+2. **Mainnet broadcast for fleet agents.** The 5-agent and
+   60-agent fleet manifests are *registration-ready* on mainnet
+   (`sbo3lagent.eth` is owned, `register-fleet.sh` builds and
+   broadcasts), but the actual fleet broadcast is gated on the
+   Sepolia path-A/B decision (see
+   [`docs/cli/ens-fleet-sepolia.md`](../cli/ens-fleet-sepolia.md)).
+   Mainnet broadcast is a $5/agent gas commitment we'd want
+   judges' read on before paying.
+
+3. **Live broadcast of dynamic records.** The reputation publisher
+   (T-4-6) and cross-chain attestations (T-3-8) are
+   *publishable* dry-run today; broadcast wires through the
+   F-5 EthSigner trait once Dev 1 lands it. The dry-run envelopes
+   are publishable on their own — same input always re-derives the
+   same calldata, so an external auditor can replay the publisher
+   and confirm without trusting SBO3L's reporting.
+
+These are spelled out so a judge isn't surprised. The gating is
+about ergonomics + cost, not about the protocol or the
+implementation.
+
+## Why this is a credible "Most Creative" submission
+
+Three reasons stack:
+
+1. **No new infrastructure.** Every component ships against
+   contracts ENS already owns or contracts SBO3L deployed cleanly
+   under standard patterns. The mainnet apex uses the canonical
+   PublicResolver. The OffchainResolver is the ENS Labs reference
+   shape. The Universal Resolver migration uses the address `viem`
+   ships with. Nothing about SBO3L's architecture pre-supposes
+   infrastructure beyond ENS itself.
+
+2. **Cross-language verification.** The cross-agent protocol has a
+   Rust reference impl (T-3-4) and a TS port (#182) pinned against
+   a known reference vector (`seed [0x2a; 32]`, known JCS bytes,
+   known signature). A consumer in either language gets the
+   identical receipt. **Two agents written in different stacks
+   authenticate each other through ENS with zero shared
+   infrastructure.**
+
+3. **The protocol composes with future ENSIPs.** The
+   `reputation_score` ENSIP draft, the cross-chain identity
+   pattern, and the contract-pin module each compose cleanly with
+   the rest of ENS. We aren't competing with ERC-8004 — we'd
+   integrate. We aren't bypassing CCIP-Read — we're showing it
+   works at production scale.
+
+4. **14 framework adapters consume ENS-resolved identities.** The
+   SBO3L stack ships first-party adapters for LangChain (TS + Py),
+   LangGraph, CrewAI, AutoGen, ElizaOS, LlamaIndex, Vercel AI,
+   OpenAI Assistants, Anthropic SDK, plus 5 more under
+   `examples/*-research-agent/`. Each adapter resolves the agent's
+   identity via the ENS records described above — the convention
+   is real-world plug-and-play across the agent-framework
+   ecosystem, not a bespoke SBO3L pattern. **One ENS name, 14
+   different stacks; same authentication semantics.**
+
+## Multi-chain reputation pipeline (R11 + R12)
+
+Three chains carry the same agent's reputation score:
+
+- **Sepolia** — L1 testnet, default-weight 0.2.
+- **Optimism Sepolia** — OP-stack L2, default-weight 0.5.
+- **Base Sepolia** — Base-stack L2, default-weight 0.5.
+
+The contract on each chain is `SBO3LReputationRegistry`
+([`crates/sbo3l-identity/contracts/SBO3LReputationRegistry.sol`](../../crates/sbo3l-identity/contracts/SBO3LReputationRegistry.sol)),
+ECDSA-gated, append-only, multi-tenant. **Per-chain signatures
+(NOT signature replay)** — the digest binds to `address(this)`
+so sigs from one deploy can't be replayed on another. Same agent,
+same score, N per-chain signatures.
+
+The CLI wires both halves:
+
+```bash
+# Publish: same score to all 3 chains.
+sbo3l agent reputation-publish \
+  --fqdn research-agent.sbo3lagent.eth \
+  --events events.json \
+  --multi-chain sepolia,optimism-sepolia,base-sepolia
+
+# Aggregate: read N chain scores, produce one weighted score.
+sbo3l agent reputation-aggregate --input snapshots.json
+```
+
+Walkthrough at [`docs/proof/multi-chain-reputation.md`](../proof/multi-chain-reputation.md).
+
+## Mainnet OffchainResolver — explicitly skipped
+
+We **chose not** to deploy `OffchainResolver` to mainnet for the
+hackathon submission. Sepolia is fully demonstrative; mainnet
+migration of the live `sbo3lagent.eth` apex carries non-trivial
+risk for marginal psychological-confidence gain. Decision logged
+at [`docs/design/mainnet-deploy-decision.md`](../design/mainnet-deploy-decision.md)
+with three "conditions to revisit" so a future operator can
+unblock the path when one triggers.
+
+## Submission metadata
+
+| Field        | Value                                                                                      |
+|--------------|--------------------------------------------------------------------------------------------|
+| Track        | ENS — Most Creative Use of ENS for AI Agents                                              |
+| Team         | SBO3L (Daniel Babjak + Dev 1..4 contributors)                                              |
+| Repository   | https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026                           |
+| Live demo    | https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/                           |
+| Mainnet apex | [`sbo3lagent.eth`](https://app.ens.domains/sbo3lagent.eth) (owner [`0xdc7EFA…D231`](https://etherscan.io/address/0xdc7EFA6b4Bd77d1a406DE4727F0DF567e597D231)) |
+| Sepolia OffchainResolver | [`0x7c6913…aCA8c3`](https://sepolia.etherscan.io/address/0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3) |
+| Sepolia AnchorRegistry | [`0x4C302b…f4Ac`](https://sepolia.etherscan.io/address/0x4C302ba8349129bd5963A22e3c7a38a246E8f4Ac) |
+| Sepolia SubnameAuction | [`0x5dE75E…114B`](https://sepolia.etherscan.io/address/0x5dE75E64739A95701367F3Ad592e0b674b22114B) |
+| Sepolia ReputationBond | [`0x750722…93dA`](https://sepolia.etherscan.io/address/0x75072217B43960414047c362198A428f0E9793dA) |
+| Sepolia ReputationRegistry | [`0x6aA95d…6dc2`](https://sepolia.etherscan.io/address/0x6aA95d8126B6221607245c068483fa5008F36dc2) |
+| Live verification | [`docs/proof/contracts-live-test.md`](../proof/contracts-live-test.md) — `cast call` reads against PublicNode RPC, all 5 contracts |
+| Submitted    | 2026-05-02                                                                                 |
+| Companion    | [`bounty-ens-most-creative.md`](bounty-ens-most-creative.md) — the original 500-word draft |
+
+## Closing
+
+DNS solved finding things. SBO3L shows that ENS, with the records
+that already exist on it, **also** solves trusting things — for
+autonomous agents specifically, in a way no other naming system
+solves at all. That's the design choice we're submitting. Every
+line of code, every record on chain, every test in CI is downstream
+of that choice.
+
+Trust DNS. ENS as identity, not just naming. Same protocol,
+sharper question.

--- a/apps/marketing/src/content/submissions/ens-most-creative.md
+++ b/apps/marketing/src/content/submissions/ens-most-creative.md
@@ -1,0 +1,48 @@
+---
+title: "SBO3L → ENS Most Creative"
+audience: "ENS bounty judges (Most Creative track)"
+source_file: docs/submission/bounty-ens-most-creative.md
+---
+
+# SBO3L → ENS Most Creative
+
+> **Audience:** ENS bounty judges (Most Creative track).
+> **Length:** ~500 words. Long-form narrative at [`docs/proof/ens-narrative.md`](../proof/ens-narrative.md) (~400 lines).
+
+## Hero claim
+
+**ENS is not the integration. ENS is the trust DNS.** SBO3L doesn't *use* ENS as a feature; SBO3L turns ENS into the load-bearing identity layer for autonomous AI agents. Two agents who only know each other's ENS name can authenticate, attest, and refuse each other — without a CA, an enrolment server, or a shared session token.
+
+## Why this bounty
+
+The "Most Creative" framing rewards using ENS for something *only ENS makes possible*. Our claim: a global, censorship-resistant, cryptographically-anchored namespace that maps human-meaningful agent names (`research-agent.sbo3lagent.eth`) to a complete trust profile (Ed25519 pubkey, policy hash, audit root, capability set, dynamic reputation). ENS isn't standing in for an alternative; ENS *is* the design choice that makes the rest of the protocol cryptographically grounded without us running any infrastructure.
+
+The mainnet apex `sbo3lagent.eth` resolves five `sbo3l:*` text records on chain today (Phase 2 adds two more for seven total). Anyone with an Ethereum RPC can verify the agent's `policy_hash` byte-matches the offline fixture in CI — no SBO3L-specific client code, no SBO3L-hosted endpoint, no trusted intermediary. **The trust profile lives in ENS itself.**
+
+## Technical depth
+
+| Record on chain | Commits to |
+|---|---|
+| `sbo3l:agent_id` | Stable identifier — survives resolver rotation |
+| `sbo3l:endpoint` | Where the daemon lives |
+| `sbo3l:policy_hash` | JCS+SHA-256 of the canonical policy snapshot — the exact hash the daemon uses internally |
+| `sbo3l:audit_root` | Latest audit-chain head, rolled forward via on-chain checkpoints |
+| `sbo3l:proof_uri` | Stable URL where the latest Passport capsule for this agent lives |
+| `sbo3l:capability` | Phase 2 — comma-separated capability tags (`x402-purchase`, `uniswap-swap`, `delegation-target`) |
+| `sbo3l:reputation` | Phase 2 — `<score>/100` computed from the audit chain (4-criteria scoring) |
+
+**Subname registration is direct ENS Registry.** Daniel owns `sbo3lagent.eth`, so `setSubnodeRecord` registers `<name>.sbo3lagent.eth` directly via the canonical `0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e` registry contract on mainnet + Sepolia. No third-party registrar abstraction (we evaluated Durin and dropped it on 2026-05-01: direct registry has fewer moving parts, no new contracts to deploy, more verifiable on Etherscan).
+
+**Cross-agent verification protocol.** Agent A delegating to agent B signs an Ed25519 attestation pinning B's expected `policy_hash` and an `expires_at`. The receiving SBO3L instance verifies the chain (sender's pubkey → recipient's published policy → recipient's actual decision) before allowing the delegated action. Tampered attestation → `cross_agent.attestation_invalid`. Expired → `cross_agent.attestation_expired`. Both rejection paths tested in the demo gate.
+
+## Live verification
+
+- **Mainnet apex:** https://app.ens.domains/sbo3lagent.eth — five `sbo3l:*` records resolve via any ENS gateway
+- **Resolve from CLI:** `cargo install sbo3l-cli --version 1.2.0 && sbo3l agent verify-ens sbo3lagent.eth --rpc-url https://ethereum-rpc.publicnode.com` — returns all 5 records + the `policy_hash = e044f13c5acb792dd3109f1be3a98536168b0990e25595b3cedc131d02e666cf` byte-match assertion
+- **Sepolia agent fleet:** 5+ named agents at `<name>.sbo3lagent.eth` — see [`docs/proof/ens-fleet-2026-05-01.json`](../proof/ens-fleet-2026-05-01.json) for the registration manifest with tx hashes
+- **Trust-DNS visualization:** https://app.sbo3l.dev/trust-dns (Vercel preview fallback while custom domain points) — D3 + canvas force-directed graph, agents discovering each other in real time
+- **1500-word essay:** https://docs.sbo3l.dev/trust-dns
+
+## Sponsor-specific value prop
+
+We didn't add ENS as a feature; we used ENS as the *backbone* of the trust model. Every agent identity lookup, every cross-agent attestation, every reputation update flows through ENS. The hosted trust-DNS visualization makes that backbone visible — and verifiable in real time. This is the strongest possible argument that ENS is *the* substrate for autonomous-agent identity, not just one of several options.

--- a/apps/marketing/src/content/submissions/keeperhub-builder-feedback.md
+++ b/apps/marketing/src/content/submissions/keeperhub-builder-feedback.md
@@ -1,0 +1,42 @@
+---
+title: "SBO3L → KeeperHub Builder Feedback"
+audience: "KeeperHub bounty judges + KH platform/docs team"
+source_file: docs/submission/bounty-keeperhub-builder-feedback.md
+---
+
+# SBO3L → KeeperHub Builder Feedback
+
+> **Audience:** KeeperHub bounty judges + KH platform/docs team.
+> **Length:** ~500 words.
+
+## Hero claim
+
+**Five concrete asks filed during real integration work**, every one motivated by a specific friction point we hit while building [`sbo3l-keeperhub-adapter`](https://crates.io/crates/sbo3l-keeperhub-adapter) and the live arm of `KeeperHubExecutor::live_from_env()`.
+
+## Why this bounty
+
+The Builder Feedback bounty rewards *specific, actionable* feedback from teams that actually shipped against KeeperHub, not generic "would be nice" suggestions. Every issue we filed includes a worked code example, a citation to the exact line in our adapter where the friction surfaced, and a proposed shape for the fix. We want the KeeperHub platform to win with us, not just be polite about reviewing our PR.
+
+## Issues filed
+
+| Issue | Subject | Friction we hit |
+|---|---|---|
+| [KeeperHub/cli#47](https://github.com/KeeperHub/cli/issues/47) | Token-prefix naming (`kh_*` vs `wfb_*`) | Cost real wiring time — split between native API tokens and workflow-webhook tokens isn't surfaced in the public docs. We filed a worked example showing the exact header each token belongs in. |
+| [KeeperHub/cli#48](https://github.com/KeeperHub/cli/issues/48) | Undocumented submission/result envelope schema | No public JSON schema for the action submission/result envelope — our hackathon adapter mocks execution by default for CI determinism. Live submissions work, but the envelope shape was reverse-engineered from `curl -v`. Proposed a JSON Schema file to mirror our expectations. |
+| [KeeperHub/cli#49](https://github.com/KeeperHub/cli/issues/49) | `executionId` lookup undocumented | No documented GET path or MCP tool for post-submit status / run-log retrieval. Policy engines (and operators) need to reconcile their own audit trails against KeeperHub's; today there's no canonical lookup. Proposed `keeperhub.lookup_execution(execution_id)` MCP tool shape. |
+| [KeeperHub/cli#50](https://github.com/KeeperHub/cli/issues/50) | First-class upstream policy/audit fields on submission | Today an auditor reading a KH execution row has no cryptographic link back to the SBO3L decision that approved it. Proposed five optional `sbo3l_*` envelope fields KH can echo on lookup (request_hash, policy_hash, receipt_signature, audit_event_id, optional passport_uri). |
+| [KeeperHub/cli#51](https://github.com/KeeperHub/cli/issues/51) | `Idempotency-Key` retry semantics on workflow webhooks | Undocumented dedup behavior on duplicate webhook delivery. Policy engines have to choose between "never retry" (loses delivery) or "retry blindly" (risks double-spending an authorisation). Proposed: KeeperHub honour `Idempotency-Key` header per-webhook with documented dedup window. |
+
+All five issues are linked from [`FEEDBACK.md`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/FEEDBACK.md) — this is the canonical source SBO3L's Phase 1 exit gate `T-2-1` ([PR #172](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/172)) literal-greps against to confirm submission.
+
+## What makes this feedback different
+
+**It's all reproducible.** Every issue has either a `curl` invocation or a Rust unit test that demonstrates the friction. None of the asks are aesthetic — they're all about making integration deterministic for third-party adapter authors. We expect any one of them to land within KeeperHub's normal docs/feature flow without coordination, since each is independent.
+
+**It's all from real integration work.** SBO3L's `KeeperHubExecutor::live_from_env()` was built end-to-end during the hackathon, against a real `wfb_…` token, against the real workflow `m4t4cnpmhv8qquce3bv3c`. The adapter is published standalone on crates.io (IP-4 path); anyone can `cargo add sbo3l-keeperhub-adapter@1.2.0` and reproduce the exact integration shape that surfaced these frictions.
+
+## Sponsor-specific value prop
+
+Builder Feedback is about *closing the loop* — teams that hit friction become the team that fixes the docs, designs the schema, or proposes the MCP tool. We want to ship IP-1..IP-5 with KH, not for SBO3L (we already shipped our side); we want it because the same friction will hit the next twenty teams that try this integration.
+
+The fastest path to landing all five: KH merges IP-1 (5 optional fields) + IP-2 (one JSON Schema file) — that's a ~1-day platform-team task that unlocks every other adapter author after us.

--- a/apps/marketing/src/content/submissions/keeperhub.md
+++ b/apps/marketing/src/content/submissions/keeperhub.md
@@ -1,0 +1,47 @@
+---
+title: "SBO3L → KeeperHub Best Use"
+audience: "KeeperHub bounty judges + Luca's team"
+source_file: docs/submission/bounty-keeperhub.md
+---
+
+# SBO3L → KeeperHub Best Use
+
+> **Audience:** KeeperHub bounty judges + Luca's team.
+> **Length:** ~500 words. Detailed technical narrative at [`docs/keeperhub-integration-paths.md`](../keeperhub-integration-paths.md).
+
+## Hero claim
+
+**KeeperHub executes. SBO3L proves the execution was authorised.** Two complementary layers in the same agent stack — the policy boundary and the execution substrate — designed from the start to compose without either side absorbing the other's responsibility.
+
+## Why this bounty
+
+KeeperHub is positioned as the *execution layer for AI agents onchain*. The integration with SBO3L is a thin adapter, not a rewrite: KeeperHub records *what was executed*, SBO3L records *why it was authorised*. SBO3L's `KeeperHubExecutor::live_from_env()` POSTs the IP-1 envelope to a real workflow webhook the moment a `decision: allow` is signed; the executionId KeeperHub returns is captured into the Passport capsule's `execution.live_evidence`. Denied actions never reach the sponsor. Allowed actions arrive with a signed envelope that lets any auditor cryptographically link the upstream policy decision to the eventual KeeperHub execution row — without trusting either side to correlate honestly.
+
+## Technical depth
+
+Five integration paths (IP-1..IP-5) catalogued in [`docs/keeperhub-integration-paths.md`](../keeperhub-integration-paths.md), each independently small and reviewable:
+
+| # | Shape | Adoption cost on KH side |
+|---|---|---|
+| **IP-1** | `sbo3l_*` upstream-proof envelope fields on the workflow webhook | 4-5 optional string fields, echo on lookup |
+| **IP-2** | Public submission/result envelope JSON Schema | One JSON Schema file under your docs |
+| **IP-3** | `keeperhub.lookup_execution(execution_id)` MCP tool | One MCP tool definition + thin handler |
+| **IP-4** | Standalone `sbo3l-keeperhub-adapter` Rust crate | Listing on your "integrations" page; crates.io publication target |
+| **IP-5** | SBO3L Passport capsule URI on the execution row | One optional string column |
+
+Stacking the shapes gives **end-to-end offline auditability** of every KeeperHub execution that flowed through SBO3L. `sbo3l-keeperhub-adapter` is published standalone on crates.io ([1.2.0 LIVE](https://crates.io/crates/sbo3l-keeperhub-adapter)), so any third-party adapter author can depend on it without pulling the rest of SBO3L.
+
+Adapter has both `local_mock()` (CI-safe default — produces a deterministic `kh-<ULID>` `execution_ref`, prints `mock: true`) and `live_from_env()` (real `wfb_…` token + workflow id) constructors. Mock and live are first-class peers; mock is the CI default for determinism, live is exercised explicitly per smoke gate.
+
+## Live verification (judges click these)
+
+- **Real KH workflow:** `https://app.keeperhub.com/api/workflows/m4t4cnpmhv8qquce3bv3c/webhook` — POST with the IP-1 envelope returns a real KH-format `executionId` (e.g. `kh-172o77rxov7mhwvpssc3x`). Verified end-to-end during the submission window.
+- **Adapter on crates.io:** https://crates.io/crates/sbo3l-keeperhub-adapter — `cargo add sbo3l-keeperhub-adapter@1.2.0`
+- **MCP tool implementation:** [`crates/sbo3l-mcp/src/lib.rs`](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/crates/sbo3l-mcp/src/lib.rs) — `sbo3l.audit_lookup(execution_id)` mirrors the proposed `keeperhub.lookup_execution` shape
+- **5 KH improvement issues filed** ([`KeeperHub/cli#47-#51`](https://github.com/KeeperHub/cli/issues)) — see the [Builder Feedback bounty one-pager](bounty-keeperhub-builder-feedback.md)
+
+## Sponsor-specific value prop
+
+A KeeperHub auditor today reading an execution row has no cryptographic link back to whoever authorised the action. With IP-1 alone, that link becomes one offline verification. With IP-1 + IP-5, that link becomes one HTTP fetch. Neither IP-1 nor IP-5 requires KeeperHub to absorb any SBO3L logic — both are optional fields that KeeperHub echoes on lookup. This is the lightest possible adoption path that turns "trust me" into "verify it."
+
+If KeeperHub merges IP-1 + IP-5 (estimated ~1 week of engineering on KH's side based on the field shapes), every execution row gains a falsifiable upstream proof — at zero runtime cost to KeeperHub, zero schema break for existing consumers.

--- a/apps/marketing/src/content/submissions/uniswap.md
+++ b/apps/marketing/src/content/submissions/uniswap.md
@@ -1,0 +1,49 @@
+---
+title: "SBO3L → Uniswap Best API"
+audience: "Uniswap bounty judges (Best API track)"
+source_file: docs/submission/bounty-uniswap.md
+---
+
+# SBO3L → Uniswap Best API
+
+> **Audience:** Uniswap bounty judges (Best API track).
+> **Length:** ~500 words.
+
+## Hero claim
+
+**A swap executed via the Uniswap API today is opaque. SBO3L makes the audit trail cryptographic — same Uniswap API, every call gated, signed, and bound to a re-derivable policy decision.**
+
+## Why this bounty
+
+"Best API" rewards integrations that surface Uniswap's strengths in a way that wouldn't exist otherwise. Our argument: an autonomous agent making a swap should produce *the same on-chain effect* as a human-driven swap, plus *a portable cryptographic proof* of why that swap was authorised. Today the audit trail for an agent-driven swap is "whatever the agent code happened to write" — i.e. usually nothing verifiable. With SBO3L's `UniswapExecutor` as a `GuardedExecutor`, every swap intent runs through a deterministic policy boundary before the swap is constructed; slippage, MEV-protection, token-allowlist, and value-cap are all expressed as policy rules — not as bot logic. The decision is signed; the audit row links that decision to the eventual on-chain `tx_hash` via the Passport capsule.
+
+The Uniswap API surface we exercise is intentionally vanilla: QuoterV2 for quotes, Universal Router for swap construction, and the standard SwapRouter02 for direct swaps. **No custom contracts, no v4 hooks competing for sponsor attention, no rewrites of Uniswap's own primitives.** Our value-add is the cryptographic envelope around the Uniswap call, not the call itself.
+
+## Technical depth
+
+### Sepolia QuoterV2 — live quote evidence
+
+`UniswapExecutor::live_from_env()` calls QuoterV2 (`0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3`) on Sepolia for every swap intent. The quote evidence (`quote_source: uniswap-v3-quoter-sepolia-…`, real `sqrt_price_x96_after`, freshness timestamp, route `WETH → USDC 0x1c7D4B19…`) is captured into the Passport capsule. Off-by-one or stale quotes → policy `protocol.deny_quote_stale` rejection.
+
+### Universal Router with per-step policy gates (T-5-2 ✅, [PR #171](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/171))
+
+Every Universal Router command (`V3_SWAP_EXACT_IN`, `WRAP_ETH`, `PERMIT2_PERMIT`, etc.) is gated by an *independent* policy decision before encoding into the calldata stream. Slippage, recipient allowlist, and value-cap rules apply per step rather than per-bundle — so a multi-hop swap can have different slippage tolerance per hop, and a recipient deny on hop 3 doesn't already-spent hops 1 and 2.
+
+### Smart Wallet integration with per-call policy gates (T-5-3 ✅, [PR #183](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/183))
+
+The agent acts as the Smart Account owner. Each call inside a Smart Wallet batch carries its own SBO3L PolicyReceipt and audit-event linkage. The capsule contains the full per-call decision tree, not just the outer batch result. Tampering with one inner call's `live_evidence` invalidates the strict-hash verifier output for the whole capsule.
+
+### MEV protection in policy (T-5-4 in flight, [PR #179](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/179))
+
+Policy rules express MEV-safety primitives directly: `slippage_bps` ≤ `policy.max_slippage`, `priority_fee` bounded, `quote.freshness` ≤ `policy.max_quote_age`, `recipient` in `policy.allowed_recipients`. The audit row records exactly which rule fired; an auditor can reconstruct the bounded swap path *without trusting our daemon being online*.
+
+## Live verification
+
+- **Sepolia QuoterV2 live quote:** `cargo install sbo3l-cli --version 1.2.0 && SBO3L_UNISWAP_RPC_URL=… sbo3l passport run swap-aprp.json --executor uniswap --mode live --quote-only --out /tmp/capsule.json && sbo3l passport verify --strict --path /tmp/capsule.json` → PASSED with quote evidence in capsule
+- **Real Sepolia swap with `tx_hash` in capsule** (T-5-5, gated on T-5-1 #165) — capsule's `execution.live_evidence.tx_hash` is the canonical proof; Etherscan link will be captured into `demo-scripts/artifacts/uniswap-real-swap-capsule.json` (artifact dir is gitignored — file appears at run time after `bash demo-scripts/sponsors/uniswap-real-swap.sh` against funded wallet)
+- **Examples:** `examples/uniswap-agent-{ts,py}/` (T-5-6, [PR #166](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/166)) — TS + Py demo
+- **Same capsule re-verified in browser:** drag into https://sbo3l.dev/proof — WASM verifier runs offline checks; tampering with `tx_hash` → `capsule.live_evidence_mismatch`
+
+## Sponsor-specific value prop
+
+The cryptographic envelope is what's *new*. The Uniswap call inside it is intentionally identical to what a human-driven swap looks like. Auditors, regulators, and operators can re-derive what was authorised, by whom, against which policy — across days, across teams, across systems — without trusting any single party. **That's the difference between an agent-driven swap and an opaque swap.** Same Uniswap API; cryptographic audit trail.

--- a/apps/marketing/src/pages/submission/[bounty].astro
+++ b/apps/marketing/src/pages/submission/[bounty].astro
@@ -4,8 +4,11 @@ import BaseLayout from "~/layouts/BaseLayout.astro";
 
 export async function getStaticPaths() {
   const all = await getCollection("submissions");
+  // Astro 5: `entry.slug` is the auto-derived slug (filename without
+  // extension). Schema cannot declare its own `slug` field — that field
+  // is reserved by the content collection runtime.
   return all.map((entry) => ({
-    params: { bounty: entry.data.slug },
+    params: { bounty: entry.slug },
     props: { entry },
   }));
 }
@@ -15,9 +18,9 @@ const { Content } = await render(entry);
 
 // All other bounty entries — for the "view another" footer.
 const all = await getCollection("submissions");
-const others = all.filter((e) => e.data.slug !== entry.data.slug);
+const others = all.filter((e) => e.slug !== entry.slug);
 
-const shareUrl = `https://sbo3l-marketing.vercel.app/submission/${entry.data.slug}`;
+const shareUrl = `https://sbo3l-marketing.vercel.app/submission/${entry.slug}`;
 const shareText = `${entry.data.title} — SBO3L · ETHGlobal Open Agents 2026`;
 ---
 <BaseLayout
@@ -52,7 +55,7 @@ const shareText = `${entry.data.title} — SBO3L · ETHGlobal Open Agents 2026`;
         <h2>Other bounty submissions</h2>
         <ul>
           {others.map((o) => (
-            <li><a href={`/submission/${o.data.slug}`}>{o.data.title}</a></li>
+            <li><a href={`/submission/${o.slug}`}>{o.data.title}</a></li>
           ))}
         </ul>
       </aside>

--- a/docs/submission/bounty-anthropic.md
+++ b/docs/submission/bounty-anthropic.md
@@ -1,0 +1,79 @@
+# SBO3L → Anthropic Claude tool-use
+
+> **Audience:** Anthropic ecosystem reviewers + judges evaluating the SBO3L coverage of the dominant agent runtime.
+> **Length:** ~500 words. Implementation in
+> [`integrations/anthropic/`](../../integrations/anthropic) +
+> [`examples/anthropic-research-agent/`](../../examples/anthropic-research-agent).
+
+## Hero claim
+
+**Claude tool-use is the dominant interface for autonomous agents in 2026.
+SBO3L wraps it with a policy boundary that emits signed receipts for every
+tool call.** No prompt re-engineering, no model swap, no SDK fork. The
+adapter is a Claude `Tool` definition + a one-line dispatcher.
+
+## Why this surface matters
+
+The bulk of agent-economy traffic in 2026 is Claude `messages.create` with
+`tool_use` blocks — and most of those tools are fire-and-forget execution
+shells with no policy gate, no audit trail, and no portable proof of what
+the agent actually did. SBO3L treats the daemon's HTTP surface as a Claude
+tool, so the agent's *intent* (the `tool_use` block) and the policy's
+*decision* (the signed `PolicyReceipt`) live in the same conversation
+turn.
+
+Result: every Claude-driven payment, swap, or workflow trigger is gated
+upstream of the model's hallucination surface. Malformed tool inputs are
+caught locally by Zod *before* the daemon round trip and surfaced back to
+Claude as a `tool_result` with `is_error: true`, so the model can
+self-correct without a network call.
+
+## Technical depth
+
+The `@sbo3l/anthropic` npm package (LIVE on npmjs.com under the
+`@sbo3l/*` scope) ships:
+
+| Export | Shape |
+|---|---|
+| `sbo3lTool` | Anthropic `Tool` definition with the APRP v1 input schema baked in |
+| `runSbo3lToolUse(tool, block, opts)` | Converts a `tool_use` content block → `tool_result` block ready to push back into the next `messages.create` call |
+| `runSbo3lToolUseLoop(client, opts)` | Drives a multi-turn conversation, dispatching `tool_use` blocks through SBO3L until Claude returns `stop_reason: "end_turn"` |
+
+Local Zod validation runs *before* the daemon HTTP call, so malformed
+inputs never consume daemon nonces or pollute the audit log. Daemon
+responses (allow signed receipt OR deny envelope) become the
+`tool_result` content — the model sees the structured outcome and can
+narrate or recover.
+
+## Live verification (judges click these)
+
+- npm: <https://www.npmjs.com/package/@sbo3l/anthropic> — published
+- Demo: `cd examples/anthropic-research-agent && npm install && npm run smoke`
+  — runs deterministic synthetic `tool_use` dispatch with no Anthropic
+  API key required (uses CI-safe mock)
+- Full Claude-driven run: `ANTHROPIC_API_KEY=sk-ant-… npm run agent`
+  — real `messages.create` calls; every tool dispatch produces a signed
+  capsule
+- Source: [`integrations/anthropic/src/`](../../integrations/anthropic/src/)
+  — TypeScript, MIT-licensed, ~250 LoC
+
+## Why this is more than "another tool"
+
+The `@sbo3l/*` namespace ships **25 npm packages** covering every major
+agent runtime: LangChain, LlamaIndex, AutoGen, CrewAI, LangGraph, Agno,
+plus low-level SDKs and 6 framework integrations. Claude tool-use is the
+*highest-traffic* surface but not the *only* surface — the same daemon,
+the same Passport capsule, the same audit chain back every adapter.
+
+A judge picking up `@sbo3l/anthropic` for the first time gets a working
+Claude agent with policy gating in **5 minutes**:
+
+```bash
+npm install @sbo3l/anthropic @anthropic-ai/sdk
+cargo install sbo3l-cli && sbo3l-server &     # the daemon
+node -e "import('./demo.mjs').then(m => m.run())"
+```
+
+That's the bar SBO3L holds itself to across every adapter: no fork, no
+SDK rewrite, real signed receipts in the same turn the model decided to
+act.


### PR DESCRIPTION
Reviewer audit: all 4 SponsorLogos hrefs return 404 on the deployed marketing site. Three root causes, fixed together: Astro 5 schema breakage (`slug` reserved), build pipeline never produced output on Vercel (rootDirectory scope), missing `bounty-anthropic.md` source.