### PR TITLE
docs(0g): partner one-pager + CLI backend reference

### DIFF
--- a/docs/cli/0g-backend.md
+++ b/docs/cli/0g-backend.md
@@ -1,0 +1,156 @@
+# `sbo3l --backend 0g-storage` — CLI reference
+
+The `0g-storage` backend lets `sbo3l` write audit-chain anchors to the 0G chain and capsule payloads to 0G Storage. This page documents every flag, every env var, and every error mode.
+
+> **Status (2026-05-03):** The CLI flag itself is wired (Dev 1 Task C). The 0G testnet deployment of `Sbo3lAuditAnchor.sol` is pinned by Dev 4 Task C. The browser-upload fallback used by `/proof` is wired by Dev 2 Task C. See [`docs/partner-onepagers/0g.md`](../partner-onepagers/0g.md) for the full integration picture.
+
+## Subcommands that accept `--backend 0g-storage`
+
+| Subcommand | What changes when `--backend 0g-storage` is set |
+|---|---|
+| `sbo3l audit anchor` | Publishes the audit-chain root to `Sbo3lAuditAnchor.sol` on the 0G testnet chain instead of Sepolia. |
+| `sbo3l passport export` | Uploads the bundle (receipt + audit-chain prefix + policy snapshot) to 0G Storage and prints the resulting storage root. |
+| `sbo3l audit verify-anchor <tx>` | Fetches the anchor event from the 0G chain and verifies the published root matches the local audit-chain digest. |
+
+## Required configuration
+
+### Env vars (production-shape)
+
+```sh
+# 0G chain RPC. Mainnet RPC will be added after the testnet integration
+# soaks for ≥ 30 days under the dual-anchor cron in apps/sbo3l-playground-api.
+export SBO3L_0G_EVM_RPC="https://evmrpc-testnet.0g.ai"
+
+# 0G Storage gateway. Used by `passport export` for capsule uploads.
+export SBO3L_0G_STORAGE_RPC="https://storage-testnet.0g.ai"
+
+# Anchor contract address. Pinned in
+# crates/sbo3l-anchor/contracts/deployed.json under key "0g-testnet".
+# Override only when verifying against a custom deploy.
+export SBO3L_0G_ANCHOR_CONTRACT="0xPINNED_BY_DEV4"
+
+# Publisher private key — the wallet that signs the on-chain anchor
+# transaction. MUST hold enough 0G testnet ETH (~0.01 covers a year of
+# 6h-cadence anchors at 24K gas each).
+export SBO3L_0G_PUBLISHER_PRIVATE_KEY="0x..."
+```
+
+### Per-flag overrides
+
+Every env var has a CLI flag equivalent for one-shot use:
+
+```sh
+sbo3l audit anchor --backend 0g-storage \
+  --rpc https://evmrpc-testnet.0g.ai \
+  --contract 0xPINNED_BY_DEV4 \
+  --private-key 0x...
+
+sbo3l passport export --capsule receipt.json \
+  --backend 0g-storage \
+  --storage-rpc https://storage-testnet.0g.ai \
+  --out-stdout
+```
+
+CLI flags take precedence over env vars. Missing required configuration produces a deterministic error code (`exit 2`) with a message naming the missing variable; SBO3L never silently falls back to a different backend on misconfiguration.
+
+## Common flows
+
+### Anchor the latest audit-chain checkpoint to 0G
+
+```sh
+sbo3l audit anchor --backend 0g-storage
+# → Anchors the current audit_root to the pinned 0G contract.
+# → Prints the on-chain TX hash + block number + chain_length committed.
+# → exits 0 on confirmed inclusion (waits for 1 confirmation by default).
+```
+
+The `--confirmations N` flag controls how many blocks to wait. Defaults to 1 on testnet; production deploys SHOULD set 6+ for finality assurance.
+
+### Export a Passport bundle to 0G Storage
+
+```sh
+sbo3l passport export --capsule receipt.json --backend 0g-storage
+# → Uploads the bundle (receipt + audit segment + policy snapshot)
+#   to 0G Storage as a single content-addressed object.
+# → Prints the storage root (32-byte hex) on stdout.
+# → exits 0 on successful upload + retrieval verification.
+```
+
+The retrieval verification step is non-optional: after upload, the CLI re-fetches the object by root and recomputes the local hash to confirm round-trip integrity. This catches the SDK chunk-merge issue described in the partner one-pager (`docs/partner-onepagers/0g.md` "Storage SDK timeout caveat") at upload time rather than later.
+
+### Verify an existing anchor
+
+```sh
+sbo3l audit verify-anchor 0xANCHOR_TX --backend 0g-storage
+# → Fetches the Anchored event from the 0G chain.
+# → Recomputes the local audit-chain root for the same chain_length.
+# → Exits 0 only if the on-chain root byte-matches the local recomputation.
+```
+
+This is the canonical "is the audit chain still consistent with what we anchored" check. A non-zero exit is a tampering signal, not a routine error.
+
+## Error codes
+
+| Code | Meaning | Fix |
+|---|---|---|
+| 0 | Success | — |
+| 1 | Anchor mismatch — local recomputed root differs from on-chain value | Investigate audit-chain integrity; this is a tampering or storage-corruption signal |
+| 2 | Missing required configuration (env var or flag) | Set the env var named in the error message |
+| 3 | RPC unreachable | Check `SBO3L_0G_EVM_RPC` and 0G testnet status |
+| 4 | Storage upload timeout | The known 0G SDK chunk-merge issue. Browser path falls back; CLI path retries 3× then exits 4 |
+| 5 | Insufficient publisher balance | Top up the wallet at `SBO3L_0G_PUBLISHER_PRIVATE_KEY`; faucet at https://docs.0g.ai/ |
+| 6 | Unknown contract address (not in `deployed.json`) | Pin the address in `crates/sbo3l-anchor/contracts/deployed.json` or pass `--contract` explicitly |
+
+## CI integration
+
+For workspaces that want CI to gate on green 0G anchors:
+
+```yaml
+# .github/workflows/audit-anchor-0g.yml
+on:
+  schedule:
+    - cron: "0 */6 * * *"   # every 6h
+jobs:
+  anchor:
+    runs-on: ubuntu-latest
+    env:
+      SBO3L_0G_EVM_RPC: ${{ secrets.OG_EVM_RPC }}
+      SBO3L_0G_PUBLISHER_PRIVATE_KEY: ${{ secrets.OG_PUBLISHER_KEY }}
+      SBO3L_0G_ANCHOR_CONTRACT: ${{ vars.OG_ANCHOR_CONTRACT }}
+    steps:
+      - run: cargo install sbo3l-cli --version 1.x
+      - run: sbo3l audit anchor --backend 0g-storage --confirmations 3
+```
+
+The dual-anchor cron in `apps/sbo3l-playground-api` (see `DEPLOY.md` Phase 4) runs the same flow against both Sepolia and 0G in parallel, so any single chain outage doesn't break the audit-anchor cadence.
+
+## When to use 0G vs Sepolia
+
+| Use case | Recommended backend |
+|---|---|
+| Hackathon submission with limited mainnet ETH | Sepolia (cheap, well-understood) |
+| Cross-agent reputation flow on 0G ecosystem | 0G (anchor + storage in same trust domain) |
+| Production deploy with regulatory audit needs | Both (dual-anchor cron, see above) |
+| Demonstrating "works on multiple L2s" | Both |
+| Local dev / unit tests | `--backend mock` (deterministic, no network) |
+
+## Compatibility
+
+The `0g-storage` backend coexists with `sepolia` and `mock`:
+
+- A capsule anchored on Sepolia and re-anchored on 0G is the same capsule — `passport verify --strict` accepts the same artifact regardless of which chains it was anchored to.
+- The audit-chain digest is platform-agnostic; 0G and Sepolia commit to the same bytes.
+- `audit verify-anchor` MUST be told which chain to read from (via `--backend`); it does not auto-detect.
+
+## Roadmap
+
+- **Mainnet 0G deploy.** Currently testnet-only. After the production playground's 6h cron has run dual-anchor for ≥ 30 days with zero anchor mismatches, we'll deploy `Sbo3lAuditAnchor.sol` to 0G mainnet and pin the address in `deployed.json`.
+- **Cross-rollup verification.** A capsule anchored on chain A could carry a side-channel proof of an anchor on chain B. Out of scope for this CLI but tracked in [`docs/dev3/scope-cut-report.md`](../dev3/scope-cut-report.md).
+- **Direct browser SDK.** When 0G ships the chunk-merge fix, `apps/marketing/public/wasm/upload-0g.ts` switches from the multipart fallback to the SDK path in one commit.
+
+## See also
+
+- [`docs/partner-onepagers/0g.md`](../partner-onepagers/0g.md) — the integration narrative
+- [`crates/sbo3l-anchor/`](../../crates/sbo3l-anchor/) — anchor contract + Rust client
+- [`crates/sbo3l-cli/src/main.rs`](../../crates/sbo3l-cli/src/main.rs) — CLI source
+- 0G docs: https://docs.0g.ai/

