### PR TITLE
fix(cli): doctor --extended — bump OffchainResolver pin to new OR (Bug #2 follow-on)

### DIFF
--- a/crates/sbo3l-cli/src/doctor_extended.rs
+++ b/crates/sbo3l-cli/src/doctor_extended.rs
@@ -44,7 +44,15 @@ use tiny_keccak::{Hasher, Keccak};
 const PROBES: &[ContractProbe] = &[
     ContractProbe {
         label: "OffchainResolver",
-        address: "0x7c6913D52DfE8f4aFc9C4931863A498A4cACA8c3",
+        // Mirrors `OFFCHAIN_RESOLVER_SEPOLIA.address` in
+        // `crates/sbo3l-identity/src/contracts.rs`. Bumped 2026-05-03
+        // alongside #396 (T-4-1 redeploy that fixed Heidi UAT bug #2 —
+        // old `0x7c6913…A8c3` had the malformed URL template; the new
+        // deploy at `0x87e9…b1f6` ships canonical
+        // `{sender}/{data}.json`). Keep this address in lockstep with
+        // contracts.rs; the inlined copy avoids dragging the identity
+        // crate into cli's dep graph.
+        address: "0x87e99508C222c6E419734CACbb6781b8d282b1F6",
         view_signature: "urls(uint256)",
         view_arg: ProbeArg::Uint256(0),
         decode_kind: DecodeKind::DynamicString,


### PR DESCRIPTION
## Summary

🚨 **Discovered during R1.5 batch 2 verification:** #396 (Task C) bumped \`OFFCHAIN_RESOLVER_SEPOLIA.address\` in \`contracts.rs\` to the new T-4-1 redeploy \`0x87e99508C222…b1F6\` — but \`sbo3l-cli/src/doctor_extended.rs\` carries an inlined copy of the address (intentional, avoids pulling sbo3l-identity into cli's dep graph). That copy was NOT updated.

Result: even after #396 landed, \`sbo3l doctor --extended\` still probes the OLD OR \`0x7c69…A8c3\` and reports FAIL with "Heidi's Bug #2 shape" — false positive.

## Fix

One-line address bump + 7-line comment explaining the lockstep requirement so the next redeploy catches both files.

## Verification

```
BEFORE: doctor --extended → FAIL OffchainResolver 0x7c6913…A8c3
        URL template missing {sender} or {data}

AFTER:  doctor --extended → ok   OffchainResolver 0x87e99508…b1F6
        urls(uint256) -> https://sbo3l-ccip.vercel.app/api/{sender}/{data}.json
        overall: ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)