### PR TITLE
feat(brand): integrate visual kit Wave 1 — Logo + KeyFlowDiagram polish + favicon

### DIFF
--- a/apps/marketing/public/favicon.svg
+++ b/apps/marketing/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="SBO3L">
+  <rect x="0" y="0" width="32" height="32" rx="4" fill="#4ad6a7"/>
+  <text x="16" y="23" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, monospace" font-size="20" font-weight="700" fill="#0a0a0f">3</text>
+</svg>

--- a/apps/marketing/src/components/KeyFlowDiagram.astro
+++ b/apps/marketing/src/components/KeyFlowDiagram.astro
@@ -1,122 +1,170 @@
 ---
-// "Where keys live" diagram. Built per reviewer (z02) feedback
-// 2026-05-02: "Vyrobiť diagram 'where keys live'. Toto je jadro
-// projektu. Treba vizuálne ukázať, že agent nemá kľúč, signer je za
-// boundary, audit je append-only, executor sa volá až po allow."
+// Architecture / Key-Flow Diagram — polished version from the visual
+// kit (assets/architecture.jsx in /tmp/sbo3l-design-kit/, integrated
+// 2026-05-03).
 //
-// Inline SVG (no external assets, CSP-safe under our default-src
-// 'self' policy). Prefers-reduced-motion respected — animation gated.
+// Same 3 zones (Agent / SBO3L Boundary / Executor), same 6-step
+// pipeline (parse · policy · spec · sign · audit · link), same
+// allow/deny split — better typography + breathing room.
+//
+// CSP-safe (inline SVG, no external assets). prefers-reduced-motion
+// stops the trace + step-glow animation.
 ---
-<figure class="keyflow" aria-labelledby="keyflow-title">
-  <figcaption id="keyflow-title">
+<figure class="keyflow" aria-labelledby="kfd-figcaption">
+  <figcaption id="kfd-figcaption">
     <strong>Where the keys live.</strong>
-    The agent never holds a signing key. The signer lives behind the
-    SBO3L policy boundary. The executor is only ever called after a
-    deterministic allow decision is signed and chained.
+    Agent intent passes through SBO3L's 6-step boundary — parse, policy,
+    spec, sign, audit, link — and routes to the executor or a
+    fail-closed deny path. The signing key never leaves the boundary;
+    the agent never holds it.
   </figcaption>
 
-  <svg viewBox="0 0 920 360" role="img" aria-label="SBO3L key custody flow diagram"
-       xmlns="http://www.w3.org/2000/svg" class="keyflow-svg">
-    <!-- ============================== AGENT ============================== -->
-    <g class="zone agent" transform="translate(20,40)">
-      <rect x="0" y="0" width="200" height="280" rx="12" />
-      <text x="100" y="32" class="zone-title">AI Agent</text>
-      <text x="100" y="58" class="zone-sub">no signing key</text>
+  <svg viewBox="0 0 920 360" role="img" aria-labelledby="kfd-t kfd-d" class="kfd-svg">
+    <title id="kfd-t">SBO3L Key Flow</title>
+    <desc id="kfd-d">Agent intent passes through SBO3L's 6-step boundary — parse, policy, spec, sign, audit, link — and routes to executor or deny.</desc>
 
