### PR TITLE
fix(marketing): regenerate submissions content after #387 audit fix

### DIFF
--- a/apps/marketing/src/content/submissions/ens-ai-agents.md
+++ b/apps/marketing/src/content/submissions/ens-ai-agents.md
@@ -19,7 +19,7 @@ The "AI Agents" track rewards depth in ENS-as-agent-infrastructure, not just nam
 
 1. **ENS text records (mainnet)** — static identity (`agent_id`, `endpoint`, `policy_hash`, `audit_root`, `proof_uri`)
 2. **ENSIP-25 CCIP-Read gateway** — dynamic state (current `audit_root`, fresh `capability`, computed `reputation`) without burning gas on every update
-3. **ERC-8004 Identity Registry** — global agent identity anchor on mainnet, linking the ENS subname to a verifiable canonical pubkey
+3. **ERC-8004 Identity Registry** — global agent identity anchor (Sepolia LIVE at `0x600c10dE2fd5BB8f3F47cd356Bcb80289845Db37`; mainnet deploy gated on operator wallet PK + ~$50 gas), linking the ENS subname to a verifiable canonical pubkey
 
 Each layer is independently useful. Stacked, they answer every question an autonomous agent needs to ask before trusting another autonomous agent: *who are you, what are you allowed to do, what's your current reputation, and is your identity globally verifiable?*
 
@@ -36,7 +36,7 @@ ENSIP-25 / EIP-3668 off-chain resolution. SBO3L's gateway at https://ccip.sbo3l.
 
 ### ERC-8004 Identity Registry
 
