### PR TITLE
feat(cli): sbo3l uniswap swap — mainnet swap envelope CLI (Daniel-broadcast)

### DIFF
--- a/crates/sbo3l-cli/src/main.rs
+++ b/crates/sbo3l-cli/src/main.rs
@@ -27,6 +27,7 @@ mod doctor_extended;
 mod key;
 mod passport;
 mod policy;
+mod uniswap_swap;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -172,6 +173,80 @@ enum Command {
     Admin {
         #[command(subcommand)]
         op: AdminCmd,
+    },
+    /// Uniswap V3 swap envelope (Task D — Daniel-broadcast demo).
+    ///
+    /// Builds an `exactInputSingle` calldata + tx envelope for either
+    /// Sepolia or mainnet, gated behind `SBO3L_ALLOW_MAINNET_TX=1`
+    /// when `--network mainnet`. Default `--dry-run` emits a JSON
+    /// envelope to stdout; `--broadcast` (with `--features
+    /// eth_broadcast`) signs + sends. The CLI never reads a private
+    /// key from a flag — operators point `--private-key-env-var` at
+    /// the env var holding the 32-byte hex key.
+    ///
+    /// See `docs/cli/uniswap-swap.md`.
+    Uniswap {
+        #[command(subcommand)]
+        op: UniswapCmd,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum UniswapCmd {
+    /// Build (and optionally broadcast) a Uniswap V3 `exactInputSingle`
+    /// swap envelope. Default `--dry-run`; `--broadcast` requires
+    /// the `eth_broadcast` Cargo feature plus `SBO3L_ALLOW_MAINNET_TX=1`
+    /// for `--network mainnet`.
+    Swap {
+        /// `mainnet` | `sepolia`. Default `sepolia`.
+        #[arg(long, default_value = "sepolia")]
+        network: String,
+
+        /// Amount + token suffix (`0.005ETH`, `1USDC`) or raw wei
+        /// integer. ETH/WETH = 18-decimal; USDC = 6-decimal.
+        #[arg(long)]
+        amount_in: String,
+
+        /// Output token: `USDC` | `ETH` | `WETH` | `0x...` hex.
+        #[arg(long)]
+        token_out: String,
+
+        /// Recipient EOA receiving `tokenOut` (EIP-55 case ignored).
+        #[arg(long)]
+        recipient: String,
+
+        /// Slippage cap in bps (1..=10000). Default 50 (0.5%).
+        #[arg(long)]
+        slippage_bps: Option<u16>,
+
+        /// Default-true. Mutually exclusive with `--broadcast`.
+        #[arg(long, default_value_t = false, conflicts_with = "broadcast")]
+        dry_run: bool,
+
+        /// Sign + send the tx. Requires `--features eth_broadcast`
+        /// at build time and the mainnet gate when network=mainnet.
+        #[arg(long, default_value_t = false)]
+        broadcast: bool,
+
+        /// JSON-RPC URL. Falls back to `SBO3L_RPC_URL`.
+        #[arg(long)]
+        rpc_url: Option<String>,
+
+        /// Env var name holding the 32-byte hex private key. The CLI
+        /// never reads the key from a flag — only via the env var
+        /// the operator names. Default `SBO3L_SIGNER_KEY`.
+        #[arg(long)]
+        private_key_env_var: Option<String>,
+
+        /// Optional local audit DB to append the envelope event to
+        /// (best-effort; failures log but don't abort).
+        #[arg(long)]
+        db: Option<PathBuf>,
+
+        /// Write the envelope JSON to `<path>` in addition to
+        /// printing.
+        #[arg(long)]
+        out: Option<PathBuf>,
     },
 }
 
@@ -1277,6 +1352,34 @@ fn main() -> ExitCode {
         Command::Admin {
             op: AdminCmd::Verify { from, decrypt_with },
         } => admin_backup::cmd_verify(admin_backup::VerifyArgs { from, decrypt_with }),
+        Command::Uniswap {
+            op:
+                UniswapCmd::Swap {
+                    network,
+                    amount_in,
+                    token_out,
+                    recipient,
+                    slippage_bps,
+                    dry_run,
+                    broadcast,
+                    rpc_url,
+                    private_key_env_var,
+                    db,
+                    out,
+                },
+        } => uniswap_swap::cmd_uniswap_swap(uniswap_swap::SwapArgs {
+            network,
+            amount_in,
+            token_out,
+            recipient,
+            slippage_bps,
+            dry_run,
+            broadcast,
+            rpc_url,
+            private_key_env_var,
+            db,
+            out,
+        }),
     }
 }
 

--- a/crates/sbo3l-cli/src/uniswap_swap.rs
+++ b/crates/sbo3l-cli/src/uniswap_swap.rs
@@ -1,0 +1,1383 @@
+//! Task D — `sbo3l uniswap swap` CLI scaffolding.
+//!
+//! Builds an `ExactInputSingle` swap envelope (Uniswap V3
+//! SwapRouter02) for either Sepolia or mainnet and either prints it
+//! as a dry-run JSON envelope (default) or, when `--broadcast` is
+//! passed AND all gates pass, signs and sends the tx. Reuses the
+//! existing calldata + quoter infrastructure in `sbo3l-execution`
+//! verbatim — this module is the operator-facing wrapper that
+//! translates `--amount-in 0.005ETH` into the wei amount the
+//! existing `SwapParams` / `encode_exact_input_single` take.
+//!
+//! # Surface
+//!
+//! ```text
+//! sbo3l uniswap swap \
+//!     --network mainnet \
+//!     --amount-in 0.005ETH \
+//!     --token-out USDC \
+//!     --recipient 0xdc7EFA6b4Bd77d1a406DE4727F0DF567e597D231 \
+//!     --dry-run
+//! ```
+//!
+//! `--dry-run` is the default. `--broadcast` requires:
+//!
+//! 1. `network=mainnet` ⇒ `SBO3L_ALLOW_MAINNET_TX=1` must be set
+//!    (same gate as `audit anchor` + `agent register`).
+//! 2. The PK env var (default `SBO3L_SIGNER_KEY`) must hold a valid
+//!    32-byte hex private key.
+//! 3. `--rpc-url` (or `SBO3L_RPC_URL`) must be set + http/https.
+//!
+//! # NOT in scope
+//!
+//! * **No private key on the CLI flag surface.** The operator points
+//!   to an env var name; the key never appears in a process-listing
+//!   readable form.
+//! * **No v4 hook integration.** This is V3 single-pool exact-input
+//!   only — Daniel's mainnet demo doesn't need v4.
+//! * **No automatic `IERC20.approve`.** A WETH-in swap requires the
+//!   caller to have already approved SwapRouter02. ETH-in is handled
+//!   via `WETH.deposit` upstream or a Universal Router multicall;
+//!   this scaffolding focuses on the WETH-in single-pool case to keep
+//!   the demo path minimal. Daniel handles the approve step out-of-
+//!   band before broadcasting.
+//!
+//! # Audit DB
+//!
+//! Optional `--db <path>` appends a structured event to the local
+//! audit chain when the envelope is built (not when broadcast — the
+//! broadcast tx hash gets a separate event through the daemon's
+//! existing surface). This is best-effort: a DB failure does not
+//! fail the CLI, it just logs a warning.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use chrono::Utc;
+use sbo3l_execution::{
+    encode_exact_input_single, hex_encode, parse_address, AddressError, JsonRpcTransport,
+    LiveConfig, ReqwestTransport, RpcError, SwapParams, MAINNET_CHAIN_ID,
+    MAINNET_QUOTER_V2_ADDRESS, MAINNET_SWAP_ROUTER_02, MAINNET_USDC, MAINNET_WETH,
+    SEPOLIA_CHAIN_ID, SEPOLIA_QUOTER_V2_ADDRESS, SEPOLIA_SWAP_ROUTER_02, SEPOLIA_USDC,
+    SEPOLIA_WETH,
+};
+
+/// Default env var holding the broadcaster's 32-byte hex private
+/// key. Operators override with `--private-key-env-var <NAME>` to
+/// keep multi-environment setups clean.
+#[cfg_attr(not(feature = "eth_broadcast"), allow(dead_code))]
+const DEFAULT_SIGNER_ENV: &str = "SBO3L_SIGNER_KEY";
+/// Default env var holding the broadcaster's JSON-RPC URL when the
+/// operator doesn't pass `--rpc-url` explicitly.
+const DEFAULT_RPC_ENV: &str = "SBO3L_RPC_URL";
+/// Hard-pin: the canonical V3 fee tier used for the demo pair.
+/// 0.3% (3000) is the deepest WETH/USDC pool on both Sepolia and
+/// mainnet. Operators wanting a different tier use the lower-level
+/// crate API directly — at this CLI's scope, pinning matches the
+/// existing `sepolia_weth_for_usdc` constructor and keeps the
+/// surface focused.
+const DEFAULT_FEE_TIER_BPS: u32 = 3_000;
+/// Tx deadline, in seconds from "now", baked into the envelope's
+/// metadata so an auditor can confirm the operator's freshness
+/// expectation. SwapRouter02 itself does not use this field (the
+/// tuple has no `deadline`); we surface it for the operator-side
+/// "build, then broadcast within N minutes" workflow.
+const DEFAULT_DEADLINE_SECONDS: u64 = 30 * 60;
+
+/// CLI args for `sbo3l uniswap swap`. Mirrors the structure of
+/// `AuditAnchorArgs` / `AgentRegisterArgs` so the dispatch in
+/// `main.rs` stays a one-liner.
+#[allow(dead_code)] // some fields only used with --features eth_broadcast
+#[derive(Debug, Clone)]
+pub struct SwapArgs {
+    /// `mainnet` | `sepolia`. Mainnet requires
+    /// `SBO3L_ALLOW_MAINNET_TX=1`.
+    pub network: String,
+    /// Decimal amount with token suffix (`0.005ETH`, `1USDC`) or a
+    /// raw wei integer (`5000000000000000`). See [`parse_amount_in`].
+    pub amount_in: String,
+    /// Output token: `USDC`, `ETH`, `WETH`, or a `0x`-prefixed hex
+    /// address.
+    pub token_out: String,
+    /// Recipient address (EIP-55 case ignored). Receives the bought
+    /// `tokenOut` after the swap settles.
+    pub recipient: String,
+    /// Slippage cap in bps. Default 50 (0.5%); range 1..=10000.
+    pub slippage_bps: Option<u16>,
+    /// Default-true dry-run mode. Mutually exclusive with
+    /// [`broadcast`].
+    pub dry_run: bool,
+    /// Sign + send the tx. Requires the mainnet gate (when
+    /// network=mainnet) AND the PK env var to be valid.
+    pub broadcast: bool,
+    /// JSON-RPC URL override. Falls back to `SBO3L_RPC_URL`.
+    pub rpc_url: Option<String>,
+    /// Env var name holding the operator's 32-byte hex private key.
+    /// Default `SBO3L_SIGNER_KEY`. The CLI never reads the key from
+    /// a flag — only from the env var the operator names.
+    pub private_key_env_var: Option<String>,
+    /// Append the envelope to a local audit DB at `<path>` as a
+    /// best-effort record. Optional.
+    pub db: Option<PathBuf>,
+    /// Write the envelope JSON to `<path>` in addition to printing.
+    pub out: Option<PathBuf>,
+}
+
+/// Networks supported by the swap CLI. The CLI accepts only the two
+/// strings; other tokens fail with a clear error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SwapNetwork {
+    Mainnet,
+    Sepolia,
+}
+
+impl SwapNetwork {
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "mainnet" => Ok(Self::Mainnet),
+            "sepolia" => Ok(Self::Sepolia),
+            other => Err(format!(
+                "unsupported network `{other}` (accepted: mainnet | sepolia)"
+            )),
+        }
+    }
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Mainnet => "mainnet",
+            Self::Sepolia => "sepolia",
+        }
+    }
+    pub fn chain_id(self) -> u64 {
+        match self {
+            Self::Mainnet => MAINNET_CHAIN_ID,
+            Self::Sepolia => SEPOLIA_CHAIN_ID,
+        }
+    }
+    pub fn router(self) -> &'static str {
+        match self {
+            Self::Mainnet => MAINNET_SWAP_ROUTER_02,
+            Self::Sepolia => SEPOLIA_SWAP_ROUTER_02,
+        }
+    }
+    pub fn quoter(self) -> &'static str {
+        match self {
+            Self::Mainnet => MAINNET_QUOTER_V2_ADDRESS,
+            Self::Sepolia => SEPOLIA_QUOTER_V2_ADDRESS,
+        }
+    }
+    pub fn weth(self) -> &'static str {
+        match self {
+            Self::Mainnet => MAINNET_WETH,
+            Self::Sepolia => SEPOLIA_WETH,
+        }
+    }
+    pub fn usdc(self) -> &'static str {
+        match self {
+            Self::Mainnet => MAINNET_USDC,
+            Self::Sepolia => SEPOLIA_USDC,
+        }
+    }
+    #[cfg_attr(not(feature = "eth_broadcast"), allow(dead_code))]
+    pub fn explorer_tx_url(self, tx_hash: &str) -> String {
+        let h = tx_hash.strip_prefix("0x").unwrap_or(tx_hash);
+        match self {
+            Self::Mainnet => format!("https://etherscan.io/tx/0x{h}"),
+            Self::Sepolia => format!("https://sepolia.etherscan.io/tx/0x{h}"),
+        }
+    }
+}
+
+/// One token symbol resolved into the on-chain address + decimals
+/// the CLI uses for amount unit conversion. ETH and WETH share the
+/// same WETH9 address; the demo treats them interchangeably for the
+/// `--token-out` direction (the swap output is always the underlying
+/// ERC-20, ETH unwrap happens separately).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedToken {
+    pub symbol: String,
+    pub address: String,
+    pub decimals: u32,
+}
+
+/// Resolve a token shorthand (`USDC`, `ETH`, `WETH`) or a literal
+/// `0x...` address against the network. Returns the canonical
+/// (address, decimals) tuple the CLI uses for amount parsing and the
+/// envelope output. Hex addresses are accepted with no decimals
+/// inference — they default to 18 (ERC-20 norm) and the CLI requires
+/// a wei-form `--amount-in` for those.
+pub fn resolve_token(network: SwapNetwork, token: &str) -> Result<ResolvedToken, String> {
+    let trimmed = token.trim();
+    let upper = trimmed.to_ascii_uppercase();
+    match upper.as_str() {
+        "ETH" | "WETH" => Ok(ResolvedToken {
+            symbol: upper,
+            address: network.weth().to_string(),
+            decimals: 18,
+        }),
+        "USDC" => Ok(ResolvedToken {
+            symbol: "USDC".to_string(),
+            address: network.usdc().to_string(),
+            decimals: 6,
+        }),
+        _ if trimmed.starts_with("0x") || trimmed.starts_with("0X") => {
+            // Hex address — accept verbatim, default decimals to 18.
+            // Callers wanting a non-18 hex token must use raw-wei
+            // amount form (no decimals shorthand resolves).
+            parse_address(trimmed).map_err(|e| format!("--token-out hex address invalid: {e}"))?;
+            Ok(ResolvedToken {
+                symbol: trimmed.to_string(),
+                address: trimmed.to_string(),
+                decimals: 18,
+            })
+        }
+        _ => Err(format!(
+            "unrecognised token `{token}` (accepted: USDC | ETH | WETH | 0x... hex)"
+        )),
+    }
+}
+
+/// Parsed amount in wei + the resolved input token. Surfaced
+/// separately so the CLI's envelope can record both the raw wei
+/// integer (canonical) AND the operator-supplied form (for human
+/// inspection).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedAmount {
+    pub raw_input: String,
+    pub token: ResolvedToken,
+    pub amount_wei_dec: String,
+}
+
+/// Parse the `--amount-in` string into a `(token, wei integer)`
+/// tuple. Accepted forms:
+///
+/// - `<decimal>ETH` / `<decimal>WETH` — decimal amount of ETH; result
+///   is wei (10^18 base units). Fractional precision below 1 wei is
+///   rejected.
+/// - `<decimal>USDC` — decimal amount of USDC; result is the 6-decimal
+///   "micros" form (10^6 base units). Below 1 micro is rejected.
+/// - `<integer>` — raw wei integer (no suffix). The token is whatever
+///   the operator implicitly intends; the CLI defaults the input
+///   token to the network's WETH for this case.
+pub fn parse_amount_in(network: SwapNetwork, raw: &str) -> Result<ParsedAmount, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("--amount-in cannot be empty".to_string());
+    }
+    // Detect a known suffix (case-insensitive).
+    let upper = trimmed.to_ascii_uppercase();
+    let (numeric, token_label, decimals) = if let Some(prefix) = upper.strip_suffix("ETH") {
+        (prefix.trim().to_string(), "ETH", 18)
+    } else if let Some(prefix) = upper.strip_suffix("WETH") {
+        (prefix.trim().to_string(), "WETH", 18)
+    } else if let Some(prefix) = upper.strip_suffix("USDC") {
+        (prefix.trim().to_string(), "USDC", 6)
+    } else {
+        // No suffix — whole string must parse as a wei integer.
+        if !trimmed.bytes().all(|b| b.is_ascii_digit()) {
+            return Err(format!(
+                "--amount-in `{raw}` has no recognised suffix \
+                 (USDC | ETH | WETH) and is not a wei integer"
+            ));
+        }
+        let token = resolve_token(network, "WETH")?;
+        return Ok(ParsedAmount {
+            raw_input: raw.to_string(),
+            token,
+            amount_wei_dec: trimmed.to_string(),
+        });
+    };
+
+    if numeric.is_empty() {
+        return Err(format!(
+            "--amount-in `{raw}` has a token suffix but no numeric prefix"
+        ));
+    }
+    // Decimal-string × 10^decimals, exact (no float). Documented
+    // truncation: any digit beyond the decimals window is a
+    // sub-base-unit fraction, which we reject — operators must
+    // express full base units. This keeps the parser deterministic
+    // and avoids silent precision loss.
+    let amount_wei = decimal_to_base_units(&numeric, decimals).map_err(|e| {
+        format!("--amount-in `{raw}`: cannot convert `{numeric}{token_label}` to base units: {e}")
+    })?;
+    let token = resolve_token(network, token_label)?;
+    Ok(ParsedAmount {
+        raw_input: raw.to_string(),
+        token,
+        amount_wei_dec: amount_wei,
+    })
+}
+
+/// Convert a decimal-formatted amount (`0.005`, `1`, `1.234567`) into
+/// the equivalent integer base-unit count given the token's decimals.
+///
+/// Returns the amount as a decimal string (so the caller can log it
+/// verbatim and the wire form is unambiguous). Rejects:
+///
+/// - Empty input.
+/// - Multiple decimal points.
+/// - Non-digit characters outside the lone `.`.
+/// - Fractional precision exceeding `decimals` (e.g. `0.0000005` of
+///   USDC where decimals=6 implies 0.5 micro — sub-base-unit and
+///   therefore rejected with a clear message).
+/// - Negative values (no leading `-` allowed).
+fn decimal_to_base_units(s: &str, decimals: u32) -> Result<String, String> {
+    if s.is_empty() {
+        return Err("amount string is empty".to_string());
+    }
+    // Reject leading sign — amounts must be positive integers.
+    if s.starts_with('-') || s.starts_with('+') {
+        return Err(format!("amount must be unsigned, got `{s}`"));
+    }
+    let parts: Vec<&str> = s.split('.').collect();
+    let (whole, frac) = match parts.as_slice() {
+        [w] => (*w, ""),
+        [w, f] => (*w, *f),
+        _ => return Err(format!("amount has more than one decimal point: `{s}`")),
+    };
+    if !whole.bytes().all(|b| b.is_ascii_digit()) || (whole.is_empty() && frac.is_empty()) {
+        return Err(format!("amount has non-digit chars: `{s}`"));
+    }
+    if !frac.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(format!("fractional part has non-digit chars: `{s}`"));
+    }
+    let dec_usize = decimals as usize;
+    if frac.len() > dec_usize {
+        // E.g. USDC (decimals=6) with 0.0000005 implies 0.5 micros —
+        // sub-base-unit. Reject loudly.
+        return Err(format!(
+            "fractional precision `{frac}` exceeds {decimals}-decimal token; \
+             smallest representable amount is 1 base unit (10^-{decimals})"
+        ));
+    }
+    // Pad the fractional part to exactly `decimals` digits, then
+    // concatenate with the whole part. The resulting digit string is
+    // the integer base-unit count.
+    let mut padded = String::with_capacity(whole.len() + dec_usize);
+    let whole_eff = if whole.is_empty() { "0" } else { whole };
+    padded.push_str(whole_eff);
+    padded.push_str(frac);
+    for _ in frac.len()..dec_usize {
+        padded.push('0');
+    }
+    // Strip leading zeros, but leave a single "0" for a zero amount.
+    let trimmed = padded.trim_start_matches('0');
+    let normalised = if trimmed.is_empty() {
+        "0".to_string()
+    } else {
+        trimmed.to_string()
+    };
+    Ok(normalised)
+}
+
+/// Validated slippage cap. Constructed via [`Self::from_args`] so
+/// the bounds-check + error message live in one place.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SlippageBps(u16);
+
+impl SlippageBps {
+    pub const DEFAULT: u16 = 50;
+    pub fn from_args(input: Option<u16>) -> Result<Self, String> {
+        let v = input.unwrap_or(Self::DEFAULT);
+        if !(1..=10_000).contains(&v) {
+            return Err(format!(
+                "--slippage-bps must be in [1, 10000]; got {v} \
+                 (1 = 0.01%, 10000 = 100%)"
+            ));
+        }
+        Ok(Self(v))
+    }
+    pub fn value(self) -> u16 {
+        self.0
+    }
+}
+
+/// Apply the slippage cap to an expected output amount, returning the
+/// `amountOutMinimum` the swap will hard-floor against on chain. The
+/// arithmetic is integer-safe: every value is a 256-bit decimal
+/// string, multiplied & divided as bytes-of-uint256 to avoid f64
+/// drift.
+pub fn apply_slippage(expected_out_dec: &str, slippage_bps: u16) -> Result<String, String> {
+    if slippage_bps == 0 || slippage_bps > 10_000 {
+        return Err(format!("slippage_bps out of range: {slippage_bps}"));
+    }
+    // amount_out_minimum = expected * (10000 - slippage_bps) / 10000.
+    // We do this as decimal-string * u128 / u128 by parsing through
+    // u128 at first (covers up to ~3.4e38 base units, ample for any
+    // realistic swap), and falling back to a string-times-u32 routine
+    // for larger values. The fallback path is exercised in tests.
+    if let Ok(parsed) = expected_out_dec.parse::<u128>() {
+        let factor = 10_000u128 - slippage_bps as u128;
+        let product = parsed.checked_mul(factor).ok_or_else(|| {
+            format!("slippage math overflow on u128 for input {expected_out_dec}")
+        })?;
+        let result = product / 10_000u128;
+        return Ok(result.to_string());
+    }
+    // Big-int path: multiply digit string by (10000 - slippage_bps)
+    // then divide by 10000. Both operands are small (max 9999); we
+    // can do schoolbook ops on the digit string in O(n) without a
+    // big-int crate.
+    let factor = (10_000u32 - slippage_bps as u32) as u64;
+    let multiplied = mul_decstr_by_u64(expected_out_dec, factor)?;
+    div_decstr_by_u64(&multiplied, 10_000u64)
+}
+
+fn mul_decstr_by_u64(dec: &str, factor: u64) -> Result<String, String> {
+    if !dec.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(format!("non-digit in decimal string `{dec}`"));
+    }
+    let mut digits: Vec<u8> = dec.bytes().rev().map(|b| b - b'0').collect();
+    let mut carry: u128 = 0;
+    for d in digits.iter_mut() {
+        let prod = (*d as u128) * (factor as u128) + carry;
+        *d = (prod % 10) as u8;
+        carry = prod / 10;
+    }
+    while carry > 0 {
+        digits.push((carry % 10) as u8);
+        carry /= 10;
+    }
+    let mut out: String = digits
+        .into_iter()
+        .rev()
+        .map(|d| (d + b'0') as char)
+        .collect();
+    let trimmed = out.trim_start_matches('0').to_string();
+    if trimmed.is_empty() {
+        out = "0".to_string();
+    } else {
+        out = trimmed;
+    }
+    Ok(out)
+}
+
+fn div_decstr_by_u64(dec: &str, divisor: u64) -> Result<String, String> {
+    if divisor == 0 {
+        return Err("division by zero".to_string());
+    }
+    let mut quotient = String::with_capacity(dec.len());
+    let mut rem: u128 = 0;
+    for c in dec.bytes() {
+        if !c.is_ascii_digit() {
+            return Err(format!("non-digit in decimal string `{dec}`"));
+        }
+        rem = rem * 10 + (c - b'0') as u128;
+        let q = rem / divisor as u128;
+        rem %= divisor as u128;
+        if !(quotient.is_empty() && q == 0) {
+            quotient.push((q as u8 + b'0') as char);
+        }
+    }
+    if quotient.is_empty() {
+        quotient.push('0');
+    }
+    Ok(quotient)
+}
+
+/// Convert a decimal-string uint256 into a 32-byte big-endian buffer.
+/// Used to inject computed amounts into [`SwapParams::new_exact_in`]
+/// without going through `u128`.
+pub fn decstr_to_u256_be(dec: &str) -> Result<[u8; 32], String> {
+    if dec.is_empty() {
+        return Err("uint256 decimal string is empty".to_string());
+    }
+    if !dec.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(format!("uint256 decimal must be digits only: `{dec}`"));
+    }
+    let mut buf = [0u8; 32];
+    for c in dec.bytes() {
+        let d = c - b'0';
+        let mut carry = d as u16;
+        for byte in buf.iter_mut().rev() {
+            let prod = (*byte as u16) * 10 + carry;
+            *byte = (prod & 0xff) as u8;
+            carry = prod >> 8;
+        }
+        if carry != 0 {
+            return Err(format!("uint256 overflow on input `{dec}`"));
+        }
+    }
+    Ok(buf)
+}
+
+/// The fully-resolved swap envelope. Serialised as JSON for both
+/// stdout and `--out`. Mirrors the audit-anchor envelope shape: a
+/// stable schema id, every input echoed back, and the
+/// `to`+`data`+`value`+`gas`+`chainId` fields a downstream signer
+/// needs to broadcast (via `cast`, `viem`, or this CLI's
+/// `--broadcast` path).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SwapEnvelope {
+    pub schema: String,
+    pub network: String,
+    pub chain_id: u64,
+    pub router: String,
+    pub quoter: String,
+    pub token_in: ResolvedTokenJson,
+    pub token_out: ResolvedTokenJson,
+    pub recipient: String,
+    pub fee_tier: u32,
+    pub amount_in_raw: String,
+    pub amount_in_wei: String,
+    pub expected_amount_out: String,
+    pub amount_out_minimum: String,
+    pub slippage_bps: u16,
+    pub deadline_seconds: u64,
+    pub deadline_unix: i64,
+    /// `to` for the eth_sendTransaction; same as `router`.
+    pub to: String,
+    /// Hex-encoded `exactInputSingle(...)` calldata.
+    pub data: String,
+    /// `0` — this CLI assumes WETH-in (operator pre-wraps ETH). On a
+    /// future ETH-in path we'd inject `value = amount_in_wei` for
+    /// the multicall(`refundETH` + WETH-deposit) wrapper.
+    pub value: String,
+    /// Quote source URL or address. For the quoter call, the format
+    /// is `uniswap-v3-quoter-<network>-<address>`.
+    pub quote_source: String,
+    pub computed_at: String,
+    pub broadcasted: bool,
+    pub tx_hash: Option<String>,
+    pub explorer_url: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ResolvedTokenJson {
+    pub symbol: String,
+    pub address: String,
+    pub decimals: u32,
+}
+
+impl From<ResolvedToken> for ResolvedTokenJson {
+    fn from(r: ResolvedToken) -> Self {
+        Self {
+            symbol: r.symbol,
+            address: r.address,
+            decimals: r.decimals,
+        }
+    }
+}
+
+const SWAP_ENVELOPE_SCHEMA: &str = "sbo3l.uniswap_swap_envelope.v1";
+
+/// Entry point invoked by `main.rs`.
+pub fn cmd_uniswap_swap(args: SwapArgs) -> ExitCode {
+    let network = match SwapNetwork::parse(&args.network) {
+        Ok(n) => n,
+        Err(e) => {
+            eprintln!("sbo3l uniswap swap: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    // Mainnet gate. Same disclosure pattern as audit anchor.
+    if network == SwapNetwork::Mainnet {
+        match std::env::var("SBO3L_ALLOW_MAINNET_TX").as_deref() {
+            Ok("1") => {}
+            _ => {
+                eprintln!(
+                    "sbo3l uniswap swap: refusing --network mainnet without SBO3L_ALLOW_MAINNET_TX=1.\n\
+                     \n\
+                     Mainnet swap envelopes encode a real Uniswap V3 trade against the live\n\
+                     pool. Set SBO3L_ALLOW_MAINNET_TX=1 to acknowledge before re-running.\n\
+                     The default network is Sepolia and never requires this gate."
+                );
+                return ExitCode::from(2);
+            }
+        }
+    }
+
+    let amount = match parse_amount_in(network, &args.amount_in) {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("sbo3l uniswap swap: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let token_out = match resolve_token(network, &args.token_out) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("sbo3l uniswap swap: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let recipient_addr = match parse_address_str(&args.recipient) {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("sbo3l uniswap swap: --recipient: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let slippage = match SlippageBps::from_args(args.slippage_bps) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("sbo3l uniswap swap: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    // Quote step: hit QuoterV2 for `expected_amount_out` if an
+    // RPC URL is supplied. When neither --rpc-url nor SBO3L_RPC_URL
+    // is set, fall back to a "no-quote" envelope where
+    // `expected_amount_out` = "0" and `amount_out_minimum` = "0".
+    // This is the truthful no-quote shape: an envelope with a zero
+    // floor would be unsafe to broadcast, so the CLI refuses
+    // --broadcast in that case.
+    let rpc_url = resolve_rpc_url(&args);
+    let (expected_out_dec, quote_source) = match rpc_url.clone() {
+        Some(url) => match live_quote(network, &amount, &token_out, &url) {
+            Ok((exp, src)) => (exp, src),
+            Err(e) => {
+                eprintln!(
+                    "sbo3l uniswap swap: quoter call failed: {e}\n\
+                     hint: confirm --rpc-url points at the right network ({})",
+                    network.as_str()
+                );
+                return ExitCode::from(1);
+            }
+        },
+        None => {
+            // No RPC URL → no quote. The envelope is still useful for
+            // manual review; broadcasting requires a real quote.
+            (
+                "0".to_string(),
+                format!("no-quote (set --rpc-url or {DEFAULT_RPC_ENV} for live quote)"),
+            )
+        }
+    };
+
+    let amount_out_minimum_dec = if expected_out_dec == "0" {
+        "0".to_string()
+    } else {
+        match apply_slippage(&expected_out_dec, slippage.value()) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("sbo3l uniswap swap: slippage application failed: {e}");
+                return ExitCode::from(1);
+            }
+        }
+    };
+
+    let amount_in_be = match decstr_to_u256_be(&amount.amount_wei_dec) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("sbo3l uniswap swap: amount_in encode failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    let amount_out_min_be = match decstr_to_u256_be(&amount_out_minimum_dec) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("sbo3l uniswap swap: amount_out_min encode failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    let token_in_addr = match parse_address(&amount.token.address) {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!(
+                "sbo3l uniswap swap: token_in address invalid ({}): {e:?}",
+                amount.token.address
+            );
+            return ExitCode::from(1);
+        }
+    };
+    let token_out_addr = match parse_address(&token_out.address) {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!(
+                "sbo3l uniswap swap: token_out address invalid ({}): {e:?}",
+                token_out.address
+            );
+            return ExitCode::from(1);
+        }
+    };
+
+    let params = SwapParams::new_exact_in(
+        token_in_addr,
+        token_out_addr,
+        DEFAULT_FEE_TIER_BPS,
+        recipient_addr,
+        amount_in_be,
+        amount_out_min_be,
+    );
+    let calldata = encode_exact_input_single(&params);
+    let calldata_hex = hex_encode(&calldata);
+
+    let now = Utc::now();
+    let deadline_unix = now.timestamp() + DEFAULT_DEADLINE_SECONDS as i64;
+    let envelope = SwapEnvelope {
+        schema: SWAP_ENVELOPE_SCHEMA.to_string(),
+        network: network.as_str().to_string(),
+        chain_id: network.chain_id(),
+        router: network.router().to_string(),
+        quoter: network.quoter().to_string(),
+        token_in: ResolvedTokenJson::from(amount.token.clone()),
+        token_out: ResolvedTokenJson::from(token_out.clone()),
+        recipient: format!("0x{}", hex::encode(recipient_addr)),
+        fee_tier: DEFAULT_FEE_TIER_BPS,
+        amount_in_raw: amount.raw_input.clone(),
+        amount_in_wei: amount.amount_wei_dec.clone(),
+        expected_amount_out: expected_out_dec.clone(),
+        amount_out_minimum: amount_out_minimum_dec.clone(),
+        slippage_bps: slippage.value(),
+        deadline_seconds: DEFAULT_DEADLINE_SECONDS,
+        deadline_unix,
+        to: network.router().to_string(),
+        data: calldata_hex,
+        value: "0".to_string(),
+        quote_source,
+        computed_at: now.to_rfc3339(),
+        broadcasted: false,
+        tx_hash: None,
+        explorer_url: None,
+    };
+
+    print_envelope(&envelope);
+    if let Some(out) = args.out.as_ref() {
+        if let Err(rc) = write_json(&envelope, out) {
+            return rc;
+        }
+        println!("envelope written to {}", out.display());
+    }
+    if let Some(db_path) = args.db.as_ref() {
+        // Best-effort audit-DB append. Failure prints a warning but
+        // doesn't fail the CLI — Daniel's primary record-keeping is
+        // the envelope JSON + the on-chain receipt, not this DB.
+        if let Err(e) = append_to_audit_db(db_path, &envelope) {
+            eprintln!("sbo3l uniswap swap: warning: audit DB append failed: {e}");
+        }
+    }
+
+    if args.broadcast {
+        return broadcast_dispatch(args, envelope, network);
+    }
+    ExitCode::SUCCESS
+}
+
+fn parse_address_str(s: &str) -> Result<[u8; 20], String> {
+    let trimmed = s.trim();
+    parse_address(trimmed).map_err(|e: AddressError| match e {
+        AddressError::BadLength(n) => {
+            format!("address must be 0x + 40 hex (42 chars total); got {n} chars")
+        }
+        AddressError::NonHex(c) => format!("address contains non-hex character: `{c}`"),
+    })
+}
+
+fn resolve_rpc_url(args: &SwapArgs) -> Option<String> {
+    if let Some(s) = args.rpc_url.as_deref() {
+        return Some(s.to_string());
+    }
+    std::env::var(DEFAULT_RPC_ENV).ok()
+}
+
+fn live_quote(
+    network: SwapNetwork,
+    amount: &ParsedAmount,
+    token_out: &ResolvedToken,
+    rpc_url: &str,
+) -> Result<(String, String), String> {
+    let cfg = match network {
+        SwapNetwork::Mainnet => LiveConfig::mainnet_default(
+            amount.token.address.clone(),
+            token_out.address.clone(),
+            DEFAULT_FEE_TIER_BPS,
+            amount.amount_wei_dec.clone(),
+            rpc_url.to_string(),
+        ),
+        SwapNetwork::Sepolia => LiveConfig::sepolia_default(
+            amount.token.address.clone(),
+            token_out.address.clone(),
+            DEFAULT_FEE_TIER_BPS,
+            amount.amount_wei_dec.clone(),
+            rpc_url.to_string(),
+        ),
+    };
+    let transport = ReqwestTransport::new(rpc_url.to_string());
+    let quote = quote_via_transport(&transport, &cfg).map_err(|e| match e {
+        RpcError::Http(s) => format!("RPC HTTP error: {s}"),
+        RpcError::Server { code, message } => format!("RPC server error {code}: {message}"),
+        RpcError::Decode(s) => format!("RPC decode error: {s}"),
+        RpcError::Parse(s) => format!("RPC parse error: {s}"),
+    })?;
+    let source = format!(
+        "uniswap-v3-quoter-{}-{}",
+        network.as_str(),
+        cfg.quoter.to_lowercase()
+    );
+    Ok((quote, source))
+}
+
+fn quote_via_transport<T: JsonRpcTransport + ?Sized>(
+    transport: &T,
+    cfg: &LiveConfig,
+) -> Result<String, RpcError> {
+    let q = sbo3l_execution::quote_exact_input_single(transport, cfg)?;
+    Ok(q.amount_out)
+}
+
+fn print_envelope(e: &SwapEnvelope) {
+    println!("schema:                 {}", e.schema);
+    println!("network:                {}", e.network);
+    println!("chain_id:               {}", e.chain_id);
+    println!("router:                 {}", e.router);
+    println!("quoter:                 {}", e.quoter);
+    println!(
+        "token_in:               {} ({})",
+        e.token_in.symbol, e.token_in.address
+    );
+    println!(
+        "token_out:              {} ({})",
+        e.token_out.symbol, e.token_out.address
+    );
+    println!("recipient:              {}", e.recipient);
+    println!(
+        "fee_tier:               {} (0.{}%)",
+        e.fee_tier,
+        e.fee_tier / 100
+    );
+    println!(
+        "amount_in:              {} ({} wei)",
+        e.amount_in_raw, e.amount_in_wei
+    );
+    println!("expected_amount_out:    {}", e.expected_amount_out);
+    println!(
+        "amount_out_minimum:     {} (slippage_bps={})",
+        e.amount_out_minimum, e.slippage_bps
+    );
+    println!(
+        "deadline:               {} ({} s window)",
+        e.deadline_unix, e.deadline_seconds
+    );
+    println!("to:                     {}", e.to);
+    println!("value:                  {}", e.value);
+    println!("data ({} bytes):       {}", (e.data.len() - 2) / 2, e.data);
+    println!("quote_source:           {}", e.quote_source);
+    println!("computed_at:            {}", e.computed_at);
+    println!("broadcasted:            {}", e.broadcasted);
+    if let Some(tx) = e.tx_hash.as_deref() {
+        println!("tx_hash:                {tx}");
+    }
+    if let Some(u) = e.explorer_url.as_deref() {
+        println!("explorer_url:           {u}");
+    }
+}
+
+fn write_json(envelope: &SwapEnvelope, path: &std::path::Path) -> Result<(), ExitCode> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                eprintln!(
+                    "sbo3l uniswap swap: failed to create parent dir {}: {e}",
+                    parent.display()
+                );
+                return Err(ExitCode::from(1));
+            }
+        }
+    }
+    let body = serde_json::to_string_pretty(envelope).map_err(|e| {
+        eprintln!("sbo3l uniswap swap: failed to serialise envelope: {e}");
+        ExitCode::from(1)
+    })?;
+    std::fs::write(path, body).map_err(|e| {
+        eprintln!(
+            "sbo3l uniswap swap: failed to write envelope to {}: {e}",
+            path.display()
+        );
+        ExitCode::from(1)
+    })?;
+    Ok(())
+}
+
+/// Best-effort audit-DB append. Records a structured event that
+/// names the swap envelope's network + token pair + recipient. Errors
+/// are returned to the caller, which logs a warning and proceeds.
+fn append_to_audit_db(_db_path: &std::path::Path, _envelope: &SwapEnvelope) -> Result<(), String> {
+    // The local audit DB schema is multi-tenant + signed-event-chained.
+    // Synthesising a daemon-shaped audit event here would require
+    // access to the daemon's signing keys; instead we treat this as
+    // a future hook: when Task D wires up to the daemon's
+    // record-this-envelope endpoint, this function delegates there.
+    // For the scaffolding PR we no-op with a return-OK so the path
+    // is exercised but doesn't claim a write that didn't happen.
+    Ok(())
+}
+
+#[cfg(not(feature = "eth_broadcast"))]
+fn broadcast_dispatch(_args: SwapArgs, _envelope: SwapEnvelope, _network: SwapNetwork) -> ExitCode {
+    eprintln!(
+        "sbo3l uniswap swap: --broadcast was accepted but this build was compiled \
+         without `--features eth_broadcast`. Drop --broadcast for the dry-run output, \
+         or rebuild with `cargo build -p sbo3l-cli --features eth_broadcast`."
+    );
+    ExitCode::from(3)
+}
+
+#[cfg(feature = "eth_broadcast")]
+fn broadcast_dispatch(args: SwapArgs, envelope: SwapEnvelope, network: SwapNetwork) -> ExitCode {
+    // Pre-flight: refuse if no quote happened (amount_out_minimum is 0).
+    // Broadcasting with a zero floor would let an MEV searcher take 100%
+    // of the output; this is the load-bearing safety net for the
+    // "no RPC supplied" path.
+    if envelope.amount_out_minimum == "0" {
+        eprintln!(
+            "sbo3l uniswap swap --broadcast: refusing to broadcast with amount_out_minimum=0 \
+             (no live quote was performed — pass --rpc-url or set SBO3L_RPC_URL so the \
+             slippage floor is computed against a real pool)."
+        );
+        return ExitCode::from(2);
+    }
+    let rt = match tokio::runtime::Runtime::new() {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("sbo3l uniswap swap --broadcast: tokio runtime init failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    rt.block_on(broadcast_live(args, envelope, network))
+}
+
+#[cfg(feature = "eth_broadcast")]
+async fn broadcast_live(args: SwapArgs, envelope: SwapEnvelope, network: SwapNetwork) -> ExitCode {
+    use alloy::network::{EthereumWallet, TransactionBuilder};
+    use alloy::primitives::{Address, Bytes, FixedBytes, U256};
+    use alloy::providers::{Provider, ProviderBuilder};
+    use alloy::rpc::types::TransactionRequest;
+    use alloy::signers::local::PrivateKeySigner;
+
+    let rpc_url = match args
+        .rpc_url
+        .clone()
+        .or_else(|| std::env::var(DEFAULT_RPC_ENV).ok())
+    {
+        Some(s) => s,
+        None => {
+            eprintln!(
+                "sbo3l uniswap swap --broadcast: pass --rpc-url <url> or set {DEFAULT_RPC_ENV}"
+            );
+            return ExitCode::from(2);
+        }
+    };
+    if !(rpc_url.starts_with("http://") || rpc_url.starts_with("https://")) {
+        eprintln!(
+            "sbo3l uniswap swap --broadcast: rpc url must be http:// or https://; got `{rpc_url}`"
+        );
+        return ExitCode::from(2);
+    }
+    let signer_env = args
+        .private_key_env_var
+        .as_deref()
+        .unwrap_or(DEFAULT_SIGNER_ENV);
+    let raw = match std::env::var(signer_env) {
+        Ok(s) => s,
+        Err(_) => {
+            eprintln!(
+                "sbo3l uniswap swap --broadcast: signer env var `{signer_env}` not set. \
+                 Export 32-byte hex private key (0x-prefixed or bare)."
+            );
+            return ExitCode::from(2);
+        }
+    };
+    let stripped = raw.trim().trim_start_matches("0x");
+    let key_bytes: [u8; 32] = match hex::decode(stripped) {
+        Ok(b) if b.len() == 32 => b.try_into().unwrap(),
+        _ => {
+            eprintln!("sbo3l uniswap swap --broadcast: signer key must be 32 bytes hex");
+            return ExitCode::from(2);
+        }
+    };
+    let signer = match PrivateKeySigner::from_bytes(&FixedBytes::from(key_bytes)) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("sbo3l uniswap swap --broadcast: signer construction failed: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    let signer_address = signer.address();
+    println!("  signer: {signer_address:?}");
+
+    let router: Address = match envelope.router.parse() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!(
+                "sbo3l uniswap swap --broadcast: bad router address {}: {e}",
+                envelope.router
+            );
+            return ExitCode::from(2);
+        }
+    };
+
+    let calldata_bytes = match hex::decode(envelope.data.trim_start_matches("0x")) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("sbo3l uniswap swap --broadcast: calldata decode failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    let wallet = EthereumWallet::from(signer);
+    let provider = ProviderBuilder::new()
+        .with_recommended_fillers()
+        .wallet(wallet)
+        .on_http(rpc_url.parse().expect("rpc url validated above"));
+
+    let chain_id = match provider.get_chain_id().await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("sbo3l uniswap swap --broadcast: eth_chainId failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    if chain_id != network.chain_id() {
+        eprintln!(
+            "sbo3l uniswap swap --broadcast: chain mismatch — RPC reports chain_id={chain_id} \
+             but envelope was built for {} (chain_id={}). Refusing to send.",
+            network.as_str(),
+            network.chain_id()
+        );
+        return ExitCode::from(2);
+    }
+    println!("  chain_id: {chain_id}");
+
+    let tx = TransactionRequest::default()
+        .with_to(router)
+        .with_input(Bytes::from(calldata_bytes))
+        .with_value(U256::ZERO)
+        .with_chain_id(chain_id);
+
+    println!(
+        "  → exactInputSingle → SwapRouter02 {} (network={})",
+        envelope.router,
+        network.as_str()
+    );
+    let pending = match provider.send_transaction(tx).await {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("sbo3l uniswap swap --broadcast: send failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    let tx_hash = *pending.tx_hash();
+    let tx_hash_hex = format!("{tx_hash:?}");
+    println!("    tx_hash:  {tx_hash_hex}");
+    let explorer = network.explorer_tx_url(&tx_hash_hex);
+    println!("    explorer: {explorer}");
+    let receipt = match pending.with_required_confirmations(1).get_receipt().await {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("sbo3l uniswap swap --broadcast: confirmation failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    if !receipt.status() {
+        eprintln!("sbo3l uniswap swap --broadcast: tx reverted on chain");
+        return ExitCode::from(1);
+    }
+    println!(
+        "    confirmed: block {} gas_used={}",
+        receipt.block_number.unwrap_or(0),
+        receipt.gas_used
+    );
+    ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args_template() -> SwapArgs {
+        SwapArgs {
+            network: "sepolia".to_string(),
+            amount_in: "0.005ETH".to_string(),
+            token_out: "USDC".to_string(),
+            recipient: "0xdc7EFA6b4Bd77d1a406DE4727F0DF567e597D231".to_string(),
+            slippage_bps: None,
+            dry_run: true,
+            broadcast: false,
+            rpc_url: None,
+            private_key_env_var: None,
+            db: None,
+            out: None,
+        }
+    }
+
+    #[test]
+    fn parse_amount_eth_decimal_to_wei() {
+        let p = parse_amount_in(SwapNetwork::Mainnet, "0.005ETH").unwrap();
+        assert_eq!(p.amount_wei_dec, "5000000000000000");
+        assert_eq!(p.token.symbol, "ETH");
+        assert_eq!(p.token.decimals, 18);
+        assert_eq!(p.token.address, MAINNET_WETH);
+    }
+
+    #[test]
+    fn parse_amount_one_eth_round_trips_to_one_e18() {
+        let p = parse_amount_in(SwapNetwork::Sepolia, "1ETH").unwrap();
+        assert_eq!(p.amount_wei_dec, "1000000000000000000");
+    }
+
+    #[test]
+    fn parse_amount_raw_wei_integer() {
+        let p = parse_amount_in(SwapNetwork::Mainnet, "5000000000000000").unwrap();
+        assert_eq!(p.amount_wei_dec, "5000000000000000");
+        // No-suffix wei amounts default to WETH (18-decimal) input.
+        assert_eq!(p.token.symbol, "WETH");
+    }
+
+    #[test]
+    fn parse_amount_one_usdc_to_micros() {
+        let p = parse_amount_in(SwapNetwork::Mainnet, "1USDC").unwrap();
+        assert_eq!(p.amount_wei_dec, "1000000");
+        assert_eq!(p.token.decimals, 6);
+        assert_eq!(p.token.address, MAINNET_USDC);
+    }
+
+    #[test]
+    fn parse_amount_rejects_sub_micro_usdc() {
+        // 0.0000005 USDC = 0.5 micros; sub-base-unit and rejected.
+        let err = parse_amount_in(SwapNetwork::Mainnet, "0.0000005USDC").unwrap_err();
+        assert!(err.contains("fractional precision"), "err = {err}");
+    }
+
+    #[test]
+    fn parse_amount_zero_is_zero() {
+        let p = parse_amount_in(SwapNetwork::Mainnet, "0ETH").unwrap();
+        assert_eq!(p.amount_wei_dec, "0");
+    }
+
+    #[test]
+    fn parse_amount_rejects_negative() {
+        let err = parse_amount_in(SwapNetwork::Mainnet, "-1ETH").unwrap_err();
+        assert!(err.contains("unsigned"), "err = {err}");
+    }
+
+    #[test]
+    fn parse_amount_rejects_unknown_suffix() {
+        let err = parse_amount_in(SwapNetwork::Mainnet, "1FOO").unwrap_err();
+        assert!(err.contains("no recognised suffix"), "err = {err}");
+    }
+
+    #[test]
+    fn slippage_default_is_50() {
+        let s = SlippageBps::from_args(None).unwrap();
+        assert_eq!(s.value(), 50);
+    }
+
+    #[test]
+    fn slippage_accepts_full_range() {
+        assert!(SlippageBps::from_args(Some(1)).is_ok());
+        assert!(SlippageBps::from_args(Some(10_000)).is_ok());
+    }
+
+    #[test]
+    fn slippage_rejects_zero_and_over_10000() {
+        assert!(SlippageBps::from_args(Some(0)).is_err());
+        assert!(SlippageBps::from_args(Some(10_001)).is_err());
+    }
+
+    #[test]
+    fn apply_slippage_50bps_to_one_unit() {
+        // 50 bps = 0.5%. expected 1_000_000 → min 995_000.
+        let v = apply_slippage("1000000", 50).unwrap();
+        assert_eq!(v, "995000");
+    }
+
+    #[test]
+    fn apply_slippage_handles_huge_uint256() {
+        // 2^200 — well past u128 — exercises the big-int fallback.
+        let big = "1606938044258990275541962092341162602522202993782792835301376";
+        let v = apply_slippage(big, 50).unwrap();
+        // Sanity: result should be (big * 9950 / 10000), strictly less than big.
+        assert!(v.len() <= big.len());
+        assert!(v != big);
+    }
+
+    #[test]
+    fn resolve_token_symbols_pin_to_correct_addresses() {
+        let usdc_main = resolve_token(SwapNetwork::Mainnet, "USDC").unwrap();
+        assert_eq!(usdc_main.address, MAINNET_USDC);
+        assert_eq!(usdc_main.decimals, 6);
+
+        let usdc_sepolia = resolve_token(SwapNetwork::Sepolia, "USDC").unwrap();
+        assert_eq!(usdc_sepolia.address, SEPOLIA_USDC);
+        assert_ne!(usdc_main.address, usdc_sepolia.address);
+
+        let eth_main = resolve_token(SwapNetwork::Mainnet, "ETH").unwrap();
+        assert_eq!(eth_main.address, MAINNET_WETH);
+        assert_eq!(eth_main.decimals, 18);
+    }
+
+    #[test]
+    fn resolve_token_accepts_hex_address() {
+        let r = resolve_token(
+            SwapNetwork::Mainnet,
+            "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+        )
+        .unwrap();
+        assert!(r.address.starts_with("0x"));
+        assert_eq!(r.decimals, 18);
+    }
+
+    #[test]
+    fn resolve_token_rejects_unknown_symbol() {
+        let err = resolve_token(SwapNetwork::Mainnet, "BLEH").unwrap_err();
+        assert!(err.contains("unrecognised"), "err = {err}");
+    }
+
+    #[test]
+    fn network_parse_accepts_canonical() {
+        assert_eq!(SwapNetwork::parse("mainnet").unwrap(), SwapNetwork::Mainnet);
+        assert_eq!(SwapNetwork::parse("sepolia").unwrap(), SwapNetwork::Sepolia);
+        assert_eq!(SwapNetwork::parse("MAINNET").unwrap(), SwapNetwork::Mainnet);
+    }
+
+    #[test]
+    fn network_parse_rejects_unknown() {
+        assert!(SwapNetwork::parse("base").is_err());
+        assert!(SwapNetwork::parse("optimism").is_err());
+    }
+
+    #[test]
+    fn decstr_to_u256_be_round_trips_via_uniswap_trading() {
+        // Match the lower-level encode_exact_input_single's expectation:
+        // u256 BE in the SwapParams. Pass through and ensure layout
+        // is what uniswap_trading::tests expects (last 16 bytes carry
+        // the u128 form for small values).
+        let buf = decstr_to_u256_be("5000000000000000").unwrap();
+        // First 16 bytes zero (small value), last 16 bytes = 5e15.
+        for &b in &buf[..16] {
+            assert_eq!(b, 0);
+        }
+        let val = u128::from_be_bytes(buf[16..].try_into().unwrap());
+        assert_eq!(val, 5_000_000_000_000_000);
+    }
+
+    #[test]
+    fn cmd_mainnet_without_gate_exits_2() {
+        // Save + clear the env var.
+        let saved = std::env::var("SBO3L_ALLOW_MAINNET_TX").ok();
+        std::env::remove_var("SBO3L_ALLOW_MAINNET_TX");
+
+        let mut a = args_template();
+        a.network = "mainnet".to_string();
+        let code = cmd_uniswap_swap(a);
+        // ExitCode lacks PartialEq; compare via the Debug repr.
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::from(2)));
+
+        if let Some(v) = saved {
+            std::env::set_var("SBO3L_ALLOW_MAINNET_TX", v);
+        }
+    }
+
+    #[test]
+    fn cmd_sepolia_dry_run_no_rpc_emits_envelope() {
+        // The dry-run path with no RPC should still build an envelope —
+        // expected_amount_out=0, amount_out_minimum=0, but every other
+        // field populated. Exit code 0 (envelope printed).
+        let saved_rpc = std::env::var(DEFAULT_RPC_ENV).ok();
+        std::env::remove_var(DEFAULT_RPC_ENV);
+
+        let mut a = args_template();
+        // Capture-friendly: write the envelope to a tempfile so the
+        // test can inspect the JSON shape.
+        let tmp = tempfile::Builder::new()
+            .prefix("uniswap-swap-envelope-")
+            .suffix(".json")
+            .tempfile()
+            .unwrap();
+        a.out = Some(tmp.path().to_path_buf());
+        let code = cmd_uniswap_swap(a);
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
+
+        let body = std::fs::read_to_string(tmp.path()).unwrap();
+        let parsed: SwapEnvelope = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed.network, "sepolia");
+        assert_eq!(parsed.chain_id, SEPOLIA_CHAIN_ID);
+        assert_eq!(parsed.token_in.symbol, "ETH");
+        assert_eq!(parsed.token_out.symbol, "USDC");
+        assert_eq!(parsed.amount_in_wei, "5000000000000000");
+        assert_eq!(parsed.expected_amount_out, "0");
+        assert_eq!(parsed.amount_out_minimum, "0");
+        assert!(parsed.data.starts_with("0x04e45aaf"));
+        assert!(!parsed.broadcasted);
+        assert!(parsed.tx_hash.is_none());
+        // Quote source must mention the no-quote fallback so an
+        // auditor reading the envelope knows broadcast was unsafe.
+        assert!(parsed.quote_source.contains("no-quote"));
+
+        if let Some(v) = saved_rpc {
+            std::env::set_var(DEFAULT_RPC_ENV, v);
+        }
+    }
+
+    #[test]
+    fn cmd_invalid_recipient_exits_2() {
+        let mut a = args_template();
+        a.recipient = "not-an-address".to_string();
+        let code = cmd_uniswap_swap(a);
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::from(2)));
+    }
+
+    #[test]
+    fn cmd_invalid_slippage_exits_2() {
+        let mut a = args_template();
+        a.slippage_bps = Some(0);
+        let code = cmd_uniswap_swap(a);
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::from(2)));
+    }
+
+    #[test]
+    fn cmd_invalid_amount_exits_2() {
+        let mut a = args_template();
+        a.amount_in = "not-a-number".to_string();
+        let code = cmd_uniswap_swap(a);
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::from(2)));
+    }
+}
+
+#[cfg(test)]
+mod live_tests {
+    //! Integration test for the live quoter path, gated behind two
+    //! env vars (intentionally cumulative to prevent accidental CI
+    //! triggers):
+    //!
+    //! - `MAINNET_RPC_URL` — the live JSON-RPC endpoint.
+    //! - `SBO3L_ALLOW_MAINNET_LIVE_TEST=1` — opt-in acknowledgement.
+    //!
+    //! When either is missing, the test is skipped (treated as
+    //! pass). When both are set, it calls QuoterV2 against the live
+    //! mainnet pool with a small WETH-in amount and asserts the
+    //! returned `amount_out` is non-zero — proves the wiring end to
+    //! end without spending gas.
+
+    use super::*;
+
+    #[test]
+    fn live_mainnet_quote_returns_nonzero_amount_out() {
+        let rpc = match std::env::var("MAINNET_RPC_URL") {
+            Ok(v) if !v.is_empty() => v,
+            _ => {
+                eprintln!("skip: MAINNET_RPC_URL not set");
+                return;
+            }
+        };
+        if std::env::var("SBO3L_ALLOW_MAINNET_LIVE_TEST").as_deref() != Ok("1") {
+            eprintln!("skip: SBO3L_ALLOW_MAINNET_LIVE_TEST != 1");
+            return;
+        }
+        let amount = parse_amount_in(SwapNetwork::Mainnet, "0.001ETH").unwrap();
+        let token_out = resolve_token(SwapNetwork::Mainnet, "USDC").unwrap();
+        let (out, source) = live_quote(SwapNetwork::Mainnet, &amount, &token_out, &rpc).unwrap();
+        let parsed: u128 = out
+            .parse()
+            .expect("amount_out fits u128 for 0.001 ETH worth of USDC");
+        assert!(parsed > 0, "live quote returned zero amount_out");
+        assert!(source.starts_with("uniswap-v3-quoter-mainnet-"));
+    }
+}

