### PR TITLE
fix(contracts): Task C — pin new OR address (Heidi UAT bug #2 closeout)

### DIFF
--- a/crates/sbo3l-identity/src/contracts.rs
+++ b/crates/sbo3l-identity/src/contracts.rs
@@ -145,21 +145,34 @@ pub const UNIVERSAL_RESOLVER_SEPOLIA: ContractPin = ContractPin {
 // SBO3L deployments (we control the private key)
 // ============================================================
 
-/// SBO3L OffchainResolver on Sepolia (T-4-1 deploy). Deployed and
-/// verified live; the Sepolia anchor for every CCIP-Read demo. Pair
-/// the gateway URL `sbo3l-ccip.vercel.app` for the full off-chain
-/// extension flow.
+/// SBO3L OffchainResolver on Sepolia (T-4-1 redeploy 2026-05-03).
+/// Deployed and verified live; the Sepolia anchor for every CCIP-Read
+/// demo. Pair the gateway URL `sbo3l-ccip.vercel.app` for the full
+/// off-chain extension flow.
 ///
-/// Migration plan (mainnet): the same `forge create` script with
+/// **Heidi UAT bug #2 fix (2026-05-03)**: the previous deploy at
+/// `0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3` stored a malformed
+/// URL template (`"...{sender/{data}.json}"` — closing `}` after
+/// `sender` migrated to the end) because of `forge create
+/// --constructor-args` brace-rebalancing. The new deploy was issued
+/// via the forge SCRIPT wrapper at
+/// `script/DeployOffchainResolver.s.sol` which encodes the URL as a
+/// Solidity string literal so CLI parsing never touches it. Live
+/// wired to `research-agent.sbo3lagent.eth` Sepolia subname (PR
+/// #390) and verifiable via the
+/// `tests/sepolia_or_live.rs::new_or_url_template_is_canonical`
+/// probe.
+///
+/// Migration plan (mainnet): the same forge script with
 /// `NETWORK=mainnet SBO3L_ALLOW_MAINNET_TX=1` produces the mainnet
-/// counterpart; pin its address as
-/// `OFFCHAIN_RESOLVER_MAINNET` once Daniel's deploy lands.
+/// counterpart; pin its address as `OFFCHAIN_RESOLVER_MAINNET` once
+/// Daniel's deploy lands.
 pub const OFFCHAIN_RESOLVER_SEPOLIA: ContractPin = ContractPin {
-    address: "0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3",
+    address: "0x87e99508C222c6E419734CACbb6781b8d282b1F6",
     network: Network::Sepolia,
-    label: "SBO3L OffchainResolver (Sepolia, T-4-1 deploy)",
+    label: "SBO3L OffchainResolver (Sepolia, T-4-1 redeploy 2026-05-03)",
     canonical_source:
-        "https://sepolia.etherscan.io/address/0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3",
+        "https://sepolia.etherscan.io/address/0x87e99508C222c6E419734CACbb6781b8d282b1F6",
 };
 
 // ============================================================
@@ -468,9 +481,13 @@ mod tests {
     /// drift.
     #[test]
     fn offchain_resolver_sepolia_pinned_to_known_deploy() {
+        // Updated 2026-05-03: redeployed to fix Heidi UAT bug #2
+        // (malformed URL template). Old address
+        // `0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3` is orphaned on
+        // chain but no longer pinned anywhere.
         assert_eq!(
             OFFCHAIN_RESOLVER_SEPOLIA.address,
-            "0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3"
+            "0x87e99508C222c6E419734CACbb6781b8d282b1F6"
         );
         assert_eq!(OFFCHAIN_RESOLVER_SEPOLIA.network, Network::Sepolia);
     }

--- a/docs/proof/etherscan-link-pack.md
+++ b/docs/proof/etherscan-link-pack.md
@@ -58,7 +58,10 @@ same; the loop just gets two more keys.
 
 | Contract | Address | Etherscan |
 |---|---|---|
-| **OffchainResolver** (T-4-1) | `0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3` | [sepolia.etherscan.io/address/0x7c69…8c3](https://sepolia.etherscan.io/address/0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3) |
+| **OffchainResolver** (T-4-1, redeploy 2026-05-03 — Heidi UAT bug #2 fix) | `0x87e99508C222c6E419734CACbb6781b8d282b1F6` | [sepolia.etherscan.io/address/0x87e9…b1f6](https://sepolia.etherscan.io/address/0x87e99508C222c6E419734CACbb6781b8d282b1F6) |
+| OffchainResolver (T-4-1, ORIGINAL — superseded; URL template malformed, kept for history) | `0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3` | [sepolia.etherscan.io/address/0x7c69…8c3](https://sepolia.etherscan.io/address/0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3) |
+| `sbo3lagent.eth` Sepolia apex (registered 2026-05-03) | owner = `0x50BA…7e9c` (driver wallet) | [register tx 0x655f2b78…1238783](https://sepolia.etherscan.io/tx/0x655f2b7860d7c435c28ab3904f4a151cf4f485cc90a5f420d307a084b1238783) |
+| `research-agent.sbo3lagent.eth` Sepolia subname | resolver = new OR | [setSubnodeRecord tx 0x71c7fd7b…95db1](https://sepolia.etherscan.io/tx/0x71c7fd7b2766783e76291060203f542c9df7f4b68d2463315281456bfcb95db1) |
 | **AnchorRegistry** (R9 P6) | `0x4C302ba8349129bd5963A22e3c7a38a246E8f4Ac` | [sepolia.etherscan.io/address/0x4C30…f4Ac](https://sepolia.etherscan.io/address/0x4C302ba8349129bd5963A22e3c7a38a246E8f4Ac) |
 | **SubnameAuction** (R13 P3) | `0x5dE75E64739A95701367F3Ad592e0b674b22114B` | [sepolia.etherscan.io/address/0x5dE7…114B](https://sepolia.etherscan.io/address/0x5dE75E64739A95701367F3Ad592e0b674b22114B) |
 | **ReputationBond** (R13 P7) | `0x75072217B43960414047c362198A428f0E9793dA` | [sepolia.etherscan.io/address/0x7507…93dA](https://sepolia.etherscan.io/address/0x75072217B43960414047c362198A428f0E9793dA) |
@@ -112,9 +115,14 @@ Pinned in code at:
 ### "Is the OffchainResolver deployed on Sepolia?"
 
 ```bash
-cast code 0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3 \
+cast code 0x87e99508C222c6E419734CACbb6781b8d282b1F6 \
   --rpc-url https://ethereum-sepolia-rpc.publicnode.com | head -c 200
 # → 0x6080604052... (non-empty bytecode, deploy confirmed)
+
+# Bonus — check the URL template is canonical (Heidi UAT bug #2 guard):
+cast call 0x87e99508C222c6E419734CACbb6781b8d282b1F6 "urls(uint256)(string)" 0 \
+  --rpc-url https://ethereum-sepolia-rpc.publicnode.com
+# → "https://sbo3l-ccip.vercel.app/api/{sender}/{data}.json"
 ```
 
 ### "Does `sbo3lagent.eth` resolve the canonical records?"

--- a/docs/submission/bounty-ens-most-creative-final.md
+++ b/docs/submission/bounty-ens-most-creative-final.md
@@ -32,8 +32,11 @@ The hero artefact: `sbo3lagent.eth` resolves seven canonical
 A judge with a public RPC and `cast` can independently verify
 every record. The same name's subnames are served via a deployed
 ENSIP-25 / EIP-3668 OffchainResolver
-([`0x7c6913…aCA8c3`](https://sepolia.etherscan.io/address/0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3))
+([`0x87e9…b1f6`](https://sepolia.etherscan.io/address/0x87e99508C222c6E419734CACbb6781b8d282b1F6))
 on Sepolia, with the gateway live at `sbo3l-ccip.vercel.app`.
+Live wired: `research-agent.sbo3lagent.eth` is registered on
+Sepolia with the new OR as its resolver — viem.getEnsText returns
+`research-agent-01` end-to-end via CCIP-Read.
 
 ## Why this bounty
 
@@ -127,7 +130,7 @@ done
 
 ```bash
 # 1. Bytecode at the Sepolia OffchainResolver
-cast code 0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3 \
+cast code 0x87e99508C222c6E419734CACbb6781b8d282b1F6 \
   --rpc-url https://ethereum-sepolia-rpc.publicnode.com | head -c 200
 
 # 2. Run the viem E2E example (no SBO3L Rust dependency).
@@ -361,7 +364,8 @@ unblock the path when one triggers.
 | Repository   | https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026                           |
 | Live demo    | https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/                           |
 | Mainnet apex | [`sbo3lagent.eth`](https://app.ens.domains/sbo3lagent.eth) (owner [`0xdc7EFA…D231`](https://etherscan.io/address/0xdc7EFA6b4Bd77d1a406DE4727F0DF567e597D231)) |
-| Sepolia OffchainResolver | [`0x7c6913…aCA8c3`](https://sepolia.etherscan.io/address/0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3) |
+| Sepolia OffchainResolver (current — 2026-05-03 redeploy) | [`0x87e9…b1f6`](https://sepolia.etherscan.io/address/0x87e99508C222c6E419734CACbb6781b8d282b1F6) |
+| Sepolia `research-agent.sbo3lagent.eth` subname (live wired) | [setSubnodeRecord tx](https://sepolia.etherscan.io/tx/0x71c7fd7b2766783e76291060203f542c9df7f4b68d2463315281456bfcb95db1) |
 | Sepolia AnchorRegistry | [`0x4C302b…f4Ac`](https://sepolia.etherscan.io/address/0x4C302ba8349129bd5963A22e3c7a38a246E8f4Ac) |
 | Sepolia SubnameAuction | [`0x5dE75E…114B`](https://sepolia.etherscan.io/address/0x5dE75E64739A95701367F3Ad592e0b674b22114B) |
 | Sepolia ReputationBond | [`0x750722…93dA`](https://sepolia.etherscan.io/address/0x75072217B43960414047c362198A428f0E9793dA) |


### PR DESCRIPTION
## Summary

Third + final PR closing Heidi UAT bug #2. Task A (PR #383) shipped the forge-script deploy fix + probe tests. Task B (PR #390) registered `sbo3lagent.eth` on Sepolia + wired `research-agent` subname to the new OR. **This PR pins the new OR `0x87e99508…b1f6` as the canonical `OFFCHAIN_RESOLVER_SEPOLIA`** in `contracts.rs` + updates judge-facing docs.

## Scope (minimal, intentionally)

- `crates/sbo3l-identity/src/contracts.rs`:
  - `OFFCHAIN_RESOLVER_SEPOLIA.address` → `0x87e99508C222c6E419734CACbb6781b8d282b1F6`
  - `canonical_source` URL updated
  - `label` updated to "T-4-1 redeploy 2026-05-03"
  - inline comment explains bug #2 + fix posture
  - regression test `offchain_resolver_sepolia_pinned_to_known_deploy` asserts the new address
- `docs/proof/etherscan-link-pack.md` — top row flips to new OR, old row preserved as historical breadcrumb, adds Sepolia apex + subname tx hashes, verification snippet updated.
- `docs/submission/bounty-ens-most-creative-final.md` — hero claim, cast verification, submission metadata all reference new OR.

## Memory (local-only, not in repo)

`memory/t41_offchain_resolver_live_2026-05-02.md` updated with bug #2 narrative, new deploy details, research-agent subname tx hashes, and "Sepolia apex now owned" gap-resolution.

## Tests at HEAD

| Suite | Result |
|---|---|
| `cargo test -p sbo3l-identity --lib contracts::` | 11/11 pass |
| `cargo test -p sbo3l-identity --test sepolia_or_live -- --ignored` (live) | 5/5 pass |

## Heidi UAT bug #2 — fully closed

| Task | PR | What |
|---|---|---|
| A | #383 | Forge script + probe tests, deploy infrastructure |
| B | #390 | Sepolia apex registered + research-agent subname wired |
| C | this | Pin new address + docs + memory |

Wire-level proof:
- `urls(0)` returns canonical `"...{sender}/{data}.json"` ✓
- `OR.resolve(name, data)` reverts with `OffchainLookup` carrying canonical URL ✓
- ENS Registry has `research-agent.sbo3lagent.eth` → new OR ✓
- Probe tests guard against regression ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)