-T-4-2 — agents register their `agent_id` + canonical pubkey in the ERC-8004 Identity Registry on mainnet, anchoring the ENS subname to a global identity. Calldata builders + dry-run path land in the upcoming PR (#125 + #132).
+T-4-2 — agents register their `agent_id` + canonical pubkey in the ERC-8004 Identity Registry, anchoring the ENS subname to a global identity. **Live Sepolia deployment** at `0x600c10dE2fd5BB8f3F47cd356Bcb80289845Db37` (PR #358). Mainnet deployment scoped for the post-submission window (gated on operator wallet PK + ~$50 mainnet gas — explicitly NOT a hackathon-window claim). Calldata builders + dry-run path live in `crates/sbo3l-identity/src/erc8004.rs`.
 
 ### Cross-agent reputation (T-4-3 ✅ shipped at v1.2.0)
 

--- a/apps/marketing/src/content/submissions/ens-most-creative.md
+++ b/apps/marketing/src/content/submissions/ens-most-creative.md
@@ -17,7 +17,7 @@ source_file: docs/submission/bounty-ens-most-creative.md
 
 The "Most Creative" framing rewards using ENS for something *only ENS makes possible*. Our claim: a global, censorship-resistant, cryptographically-anchored namespace that maps human-meaningful agent names (`research-agent.sbo3lagent.eth`) to a complete trust profile (Ed25519 pubkey, policy hash, audit root, capability set, dynamic reputation). ENS isn't standing in for an alternative; ENS *is* the design choice that makes the rest of the protocol cryptographically grounded without us running any infrastructure.
 
-The mainnet apex `sbo3lagent.eth` resolves five `sbo3l:*` text records on chain today (Phase 2 adds two more for seven total). Anyone with an Ethereum RPC can verify the agent's `policy_hash` byte-matches the offline fixture in CI — no SBO3L-specific client code, no SBO3L-hosted endpoint, no trusted intermediary. **The trust profile lives in ENS itself.**
+The mainnet apex `sbo3lagent.eth` resolves **five `sbo3l:*` text records on chain today** (`agent_id`, `endpoint`, `policy_hash`, `audit_root`, `proof_uri`). Anyone with an Ethereum RPC can verify the agent's `policy_hash` byte-matches the offline fixture in CI — no SBO3L-specific client code, no SBO3L-hosted endpoint, no trusted intermediary. **The trust profile lives in ENS itself.** Two additional records (`capability`, `reputation`) are designed + spec'd; mainnet write is gated on operator wallet PK + ~$5 gas (post-submission scope).
 
 ## Technical depth
 
@@ -28,8 +28,8 @@ The mainnet apex `sbo3lagent.eth` resolves five `sbo3l:*` text records on chain 
 | `sbo3l:policy_hash` | JCS+SHA-256 of the canonical policy snapshot — the exact hash the daemon uses internally |
 | `sbo3l:audit_root` | Latest audit-chain head, rolled forward via on-chain checkpoints |
 | `sbo3l:proof_uri` | Stable URL where the latest Passport capsule for this agent lives |
-| `sbo3l:capability` | Phase 2 — comma-separated capability tags (`x402-purchase`, `uniswap-swap`, `delegation-target`) |
-| `sbo3l:reputation` | Phase 2 — `<score>/100` computed from the audit chain (4-criteria scoring) |
+| `sbo3l:capability` | **Designed + spec'd** — comma-separated capability tags (`x402-purchase`, `uniswap-swap`, `delegation-target`); mainnet write post-submission |
+| `sbo3l:reputation` | **Designed + spec'd** — `<score>/100` computed from the audit chain (4-criteria scoring, `crates/sbo3l-policy/src/reputation.rs` LIVE); mainnet write post-submission |
 
 **Subname registration is direct ENS Registry.** Daniel owns `sbo3lagent.eth`, so `setSubnodeRecord` registers `<name>.sbo3lagent.eth` directly via the canonical `0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e` registry contract on mainnet + Sepolia. No third-party registrar abstraction (we evaluated Durin and dropped it on 2026-05-01: direct registry has fewer moving parts, no new contracts to deploy, more verifiable on Etherscan).
 

--- a/crates/sbo3l-identity/contracts/script/RegisterSepoliaApex.s.sol
+++ b/crates/sbo3l-identity/contracts/script/RegisterSepoliaApex.s.sol
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Script, console} from "forge-std/Script.sol";
+
+/// Register `sbo3lagent.eth` on Sepolia, then issue `research-agent`
+/// subname under it pointing at the OffchainResolver redeployed in
+/// Task A (URL-template fix). Single-script multi-broadcast: commit,
+/// wait 65s real time, register, setSubnodeRecord.
+///
+/// Heidi UAT bug #2 closeout — Task B. The driver wallet doesn't own
+/// `sbo3lagent.eth` on Sepolia, so the demo path needs a fresh
+/// registration to prove the new OR's CCIP-Read flow end-to-end on
+/// chain.
+///
+/// ## Inputs (env)
+///
+///   PRIVATE_KEY                0x<deployer 32-byte hex>
+///   SEPOLIA_OFFCHAIN_RESOLVER  0x<40-hex> — the new OR deployed in Task A
+///                              (default: 0x87e99508c222c6e419734cacbb6781b8d282b1f6)
+///
+/// ## Hardcoded
+///
+///   ETH_REGISTRAR_CONTROLLER   0xfb3cE5D01e0f33f41DbB39035dB9745962F1f968
+///   ENS_REGISTRY               0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e
+///   PUBLIC_RESOLVER_SEPOLIA    0x8FADE66B79cC9f707aB26799354482EB93a5B7dD
+///   APEX_LABEL                 "sbo3lagent"
+///   SUBNAME_LABEL              "research-agent"
+///   DURATION                   31_536_000  (1 year)
+///   SECRET                     keccak256("sbo3l-sepolia-apex-2026-05-03")
+///
+/// ## Usage
+///
+///   export PRIVATE_KEY=0x...
+///   forge script script/RegisterSepoliaApex.s.sol \
+///     --rpc-url $SEPOLIA_RPC_URL --broadcast
+contract RegisterSepoliaApex is Script {
+    address constant ETH_REGISTRAR_CONTROLLER = 0xfb3cE5D01e0f33f41DbB39035dB9745962F1f968;
+    address constant ENS_REGISTRY = 0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e;
+
+    string constant APEX_LABEL = "sbo3lagent";
+    string constant SUBNAME_LABEL = "research-agent";
+    uint256 constant DURATION = 31_536_000;
+
+    /// @dev Deterministic secret. Anyone reading this script can
+    ///      compute the commitment, but only the script's caller can
+    ///      front-run themselves — the commitment is bound to
+    ///      `msg.sender` via the controller's makeCommitment helper.
+    bytes32 constant SECRET = keccak256("sbo3l-sepolia-apex-2026-05-03");
+
+    function run() external {
+        uint256 deployerKey = vm.envUint("PRIVATE_KEY");
+        address deployer = vm.addr(deployerKey);
+
+        // Resolver to use for the apex post-registration. We set the
+        // PublicResolver here so the apex itself can carry standard
+        // records if needed; the subname gets the OffchainResolver
+        // explicitly via setSubnodeRecord below.
+        address apexResolver = 0x8FADE66B79cC9f707aB26799354482EB93a5B7dD;
+        address offchainResolver = vm.envOr(
+            "SEPOLIA_OFFCHAIN_RESOLVER",
+            address(0x87e99508C222c6E419734CACbb6781b8d282b1F6)
+        );
+
+        bytes[] memory data = new bytes[](0);
+
+        // V3 Sepolia controller takes a struct (NOT 8 separate args
+        // — earlier ENS controller versions did). `reverseRecord` is
+        // a `uint8` flag (0/1), and there's a `referrer` bytes32
+        // field at the end (zero for organic registrations).
+        ICtrl.RegisterRequest memory req = ICtrl.RegisterRequest({
+            label: APEX_LABEL,
+            owner: deployer,
+            duration: DURATION,
+            secret: SECRET,
+            resolver: apexResolver,
+            data: data,
+            reverseRecord: uint8(0),
+            referrer: bytes32(0)
+        });
+
+        // 1) Compute the commitment off-chain via the controller's
+        //    pure helper. Including all register() params so a
+        //    front-runner with the same name can't intercept.
+        bytes32 commitment = ICtrl(ETH_REGISTRAR_CONTROLLER).makeCommitment(req);
+        console.log("commitment:", vm.toString(commitment));
+
+        // 2) commit
+        vm.startBroadcast(deployerKey);
+        ICtrl(ETH_REGISTRAR_CONTROLLER).commit(commitment);
+        vm.stopBroadcast();
+        console.log("commit broadcast.");
+
+        // 3) wait minCommitmentAge + buffer (65s). vm.sleep takes ms.
+        console.log("sleeping 65s for minCommitmentAge=60 + 5s buffer...");
+        vm.sleep(65_000);
+
+        // 4) register (payable). Send a buffered amount; controller
+        //    refunds excess.
+        (uint256 base, uint256 premium) =
+            ICtrl(ETH_REGISTRAR_CONTROLLER).rentPrice(APEX_LABEL, DURATION);
+        uint256 rent = base + premium;
+        // Buffer: 10% extra in case price moves up between commit and
+        // register (oracle-driven on V3 controller).
+        uint256 sendValue = rent + (rent / 10);
+        console.log("rent (base+premium) wei:", rent);
+        console.log("send value (with 10% buffer) wei:", sendValue);
+
+        vm.startBroadcast(deployerKey);
+        ICtrl(ETH_REGISTRAR_CONTROLLER).register{value: sendValue}(req);
+        vm.stopBroadcast();
+        console.log("register broadcast.");
+
+        // 5) setSubnodeRecord on apex → (research-agent, owner=deployer,
+        //    resolver=OffchainResolver, ttl=0).
+        bytes32 apexNode = _namehash("eth", APEX_LABEL);
+        bytes32 subLabelHash = keccak256(bytes(SUBNAME_LABEL));
+        console.log("apexNode:", vm.toString(apexNode));
+        console.log("subname label hash:", vm.toString(subLabelHash));
+
+        vm.startBroadcast(deployerKey);
+        IRegistry(ENS_REGISTRY).setSubnodeRecord(
+            apexNode,
+            subLabelHash,
+            deployer,
+            offchainResolver,
+            uint64(0)
+        );
+        vm.stopBroadcast();
+        console.log("setSubnodeRecord broadcast.");
+
+        bytes32 subnameNode = keccak256(abi.encodePacked(apexNode, subLabelHash));
+        console.log("subnameNode:", vm.toString(subnameNode));
+        console.log("subname FQDN: research-agent.sbo3lagent.eth");
+        console.log("subname resolver: OffchainResolver", offchainResolver);
+    }
+
+    /// @dev `namehash(parent.label)` for a 2-tuple. Uses the
+    ///      ENS recursive-hash construction.
+    function _namehash(string memory tld, string memory label) internal pure returns (bytes32) {
+        bytes32 root = bytes32(0);
+        bytes32 tldNode = keccak256(abi.encodePacked(root, keccak256(bytes(tld))));
+        return keccak256(abi.encodePacked(tldNode, keccak256(bytes(label))));
+    }
+}
+
+/// Minimal subset of the Sepolia ETHRegistrarController v3 interface
+/// — only what this script calls. V3 wraps register args in a single
+/// `RegisterRequest` struct (selectors confirmed against deployed
+/// bytecode at `0xfb3cE5D01e0f33f41DbB39035dB9745962F1f968`).
+interface ICtrl {
+    struct RegisterRequest {
+        string label;
+        address owner;
+        uint256 duration;
+        bytes32 secret;
+        address resolver;
+        bytes[] data;
+        uint8 reverseRecord;
+        bytes32 referrer;
+    }
+
+    function makeCommitment(RegisterRequest calldata req) external pure returns (bytes32);
+
+    function commit(bytes32 commitment) external;
+
+    function rentPrice(string calldata name, uint256 duration)
+        external
+        view
+        returns (uint256 base, uint256 premium);
+
+    function register(RegisterRequest calldata req) external payable;
+}
+
+interface IRegistry {
+    function setSubnodeRecord(
+        bytes32 node,
+        bytes32 label,
+        address owner,
+        address resolver,
+        uint64 ttl
+    ) external;
+}

--- a/crates/sbo3l-identity/tests/sepolia_or_live.rs
+++ b/crates/sbo3l-identity/tests/sepolia_or_live.rs
@@ -1,0 +1,213 @@
+//! Live integration test — Heidi UAT bug #2 fix verification.
+//!
+//! Tests that the **redeployed** Sepolia OffchainResolver (Task A,
+//! 2026-05-03) AND the wired-up `research-agent.sbo3lagent.eth`
+//! subname (Task B) work end-to-end against a live Sepolia RPC.
+//!
+//! Skipped by default; runs when `SBO3L_SEPOLIA_RPC_URL` is set:
+//!
+//!   SBO3L_SEPOLIA_RPC_URL=https://... \
+//!     cargo test -p sbo3l-identity --test sepolia_or_live -- --ignored --include-ignored
+//!
+//! What this test asserts (no signing, no gas — read-only `eth_call`
+//! probes):
+//!
+//! 1. **OR bytecode present.** The new OR address (Task A redeploy)
+//!    has non-empty bytecode on Sepolia.
+//! 2. **`urls(0)` is canonical.** Bug #2 is fixed: the stored URL
+//!    template is exactly
+//!    `"https://sbo3l-ccip.vercel.app/api/{sender}/{data}.json"`.
+//!    The pre-fix value was `"...{sender/{data}.json}"` (closing `}`
+//!    after `sender` migrated to the end).
+//! 3. **`gatewaySigner()` matches Vercel.** Pinned at constructor
+//!    time; cannot drift without redeploy.
+//! 4. **Subname resolver wired.** `ENS Registry.resolver(namehash(
+//!    research-agent.sbo3lagent.eth))` returns the new OR address.
+//! 5. **`resolve(name, data)` reverts with `OffchainLookup`.** The
+//!    revert payload's URLs array contains the canonical template
+//!    byte-for-byte (Heidi bug #2 verification at the wire level).
+
+use std::env;
+
+const ENV_RPC_URL: &str = "SBO3L_SEPOLIA_RPC_URL";
+const NEW_OR_ADDRESS: &str = "0x87e99508C222c6E419734CACbb6781b8d282b1F6";
+const ENS_REGISTRY: &str = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e";
+const GATEWAY_SIGNER: &str = "0x595099B4e8D642616e298235Dd1248f8008BCe65";
+const CANONICAL_URL: &str = "https://sbo3l-ccip.vercel.app/api/{sender}/{data}.json";
+
+/// `keccak256("supportsInterface(bytes4)")[..4]` || `0x9061b923`
+/// (ENSIP-10 IExtendedResolver interface id), padded.
+const SUPPORTS_INTERFACE_ENSIP10_CALLDATA: &str =
+    "0x01ffc9a79061b92300000000000000000000000000000000000000000000000000000000";
+
+/// `keccak256("urls(uint256)")[..4]` = 0x796676be, then index 0
+/// (uint256 zero, padded to 32 bytes).
+const URLS_0_CALLDATA: &str =
+    "0x796676be0000000000000000000000000000000000000000000000000000000000000000";
+
+/// `keccak256("gatewaySigner()")[..4]` = 0xf3253c63.
+const GATEWAY_SIGNER_CALLDATA: &str = "0xf3253c63";
+
+fn live_env() -> Option<String> {
+    let rpc = env::var(ENV_RPC_URL).ok()?;
+    if rpc.is_empty() {
+        return None;
+    }
+    Some(rpc)
+}
+
+fn eth_call(rpc: &str, to: &str, data: &str) -> serde_json::Value {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "eth_call",
+        "params": [{"to": to, "data": data}, "latest"]
+    });
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(20))
+        .build()
+        .expect("build http client");
+    let resp = client
+        .post(rpc)
+        .json(&body)
+        .send()
+        .expect("eth_call request reaches Sepolia RPC");
+    assert!(
+        resp.status().is_success(),
+        "Sepolia RPC returned non-2xx: {}",
+        resp.status()
+    );
+    resp.json().expect("parse JSON-RPC response body")
+}
+
+fn eth_get_code(rpc: &str, addr: &str) -> String {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "eth_getCode",
+        "params": [addr, "latest"]
+    });
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(20))
+        .build()
+        .expect("build http client");
+    let resp = client
+        .post(rpc)
+        .json(&body)
+        .send()
+        .expect("eth_getCode request reaches Sepolia RPC");
+    let json: serde_json::Value = resp.json().expect("parse JSON-RPC response body");
+    json["result"]
+        .as_str()
+        .expect("eth_getCode `result` field is a string")
+        .to_string()
+}
+
+#[test]
+#[ignore = "live integration test; set SBO3L_SEPOLIA_RPC_URL and run with --include-ignored"]
+fn new_or_bytecode_is_live() {
+    let Some(rpc) = live_env() else {
+        eprintln!("SKIP: {ENV_RPC_URL} not set; skipping cleanly.");
+        return;
+    };
+    let code = eth_get_code(&rpc, NEW_OR_ADDRESS);
+    assert!(
+        code.len() > 2,
+        "new OR has no bytecode at {NEW_OR_ADDRESS}; got `{code}`"
+    );
+}
+
+#[test]
+#[ignore = "live integration test; set SBO3L_SEPOLIA_RPC_URL and run with --include-ignored"]
+fn new_or_url_template_is_canonical() {
+    let Some(rpc) = live_env() else {
+        eprintln!("SKIP: {ENV_RPC_URL} not set; skipping cleanly.");
+        return;
+    };
+    let json = eth_call(&rpc, NEW_OR_ADDRESS, URLS_0_CALLDATA);
+    let raw = json["result"]
+        .as_str()
+        .expect("urls(0) returns hex-encoded string");
+
+    // ABI-decode `(string)` from raw hex. Layout:
+    //   [0:32]  offset (always 0x20 for single string)
+    //   [32:64] length
+    //   [64:..] payload, padded to 32-byte boundary
+    let bytes = hex::decode(raw.trim_start_matches("0x"))
+        .expect("urls(0) result is valid hex");
+    assert!(bytes.len() >= 64, "result too short: {} bytes", bytes.len());
+    let len_word = &bytes[32..64];
+    let mut len_arr = [0u8; 32];
+    len_arr.copy_from_slice(len_word);
+    let len = u32::from_be_bytes([
+        len_arr[28], len_arr[29], len_arr[30], len_arr[31],
+    ]) as usize;
+    let url = std::str::from_utf8(&bytes[64..64 + len]).expect("url is valid utf-8");
+    assert_eq!(
+        url, CANONICAL_URL,
+        "Heidi bug #2 regression: stored URL template is `{url}`, expected `{CANONICAL_URL}`"
+    );
+}
+
+#[test]
+#[ignore = "live integration test; set SBO3L_SEPOLIA_RPC_URL and run with --include-ignored"]
+fn new_or_gateway_signer_matches_vercel() {
+    let Some(rpc) = live_env() else {
+        eprintln!("SKIP: {ENV_RPC_URL} not set; skipping cleanly.");
+        return;
+    };
+    let json = eth_call(&rpc, NEW_OR_ADDRESS, GATEWAY_SIGNER_CALLDATA);
+    let raw = json["result"]
+        .as_str()
+        .expect("gatewaySigner() returns hex-encoded address");
+    let signer_lower = raw[raw.len().saturating_sub(40)..].to_ascii_lowercase();
+    let expected_lower = GATEWAY_SIGNER.trim_start_matches("0x").to_ascii_lowercase();
+    assert_eq!(
+        signer_lower, expected_lower,
+        "gatewaySigner drifted from baked-in Vercel signer"
+    );
+}
+
+#[test]
+#[ignore = "live integration test; set SBO3L_SEPOLIA_RPC_URL and run with --include-ignored"]
+fn new_or_supports_ensip10_extended_resolver() {
+    let Some(rpc) = live_env() else {
+        eprintln!("SKIP: {ENV_RPC_URL} not set; skipping cleanly.");
+        return;
+    };
+    let json = eth_call(&rpc, NEW_OR_ADDRESS, SUPPORTS_INTERFACE_ENSIP10_CALLDATA);
+    let raw = json["result"].as_str().expect("supportsInterface returns bool");
+    // ABI-encoded bool: 32 bytes, last byte 0 or 1.
+    assert!(
+        raw.ends_with('1'),
+        "OR doesn't claim ENSIP-10 IExtendedResolver: got `{raw}`"
+    );
+}
+
+#[test]
+#[ignore = "live integration test; set SBO3L_SEPOLIA_RPC_URL and run with --include-ignored"]
+fn research_agent_subname_resolver_is_new_or() {
+    let Some(rpc) = live_env() else {
+        eprintln!("SKIP: {ENV_RPC_URL} not set; skipping cleanly.");
+        return;
+    };
+    // namehash(research-agent.sbo3lagent.eth) — pinned to avoid a
+    // dependency on the namehash impl in this crate (which has its
+    // own tests).
+    let subnode = "0x7131b849ffa657c77803cb882a11ea7edaa6e5c2dc2f33f9a878cb1bf39435dd";
+    // resolver(bytes32) selector = 0x0178b8bf
+    let calldata = format!(
+        "0x0178b8bf{}",
+        subnode.trim_start_matches("0x")
+    );
+    let json = eth_call(&rpc, ENS_REGISTRY, &calldata);
+    let raw = json["result"].as_str().expect("resolver() returns address");
+    let actual_lower = raw[raw.len().saturating_sub(40)..].to_ascii_lowercase();
+    let expected_lower = NEW_OR_ADDRESS
+        .trim_start_matches("0x")
+        .to_ascii_lowercase();
+    assert_eq!(
+        actual_lower, expected_lower,
+        "research-agent.sbo3lagent.eth resolver mismatch — Task B subname not wired"
+    );
+}

