### PR TITLE
fix(deploy): Task A — pin canonical URL template + probe tests (Heidi UAT bug #2)

### DIFF
--- a/crates/sbo3l-identity/contracts/script/DeployOffchainResolver.s.sol
+++ b/crates/sbo3l-identity/contracts/script/DeployOffchainResolver.s.sol
@@ -4,6 +4,23 @@ pragma solidity ^0.8.24;
 import {Script, console} from "forge-std/Script.sol";
 import {OffchainResolver} from "../OffchainResolver.sol";
 
+// The canonical SBO3L CCIP-Read gateway URL template.
+//
+// Exact ENSIP-25 / EIP-3668 syntax: `{sender}` and `{data}` are
+// placeholder tokens the client substitutes. Hardcoded as a Solidity
+// string literal so `forge create --constructor-args` CLI tokenization
+// (which rebalances `{...}` patterns) never gets a chance to mangle
+// it. File-level so probe tests can `import {CANONICAL_URL_TEMPLATE}`
+// directly without instantiating the deploy script — single source of
+// truth, no drift possible.
+//
+// Heidi UAT 2026-05-03 caught the original Sepolia deploy storing
+// `"...{sender/{data}.json}"`. This constant is the post-fix canonical
+// form; probe tests in `test/DeployOffchainResolver.t.sol` pin it
+// byte-for-byte.
+string constant CANONICAL_URL_TEMPLATE =
+    "https://sbo3l-ccip.vercel.app/api/{sender}/{data}.json";
+
 // Forge script wrapper around the OffchainResolver constructor.
 //
 // Replaces direct `forge create --constructor-args` invocation, which
@@ -28,15 +45,6 @@ import {OffchainResolver} from "../OffchainResolver.sol";
 //   forge script script/DeployOffchainResolver.s.sol \
 //     --rpc-url $SEPOLIA_RPC_URL --broadcast
 contract DeployOffchainResolver is Script {
-    /// @dev The canonical SBO3L CCIP-Read gateway URL template.
-    ///      Exact ENSIP-25 / EIP-3668 syntax: `{sender}` and `{data}`
-    ///      are placeholder tokens the client substitutes. Hardcoded
-    ///      here so a future operator can't accidentally pass a
-    ///      malformed template via env var (and so CLI tokenizers
-    ///      don't get a chance to rebalance the braces).
-    string internal constant CANONICAL_URL_TEMPLATE =
-        "https://sbo3l-ccip.vercel.app/api/{sender}/{data}.json";
-
     function run() external returns (OffchainResolver resolver) {
         uint256 deployerKey = vm.envUint("PRIVATE_KEY");
         address gatewaySigner = vm.envAddress("GATEWAY_SIGNER_ADDRESS");

--- a/crates/sbo3l-identity/contracts/test/DeployOffchainResolver.t.sol
+++ b/crates/sbo3l-identity/contracts/test/DeployOffchainResolver.t.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {OffchainResolver} from "../OffchainResolver.sol";
+import {CANONICAL_URL_TEMPLATE} from "../script/DeployOffchainResolver.s.sol";
+
+/// Probe test for the OffchainResolver deploy-script URL template.
+///
+/// Heidi UAT 2026-05-03 caught the original Sepolia deploy storing a
+/// malformed URL template (`"...{sender/{data}.json}"`) because
+/// `forge create --constructor-args` mis-parses `{...}` patterns
+/// inside string-array literals. The deploy script wrapper encodes
+/// the URL template as a Solidity string literal, sidestepping the
+/// CLI parser entirely.
+///
+/// These tests pin the canonical template byte-for-byte. If a future
+/// touch of the deploy script accidentally drops or rebalances a
+/// brace, the tests fail before any tx hits a live RPC.
+contract DeployOffchainResolverTest is Test {
+    /// @dev The exact byte sequence the gateway expects clients to
+    ///      receive. ENSIP-25 / EIP-3668 placeholder syntax.
+    bytes internal constant CANONICAL_URL_BYTES =
+        bytes("https://sbo3l-ccip.vercel.app/api/{sender}/{data}.json");
+
+    function test_deployScriptConstantIsCanonical() public pure {
+        // Pin the constant exposed by the deploy script byte-for-byte.
+        // Any subtle drift (missing brace, swapped slash, wrong host)
+        // surfaces here.
+        bytes memory actual = bytes(CANONICAL_URL_TEMPLATE);
+        assertEq(actual.length, CANONICAL_URL_BYTES.length, "URL length drift");
+        for (uint256 i = 0; i < actual.length; i++) {
+            assertEq(actual[i], CANONICAL_URL_BYTES[i], "URL byte drift");
+        }
+    }
+
+    function test_constructorPreservesCanonicalTemplate() public {
+        // The OffchainResolver constructor must store the template
+        // verbatim. (Heidi bug #2 was CLI-side, but pinning the
+        // round-trip closes the loop.)
+        string[] memory urls = new string[](1);
+        urls[0] = CANONICAL_URL_TEMPLATE;
+
+        address dummySigner = address(uint160(uint256(keccak256("dummy"))));
+        OffchainResolver resolver = new OffchainResolver(dummySigner, urls);
+
+        bytes memory roundtripped = bytes(resolver.urls(0));
+        assertEq(roundtripped.length, CANONICAL_URL_BYTES.length, "round-trip length drift");
+        for (uint256 i = 0; i < roundtripped.length; i++) {
+            assertEq(
+                roundtripped[i],
+                CANONICAL_URL_BYTES[i],
+                "round-trip byte drift"
+            );
+        }
+    }
+
+    function test_canonicalTemplateContainsBothPlaceholders() public pure {
+        // Cheap sanity: the canonical string must contain both
+        // `{sender}` and `{data}` placeholders ENSIP-25 specifies.
+        // The malformed pre-fix template was `{sender/{data}.json}` —
+        // would fail this on the missing `}` after `sender`.
+        string memory tmpl = CANONICAL_URL_TEMPLATE;
+        assertTrue(_contains(tmpl, "{sender}"), "missing {sender} placeholder");
+        assertTrue(_contains(tmpl, "{data}"), "missing {data} placeholder");
+    }
+
+    function _contains(string memory haystack, string memory needle)
+        internal
+        pure
+        returns (bool)
+    {
+        bytes memory hb = bytes(haystack);
+        bytes memory nb = bytes(needle);
+        if (nb.length == 0 || hb.length < nb.length) return false;
+        for (uint256 i = 0; i + nb.length <= hb.length; i++) {
+            bool match_ = true;
+            for (uint256 j = 0; j < nb.length; j++) {
+                if (hb[i + j] != nb[j]) {
+                    match_ = false;
+                    break;
+                }
+            }
+            if (match_) return true;
+        }
+        return false;
+    }
+}

--- a/docs/dev4/sepolia-or-redeploy-2026-05-03.md
+++ b/docs/dev4/sepolia-or-redeploy-2026-05-03.md
@@ -1,0 +1,80 @@
+# Sepolia OffchainResolver redeploy — 2026-05-03
+
+> **Why this exists:** Heidi's UAT 2026-05-03 caught Bug #2 — the
+> Sepolia OffchainResolver at
+> [`0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3`](https://sepolia.etherscan.io/address/0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3)
+> stored a malformed URL template
+> (`"https://sbo3l-ccip.vercel.app/api/{sender/{data}.json}"`)
+> instead of the canonical ENSIP-25 form
+> (`"https://sbo3l-ccip.vercel.app/api/{sender}/{data}.json"`).
+> CCIP-Read clients that follow the spec strictly fail before the
+> gateway is even reached.
+
+## Root cause
+
+`forge create --constructor-args "$ADDR" "[$URL]"` rebalances the
+`{...}` patterns inside the URL string when tokenizing the array
+literal. The closing `}` after `sender` migrated to the end. This
+happens regardless of shell quoting — even with
+`"[\"$URL\"]"` the same mangling occurs.
+
+## Fix posture
+
+Replaced direct `forge create --constructor-args` invocation with a
+forge SCRIPT wrapper at
+[`script/DeployOffchainResolver.s.sol`](../../crates/sbo3l-identity/contracts/script/DeployOffchainResolver.s.sol).
+The URL template is encoded as a Solidity string literal at file
+level (`CANONICAL_URL_TEMPLATE`) so CLI parsing never touches it.
+
+Probe tests at
+[`test/DeployOffchainResolver.t.sol`](../../crates/sbo3l-identity/contracts/test/DeployOffchainResolver.t.sol)
+pin the constant byte-for-byte, run end-to-end through the
+constructor, and confirm both `{sender}` and `{data}` placeholders
+survive.
+
+## New live deploy
+
+| Item | Value |
+|---|---|
+| Address | [`0x87e99508c222c6e419734cacbb6781b8d282b1f6`](https://sepolia.etherscan.io/address/0x87e99508c222c6e419734cacbb6781b8d282b1f6) |
+| Network | Sepolia (chain id 11155111) |
+| Deployer | `0x50BA7BF5FDe124DB51777A2bF0eED733756B7e9c` (driver wallet) |
+| Gateway signer | `0x595099B4e8D642616e298235Dd1248f8008BCe65` (matches Vercel `GATEWAY_PRIVATE_KEY`) |
+| Deploy tx | (forge script, see broadcast manifest) |
+| Bytecode length | 4747 hex chars |
+
+Verified on chain via PublicNode + Alchemy RPC:
+
+```bash
+RPC=https://eth-sepolia.g.alchemy.com/v2/<key>
+ADDR=0x87e99508c222c6e419734cacbb6781b8d282b1f6
+
+cast call "$ADDR" "urls(uint256)(string)" 0 --rpc-url "$RPC"
+# → "https://sbo3l-ccip.vercel.app/api/{sender}/{data}.json"  ✓ canonical
+
+cast call "$ADDR" "gatewaySigner()(address)" --rpc-url "$RPC"
+# → 0x595099B4e8D642616e298235Dd1248f8008BCe65
+
+cast call "$ADDR" "supportsInterface(bytes4)(bool)" 0x9061b923 --rpc-url "$RPC"
+# → true   (ENSIP-10 IExtendedResolver)
+```
+
+## What this PR does NOT do
+
+- **No `contracts.rs` change.** Pinning the new address into
+  `OFFCHAIN_RESOLVER_SEPOLIA` happens in Task C, after Task B
+  verifies a working subname E2E. The old address stays pinned in
+  this PR so judge-facing docs that reference
+  [`0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3`](https://sepolia.etherscan.io/address/0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3)
+  don't break mid-cascade.
+- **No memory note rewrite.** Same reason — Task C consolidates.
+- **No subname registration.** Driver wallet doesn't own
+  `sbo3lagent.eth` on Sepolia; that's Task B.
+
+## Decommissioning the old deploy
+
+The old contract at `0x7c6913…aCA8c3` remains on chain
+(immutable). Once Task C lands and `OFFCHAIN_RESOLVER_SEPOLIA`
+points at the new address, the old contract is orphaned but
+harmless — no records on `sbo3lagent.eth` Sepolia ever pointed at
+it (driver wallet doesn't own the parent on Sepolia).


### PR DESCRIPTION
## Summary

First of three PRs (A/B/C) closing Heidi UAT bug #2 — the original Sepolia OffchainResolver stored a malformed URL template `"...{sender/{data}.json}"` (closing `}` after `sender` migrated to the end). This PR pins the canonical template at the deploy-script level and adds probe tests so any future drift fails before a tx hits chain.

## What this PR does

- **Refactor** `CANONICAL_URL_TEMPLATE` from an internal contract constant to a file-level constant in `script/DeployOffchainResolver.s.sol`. Probe tests can now `import {CANONICAL_URL_TEMPLATE}` directly — single source of truth, no instantiation drift.
- **Add** `test/DeployOffchainResolver.t.sol` with three probe tests pinning the constant byte-for-byte, end-to-end through the constructor, and sanity-checking both `{sender}` and `{data}` placeholders survive.
- **Add** `docs/dev4/sepolia-or-redeploy-2026-05-03.md` documenting root cause, fix posture, and the new live deploy address.

## What this PR does NOT do

- ❌ Update `crates/sbo3l-identity/src/contracts.rs::OFFCHAIN_RESOLVER_SEPOLIA` — that's **Task C**, after Task B verifies a working subname E2E. Old address `0x7c6913…aCA8c3` stays pinned for now.
- ❌ Register `sbo3lagent.eth` on Sepolia or wire a subname — **Task B**.
- ❌ Update memory or judge-facing docs that reference the old address — **Task C**.

## New live deploy

| Item | Value |
|---|---|
| Address | [`0x87e99508c222c6e419734cacbb6781b8d282b1f6`](https://sepolia.etherscan.io/address/0x87e99508c222c6e419734cacbb6781b8d282b1f6) |
| Network | Sepolia |
| Deployer | `0x50BA…7e9c` (driver wallet) |
| Gateway signer | `0x595099B4…BCe65` (matches Vercel `GATEWAY_PRIVATE_KEY`) |
| Bytecode length | 4747 hex chars |
| `urls(0)` | `"https://sbo3l-ccip.vercel.app/api/{sender}/{data}.json"` ✓ canonical |

## Test plan

- [x] `forge test --match-contract DeployOffchainResolverTest` → 3/3 pass.
- [x] Live `cast call urls(uint256) 0` returns canonical template.
- [x] Live `supportsInterface(0x9061b923)` returns true (ENSIP-10).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)