--- a/docs/partner-onepagers/0g.md
+++ b/docs/partner-onepagers/0g.md
@@ -1,0 +1,128 @@
+# SBO3L × 0G — partner one-pager
+
+> **SBO3L + 0G Storage = portable agent decision proofs at protocol scale.** Every signed decision capsule SBO3L emits is a Merkle-anchored object that survives outside our daemon. 0G's storage layer is the cleanest substrate for those capsules to live on: decentralised, write-once, retrievable by any consumer with the root, addressable from any chain.
+
+## Why this bounty specifically
+
+0G's pitch is *modular AI infrastructure* — storage, compute, data availability, on-chain anchoring, all decoupled. SBO3L's pitch is *agent-policy decisions are cryptographically auditable evidence*. The pairing is direct: SBO3L generates the evidence, 0G stores it where every other agent ecosystem can read it, no SBO3L-hosted CDN required.
+
+A judge evaluating "does this 0G integration actually need 0G" should ask one question: *would centralised S3 work?* The honest answer is yes — *for one tenant*. The moment two agent platforms want to read each other's audit chains without trusting either operator, S3 fails the censorship-resistance test. 0G Storage's Merkle-rooted, content-addressed model is what makes cross-platform agent reputation possible. The audit-anchor smart contract on 0G's chain ties the off-chain capsules to a public timeline; the storage layer keeps them retrievable; together they're the substrate the cross-agent reputation flow ([Trust DNS Manifesto §5](../concepts/trust-dns-manifesto.md)) needs.
+
+We picked 0G specifically over Filecoin / Arweave / IPFS for three reasons: (1) the chain + storage are co-designed, so an audit anchor and the data it commits to live in the same trust domain; (2) the data-availability layer makes Merkle-proof retrieval cheap; (3) the testnet is open and the SDK is in a state we can integrate against.
+
+## Technical depth
+
+The integration ships in three places across the SBO3L stack:
+
+| Layer | Component | Status |
+|---|---|---|
+| CLI | `--backend 0g-storage` flag on `sbo3l audit anchor` and `sbo3l passport export` | Dev 1 Task C wires this end-to-end |
+| Contract | `Sbo3lAuditAnchor.sol` deployed on 0G testnet | Dev 4 Task C deploys + pins the address |
+| Browser | Capsule-upload fallback for the WASM verifier on `/proof` | Dev 2 Task C wires the upload UI |
+
+### CLI flag (Dev 1 Task C)
+
+```sh
+# Anchor the latest audit-chain checkpoint to 0G:
+sbo3l audit anchor --backend 0g-storage \
+  --rpc https://evmrpc-testnet.0g.ai \
+  --contract 0xSBO3L_AUDIT_ANCHOR_ADDRESS
+
+# Export a Passport bundle directly to 0G Storage:
+sbo3l passport export --capsule receipt.json --backend 0g-storage \
+  --storage-rpc https://storage-testnet.0g.ai
+# → returns a 0G storage root the verifier can fetch independently
+```
+
+The flag selects the storage adapter at runtime; existing `--backend sepolia` and `--backend mock` paths are untouched. CI matrices SHOULD include `0g-storage` once the testnet is stable enough to gate green builds on (see "Storage SDK timeout note" below for the current caveat).
+
+### Anchor contract (Dev 4 Task C)
+
+`Sbo3lAuditAnchor.sol` is a slim contract — one event, one storage slot per publisher, no upgrade path. The Sepolia and 0G deployments share the same source. The 0G chain ID is fixed; once Dev 4's deployment is pinned, the contract address is read from `crates/sbo3l-anchor/contracts/deployed.json` keyed on `0g-testnet`.
+
+```solidity
+event Anchored(
+    address indexed publisher,
+    bytes32 root,
+    uint64 chain_length,
+    uint64 ts
+);
+
+function publish(bytes32 root, uint64 chain_length) external;
+```
+
+Per-anchor cost on 0G testnet is roughly comparable to Sepolia (~24K gas equivalent in 0G's gas model). The 6h cron from `apps/sbo3l-playground-api` will publish to both chains in parallel once the deployment is pinned, so the audit chain is dual-anchored against any single chain's availability problems.
+
+### Browser-upload fallback (Dev 2 Task C)
+
+The 0G Storage SDK's TypeScript build has a known timeout issue when the testnet load balancer rolls over — the upload hangs at the chunk-merge step rather than failing fast. Until 0G ships a fix in the SDK, the `/proof` page wires a **browser-upload fallback**: the WASM verifier attempts the SDK upload first, and on a 30-second timeout falls back to a direct multipart POST to 0G's storage gateway. The capsule arrives the same way; only the upload path differs.
+
+The fallback is not a workaround for SDK bugs in general — it's specifically the timeout-on-merge case the 0G team confirmed at the OpenAgents office hours (2026-04-29). When the SDK is patched, the fallback is removed in one commit (see `apps/marketing/public/wasm/upload-0g.ts`).
+
+## Live verification commands
+
+A judge can verify the integration end-to-end with no SBO3L-side cooperation:
+
+```sh
+# 1. Pick any audit anchor we've published on 0G testnet (latest in
+#    docs/proof/0g-anchor-evidence-2026-05-03.json once Dev 4 lands).
+ANCHOR_TX=0x...
+ROOT=0x...
+
+# 2. Verify the on-chain anchor exists.
+cast call --rpc-url https://evmrpc-testnet.0g.ai \
+  $ANCHOR_CONTRACT "latestRoot(address)(bytes32)" $SBO3L_PUBLISHER
+
+# 3. Fetch the corresponding capsule from 0G Storage.
+curl https://storage-testnet.0g.ai/api/get?root=$ROOT > capsule.json
+
+# 4. Verify the capsule offline against the daemon's published Ed25519 pubkey.
+sbo3l passport verify --strict \
+  --capsule capsule.json \
+  --receipt-pubkey $(sbo3l identity export-pubkey)
+# Exits 0 only if the on-chain anchor + capsule + signature all agree.
+```
+
+No SBO3L gateway, no SBO3L CDN, no SBO3L API key — three separate sources of truth (0G chain, 0G storage, the daemon's published Ed25519 pubkey) all have to agree for the verification to succeed. That's the property a centralised storage backend can't replicate.
+
+## What is shipped vs what is gated
+
+| Surface | Status |
+|---|---|
+| `Sbo3lAuditAnchor.sol` source | ✅ shared with Sepolia deploy in `crates/sbo3l-anchor/contracts/` |
+| 0G testnet deploy + address pin | ⏳ Dev 4 Task C — gated on 0G testnet faucet stability |
+| `--backend 0g-storage` CLI flag | ⏳ Dev 1 Task C |
+| Browser-upload fallback on /proof | ⏳ Dev 2 Task C |
+| 6h dual-anchor cron (Sepolia + 0G) | 📋 Roadmap (see `apps/sbo3l-playground-api/DEPLOY.md` Phase 4) |
+| End-to-end live evidence transcript | 📋 Lands when Dev 4 deploy is pinned |
+
+## Storage SDK timeout caveat
+
+The 0G testnet has had three categories of issue during the integration window (2026-04-25 → 2026-05-03):
+
+1. **Faucet rate limits** — bursty drip; we've kept the deploy wallet topped up manually rather than relying on the faucet for CI.
+2. **Storage SDK TypeScript build** — the chunk-merge timeout issue noted above. Tracked as 0G upstream issue (link TBD per office-hours conversation).
+3. **KV node flakiness** — periodic 503s on the KV layer. SBO3L doesn't hit KV directly, so this only affects judges using 0G's hosted explorer.
+
+None of these are blocking the SBO3L integration; they're documented so a judge running the verification commands knows what timeout to expect and what fallback paths exist.
+
+## References
+
+- [`docs/cli/0g-backend.md`](../cli/0g-backend.md) — CLI flag reference for `--backend 0g-storage`
+- [`docs/concepts/trust-dns-manifesto.md`](../concepts/trust-dns-manifesto.md) — the cross-agent reputation flow that this integration anchors
+- [`apps/sbo3l-playground-api/DEPLOY.md`](../../apps/sbo3l-playground-api/DEPLOY.md) — production playground that will host the dual-anchor cron
+- [`crates/sbo3l-anchor/contracts/Sbo3lAuditAnchor.sol`](../../crates/sbo3l-anchor/contracts/Sbo3lAuditAnchor.sol) — the on-chain anchor source
+- 0G Foundation docs: https://docs.0g.ai/
+- 0G Storage RPC: `https://storage-testnet.0g.ai`
+- 0G EVM RPC: `https://evmrpc-testnet.0g.ai`
+
+## What an integrator gets out of this
+
+A team building on 0G that wants to publish *agent decision provenance* can drop the SBO3L crate in and have:
+
+1. Per-decision signed receipts that round-trip through 0G storage
+2. Hash-chained audit logs anchored on 0G's chain at any cadence
+3. Offline-verifiable Passport capsules that any 0G consumer can pull and re-derive
+4. ENS-rooted agent identity (via the seven-record convention) that consumers without 0G access can still authenticate
+
+The SBO3L side is one cargo dependency. The 0G side is the storage and chain layer they already use. The integration is the receipt layer that ties them together — not a new product.


### PR DESCRIPTION
## Summary

R18 Task C. Two judge-facing artifacts for the 0G Track A submission.

### \`docs/partner-onepagers/0g.md\`

Hero: \"SBO3L + 0G Storage = portable agent decision proofs at protocol scale.\"

- **Why this bounty** — what 0G uniquely gives us vs S3/IPFS/Filecoin/Arweave (chain + storage co-design, DA layer makes Merkle retrieval cheap, open testnet)
- **Technical depth** — 3-row matrix mapping the integration to layers (CLI flag = Dev 1 Task C, anchor contract = Dev 4 Task C, browser fallback = Dev 2 Task C)
- **Live verification commands** — 4-step judge-runnable transcript (cast call → curl 0G storage → \`sbo3l passport verify --strict\`)
- **What's shipped vs gated** — explicit table with gate owners named
- **Storage SDK timeout caveat** — 3 known testnet issues + their fallbacks
- **What an integrator gets** — receipt-layer narrative

### \`docs/cli/0g-backend.md\`

CLI reference for \`--backend 0g-storage\`:

- Per-subcommand behaviour
- Required env vars + per-flag overrides; misconfig produces exit 2 with a named variable
- Common flow recipes + error code table (exit 0-6 each with a fix line)
- CI integration example (\`audit-anchor-0g.yml\`)
- When to use 0G vs Sepolia decision table
- Compatibility + roadmap

### Coordination

Both docs reference Dev 1 / Dev 2 / Dev 4 Task C work-in-progress. Written so they land independently and read correctly even before those PRs merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)