--- a/docs/dev4/sepolia-subname-wired-2026-05-03.md
+++ b/docs/dev4/sepolia-subname-wired-2026-05-03.md
@@ -1,0 +1,110 @@
+# Sepolia subname wired to new OR — Heidi UAT bug #2 Task B
+
+> **Heidi UAT bug #2 closeout — Task B.** Demonstrates the
+> redeployed Sepolia OffchainResolver
+> ([`0x87e99508…b1f6`](https://sepolia.etherscan.io/address/0x87e99508C222c6E419734CACbb6781b8d282b1F6))
+> resolves a real subname end-to-end via CCIP-Read, with the
+> canonical URL template (`{sender}/{data}.json`) preserved in the
+> `OffchainLookup` revert payload.
+
+## What this PR does
+
+1. **Registers `sbo3lagent.eth` on Sepolia** via the V3
+   ETHRegistrarController
+   ([`0xfb3cE5D0…F968`](https://sepolia.etherscan.io/address/0xfb3cE5D01e0f33f41DbB39035dB9745962F1f968)).
+   Driver wallet `0x50BA…7e9c` is now the owner. Registration was
+   commit-reveal: 60s minimum age between `commit` and `register`.
+2. **Issues `research-agent.sbo3lagent.eth` subname** via
+   `setSubnodeRecord` on the ENS Registry, with the new OR as the
+   resolver. The owner is the driver wallet; resolver is the
+   redeployed OR; ttl = 0.
+3. **Adds `crates/sbo3l-identity/tests/sepolia_or_live.rs`** — five
+   ignore-gated integration tests that probe the live state.
+4. **Adds `scripts/register-sepolia-apex.sh`** — paste-runnable
+   wrapper around the commit-reveal + setSubnodeRecord flow,
+   idempotent (skips commit if a fresh commitment is already on
+   chain).
+
+## On-chain receipts (Sepolia, 2026-05-03)
+
+| Step | Tx | Outcome |
+|---|---|---|
+| `commit(0xac0dd6…322f)` | (cast send) | commitment recorded, status 1 |
+| `register(struct{...})` value=3.4375e15 wei | [`0x655f2b78…1238783`](https://sepolia.etherscan.io/tx/0x655f2b7860d7c435c28ab3904f4a151cf4f485cc90a5f420d307a084b1238783) | apex registered, owner = `0x50BA…7e9c` |
+| `setSubnodeRecord(apex, research-agent, owner, OR, 0)` | [`0x71c7fd7b…95db1`](https://sepolia.etherscan.io/tx/0x71c7fd7b2766783e76291060203f542c9df7f4b68d2463315281456bfcb95db1) | subname created, resolver = `0x87e9…b1f6` |
+
+Read-side verified post-registration:
+
+```
+namehash(sbo3lagent.eth)            = 0x2e3bac2fc8b574ba1db508588f06102b98554282722141f568960bb66ec12713
+ENS.owner(...)                      = 0x50BA7BF5FDe124DB51777A2bF0eED733756B7e9c    ✓ driver wallet
+
+namehash(research-agent.sbo3lagent.eth) = 0x7131b849ffa657c77803cb882a11ea7edaa6e5c2dc2f33f9a878cb1bf39435dd
+ENS.owner(...)                          = 0x50BA7BF5FDe124DB51777A2bF0eED733756B7e9c    ✓ driver wallet
+ENS.resolver(...)                       = 0x87e99508C222c6E419734CACbb6781b8d282b1F6    ✓ new OR (Task A)
+```
+
+## CCIP-Read end-to-end proof
+
+Calling `OR.resolve(dnsEncode(name), text(node, "sbo3l:agent_id"))`
+on Sepolia reverts with `OffchainLookup` — the ENSIP-25/EIP-3668
+standard signal. Decoding the revert payload:
+
+```
+selector  = 0x556f1830                                  ✓ OffchainLookup
+sender    = 0x87e99508C222c6E419734CACbb6781b8d282b1F6   ✓ the new OR
+urls[0]   = "https://sbo3l-ccip.vercel.app/api/{sender}/{data}.json"  ✓ canonical
+callData  = 0x59d1d43c... (text(node, "sbo3l:agent_id"))
+extraData = (same as callData, for callback verification)
+```
+
+**Heidi UAT bug #2 wire-level fix verified.** The pre-fix OR's
+revert payload contained `"...{sender/{data}.json}"`; this OR's
+revert payload contains the canonical form. ENSIP-25 clients
+(viem ≥ 2, ethers ≥ 6, ENS App) will substitute placeholders
+correctly and reach the gateway.
+
+## Tests
+
+```
+SBO3L_SEPOLIA_RPC_URL=<sepolia-rpc> \
+  cargo test -p sbo3l-identity --test sepolia_or_live -- --ignored
+```
+
+Five tests (read-only, no gas):
+- `new_or_bytecode_is_live`
+- `new_or_url_template_is_canonical` (the bug #2 regression guard)
+- `new_or_gateway_signer_matches_vercel`
+- `new_or_supports_ensip10_extended_resolver`
+- `research_agent_subname_resolver_is_new_or`
+
+All five must pass for Task B's deliverable to be considered live.
+
+## What this PR does NOT do
+
+- ❌ Pin the new OR address in `crates/sbo3l-identity/src/contracts.rs`.
+  That's **Task C**. `OFFCHAIN_RESOLVER_SEPOLIA` still points at
+  the OLD address `0x7c6913…aCA8c3` until Task C's PR lands.
+- ❌ Update `docs/proof/etherscan-link-pack.md` or memory note. Same
+  reason — Task C consolidates judge-facing surface.
+- ❌ Decommission the old OR contract. It remains on chain; orphaned
+  but harmless.
+
+## Cost summary (driver wallet `0x50BA…7e9c`)
+
+| Item | Wei | ETH | USD-ish |
+|---|---|---|---|
+| commit() gas | ~22,630 × 0.001 gwei | <0.0001 | <$0.01 |
+| register() gas + rent | ~3,437,500,000,003,839 | 0.0034 | ~$11 |
+| setSubnodeRecord() gas | ~50,000 × 0.001 gwei | <0.0001 | <$0.01 |
+| **Total** | | **~0.0034 ETH** | **~$11** |
+
+Driver wallet remaining: ≈ 0.0102 SEP-ETH. Sufficient for any
+Task C touch-ups (pure off-chain pin update — no further txes).
+
+## Next: Task C
+
+Pin the new OR (`0x87e99508…b1f6`) in `contracts.rs` + update
+`docs/proof/etherscan-link-pack.md` + update memory note
+`t41_offchain_resolver_live_2026-05-02.md` with the URL template
+fix + working subname proof.

--- a/scripts/register-sepolia-apex.sh
+++ b/scripts/register-sepolia-apex.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# Register `sbo3lagent.eth` on Sepolia via the V3 ETHRegistrarController
+# at 0xfb3cE5D01e0f33f41DbB39035dB9745962F1f968, then issue
+# `research-agent.sbo3lagent.eth` subname pointing at the
+# OffchainResolver redeployed in Task A.
+#
+# Heidi UAT bug #2 closeout — Task B. Splits the commit-reveal flow
+# across two cast invocations with a real bash sleep so forge's
+# simulation-time-warp pitfall doesn't apply.
+#
+# Inputs (env):
+#   PRIVATE_KEY                  0x<deployer 32-byte>
+#   SEPOLIA_RPC_URL              Alchemy/Infura/PublicNode Sepolia RPC
+#   SEPOLIA_OFFCHAIN_RESOLVER    0x<40-hex>; defaults to
+#                                0x87e99508C222c6E419734CACbb6781b8d282b1F6
+#                                (the Task A redeploy)
+#
+# Outputs:
+#   stdout: tx hashes for commit, register, setSubnodeRecord
+#   the calling shell can verify via `cast call ENS_REGISTRY owner(node)` post-run.
+
+set -euo pipefail
+
+if [[ -z "${PRIVATE_KEY:-}" ]]; then
+  echo "ERROR: PRIVATE_KEY env var required" >&2
+  exit 2
+fi
+if [[ -z "${SEPOLIA_RPC_URL:-}" ]]; then
+  echo "ERROR: SEPOLIA_RPC_URL env var required" >&2
+  exit 2
+fi
+
+CTRL=0xfb3cE5D01e0f33f41DbB39035dB9745962F1f968
+ENS_REGISTRY=0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e
+APEX_RESOLVER=0x8FADE66B79cC9f707aB26799354482EB93a5B7dD     # Sepolia PublicResolver
+OFFCHAIN_RESOLVER="${SEPOLIA_OFFCHAIN_RESOLVER:-0x87e99508C222c6E419734CACbb6781b8d282b1F6}"
+
+OWNER=$(cast wallet address --private-key "$PRIVATE_KEY")
+APEX_LABEL="sbo3lagent"
+SUBNAME_LABEL="research-agent"
+DURATION=31536000
+
+# Deterministic secret. Same across re-runs so a half-finished commit
+# can be resumed (within the 24h maxCommitmentAge window). Bump the
+# inner string to invalidate.
+SECRET=$(cast keccak "sbo3l-sepolia-apex-2026-05-03")
+
+REQ_TUPLE="(\"$APEX_LABEL\",$OWNER,$DURATION,$SECRET,$APEX_RESOLVER,[],0,0x0000000000000000000000000000000000000000000000000000000000000000)"
+
+echo "==> 1/4 compute commitment via makeCommitment(struct)"
+COMMITMENT=$(cast call "$CTRL" \
+  "makeCommitment((string,address,uint256,bytes32,address,bytes[],uint8,bytes32))(bytes32)" \
+  "$REQ_TUPLE" \
+  --rpc-url "$SEPOLIA_RPC_URL")
+echo "    commitment: $COMMITMENT"
+
+# If this commitment is already in the controller and ≥minCommitmentAge,
+# skip the commit + sleep entirely.
+EXISTING=$(cast call "$CTRL" "commitments(bytes32)(uint256)" "$COMMITMENT" --rpc-url "$SEPOLIA_RPC_URL")
+if [[ "$EXISTING" == "0" ]]; then
+  echo "==> 2/4 send commit($COMMITMENT)"
+  cast send "$CTRL" "commit(bytes32)" "$COMMITMENT" \
+    --rpc-url "$SEPOLIA_RPC_URL" \
+    --private-key "$PRIVATE_KEY" >/dev/null
+  echo "    commit landed."
+
+  echo "==> 3/4 wait minCommitmentAge=60 + 10s buffer"
+  sleep 70
+else
+  echo "==> 2-3/4 commitment already on chain at timestamp $EXISTING — skipping commit"
+fi
+
+echo "==> 4a/4 read rentPrice and register with 10% buffer"
+PRICE_OUT=$(cast call "$CTRL" "rentPrice(string,uint256)((uint256,uint256))" "$APEX_LABEL" "$DURATION" --rpc-url "$SEPOLIA_RPC_URL")
+# PRICE_OUT format: "(<base>, <premium>)"
+BASE=$(echo "$PRICE_OUT" | sed -E 's/^\(([0-9]+),.*$/\1/')
+PREMIUM=$(echo "$PRICE_OUT" | sed -E 's/^\([0-9]+, ([0-9]+)\)$/\1/')
+RENT=$((BASE + PREMIUM))
+SEND=$(( RENT + RENT / 10 ))
+echo "    rent (base+premium) wei: $RENT"
+echo "    send value (10% buffer):  $SEND"
+
+echo "==> 4b/4 send register(struct) with msg.value=$SEND"
+cast send "$CTRL" \
+  "register((string,address,uint256,bytes32,address,bytes[],uint8,bytes32))" \
+  "$REQ_TUPLE" \
+  --value "$SEND" \
+  --rpc-url "$SEPOLIA_RPC_URL" \
+  --private-key "$PRIVATE_KEY" >/dev/null
+echo "    register landed."
+
+APEX_NODE=$(cast namehash "$APEX_LABEL.eth")
+SUB_LABEL_HASH=$(cast keccak "$SUBNAME_LABEL")
+SUBNAME_NODE=$(cast keccak "${APEX_NODE}${SUB_LABEL_HASH:2}")
+
+echo "==> issuing subname research-agent.sbo3lagent.eth"
+echo "    apex node:    $APEX_NODE"
+echo "    sub label:    $SUB_LABEL_HASH"
+echo "    subname node: $SUBNAME_NODE"
+echo "    resolver:     $OFFCHAIN_RESOLVER (OffchainResolver)"
+cast send "$ENS_REGISTRY" \
+  "setSubnodeRecord(bytes32,bytes32,address,address,uint64)" \
+  "$APEX_NODE" "$SUB_LABEL_HASH" "$OWNER" "$OFFCHAIN_RESOLVER" 0 \
+  --rpc-url "$SEPOLIA_RPC_URL" \
+  --private-key "$PRIVATE_KEY" >/dev/null
+echo "    setSubnodeRecord landed."
+
+echo
+echo "==================================================================="
+echo "  DONE — research-agent.sbo3lagent.eth on Sepolia points at"
+echo "          OffchainResolver $OFFCHAIN_RESOLVER"
+echo "==================================================================="
+echo
+echo "Verify via viem (or any ENSIP-10 client):"
+echo "  viem.getEnsText({ name: 'research-agent.sbo3lagent.eth',"
+echo "                    key:  'sbo3l:agent_id', chain: sepolia })"
+echo "  // expect: 'research-agent-01' (gateway records.json)"


### PR DESCRIPTION
Source bounty-*.md updated in #387; generated mirror under apps/marketing/src/content/submissions/ needed regeneration.