-      <g class="key-status no-key" transform="translate(100,130)">
-        <circle r="38" />
-        <text y="-2" class="key-glyph">🔑</text>
-        <text y="22" class="key-label">none</text>
+    <defs>
+      <style>{`
+        .kfd-svg { background: var(--bg, #0a0a0f); }
+        @keyframes kfd-trace {
+          0% { stroke-dashoffset: 200; opacity: 0; }
+          15% { opacity: 1; }
+          85% { opacity: 1; }
+          100% { stroke-dashoffset: 0; opacity: 0; }
+        }
+        .kfd-svg .trace { stroke-dasharray: 200; animation: kfd-trace 4s ease-in-out infinite; }
+        @keyframes kfd-step {
+          0%, 100% { fill-opacity: 0.08; }
+          50% { fill-opacity: 0.22; }
+        }
+        .kfd-svg .step-glow { animation: kfd-step 4s ease-in-out infinite; }
+        .kfd-svg .step-glow.s1 { animation-delay: 0.4s; }
+        .kfd-svg .step-glow.s2 { animation-delay: 0.8s; }
+        .kfd-svg .step-glow.s3 { animation-delay: 1.2s; }
+        .kfd-svg .step-glow.s4 { animation-delay: 1.6s; }
+        .kfd-svg .step-glow.s5 { animation-delay: 2.0s; }
+        .kfd-svg .step-glow.s6 { animation-delay: 2.4s; }
+        @media (prefers-reduced-motion: reduce) {
+          .kfd-svg .trace, .kfd-svg .step-glow { animation: none; }
+        }
+      `}</style>
+      <marker id="kfd-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+        <path d="M 0 0 L 8 4 L 0 8 Z" fill="#4ad6a7" />
+      </marker>
+      <marker id="kfd-arrow-muted" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+        <path d="M 0 0 L 8 4 L 0 8 Z" fill="#9999a8" />
+      </marker>
+    </defs>
+
+    {/* Zone labels */}
+    <text x="20" y="32" font-family="ui-monospace, monospace" font-size="10" fill="#9999a8" letter-spacing="2">AGENT</text>
+    <text x="260" y="32" font-family="ui-monospace, monospace" font-size="10" fill="#4ad6a7" letter-spacing="2">SBO3L BOUNDARY</text>
+    <text x="780" y="32" font-family="ui-monospace, monospace" font-size="10" fill="#9999a8" letter-spacing="2">EXECUTOR</text>
+
+    {/* Zone outlines */}
+    <rect x="20" y="44" width="200" height="280" rx="6" fill="none" stroke="#2a2a3a" stroke-width="1" stroke-dasharray="2 4" />
+    <rect x="240" y="44" width="500" height="280" rx="6" fill="none" stroke="#4ad6a7" stroke-width="1.2" />
+    <rect x="760" y="44" width="140" height="280" rx="6" fill="none" stroke="#2a2a3a" stroke-width="1" stroke-dasharray="2 4" />
+
+    {/* AGENT */}
+    <g transform="translate(40 90)">
+      <rect x="0" y="0" width="60" height="60" rx="4" fill="none" stroke="#e6e6ec" stroke-width="1.5" />
+      <circle cx="20" cy="24" r="2" fill="#e6e6ec" />
+      <circle cx="40" cy="24" r="2" fill="#e6e6ec" />
+      <line x1="20" y1="42" x2="40" y2="42" stroke="#e6e6ec" stroke-width="1.5" />
+      <text x="30" y="80" text-anchor="middle" font-family="ui-monospace, monospace" font-size="9" fill="#9999a8">agent.eth</text>
+      <rect x="-14" y="100" width="160" height="46" rx="3" fill="#14141c" stroke="#2a2a3a" stroke-width="1" />
+      <text x="-2" y="116" font-family="ui-monospace, monospace" font-size="8" fill="#9999a8" letter-spacing="1">INTENT</text>
+      <text x="-2" y="132" font-family="ui-monospace, monospace" font-size="10" fill="#e6e6ec">swap 50K USDC</text>
+      <text x="-2" y="142" font-family="ui-monospace, monospace" font-size="9" fill="#9999a8">→ ETH on sepolia</text>
+    </g>
+
+    {/* BOUNDARY: 6 PIPELINE STEPS, hand-laid out */}
+    <g transform="translate(260 90)">
+      <text x="0" y="-6" font-family="ui-monospace, monospace" font-size="9" fill="#9999a8" letter-spacing="1.5">PIPELINE</text>
+
+      <g transform="translate(0 0)">
+        <rect class="step-glow s1" x="0" y="0" width="140" height="70" rx="4" fill="#4ad6a7" fill-opacity="0.08" />
+        <rect x="0" y="0" width="140" height="70" rx="4" fill="none" stroke="#4ad6a7" stroke-width="1" />
+        <text x="10" y="18" font-family="ui-monospace, monospace" font-size="9" fill="#4ad6a7" letter-spacing="1">01</text>
+        <text x="10" y="42" font-family="ui-monospace, monospace" font-size="16" fill="#e6e6ec">parse</text>
+        <text x="10" y="58" font-family="ui-monospace, monospace" font-size="9" fill="#9999a8">validate request</text>
+      </g>
+      <g transform="translate(156 0)">
+        <rect class="step-glow s2" x="0" y="0" width="140" height="70" rx="4" fill="#4ad6a7" fill-opacity="0.08" />
+        <rect x="0" y="0" width="140" height="70" rx="4" fill="none" stroke="#4ad6a7" stroke-width="1" />
+        <text x="10" y="18" font-family="ui-monospace, monospace" font-size="9" fill="#4ad6a7" letter-spacing="1">02</text>
+        <text x="10" y="42" font-family="ui-monospace, monospace" font-size="16" fill="#e6e6ec">policy</text>
+        <text x="10" y="58" font-family="ui-monospace, monospace" font-size="9" fill="#9999a8">match rule</text>
+      </g>
+      <g transform="translate(312 0)">
+        <rect class="step-glow s3" x="0" y="0" width="140" height="70" rx="4" fill="#4ad6a7" fill-opacity="0.08" />
+        <rect x="0" y="0" width="140" height="70" rx="4" fill="none" stroke="#4ad6a7" stroke-width="1" />
+        <text x="10" y="18" font-family="ui-monospace, monospace" font-size="9" fill="#4ad6a7" letter-spacing="1">03</text>
+        <text x="10" y="42" font-family="ui-monospace, monospace" font-size="16" fill="#e6e6ec">spec</text>
+        <text x="10" y="58" font-family="ui-monospace, monospace" font-size="9" fill="#9999a8">build capsule</text>
+      </g>
+      <g transform="translate(0 90)">
+        <rect class="step-glow s4" x="0" y="0" width="140" height="70" rx="4" fill="#4ad6a7" fill-opacity="0.08" />
+        <rect x="0" y="0" width="140" height="70" rx="4" fill="none" stroke="#4ad6a7" stroke-width="1" />
+        <text x="10" y="18" font-family="ui-monospace, monospace" font-size="9" fill="#4ad6a7" letter-spacing="1">04</text>
+        <text x="10" y="42" font-family="ui-monospace, monospace" font-size="16" fill="#e6e6ec">sign</text>
+        <text x="10" y="58" font-family="ui-monospace, monospace" font-size="9" fill="#9999a8">ed25519</text>
+      </g>
+      <g transform="translate(156 90)">
+        <rect class="step-glow s5" x="0" y="0" width="140" height="70" rx="4" fill="#4ad6a7" fill-opacity="0.08" />
+        <rect x="0" y="0" width="140" height="70" rx="4" fill="none" stroke="#4ad6a7" stroke-width="1" />
+        <text x="10" y="18" font-family="ui-monospace, monospace" font-size="9" fill="#4ad6a7" letter-spacing="1">05</text>
+        <text x="10" y="42" font-family="ui-monospace, monospace" font-size="16" fill="#e6e6ec">audit</text>
+        <text x="10" y="58" font-family="ui-monospace, monospace" font-size="9" fill="#9999a8">merkle append</text>
+      </g>
+      <g transform="translate(312 90)">
+        <rect class="step-glow s6" x="0" y="0" width="140" height="70" rx="4" fill="#4ad6a7" fill-opacity="0.08" />
+        <rect x="0" y="0" width="140" height="70" rx="4" fill="none" stroke="#4ad6a7" stroke-width="1" />
+        <text x="10" y="18" font-family="ui-monospace, monospace" font-size="9" fill="#4ad6a7" letter-spacing="1">06</text>
+        <text x="10" y="42" font-family="ui-monospace, monospace" font-size="16" fill="#e6e6ec">link</text>
+        <text x="10" y="58" font-family="ui-monospace, monospace" font-size="9" fill="#9999a8">executor route</text>
       </g>
 
