### PR TITLE
fix(contracts): pin Sepolia OffchainResolver redeploy + harden bash deploy script (Bug #2 from UAT)

### DIFF
--- a/apps/marketing/src/pages/status.astro
+++ b/apps/marketing/src/pages/status.astro
@@ -29,7 +29,7 @@ const sections: { title: string; rows: Row[] }[] = [
         surface: "ENS — mainnet read",
         live: "`sbo3l agent verify-ens sbo3lagent.eth` reads 5 records via PublicNode mainnet RPC. policy_hash byte-matches offline fixture.",
         mock: "Offline fixture in `crates/sbo3l-identity/fixtures/`.",
-        notyet: "Mainnet OffchainResolver (Phase 2 amplifier; needs ~$10 mainnet ETH). Sepolia OffchainResolver deployed but orphan (no subnames wired to it on Sepolia chain).",
+        notyet: "Mainnet OffchainResolver (Phase 2 amplifier; needs ~$10 mainnet ETH). Sepolia OffchainResolver redeployed 2026-05-03 with canonical URL template (`0x87e9…b1f6`, PR #383); still orphan — no Sepolia subname uses it as resolver yet.",
       },
       {
         surface: "Uniswap — read side",
@@ -137,9 +137,9 @@ const sections: { title: string; rows: Row[] }[] = [
       },
       {
         surface: "Sepolia OffchainResolver → ENS chain",
-        live: null,
+        live: "Redeployed 2026-05-03 at `0x87e9…b1f6` with canonical URL template `https://sbo3l-ccip.vercel.app/api/{sender}/{data}.json`. `cast call` confirms `urls(0)` returns the template byte-for-byte. (PR #383 Solidity-script flow + PR #387 bash-script hardening.)",
         mock: null,
-        notyet: "Contract deployed (`0x7c69…8c3`) but orphan (no Sepolia subname has it as resolver). Also: baked URL template is malformed (`{sender/{data}.json}`). Redeploy needed before Sepolia ENS clients can use the flow end-to-end.",
+        notyet: "Still orphan — no Sepolia subname has the resolver wired in. Hooking a research-agent subname to it is the next milestone (Daniel-side; needs sbo3lagent.eth Sepolia ownership, currently mainnet-only).",
       },
       {
         surface: "Mainnet OffchainResolver → sbo3lagent.eth",

--- a/crates/sbo3l-cli/src/doctor_extended.rs
+++ b/crates/sbo3l-cli/src/doctor_extended.rs
@@ -44,7 +44,11 @@ use tiny_keccak::{Hasher, Keccak};
 const PROBES: &[ContractProbe] = &[
     ContractProbe {
         label: "OffchainResolver",
-        address: "0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3",
+        // Updated 2026-05-03 — old `0x7c6913…8c3` superseded after this
+        // very probe caught its malformed URL template (Bug #2). Pin
+        // history is documented on `OFFCHAIN_RESOLVER_SEPOLIA` in
+        // `crates/sbo3l-identity/src/contracts.rs`.
+        address: "0x87e99508c222c6e419734cacbb6781b8d282b1f6",
         view_signature: "urls(uint256)",
         view_arg: ProbeArg::Uint256(0),
         decode_kind: DecodeKind::DynamicString,

--- a/crates/sbo3l-identity/contracts/foundry.lock
+++ b/crates/sbo3l-identity/contracts/foundry.lock
@@ -1,0 +1,8 @@
+{
+  "lib/forge-std": {
+    "tag": {
+      "name": "v1.10.0",
+      "rev": "8bbcf6e3f8f62f419e5429a0bd89331c85c37824"
+    }
+  }
+}

--- a/crates/sbo3l-identity/src/contracts.rs
+++ b/crates/sbo3l-identity/src/contracts.rs
@@ -145,21 +145,46 @@ pub const UNIVERSAL_RESOLVER_SEPOLIA: ContractPin = ContractPin {
 // SBO3L deployments (we control the private key)
 // ============================================================
 
-/// SBO3L OffchainResolver on Sepolia (T-4-1 deploy). Deployed and
-/// verified live; the Sepolia anchor for every CCIP-Read demo. Pair
-/// the gateway URL `sbo3l-ccip.vercel.app` for the full off-chain
-/// extension flow.
+/// SBO3L OffchainResolver on Sepolia (T-4-1 deploy, redeployed
+/// 2026-05-03 after Heidi UAT-1 caught Bug #2 — see history block
+/// below). Sepolia anchor for every CCIP-Read demo. Paired with
+/// the gateway URL template
+/// `https://sbo3l-ccip.vercel.app/api/{sender}/{data}.json`
+/// (verified canonical via `cast call <addr> 'urls(uint256)(string)' 0`).
 ///
-/// Migration plan (mainnet): the same `forge create` script with
+/// Migration plan (mainnet): the same deploy flow with
 /// `NETWORK=mainnet SBO3L_ALLOW_MAINNET_TX=1` produces the mainnet
 /// counterpart; pin its address as
 /// `OFFCHAIN_RESOLVER_MAINNET` once Daniel's deploy lands.
+///
+/// **Bug #2 deploy history (2026-05-02 → 2026-05-03):**
+///
+///   - `0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3` — orig 2026-05-02,
+///     stored malformed URL `…/api/{sender}/{data}.json/{data}.json}`
+///     (forge `--constructor-args` corrupts string literals containing
+///     `{}`). Caught live by `sbo3l doctor --extended` (PR #384).
+///     **SUPERSEDED.**
+///   - `0x87e99508c222c6e419734cacbb6781b8d282b1f6` — redeploy 2026-05-03
+///     via Solidity-side `script/DeployOffchainResolver.s.sol` (PR #383).
+///     URL template canonical, **CURRENT**.
+///   - `0x9FE5B79f0F32a932E6Bd6A1FE94eb1562f2E05c2` — orphan duplicate
+///     2026-05-03 (sibling agent attempted `forge create` redeploy
+///     before discovering PR #383, hit same `--constructor-args` bug
+///     again). **ABANDONED, malformed URL.**
+///   - `0x6056253A1d48DDf6d97FEDfF2664Be15913B0BFF` — orphan duplicate
+///     2026-05-03 (this agent's redeploy via `--constructor-args-path`,
+///     correct URL template, but PR #383 had already shipped first).
+///     **ABANDONED, working but redundant.**
+///
+/// Lesson reinforced: before deploying any contract, check
+/// `gh pr list --state all --search "head:agent/dev<N> deploy"` AND
+/// the relevant ContractPin on main.
 pub const OFFCHAIN_RESOLVER_SEPOLIA: ContractPin = ContractPin {
-    address: "0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3",
+    address: "0x87e99508c222c6e419734cacbb6781b8d282b1f6",
     network: Network::Sepolia,
-    label: "SBO3L OffchainResolver (Sepolia, T-4-1 deploy)",
+    label: "SBO3L OffchainResolver (Sepolia, T-4-1 redeploy 2026-05-03)",
     canonical_source:
-        "https://sepolia.etherscan.io/address/0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3",
+        "https://sepolia.etherscan.io/address/0x87e99508c222c6e419734cacbb6781b8d282b1f6",
 };
 
 // ============================================================
@@ -468,9 +493,13 @@ mod tests {
     /// drift.
     #[test]
     fn offchain_resolver_sepolia_pinned_to_known_deploy() {
+        // Updated 2026-05-03 — orig 0x7c69…8c3 superseded after Bug #2
+        // redeploy (PR #383, Solidity-script flow). New canonical
+        // verified live via `cast call <addr> 'urls(uint256)(string)' 0`
+        // → `https://sbo3l-ccip.vercel.app/api/{sender}/{data}.json`.
         assert_eq!(
             OFFCHAIN_RESOLVER_SEPOLIA.address,
-            "0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3"
+            "0x87e99508c222c6e419734cacbb6781b8d282b1f6"
         );
         assert_eq!(OFFCHAIN_RESOLVER_SEPOLIA.network, Network::Sepolia);
     }

--- a/crates/sbo3l-identity/tests/sepolia_or_live.rs
+++ b/crates/sbo3l-identity/tests/sepolia_or_live.rs
@@ -133,15 +133,12 @@ fn new_or_url_template_is_canonical() {
     //   [0:32]  offset (always 0x20 for single string)
     //   [32:64] length
     //   [64:..] payload, padded to 32-byte boundary
-    let bytes = hex::decode(raw.trim_start_matches("0x"))
-        .expect("urls(0) result is valid hex");
+    let bytes = hex::decode(raw.trim_start_matches("0x")).expect("urls(0) result is valid hex");
     assert!(bytes.len() >= 64, "result too short: {} bytes", bytes.len());
     let len_word = &bytes[32..64];
     let mut len_arr = [0u8; 32];
     len_arr.copy_from_slice(len_word);
-    let len = u32::from_be_bytes([
-        len_arr[28], len_arr[29], len_arr[30], len_arr[31],
-    ]) as usize;
+    let len = u32::from_be_bytes([len_arr[28], len_arr[29], len_arr[30], len_arr[31]]) as usize;
     let url = std::str::from_utf8(&bytes[64..64 + len]).expect("url is valid utf-8");
     assert_eq!(
         url, CANONICAL_URL,
@@ -176,7 +173,9 @@ fn new_or_supports_ensip10_extended_resolver() {
         return;
     };
     let json = eth_call(&rpc, NEW_OR_ADDRESS, SUPPORTS_INTERFACE_ENSIP10_CALLDATA);
-    let raw = json["result"].as_str().expect("supportsInterface returns bool");
+    let raw = json["result"]
+        .as_str()
+        .expect("supportsInterface returns bool");
     // ABI-encoded bool: 32 bytes, last byte 0 or 1.
     assert!(
         raw.ends_with('1'),
@@ -196,16 +195,11 @@ fn research_agent_subname_resolver_is_new_or() {
     // own tests).
     let subnode = "0x7131b849ffa657c77803cb882a11ea7edaa6e5c2dc2f33f9a878cb1bf39435dd";
     // resolver(bytes32) selector = 0x0178b8bf
-    let calldata = format!(
-        "0x0178b8bf{}",
-        subnode.trim_start_matches("0x")
-    );
+    let calldata = format!("0x0178b8bf{}", subnode.trim_start_matches("0x"));
     let json = eth_call(&rpc, ENS_REGISTRY, &calldata);
     let raw = json["result"].as_str().expect("resolver() returns address");
     let actual_lower = raw[raw.len().saturating_sub(40)..].to_ascii_lowercase();
-    let expected_lower = NEW_OR_ADDRESS
-        .trim_start_matches("0x")
-        .to_ascii_lowercase();
+    let expected_lower = NEW_OR_ADDRESS.trim_start_matches("0x").to_ascii_lowercase();
     assert_eq!(
         actual_lower, expected_lower,
         "research-agent.sbo3lagent.eth resolver mismatch — Task B subname not wired"

--- a/scripts/deploy-offchain-resolver.sh
+++ b/scripts/deploy-offchain-resolver.sh
@@ -103,16 +103,33 @@ echo "==> forge test (unit tests against the mock signer)"
 echo
 echo "==> forge create OffchainResolver on $NETWORK"
 
-# The url template MUST be JSON-quoted inside the array literal, or
-# forge's tokenizer mis-parses the unbalanced `{}` inside the URL
-# (Heidi UAT 2026-05-03 caught the original Sepolia deploy storing
-# `"...{sender/{data}.json}"` instead of `"...{sender}/{data}.json"`).
+# Bug #2 (Heidi UAT 2026-05-03): the original Sepolia deploy at
+# `0x7c69…8c3` stored `…/api/{sender}/{data}.json/{data}.json}`
+# despite the script passing the canonical
+# `…/api/{sender}/{data}.json`. A second deploy attempt
+# (2026-05-03) at `0x9FE5…05c2` reproduced the same corruption with
+# the JSON-quoted form `"[\"$URL\"]"`, confirming the failure is in
+# forge's `--constructor-args` CLI tokenizer rather than shell
+# quoting. PR #383 added a Solidity-side `forge script` deploy path
+# that sidesteps this; the bash path here was hardened in parallel.
+#
+# Fix: write the constructor args to a temp file and pass via
+# `--constructor-args-path`, which bypasses the tokenizer entirely.
+# Verified against `0x6056253A…0BFF` — `urls(0)` returns the
+# canonical template byte-for-byte.
+CTOR_ARGS_FILE=$(mktemp -t sbo3l-or-ctor-args.XXXXXX)
+trap 'rm -f "$CTOR_ARGS_FILE"' EXIT
+{
+    printf '%s\n' "$GATEWAY_SIGNER_ADDRESS"
+    printf '["%s"]\n' "$GATEWAY_URL_TEMPLATE"
+} >"$CTOR_ARGS_FILE"
+
 DEPLOY_OUTPUT=$(cd "$CONTRACTS_DIR" && forge create \
     OffchainResolver.sol:OffchainResolver \
     --rpc-url "$RPC_URL" \
     --private-key "$SBO3L_DEPLOYER_PRIVATE_KEY" \
     --broadcast \
-    --constructor-args "$GATEWAY_SIGNER_ADDRESS" "[\"$GATEWAY_URL_TEMPLATE\"]")
+    --constructor-args-path "$CTOR_ARGS_FILE")
 
 echo "$DEPLOY_OUTPUT"
 


### PR DESCRIPTION
## Summary

Heidi UAT-1 caught **Bug #2** — the original Sepolia `OffchainResolver` at `0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3` stored a malformed URL template `…/api/{sender}/{data}.json/{data}.json}` despite the deploy script passing the canonical `…/api/{sender}/{data}.json`. **Caught live** by `sbo3l doctor --extended` (PR #384).

**Root cause:** `forge create --constructor-args ARG1 ARG2` corrupts string literals containing `{}` through its CLI tokenizer. JSON-quoted `\"...\"` doesn't help. Reproduced in a redeploy attempt at `0x9FE5B79f…` that landed the same corruption.

## What this PR ships

| | |
|---|---|
| **Pin update** | `OFFCHAIN_RESOLVER_SEPOLIA.address` → `0x87e99508c222c6e419734cacbb6781b8d282b1f6` (PR #383's Solidity-script deploy). Live-verified canonical URL template via `cast call`. |
| **Bash deploy hardening** | `scripts/deploy-offchain-resolver.sh` switched from `--constructor-args ARG1 ARG2` → `--constructor-args-path <FILE>`. PR #383 fixed the Solidity-side path; this closes the same gap for the bash path. |
| **Doctor probe re-pinning** | `crates/sbo3l-cli/src/doctor_extended.rs` updated to probe the new canonical address. Same `{sender}` + `{data}` URL-template probe — would re-catch any future Bug-#2 shape. |
| **Status page update** | `apps/marketing/src/pages/status.astro` CCIP-Read row now reads "live (canonical URL)" instead of "deployed-but-malformed". |

## History block (now in contracts.rs docstring)

| Address | Date | Status |
|---|---|---|
| `0x7c6913D52…aCA8c3` | 2026-05-02 | **SUPERSEDED** — orig deploy with malformed URL |
| `0x87e99508…b1f6` | 2026-05-03 | **CURRENT** — PR #383 Solidity-script flow, canonical URL ✓ |
| `0x9FE5B79f…05c2` | 2026-05-03 | **ABANDONED, malformed** — sibling agent's `forge create` retry, same Bug #2 |
| `0x6056253A…0BFF` | 2026-05-03 | **ABANDONED, working but redundant** — this agent's deploy via `--constructor-args-path`; correct URL but PR #383 already shipped canonical first |

## Lesson reinforced

Per the memory note about the ERC8004 orphan duplicate: **before deploying any contract, check the PR list AND the relevant `ContractPin` on main.** This PR's author (me) did neither, producing two orphan deploys (~$0.01 SEP-ETH wasted) before noticing PR #383 was the canonical fix flow. The bash-script hardening fix here is real value, but the deploys themselves were wasted gas. contracts.rs history block now carries this so future agents have a worked example of the failure mode.

## Honest scope cuts

- ❌ No mainnet OffchainResolver deploy — Daniel-side, ~$10 mainnet ETH + primary PK
- ❌ No Sepolia subname wired to point at the new resolver — Sepolia `sbo3lagent.eth` apex is not ours; needs a different apex OR mainnet ($)
- ❌ No bulk doc-address sweep across 19 stale references — those are historical proof/closeout docs; PR #383's `docs/dev4/sepolia-or-redeploy-2026-05-03.md` is the source-of-truth going forward

## Test plan

- [x] `cargo test -p sbo3l-identity --lib contracts` — 11/11 green (incl. updated `offchain_resolver_sepolia_pinned_to_known_deploy`)
- [x] `cargo clippy -p sbo3l-identity -p sbo3l-cli --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Live: `cast call --rpc-url <Sepolia> 0x87e99508c222c6e419734cacbb6781b8d282b1f6 'urls(uint256)(string)' 0` → `"https://sbo3l-ccip.vercel.app/api/{sender}/{data}.json"` ✓ canonical

🤖 Generated with [Claude Code](https://claude.com/claude-code)