### PR TITLE
fix(install-smoke): daemon needs SBO3L_DEV_ONLY_SIGNER=1 in mock mode

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -152,9 +152,15 @@ jobs:
           # Mock-mode = SBO3L_ALLOW_UNAUTHENTICATED=1 (no bearer token / JWT
           # required). Bound to loopback only — the safety check inside the
           # daemon refuses non-loopback bind without SBO3L_ALLOW_UNSAFE_PUBLIC_BIND.
+          # SBO3L_DEV_ONLY_SIGNER=1 is the production-lockout escape hatch the
+          # dev signer requires (the daemon refuses to start without it when
+          # SBO3L_SIGNER_BACKEND=dev — guards against a prod deploy that
+          # forgets to swap the backend).
           SBO3L_ALLOW_UNAUTHENTICATED=1 \
           SBO3L_LISTEN_ADDR=127.0.0.1:8730 \
           SBO3L_DB="$RUNNER_TEMP/sbo3l-data/sbo3l.db" \
+          SBO3L_SIGNER_BACKEND=dev \
+          SBO3L_DEV_ONLY_SIGNER=1 \
             ./daemon/sbo3l-server > "$RUNNER_TEMP/sbo3l-server.log" 2>&1 &
           echo $! > "$RUNNER_TEMP/sbo3l.pid"
           # Wait up to 30s for the daemon to come up.
@@ -256,9 +262,15 @@ jobs:
           set -euo pipefail
           chmod +x ./daemon/sbo3l-server
           mkdir -p "$RUNNER_TEMP/sbo3l-data"
+          # SBO3L_DEV_ONLY_SIGNER=1 is the production-lockout escape hatch the
+          # dev signer requires (the daemon refuses to start without it when
+          # SBO3L_SIGNER_BACKEND=dev — guards against a prod deploy that
+          # forgets to swap the backend).
           SBO3L_ALLOW_UNAUTHENTICATED=1 \
           SBO3L_LISTEN_ADDR=127.0.0.1:8730 \
           SBO3L_DB="$RUNNER_TEMP/sbo3l-data/sbo3l.db" \
+          SBO3L_SIGNER_BACKEND=dev \
+          SBO3L_DEV_ONLY_SIGNER=1 \
             ./daemon/sbo3l-server > "$RUNNER_TEMP/sbo3l-server.log" 2>&1 &
           echo $! > "$RUNNER_TEMP/sbo3l.pid"
           for i in $(seq 1 30); do


### PR DESCRIPTION
## Summary
PR #379 (the install-smoke workflow) merged at the original sha before the daemon-startup fix landed. Result: every nightly + push run fails because the daemon refuses to start.

## Root cause

The dev signer backend has a production-lockout escape hatch — refuses to run unless `SBO3L_DEV_ONLY_SIGNER=1` is explicitly set, so a prod deploy that forgets to swap the backend fails loudly instead of silently using ephemeral keys. Mock-mode CI needs **both** `SBO3L_SIGNER_BACKEND=dev` and `SBO3L_DEV_ONLY_SIGNER=1`.

Failure from PR #379's first run (job 74073431741):

```
ERROR: refusing to start; signer backend rejected:
  DEV signer requires SBO3L_DEV_ONLY_SIGNER=1 to be set; this is a
  production-mode lockout, not a configuration nag
```

## Fix

Both `npm-smoke` and `pip-smoke` daemon-startup steps now set the two env vars. `cargo-smoke` is unaffected (no daemon needed for `sbo3l --version`).

## Test plan
- [ ] After merge, next push-to-main triggers a fresh install-smoke run
- [ ] All 32 jobs (1 build-daemon + 1 cargo + 25 npm + 5 pip + 1 summary) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)