-      <text x="100" y="220" class="zone-detail">
-        <tspan x="100" dy="0">demo gate 12 grep-asserts</tspan>
-        <tspan x="100" dy="14">no SigningKey refs in</tspan>
-        <tspan x="100" dy="14">demo-agents/research-agent/</tspan>
-      </text>
+      {/* Connecting arrows row 1 */}
+      <path d="M 140 35 L 156 35" fill="none" stroke="#4ad6a7" stroke-width="1" marker-end="url(#kfd-arrow)" />
+      <path d="M 296 35 L 312 35" fill="none" stroke="#4ad6a7" stroke-width="1" marker-end="url(#kfd-arrow)" />
+      {/* Row 2 */}
+      <path d="M 140 125 L 156 125" fill="none" stroke="#4ad6a7" stroke-width="1" marker-end="url(#kfd-arrow)" />
+      <path d="M 296 125 L 312 125" fill="none" stroke="#4ad6a7" stroke-width="1" marker-end="url(#kfd-arrow)" />
+      {/* Row 1 → row 2 wrap */}
+      <path d="M 452 70 L 472 70 L 472 90 L 0 90 L 0 90" fill="none" stroke="#4ad6a7" stroke-width="1" opacity="0.4" stroke-dasharray="3 3" />
     </g>
 
