### PR TITLE
fix(cli): drop obsolete P-marker phase tags from passport surfaces (UAT-1 R1)

### DIFF
--- a/crates/sbo3l-cli/src/main.rs
+++ b/crates/sbo3l-cli/src/main.rs
@@ -478,8 +478,9 @@ enum PassportCmd {
     /// (schema → request_hash → policy → budget → audit → signed
     /// receipt) and emit one `sbo3l.passport_capsule.v1` JSON to
     /// `--out`. Wraps existing primitives — no policy/audit/crypto
-    /// rewrite. P2.1 supports `--mode mock` only; `--mode live` is
-    /// rejected (live integration is P5.1/P6.1 work).
+    /// rewrite. Supports `--mode mock` only; `--mode live` is
+    /// rejected (live executor integration runs in the daemon, not
+    /// in this offline CLI surface).
     Run {
         /// Path to an APRP JSON file (the request body the agent
         /// would normally POST to `/v1/payment-requests`).
@@ -507,10 +508,11 @@ enum PassportCmd {
         /// this value (status=not_called is hard-enforced).
         #[arg(long, value_enum)]
         executor: ExecutorChoiceArg,
-        /// Execution mode. P2.1 only supports `mock`. `live` is
-        /// rejected with exit 2 (truthfulness rule: live claims
-        /// require real evidence). For real live execution, use the
-        /// daemon (`sbo3l-server`) with configured executor credentials.
+        /// Execution mode. This offline CLI only supports `mock`.
+        /// `live` is rejected with exit 2 (truthfulness rule: live
+        /// claims require real evidence). For real live execution,
+        /// use the daemon (`sbo3l-server`) with configured executor
+        /// credentials.
         #[arg(long, value_enum, default_value_t = ModeChoiceArg::Mock)]
         mode: ModeChoiceArg,
         /// Output path for the capsule JSON. Written atomically

--- a/crates/sbo3l-cli/src/passport.rs
+++ b/crates/sbo3l-cli/src/passport.rs
@@ -551,7 +551,7 @@ fn non_empty_or_dash(s: &str) -> &str {
 }
 
 // ===========================================================================
-// `sbo3l passport run` — orchestration (P2.1)
+// `sbo3l passport run` — orchestration
 // ===========================================================================
 
 /// Configuration for `cmd_run`. One struct so `main.rs` can map clap
@@ -643,10 +643,11 @@ impl ModeChoice {
 /// - 0 — capsule emitted to `--out`.
 /// - 1 — IO / parse failure (file missing, bad JSON, executor backend
 ///   IO error, capsule write failure).
-/// - 2 — invalid input (bad APRP, ENS resolution failed, mode=live
-///   rejected by P2.1, executor refused, capsule self-verify failed
-///   — i.e. we somehow built a capsule that wouldn't pass our own
-///   verifier; that's a hard refuse, not a "ship anyway").
+/// - 2 — invalid input (bad APRP, ENS resolution failed, `--mode live`
+///   rejected by the offline CLI, executor refused, capsule
+///   self-verify failed — i.e. we somehow built a capsule that
+///   wouldn't pass our own verifier; that's a hard refuse, not a
+///   "ship anyway").
 pub fn cmd_run(args: RunArgs) -> ExitCode {
     // Live mode is rejected here: the CLI must not produce a capsule
     // that *claims* live mode without real credentials + live evidence
@@ -676,8 +677,10 @@ pub fn cmd_run(args: RunArgs) -> ExitCode {
         },
         ResolverChoice::LiveEns => {
             eprintln!(
-                "sbo3l passport run: --resolver live-ens is reserved for P4.1 \
-                 (live ENS resolver). Use --resolver offline-fixture in P2.1."
+                "sbo3l passport run: --resolver live-ens is not supported by the \
+                 offline CLI; live ENS resolution flows through \
+                 `sbo3l agent verify-ens` against a configured RPC. Use \
+                 --resolver offline-fixture for the offline capsule path."
             );
             return ExitCode::from(2);
         }
@@ -1083,7 +1086,7 @@ fn call_mock_executor(
     );
     block.insert("status".into(), Value::String("submitted".to_string()));
     block.insert("sponsor_payload_hash".into(), Value::Null);
-    // P6.1: `live_evidence` stays Null in mock mode — the verifier's
+    // `live_evidence` stays Null in mock mode — the verifier's
     // bidirectional invariant (mock ⇒ no `live_evidence`, live ⇒
     // `live_evidence` populated with a concrete transport/response/
     // block ref) is unchanged by this round of work. Sponsor-specific


### PR DESCRIPTION
## Summary

Heidi UAT-1 Round 1 caught that PR #374 didn't fully scrub the `P\d.\d` phase markers from user-facing CLI surfaces. `sbo3l passport run --help` still surfaced the tags in clap doc-comments + the runtime `--mode live` / `--resolver live-ens` rejection messages.

**8 hits across 2 files, all replaced with prose.** Zero P-markers remain in the CLI source.

## Verification

```
grep -rn 'P[0-9]\.[0-9]' crates/sbo3l-cli/src/  # 0 hits
./target/debug/sbo3l passport run --help | grep -E 'P[0-9]\.[0-9]'  # no match (exit 1)
./target/debug/sbo3l passport --help | grep -E 'P[0-9]\.[0-9]'      # no match (exit 1)
```

- [x] `cargo build -p sbo3l-cli` clean
- [x] `cargo clippy -p sbo3l-cli --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)