--- a/crates/sbo3l-cli/tests/uniswap_swap_cli.rs
+++ b/crates/sbo3l-cli/tests/uniswap_swap_cli.rs
@@ -1,0 +1,174 @@
+//! Integration tests for `sbo3l uniswap swap` (Task D).
+//!
+//! Exercises the real `sbo3l` binary end-to-end. Three things to
+//! pin here that pure unit tests can't (because they bypass clap):
+//!
+//! 1. `--dry-run` + `--broadcast` are mutually exclusive at the
+//!    clap layer (clap rejects with exit status 2 BEFORE the
+//!    command body sees the args).
+//! 2. The `--help` text is generated and lists the subcommand —
+//!    proves the wire-up survived Cargo build.
+//! 3. A sepolia dry-run with no RPC produces a valid JSON envelope
+//!    on stdout and exits zero.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn cli_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_sbo3l"))
+}
+
+#[test]
+fn uniswap_swap_help_lists_subcommand() {
+    let out = Command::new(cli_bin())
+        .args(["uniswap", "--help"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "uniswap --help should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("swap"),
+        "uniswap --help missing `swap` subcommand: {stdout}"
+    );
+}
+
+#[test]
+fn uniswap_swap_help_documents_flags() {
+    let out = Command::new(cli_bin())
+        .args(["uniswap", "swap", "--help"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for needle in [
+        "--network",
+        "--amount-in",
+        "--token-out",
+        "--recipient",
+        "--slippage-bps",
+        "--dry-run",
+        "--broadcast",
+        "--rpc-url",
+        "--private-key-env-var",
+    ] {
+        assert!(
+            stdout.contains(needle),
+            "uniswap swap --help missing flag {needle}: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn dry_run_and_broadcast_are_mutually_exclusive() {
+    let out = Command::new(cli_bin())
+        .args([
+            "uniswap",
+            "swap",
+            "--network",
+            "sepolia",
+            "--amount-in",
+            "0.005ETH",
+            "--token-out",
+            "USDC",
+            "--recipient",
+            "0xdc7EFA6b4Bd77d1a406DE4727F0DF567e597D231",
+            "--dry-run",
+            "--broadcast",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "clap should reject --dry-run + --broadcast together"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--broadcast")
+            || stderr.contains("conflicts")
+            || stderr.contains("cannot be used"),
+        "expected clap conflict-with error, got: {stderr}"
+    );
+}
+
+#[test]
+fn mainnet_without_gate_refused() {
+    // Hermetic against caller env: explicitly clear the gate. We can't
+    // un-set in the parent process but we CAN ensure the child doesn't
+    // see it (by not propagating, then env-clearing).
+    let out = Command::new(cli_bin())
+        .env_remove("SBO3L_ALLOW_MAINNET_TX")
+        .args([
+            "uniswap",
+            "swap",
+            "--network",
+            "mainnet",
+            "--amount-in",
+            "0.005ETH",
+            "--token-out",
+            "USDC",
+            "--recipient",
+            "0xdc7EFA6b4Bd77d1a406DE4727F0DF567e597D231",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "mainnet without SBO3L_ALLOW_MAINNET_TX=1 must refuse"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("SBO3L_ALLOW_MAINNET_TX"),
+        "stderr must mention the gate var, got: {stderr}"
+    );
+}
+
+#[test]
+fn sepolia_dry_run_emits_envelope_to_stdout_and_out() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out_path = tmp.path().join("envelope.json");
+    let out = Command::new(cli_bin())
+        .env_remove("SBO3L_RPC_URL") // ensure deterministic no-quote path
+        .args([
+            "uniswap",
+            "swap",
+            "--network",
+            "sepolia",
+            "--amount-in",
+            "0.005ETH",
+            "--token-out",
+            "USDC",
+            "--recipient",
+            "0xdc7EFA6b4Bd77d1a406DE4727F0DF567e597D231",
+            "--out",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("network:"),
+        "expected envelope print, got: {stdout}"
+    );
+    assert!(stdout.contains("router:"), "missing router");
+    assert!(stdout.contains("data ("), "missing calldata line");
+    // The on-disk JSON must parse and have the right shape.
+    let body = std::fs::read_to_string(&out_path).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v["network"], "sepolia");
+    assert_eq!(v["chain_id"], 11_155_111);
+    assert_eq!(v["broadcasted"], false);
+    assert_eq!(v["fee_tier"], 3000);
+    assert_eq!(v["token_in"]["symbol"], "ETH");
+    assert_eq!(v["token_out"]["symbol"], "USDC");
+    // Hex-encoded calldata starts with the exactInputSingle selector.
+    let data = v["data"].as_str().unwrap();
+    assert!(
+        data.starts_with("0x04e45aaf"),
+        "unexpected calldata prefix: {data}"
+    );
+}

--- a/crates/sbo3l-execution/src/lib.rs
+++ b/crates/sbo3l-execution/src/lib.rs
@@ -36,8 +36,8 @@ pub use uniswap::{
 };
 pub use uniswap_live::{
     quote_exact_input_single, JsonRpcTransport, LiveConfig, QuoteResult, ReqwestTransport,
-    RpcError, QUOTE_EXACT_INPUT_SINGLE_SELECTOR, SEPOLIA_CHAIN_ID, SEPOLIA_QUOTER_V2_ADDRESS,
-    SEPOLIA_WETH,
+    RpcError, MAINNET_CHAIN_ID, MAINNET_QUOTER_V2_ADDRESS, MAINNET_WETH,
+    QUOTE_EXACT_INPUT_SINGLE_SELECTOR, SEPOLIA_CHAIN_ID, SEPOLIA_QUOTER_V2_ADDRESS, SEPOLIA_WETH,
 };
 pub use uniswap_router::{
     CommandVerdict, EvaluatedCommand, MulticallOutcome, PolicyGate, UniversalRouterCommand,
@@ -45,7 +45,8 @@ pub use uniswap_router::{
 };
 pub use uniswap_trading::{
     encode_exact_input_single, hex_encode, parse_address, sepolia_etherscan_tx_url, AddressError,
-    SwapParams, EXACT_INPUT_SINGLE_SELECTOR, SEPOLIA_SWAP_ROUTER_02, SEPOLIA_USDC,
+    SwapParams, EXACT_INPUT_SINGLE_SELECTOR, MAINNET_SWAP_ROUTER_02, MAINNET_USDC,
+    SEPOLIA_SWAP_ROUTER_02, SEPOLIA_USDC,
 };
 
 /// Back-compat re-export of the old `keeperhub` submodule. Existing

--- a/crates/sbo3l-execution/src/uniswap_live.rs
+++ b/crates/sbo3l-execution/src/uniswap_live.rs
@@ -43,6 +43,22 @@ pub const SEPOLIA_CHAIN_ID: u64 = 11_155_111;
 /// `token_in` when the operator provides no override.
 pub const SEPOLIA_WETH: &str = "0xfff9976782d46cc05630d1f6ebab18b2324d6b14";
 
+/// Mainnet QuoterV2 deployment address. Source:
+/// developers.uniswap.org/contracts/v3/reference/deployments/ethereum-deployments
+///
+/// Used by `sbo3l uniswap swap --network mainnet` (Task D) to
+/// price-quote `--amount-in` against the live mainnet pool before
+/// computing `amountOutMinimum` from the slippage cap. Mainnet calls
+/// are gated behind `SBO3L_ALLOW_MAINNET_TX=1` at the CLI layer.
+pub const MAINNET_QUOTER_V2_ADDRESS: &str = "0x61fFE014bA17989E743c5F6cB21bF9697530B21e";
+
+/// EIP-155 mainnet chain id (1).
+pub const MAINNET_CHAIN_ID: u64 = 1;
+
+/// Mainnet WETH9 token address. Canonical wrapped-ETH; same address
+/// every Ethereum tooling has used since 2017.
+pub const MAINNET_WETH: &str = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+
 /// Selector for `quoteExactInputSingle((address,address,uint256,uint24,uint160))`.
 /// Pinned in tests against `keccak256(canonical_type_string)[0..4]`.
 pub const QUOTE_EXACT_INPUT_SINGLE_SELECTOR: [u8; 4] = [0xc6, 0xa5, 0x02, 0x6a];
@@ -179,6 +195,30 @@ impl LiveConfig {
             rpc_url,
             quoter: SEPOLIA_QUOTER_V2_ADDRESS.to_string(),
             chain_id: SEPOLIA_CHAIN_ID,
+            token_in,
+            token_out,
+            fee_tier,
+            amount_in_wei,
+        }
+    }
+
+    /// Mainnet config with sane defaults. Pair to
+    /// [`Self::sepolia_default`] for the `sbo3l uniswap swap
+    /// --network mainnet` flow. Caller supplies `token_in` /
+    /// `token_out` / `amount_in_wei` / `rpc_url`; `quoter` and
+    /// `chain_id` are pinned to the canonical mainnet QuoterV2 +
+    /// chain id.
+    pub fn mainnet_default(
+        token_in: String,
+        token_out: String,
+        fee_tier: u32,
+        amount_in_wei: String,
+        rpc_url: String,
+    ) -> Self {
+        Self {
+            rpc_url,
+            quoter: MAINNET_QUOTER_V2_ADDRESS.to_string(),
+            chain_id: MAINNET_CHAIN_ID,
             token_in,
             token_out,
             fee_tier,

--- a/crates/sbo3l-execution/src/uniswap_trading.rs
+++ b/crates/sbo3l-execution/src/uniswap_trading.rs
@@ -42,7 +42,7 @@
 //!   official Circle Sepolia USDC; surfaced as the default `token_out`.
 //! - Selector pinned in tests against `keccak256("exactInputSingle((address,address,uint24,address,uint256,uint256,uint160))")[0..4]`.
 
-use crate::uniswap_live::SEPOLIA_WETH;
+use crate::uniswap_live::{MAINNET_WETH, SEPOLIA_WETH};
 
 /// Sepolia SwapRouter02 deployment address.
 ///
@@ -51,6 +51,15 @@ pub const SEPOLIA_SWAP_ROUTER_02: &str = "0x3bFA4769FB09eefC5a80d6E87c3B9C650f7A
 
 /// Sepolia USDC (Circle's official testnet USDC). 6 decimals.
 pub const SEPOLIA_USDC: &str = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238";
+
+/// Mainnet SwapRouter02 deployment address. Used by Task D's
+/// `sbo3l uniswap swap --network mainnet` envelope.
+///
+/// Source: `developers.uniswap.org/contracts/v3/reference/deployments/ethereum-deployments`.
+pub const MAINNET_SWAP_ROUTER_02: &str = "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45";
+
+/// Mainnet USDC (Circle's canonical USDC contract). 6 decimals.
+pub const MAINNET_USDC: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 
 /// Selector for `exactInputSingle((address,address,uint24,address,uint256,uint256,uint160))`.
 ///
@@ -119,6 +128,52 @@ impl SwapParams {
             amount_out_minimum: u128_to_u256_be(amount_out_minimum_wei),
             sqrt_price_limit_x96: [0u8; 32],
         })
+    }
+
+    /// Mainnet WETH → USDC swap with 0.3% fee tier defaults. Pair to
+    /// [`Self::sepolia_weth_for_usdc`] for Task D's mainnet demo.
+    /// Caller supplies the recipient EOA, the WETH-in amount in wei,
+    /// and the USDC-out floor (6-decimal micros).
+    pub fn mainnet_weth_for_usdc(
+        recipient: [u8; 20],
+        amount_in_wei: u128,
+        amount_out_minimum_usdc_micros: u128,
+    ) -> Result<Self, AddressError> {
+        let token_in = parse_address(MAINNET_WETH)?;
+        let token_out = parse_address(MAINNET_USDC)?;
+        Ok(Self {
+            token_in,
+            token_out,
+            fee: 3_000,
+            recipient,
+            amount_in: u128_to_u256_be(amount_in_wei),
+            amount_out_minimum: u128_to_u256_be(amount_out_minimum_usdc_micros),
+            sqrt_price_limit_x96: [0u8; 32],
+        })
+    }
+
+    /// Generic ctor for arbitrary `(token_in, token_out, fee, recipient,
+    /// amount_in_u256, amount_out_min_u256)` tuples. Both amounts are
+    /// supplied as already-padded 32-byte big-endian buffers, so the
+    /// CLI layer can route any 256-bit value through without going via
+    /// `u128`. `sqrtPriceLimitX96` is fixed at `0` (no price limit).
+    pub fn new_exact_in(
+        token_in: [u8; 20],
+        token_out: [u8; 20],
+        fee: u32,
+        recipient: [u8; 20],
+        amount_in: [u8; 32],
+        amount_out_minimum: [u8; 32],
+    ) -> Self {
+        Self {
+            token_in,
+            token_out,
+            fee,
+            recipient,
+            amount_in,
+            amount_out_minimum,
+            sqrt_price_limit_x96: [0u8; 32],
+        }
     }
 }
 

--- a/docs/cli/uniswap-swap.md
+++ b/docs/cli/uniswap-swap.md
@@ -1,0 +1,192 @@
+# `sbo3l uniswap swap` — Uniswap V3 swap envelope
+
+> **Task D — Daniel-broadcast demo.** This CLI builds a signed-tx
+> envelope for a Uniswap V3 `exactInputSingle` swap on either
+> Sepolia or mainnet. Default `--dry-run` emits a JSON envelope you
+> can inspect, hand off to a separate signer, or feed into `cast
+> send`. Daniel runs the actual mainnet broadcast on his own primary
+> key — this CLI prepares the bytes; signing-and-sending is a
+> separate step.
+
+## TL;DR — the demo invocation
+
+```bash
+sbo3l uniswap swap \
+    --network mainnet \
+    --amount-in 0.005ETH \
+    --token-out USDC \
+    --recipient 0xdc7EFA6b4Bd77d1a406DE4727F0DF567e597D231 \
+    --rpc-url "$ALCHEMY_MAINNET_RPC_URL" \
+    --dry-run \
+    --out /tmp/sbo3l-swap-envelope.json
+```
+
+> `--dry-run` is the default; passing it explicitly is
+> defense-in-depth for automation. Mutually exclusive with
+> `--broadcast`.
+
+The CLI prints a human-readable envelope summary AND writes the same
+content as JSON to `--out`. The JSON shape is pinned by the
+`sbo3l.uniswap_swap_envelope.v1` schema id (the first field in every
+envelope).
+
+## What the envelope contains
+
+| Field | Meaning |
+| --- | --- |
+| `schema` | `sbo3l.uniswap_swap_envelope.v1` (stable) |
+| `network`, `chain_id` | `mainnet` / `1` or `sepolia` / `11155111` |
+| `router`, `quoter` | Uniswap V3 SwapRouter02 + QuoterV2 addresses for the network |
+| `token_in`, `token_out` | Symbol + address + decimals |
+| `recipient` | EIP-55 hex of who receives `tokenOut` |
+| `fee_tier` | Pinned `3000` (0.3% pool — deepest WETH/USDC liquidity) |
+| `amount_in_raw` | Exactly what the operator typed (`0.005ETH`) |
+| `amount_in_wei` | The integer base-unit form that hits the wire (`5000000000000000`) |
+| `expected_amount_out` | Live QuoterV2 result (`0` if no `--rpc-url` was supplied) |
+| `amount_out_minimum` | `expected × (10000 − slippage_bps) / 10000` |
+| `slippage_bps` | Default `50` (0.5%); accepts `1..=10000` |
+| `deadline_unix` / `deadline_seconds` | Soft window (envelope-side; SwapRouter02's tuple has no on-chain deadline) |
+| `to`, `data`, `value` | Drop-in for `eth_sendTransaction` |
+| `quote_source` | `uniswap-v3-quoter-{network}-{quoter_addr}` or `no-quote (...)` |
+| `computed_at` | RFC3339 timestamp |
+| `broadcasted` | `false` for dry-run; `true` after `--broadcast` |
+| `tx_hash`, `explorer_url` | Populated only after a successful `--broadcast` |
+
+## Two-step flow — prepare locally, broadcast separately
+
+Daniel's pattern for the mainnet demo:
+
+### Step 1 — Prepare the envelope
+
+```bash
+# On Daniel's machine, with funded wallet selected via the
+# Alchemy / PublicNode RPC URL.
+SBO3L_ALLOW_MAINNET_TX=1 \
+sbo3l uniswap swap \
+    --network mainnet \
+    --amount-in 0.005ETH \
+    --token-out USDC \
+    --recipient 0xdc7EFA6b4Bd77d1a406DE4727F0DF567e597D231 \
+    --rpc-url "$ALCHEMY_MAINNET_RPC_URL" \
+    --slippage-bps 50 \
+    --out /tmp/sbo3l-swap-envelope.json
+```
+
+Inspect the printed envelope. Confirm:
+
+- `expected_amount_out` looks reasonable (e.g. ~13.5 USDC for
+  0.005 ETH at $2700/ETH).
+- `amount_out_minimum` is exactly `expected × 0.995` (50 bps).
+- `to` is `0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45` (mainnet
+  SwapRouter02).
+- `recipient` matches Daniel's wallet.
+
+### Step 2a — Broadcast via this CLI (`--features eth_broadcast`)
+
+```bash
+# Build with the broadcast feature once.
+cargo build -p sbo3l-cli --features eth_broadcast --release
+
+# Set the gate + signer + RPC, then re-run with --broadcast (NOT --dry-run).
+export SBO3L_ALLOW_MAINNET_TX=1
+export SBO3L_SIGNER_KEY=0x<your-32-byte-hex-key>
+export SBO3L_RPC_URL=$ALCHEMY_MAINNET_RPC_URL
+
+./target/release/sbo3l uniswap swap \
+    --network mainnet \
+    --amount-in 0.005ETH \
+    --token-out USDC \
+    --recipient 0xdc7EFA6b4Bd77d1a406DE4727F0DF567e597D231 \
+    --slippage-bps 50 \
+    --broadcast
+```
+
+The CLI:
+
+1. Refuses if `SBO3L_ALLOW_MAINNET_TX=1` is unset.
+2. Refuses if the key env var is unset / not 32 bytes hex.
+3. Refuses if the RPC URL's `eth_chainId` doesn't match the
+   `--network` argument.
+4. Refuses if no live quote was performed (would broadcast with
+   `amount_out_minimum=0` — unsafe MEV exposure).
+5. Calls QuoterV2, applies slippage, builds calldata, signs, sends,
+   waits for 1 confirmation, prints the tx hash + Etherscan URL.
+
+### Step 2b — Broadcast via `cast send` (alt path)
+
+If you'd rather not recompile with `--features eth_broadcast`:
+
+```bash
+ENV=$(cat /tmp/sbo3l-swap-envelope.json)
+TO=$(jq -r .to <<<"$ENV")
+DATA=$(jq -r .data <<<"$ENV")
+
+cast send \
+    --rpc-url "$ALCHEMY_MAINNET_RPC_URL" \
+    --private-key "$SBO3L_SIGNER_KEY" \
+    "$TO" \
+    "$DATA"
+```
+
+## Env-var matrix
+
+| Variable | Required for | Notes |
+| --- | --- | --- |
+| `SBO3L_ALLOW_MAINNET_TX=1` | `--network mainnet` (always) | Same gate as `audit anchor` + `agent register`. Without it the CLI refuses to even build the envelope. |
+| `SBO3L_SIGNER_KEY` | `--broadcast` only | Override with `--private-key-env-var <NAME>`. The CLI never accepts the key on a flag. |
+| `SBO3L_RPC_URL` | `--broadcast` always; dry-run with quote | Override with `--rpc-url <url>`. http/https only. |
+| `MAINNET_RPC_URL` + `SBO3L_ALLOW_MAINNET_LIVE_TEST=1` | The opt-in live mainnet quoter integration test | Cumulative gates so CI never accidentally hits mainnet. |
+
+## Pinned addresses (for verification)
+
+| Network | Role | Address |
+| --- | --- | --- |
+| mainnet | SwapRouter02 | `0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45` |
+| mainnet | QuoterV2 | `0x61fFE014bA17989E743c5F6cB21bF9697530B21e` |
+| mainnet | WETH9 | `0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2` |
+| mainnet | USDC | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` |
+| sepolia | SwapRouter02 | `0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E` |
+| sepolia | QuoterV2 | `0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3` |
+| sepolia | WETH9 | `0xfff9976782d46cc05630d1f6ebab18b2324d6b14` |
+| sepolia | USDC (Circle testnet) | `0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238` |
+
+Sources: `developers.uniswap.org/contracts/v3/reference/deployments`.
+
+## Default recipient
+
+`0xdc7EFA6b4Bd77d1a406DE4727F0DF567e597D231` — Daniel's wallet
+(provisioned 2026-05-01, funded with 0.1 SEP-ETH via Alchemy
+faucet). Set as the demo's swap-output recipient so the on-chain
+trail is recoverable from one address.
+
+## Pre-broadcast checklist (for the live mainnet run)
+
+1. Approve WETH spend by SwapRouter02 if input is WETH:
+   ```bash
+   cast send "$WETH" "approve(address,uint256)" \
+       0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45 \
+       0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff \
+       --rpc-url "$RPC" --private-key "$KEY"
+   ```
+   (One-time; idempotent.) ETH-in flows go through a multicall
+   wrapper outside this CLI's scope — for the demo, pre-wrap a
+   small amount of ETH into WETH separately.
+2. Verify chain ID with `cast chain-id --rpc-url "$RPC"` → expect `1`.
+3. Run `--dry-run` first; eyeball the envelope.
+4. Run `--broadcast`. Wait for confirmation. Save the tx hash.
+5. Verify on Etherscan: input matches, output ≥ `amount_out_minimum`.
+
+## What this CLI deliberately doesn't do
+
+- **No private key on flags.** Only env vars. Never log the key
+  itself; the broadcast prints `signer: 0x<address>` and a redacted
+  RPC URL.
+- **No automatic ERC-20 approve.** WETH-in needs a one-time approve;
+  Daniel runs it once out-of-band. (Permit2 + Universal Router is a
+  follow-up.)
+- **No v4 hooks.** V3 single-pool exact-input only.
+- **No on-chain deadline.** SwapRouter02's `exactInputSingle` tuple
+  has no `deadline` field; the envelope's `deadline_unix` is for
+  human-side "build, then broadcast within N minutes" workflow.
+- **No MEV protection.** Submit through Flashbots Protect / MEV-Share
+  if the size warrants it; this CLI only constructs the bytes.


### PR DESCRIPTION
## Summary

Task D scaffolding: a `sbo3l uniswap swap` CLI that builds Uniswap V3 `exactInputSingle` swap envelopes for either Sepolia or mainnet, **default `--dry-run`**. Daniel runs the live mainnet broadcast separately with his primary key — this CLI prepares the bytes (and, with `--features eth_broadcast`, signs + sends).

- New module `crates/sbo3l-cli/src/uniswap_swap.rs` (~1,000 LoC) with `cmd_uniswap_swap(SwapArgs)`.
- New subcommand wired into `main.rs`: `sbo3l uniswap swap --network <mainnet|sepolia> --amount-in <0.005ETH|1USDC|wei-int> --token-out <USDC|ETH|WETH|0xhex> --recipient 0x... [--slippage-bps 50] [--rpc-url ...] [--private-key-env-var SBO3L_SIGNER_KEY] [--out path] [--db path] [--dry-run|--broadcast]`.
- Mainnet pins added to `sbo3l-execution`: `MAINNET_USDC` (`0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`), `MAINNET_WETH` (`0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2`), `MAINNET_QUOTER_V2_ADDRESS` (`0x61fFE014bA17989E743c5F6cB21bF9697530B21e`), `MAINNET_SWAP_ROUTER_02` (`0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45`), `MAINNET_CHAIN_ID = 1`.
- `LiveConfig::mainnet_default` ctor + `SwapParams::mainnet_weth_for_usdc` + `SwapParams::new_exact_in` (generic uint256 entry point) so the CLI doesn't duplicate the existing ABI encoding logic.
- Docs: `docs/cli/uniswap-swap.md` covering the full env-var matrix, two-step "envelope locally + broadcast separately" flow, address pins for verification, and pre-broadcast checklist.

## Safety gates

| Gate | Trigger |
| --- | --- |
| `SBO3L_ALLOW_MAINNET_TX=1` required | `--network mainnet` (envelope build OR broadcast) — same gate as `audit anchor` + `agent register` |
| PK never on a flag | Operator names env var via `--private-key-env-var <NAME>`; default `SBO3L_SIGNER_KEY` |
| `--broadcast` ↔ `--dry-run` clap mutex | Enforced by `conflicts_with` |
| Refuse broadcast with `amount_out_minimum=0` | When no live quote ran (no `--rpc-url`), broadcast is refused — would expose 100% MEV |
| RPC chain ID must match `--network` | `eth_chainId` checked before sending |
| `--features eth_broadcast` required to actually broadcast | Default builds parse `--broadcast` and exit 3 with a clear "rebuild with..." message — matches `audit anchor` pattern |

## Tests (30 new, all green)

**Unit (25, in `uniswap_swap::tests` + `live_tests`):**
- Amount parser: `0.005ETH` → `5000000000000000` wei; `1USDC` → `1000000`; raw wei integers; `0.0000005USDC` rejected (sub-base-unit); negative rejected; unknown suffix rejected
- Slippage default 50; range 1..=10000; rejects 0 + >10000
- `apply_slippage` exact arithmetic (50bps on 1e6 = 995_000); big-int fallback for 2^200-class numbers
- Token resolution: `USDC` → mainnet `0xA0b8...` vs Sepolia `0x1c7D...`; hex addresses accepted; unknown rejected
- Network parsing: `mainnet`/`sepolia` (case-insensitive); `base`/`optimism` rejected
- `decstr_to_u256_be` round-trip via `uniswap_trading::SwapParams` layout
- Mainnet without gate → exit 2; invalid recipient → exit 2; invalid slippage → exit 2; invalid amount → exit 2
- Sepolia dry-run no-RPC produces valid envelope (calldata starts with `0x04e45aaf` selector)
- **Live mainnet quote integration test** gated behind cumulative `MAINNET_RPC_URL` + `SBO3L_ALLOW_MAINNET_LIVE_TEST=1` (skips otherwise)

**Integration (5, in `tests/uniswap_swap_cli.rs` driving the real binary):**
- `uniswap --help` lists `swap`
- `uniswap swap --help` documents every flag
- `--dry-run --broadcast` rejected by clap
- `--network mainnet` without gate refused with clear stderr
- Sepolia dry-run writes valid JSON envelope to `--out`

Existing 54 `sbo3l-execution` tests still green; full workspace `cargo test` clean.

## Verification

- [x] `cargo build --workspace`
- [x] `cargo build -p sbo3l-cli --features eth_broadcast`
- [x] `cargo test -p sbo3l-cli uniswap_swap` → 25 passed
- [x] `cargo test -p sbo3l-cli --test uniswap_swap_cli` → 5 passed
- [x] `cargo test -p sbo3l-execution` → 54 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (default features)
- [x] `cargo clippy -p sbo3l-cli --features eth_broadcast --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check` (touched files; pre-existing fmt drift in `sepolia_or_live.rs` left as-is — out of scope)

## Daniel-side mainnet broadcast steps

```bash
# 1. Build with broadcast feature
cargo build -p sbo3l-cli --features eth_broadcast --release

# 2. Approve WETH spend by mainnet SwapRouter02 (one-time)
cast send 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 \
  "approve(address,uint256)" \
  0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45 \
  0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff \
  --rpc-url $ALCHEMY_MAINNET_RPC_URL --private-key $SBO3L_SIGNER_KEY

# 3. Wrap a small amount of ETH into WETH (out-of-band)
cast send 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 \
  "deposit()" --value 0.005ether \
  --rpc-url $ALCHEMY_MAINNET_RPC_URL --private-key $SBO3L_SIGNER_KEY

# 4. Dry-run the envelope and eyeball it
SBO3L_ALLOW_MAINNET_TX=1 \
./target/release/sbo3l uniswap swap \
  --network mainnet --amount-in 0.005ETH --token-out USDC \
  --recipient 0xdc7EFA6b4Bd77d1a406DE4727F0DF567e597D231 \
  --rpc-url $ALCHEMY_MAINNET_RPC_URL \
  --out /tmp/sbo3l-swap-envelope.json

# 5. Broadcast for real
SBO3L_ALLOW_MAINNET_TX=1 SBO3L_RPC_URL=$ALCHEMY_MAINNET_RPC_URL \
SBO3L_SIGNER_KEY=$YOUR_PK \
./target/release/sbo3l uniswap swap \
  --network mainnet --amount-in 0.005ETH --token-out USDC \
  --recipient 0xdc7EFA6b4Bd77d1a406DE4727F0DF567e597D231 \
  --broadcast
```

## Out of scope (intentional)

- v4 hooks (V3 single-pool exact-input only — sufficient for demo)
- Automatic ERC-20 `approve` (Daniel runs once out-of-band)
- ETH-in via Universal Router multicall (the demo pre-wraps to WETH)
- MEV protection (Flashbots Protect / MEV-Share submission is operator-side)
- Audit-DB write is wired but no-op pending daemon endpoint (`append_to_audit_db` is a future hook)

## Test plan

- [ ] `cargo build -p sbo3l-cli --features eth_broadcast` clean
- [ ] `cargo test -p sbo3l-cli uniswap_swap` all 25 unit tests pass
- [ ] `cargo test -p sbo3l-cli --test uniswap_swap_cli` all 5 integration tests pass
- [ ] Spot-check `sbo3l uniswap swap --help` output matches `docs/cli/uniswap-swap.md`
- [ ] Daniel: dry-run with `--rpc-url` populated → `expected_amount_out` non-zero, `amount_out_minimum = expected × 0.995` for default 50 bps
- [ ] Daniel: live mainnet broadcast → tx confirms on Etherscan, output ≥ `amount_out_minimum`

🤖 Generated with [Claude Code](https://claude.com/claude-code)