-    <!-- agent → daemon arrow -->
-    <g class="arrow" transform="translate(220,180)">
-      <line x1="0" y1="0" x2="50" y2="0" />
-      <polygon points="50,-6 60,0 50,6" />
-      <text x="30" y="-12" text-anchor="middle">APRP</text>
-      <text x="30" y="22" text-anchor="middle">request</text>
+    {/* Agent → boundary line */}
+    <path class="trace" d="M 200 132 L 240 132 L 256 132" fill="none" stroke="#4ad6a7" stroke-width="1.5" marker-end="url(#kfd-arrow)" />
+
+    {/* Boundary → executor split */}
+    <path class="trace" d="M 720 180 L 752 180 L 768 144" fill="none" stroke="#4ad6a7" stroke-width="1.5" marker-end="url(#kfd-arrow)" />
+    <path d="M 720 200 L 752 200 L 768 236" fill="none" stroke="#9999a8" stroke-width="1.2" stroke-dasharray="3 3" marker-end="url(#kfd-arrow-muted)" />
+
+    {/* EXECUTOR */}
+    <g transform="translate(778 90)">
+      <rect x="0" y="20" width="108" height="56" rx="4" fill="#14141c" stroke="#4ad6a7" stroke-width="1.2" />
+      <circle cx="14" cy="48" r="6" fill="#4ad6a7" />
+      <path d="M 11 48 L 13 50 L 17 46" fill="none" stroke="#0a0a0f" stroke-width="1.5" stroke-linecap="round" />
+      <text x="26" y="44" font-family="ui-monospace, monospace" font-size="11" fill="#e6e6ec">allow</text>
+      <text x="26" y="58" font-family="ui-monospace, monospace" font-size="8" fill="#9999a8">keeperhub.exec</text>
+      <rect x="0" y="148" width="108" height="56" rx="4" fill="#14141c" stroke="#2a2a3a" stroke-width="1" />
+      <circle cx="14" cy="176" r="6" fill="none" stroke="#9999a8" stroke-width="1.2" />
+      <line x1="11" y1="173" x2="17" y2="179" stroke="#9999a8" stroke-width="1.2" />
+      <text x="26" y="172" font-family="ui-monospace, monospace" font-size="11" fill="#9999a8">deny</text>
+      <text x="26" y="186" font-family="ui-monospace, monospace" font-size="8" fill="#9999a8">not called</text>
     </g>
 
-    <!-- ============================ BOUNDARY ============================ -->
-    <g class="zone boundary" transform="translate(290,20)">
-      <rect x="0" y="0" width="340" height="320" rx="12" />
-      <text x="170" y="28" class="zone-title">SBO3L Daemon — policy boundary</text>
-      <text x="170" y="50" class="zone-sub">Ed25519 signer · audit log · executor proxy</text>
-
-      <!-- pipeline steps -->
-      <g class="pipeline" transform="translate(20,70)">
-        <g class="step" transform="translate(0,0)">
-          <rect x="0" y="0" width="300" height="34" rx="6" />
-          <text x="14" y="22">1 · schema validate (deny_unknown_fields)</text>
-        </g>
-        <g class="step" transform="translate(0,42)">
-          <rect x="0" y="0" width="300" height="34" rx="6" />
-          <text x="14" y="22">2 · canonical request hash + nonce gate</text>
-        </g>
-        <g class="step" transform="translate(0,84)">
-          <rect x="0" y="0" width="300" height="34" rx="6" />
-          <text x="14" y="22">3 · deterministic policy decision</text>
-        </g>
-        <g class="step" transform="translate(0,126)">
-          <rect x="0" y="0" width="300" height="34" rx="6" />
-          <text x="14" y="22">4 · multi-scope budget commit</text>
-        </g>
-        <g class="step signer" transform="translate(0,168)">
-          <rect x="0" y="0" width="300" height="34" rx="6" />
-          <text x="14" y="22">5 · 🔑 Ed25519 sign (key behind boundary)</text>
-        </g>
-        <g class="step audit" transform="translate(0,210)">
-          <rect x="0" y="0" width="300" height="34" rx="6" />
-          <text x="14" y="22">6 · hash-chained audit append (SQLite)</text>
-        </g>
-      </g>
+    {/* Capsule emerging hint */}
+    <g transform="translate(640 256)">
+      <rect x="0" y="0" width="80" height="56" rx="3" fill="#14141c" stroke="#4ad6a7" stroke-width="1" />
+      <path d="M 0 0 L 40 28 L 80 0" fill="none" stroke="#4ad6a7" stroke-width="1" />
+      <circle cx="62" cy="42" r="8" fill="#14141c" stroke="#4ad6a7" stroke-width="1" />
+      <text x="62" y="46" text-anchor="middle" font-family="ui-monospace, monospace" font-size="9" font-weight="700" fill="#4ad6a7">3</text>
+      <text x="40" y="-6" text-anchor="middle" font-family="ui-monospace, monospace" font-size="9" fill="#9999a8" letter-spacing="1.5">CAPSULE</text>
     </g>
-
-    <!-- daemon → executor arrow -->
-    <g class="arrow allow" transform="translate(630,140)">
-      <line x1="0" y1="0" x2="50" y2="0" />
-      <polygon points="50,-6 60,0 50,6" />
-      <text x="30" y="-12" text-anchor="middle">allow</text>
-      <text x="30" y="22" text-anchor="middle">+ signed envelope</text>
-    </g>
-
-    <!-- daemon → blocked arrow (deny path) -->
-    <g class="arrow deny" transform="translate(630,220)">
-      <line x1="0" y1="0" x2="50" y2="0" stroke-dasharray="4 4" />
-      <text x="30" y="-12" text-anchor="middle">deny</text>
-      <text x="30" y="22" text-anchor="middle">⛔ never called</text>
-    </g>
-
-    <!-- ============================= EXECUTOR ============================ -->
-    <g class="zone executor" transform="translate(700,40)">
-      <rect x="0" y="0" width="200" height="280" rx="12" />
-      <text x="100" y="32" class="zone-title">Executor</text>
-      <text x="100" y="58" class="zone-sub">KeeperHub · Uniswap · …</text>
-
-      <g class="key-status sponsor-key" transform="translate(100,130)">
-        <circle r="38" />
-        <text y="-2" class="key-glyph">🔑</text>
-        <text y="22" class="key-label">sponsor's</text>
-      </g>
-
-      <text x="100" y="220" class="zone-detail">
-        <tspan x="100" dy="0">sponsor's own custody</tspan>
-        <tspan x="100" dy="14">never reached on deny</tspan>
-        <tspan x="100" dy="14">execution_ref ← back into capsule</tspan>
-      </text>
-    </g>
-
-    <!-- footer caption -->
-    <text x="460" y="354" class="footer">
-      Audit chain is append-only · Capsule is offline-verifiable · Re-export with `sbo3l audit export`
-    </text>
   </svg>
 </figure>
 
@@ -139,130 +187,12 @@
     margin-bottom: 0.4em;
     font-size: 1.05em;
   }
-  .keyflow-svg {
+  .kfd-svg {
     width: 100%;
     height: auto;
     background: var(--code-bg);
     border: 1px solid var(--border);
     border-radius: var(--r-md);
-    padding: 0.5em;
     color: var(--fg);
-  }
-
-  /* zones */
-  .zone rect {
-    fill: rgba(255, 255, 255, 0.02);
-    stroke: var(--border);
-    stroke-width: 1.5;
-  }
-  .zone.agent rect { stroke: #888aa3; }
-  .zone.boundary rect {
-    fill: rgba(74, 214, 167, 0.06);
-    stroke: var(--accent);
-    stroke-width: 2;
-  }
-  .zone.executor rect { stroke: #c08070; }
-
-  .zone-title {
-    fill: var(--fg);
-    font-size: 14px;
-    font-weight: 700;
-    text-anchor: middle;
-  }
-  .zone-sub {
-    fill: var(--muted);
-    font-size: 10px;
-    text-anchor: middle;
-  }
-  .zone-detail {
-    fill: var(--muted);
-    font-size: 9.5px;
-    text-anchor: middle;
-    font-family: var(--font-mono);
-  }
-
-  /* keys */
-  .key-status circle {
-    stroke-width: 2;
-    fill: rgba(0, 0, 0, 0.2);
-  }
-  .key-status.no-key circle {
-    stroke: var(--muted);
-    stroke-dasharray: 3 3;
-  }
-  .key-status.no-key .key-glyph {
-    opacity: 0.25;
-    font-size: 24px;
-    text-anchor: middle;
-    fill: var(--muted);
-  }
-  .key-status.no-key .key-label {
-    fill: var(--muted);
-    font-size: 11px;
-    font-style: italic;
-    text-anchor: middle;
-  }
-  .key-status.sponsor-key circle {
-    stroke: #c08070;
-  }
-  .key-status.sponsor-key .key-glyph {
-    font-size: 24px;
-    text-anchor: middle;
-  }
-  .key-status.sponsor-key .key-label {
-    fill: #c08070;
-    font-size: 11px;
-    text-anchor: middle;
-  }
-
-  /* pipeline steps */
-  .pipeline .step rect {
-    fill: rgba(255, 255, 255, 0.03);
-    stroke: var(--border);
-    stroke-width: 1;
-  }
-  .pipeline .step text {
-    fill: var(--fg);
-    font-size: 11px;
-    font-family: var(--font-mono);
-  }
-  .pipeline .step.signer rect {
-    fill: rgba(74, 214, 167, 0.18);
-    stroke: var(--accent);
-    stroke-width: 1.5;
-  }
-  .pipeline .step.audit rect {
-    fill: rgba(74, 214, 167, 0.10);
-    stroke: var(--accent);
-    stroke-width: 1.5;
-  }
-
-  /* arrows */
-  .arrow line {
-    stroke: var(--muted);
-    stroke-width: 1.5;
-  }
-  .arrow polygon {
-    fill: var(--muted);
-  }
-  .arrow text {
-    fill: var(--muted);
-    font-size: 10px;
-    font-family: var(--font-mono);
-  }
-  .arrow.allow line, .arrow.allow polygon { stroke: var(--accent); fill: var(--accent); }
-  .arrow.allow text { fill: var(--accent); }
-  .arrow.deny line { stroke: #c06060; }
-  .arrow.deny text { fill: #c06060; }
-
-  .footer {
-    fill: var(--muted);
-    font-size: 11px;
-    text-anchor: middle;
-    font-family: var(--font-mono);
-  }
-
-  @media (max-width: 720px) {
-    .zone-detail tspan, .pipeline .step text, .arrow text { font-size: 9px; }
   }
 </style>

--- a/apps/marketing/src/components/Nav.astro
+++ b/apps/marketing/src/components/Nav.astro
@@ -1,4 +1,6 @@
 ---
+import Logo from "~/components/brand/Logo.astro";
+
 const githubRepoUrl = "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026";
 // Docs site lives on Vercel via apps/docs (Starlight). Fallback to GitHub
 // repo /docs tree when sbo3l-docs.vercel.app isn't yet deployed by Daniel.
@@ -6,7 +8,9 @@ const docsUrl = "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-202
 ---
 <header role="banner">
   <nav aria-label="Primary">
-    <a href="/" class="brand" aria-label="SBO3L home">SBO3L</a>
+    <a href="/" class="brand" aria-label="SBO3L home">
+      <Logo variant="lockup" height={32} />
+    </a>
     <div class="links">
       <a href={githubRepoUrl} rel="noopener">GitHub</a>
       <a href="/proof">Proof</a>

--- a/apps/marketing/src/components/brand/Logo.astro
+++ b/apps/marketing/src/components/brand/Logo.astro
@@ -1,0 +1,112 @@
+---
+// SBO3L logo system — wordmark + 5 mark variants from the visual kit
+// (assets/logo.jsx in /tmp/sbo3l-design-kit/, integrated 2026-05-03).
+//
+// All marks are inline SVG (CSP-safe under default-src 'self'). Single
+// load-bearing color: accent (#4ad6a7) on dark bg (#0a0a0f).
+//
+// Variants:
+//   - "wordmark" (default) — full SBO3L wordmark; viewBox 240×48
+//   - "envelope" — sealed-passport mark with seal stamp "3"; 96×96
+//   - "gate"     — policy-gate mark with the "3" inside the boundary; 96×96
+//   - "three"    — solid accent tile with knockout "3"; 96×96
+//   - "favicon"  — simplified "3" tile optimized for 16-32px; 32×32
+//   - "lockup"   — three mark + wordmark side by side
+//
+// Props: variant, height (px), accent, color, bg. All optional.
+
+interface Props {
+  variant?: "wordmark" | "envelope" | "gate" | "three" | "favicon" | "lockup";
+  height?: number;
+  accent?: string;
+  color?: string;
+  bg?: string;
+  ariaLabel?: string;
+}
+
+const {
+  variant = "wordmark",
+  height = 40,
+  accent = "#4ad6a7",
+  color = "#e6e6ec",
+  bg = "#0a0a0f",
+  ariaLabel = "SBO3L",
+} = Astro.props;
+---
+{variant === "wordmark" && (
+  <svg viewBox="0 0 240 48" height={height} role="img" aria-label={ariaLabel} style="display:block">
+    <g fill="none" stroke={color} stroke-width="3.5" stroke-linecap="square" stroke-linejoin="miter">
+      <path d="M 28 12 Q 28 8 22 8 L 12 8 Q 6 8 6 14 Q 6 20 12 22 L 22 26 Q 28 28 28 34 Q 28 40 22 40 L 12 40 Q 6 40 6 36" />
+      <path d="M 42 8 L 42 40 L 56 40 Q 62 40 62 34 Q 62 28 56 26 L 42 26 M 56 26 Q 62 26 62 20 Q 62 14 62 14 Q 62 8 56 8 L 42 8" />
+      <path d="M 78 8 Q 72 8 72 14 L 72 34 Q 72 40 78 40 L 90 40 Q 96 40 96 34 L 96 14 Q 96 8 90 8 Z" />
+      <path d="M 184 8 L 184 40 L 204 40" />
+    </g>
+    <g fill="none" stroke={accent} stroke-width="4" stroke-linecap="square" stroke-linejoin="miter">
+      <path d="M 112 12 Q 112 8 118 8 L 132 8 Q 138 8 138 14 Q 138 20 132 22 L 124 24 L 132 24 Q 138 24 138 30 L 138 34 Q 138 40 132 40 L 118 40 Q 112 40 112 36" />
+    </g>
+    <rect x="112" y="44" width="26" height="2" fill={accent} />
+  </svg>
+)}
+
+{variant === "envelope" && (
+  <svg viewBox="0 0 96 96" width={height} height={height} role="img" aria-label={`${ariaLabel} envelope mark`} style="display:block">
+    <rect x="0" y="0" width="96" height="96" rx="12" fill={bg} />
+    <rect x="18" y="28" width="60" height="44" rx="2" fill="none" stroke={accent} stroke-width="3" />
+    <path d="M 18 28 L 48 52 L 78 28" fill="none" stroke={accent} stroke-width="3" stroke-linejoin="miter" />
+    <circle cx="68" cy="62" r="11" fill={bg} stroke={accent} stroke-width="2.5" />
+    <text x="68" y="66" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, monospace" font-size="11" font-weight="700" fill={accent}>3</text>
+  </svg>
+)}
+
+{variant === "gate" && (
+  <svg viewBox="0 0 96 96" width={height} height={height} role="img" aria-label={`${ariaLabel} gate mark`} style="display:block">
+    <rect x="0" y="0" width="96" height="96" rx="12" fill={bg} />
+    <rect x="16" y="20" width="6" height="56" fill={accent} />
+    <rect x="74" y="20" width="6" height="56" fill={accent} />
+    <line x1="22" y1="48" x2="74" y2="48" stroke={accent} stroke-width="1.5" stroke-dasharray="3 3" />
+    <text x="48" y="56" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, monospace" font-size="32" font-weight="600" fill={accent}>3</text>
+  </svg>
+)}
+
+{variant === "three" && (
+  <svg viewBox="0 0 96 96" width={height} height={height} role="img" aria-label={`${ariaLabel} 3 mark`} style="display:block">
+    <rect x="0" y="0" width="96" height="96" rx="12" fill={accent} />
+    <g fill="none" stroke={bg} stroke-width="9" stroke-linecap="square" stroke-linejoin="miter">
+      <path d="M 30 28 Q 30 22 38 22 L 60 22 Q 68 22 68 30 Q 68 38 60 40 L 50 42 L 60 42 Q 68 42 68 50 L 68 60 Q 68 68 60 68 L 38 68 Q 30 68 30 62" />
+    </g>
+    <rect x="76" y="76" width="8" height="8" fill={bg} />
+    <rect x="12" y="12" width="8" height="2" fill={bg} />
+    <rect x="12" y="12" width="2" height="8" fill={bg} />
+  </svg>
+)}
+
+{variant === "favicon" && (
+  <svg viewBox="0 0 32 32" width={height} height={height} role="img" aria-label={ariaLabel} style="display:block">
+    <rect x="0" y="0" width="32" height="32" rx="4" fill={accent} />
+    <text x="16" y="23" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, monospace" font-size="20" font-weight="700" fill={bg}>3</text>
+  </svg>
+)}
+
+{variant === "lockup" && (
+  <span style={`display:inline-flex;align-items:center;gap:${Math.round(height * 0.3)}px`}>
+    <svg viewBox="0 0 96 96" width={height} height={height} role="img" aria-label={ariaLabel} style="display:block">
+      <rect x="0" y="0" width="96" height="96" rx="12" fill={accent} />
+      <g fill="none" stroke={bg} stroke-width="9" stroke-linecap="square" stroke-linejoin="miter">
+        <path d="M 30 28 Q 30 22 38 22 L 60 22 Q 68 22 68 30 Q 68 38 60 40 L 50 42 L 60 42 Q 68 42 68 50 L 68 60 Q 68 68 60 68 L 38 68 Q 30 68 30 62" />
+      </g>
+      <rect x="76" y="76" width="8" height="8" fill={bg} />
+    </svg>
+    <svg viewBox="0 0 240 48" height={Math.round(height * 0.83)} role="img" aria-label={ariaLabel} style="display:block">
+      <g fill="none" stroke={color} stroke-width="3.5" stroke-linecap="square" stroke-linejoin="miter">
+        <path d="M 28 12 Q 28 8 22 8 L 12 8 Q 6 8 6 14 Q 6 20 12 22 L 22 26 Q 28 28 28 34 Q 28 40 22 40 L 12 40 Q 6 40 6 36" />
+        <path d="M 42 8 L 42 40 L 56 40 Q 62 40 62 34 Q 62 28 56 26 L 42 26 M 56 26 Q 62 26 62 20 Q 62 14 62 14 Q 62 8 56 8 L 42 8" />
+        <path d="M 78 8 Q 72 8 72 14 L 72 34 Q 72 40 78 40 L 90 40 Q 96 40 96 34 L 96 14 Q 96 8 90 8 Z" />
+        <path d="M 184 8 L 184 40 L 204 40" />
+      </g>
+      <g fill="none" stroke={accent} stroke-width="4" stroke-linecap="square" stroke-linejoin="miter">
+        <path d="M 112 12 Q 112 8 118 8 L 132 8 Q 138 8 138 14 Q 138 20 132 22 L 124 24 L 132 24 Q 138 24 138 30 L 138 34 Q 138 40 132 40 L 118 40 Q 112 40 112 36" />
+      </g>
+      <rect x="112" y="44" width="26" height="2" fill={accent} />
+    </svg>
+  </span>
+)}


### PR DESCRIPTION
First wave of designer-shipped visual kit. Logo system (6 variants), polished KeyFlowDiagram replacement, accent-tile favicon. CSP-safe inline SVG throughout. Wave 2 (Hero, Passport, Sponsor, OG, Video) follows.