### PR TITLE
fix(docs): clear gitleaks false-positive in dev4 doc (use public RPC)

### DIFF
--- a/docs/dev4/sepolia-or-redeploy-2026-05-03.md
+++ b/docs/dev4/sepolia-or-redeploy-2026-05-03.md
@@ -43,10 +43,10 @@ survive.
 | Deploy tx | (forge script, see broadcast manifest) |
 | Bytecode length | 4747 hex chars |
 
-Verified on chain via PublicNode + Alchemy RPC:
+Verified on chain via PublicNode (open RPC, no key needed):
 
 ```bash
-RPC=https://eth-sepolia.g.alchemy.com/v2/<key>
+RPC=https://ethereum-sepolia-rpc.publicnode.com
 ADDR=0x87e99508c222c6e419734cacbb6781b8d282b1f6
 
 cast call "$ADDR" "urls(uint256)(string)" 0 --rpc-url "$RPC"


### PR DESCRIPTION
## Summary

Self-review of PR #383 caught the `gitleaks (secret scanning)` check failing because of a false positive on `<key>` in the URL placeholder. PR #383 already merged (admin-bypass on the failure), but the underlying gitleaks finding remained on main. This PR clears it.

## Why this is a real fix

- gitleaks reads diffs and flags `<key>` as a `generic-api-key` (entropy 4.145, regex matched the URL shape).
- The placeholder isn't actually a secret, but every future scan of this file will continue to flag it.
- Replacing with the public PublicNode RPC URL has the additional benefit that judges can paste-run the doc's `cast call` snippets without needing their own Alchemy key.

## Diff

`docs/dev4/sepolia-or-redeploy-2026-05-03.md` line 49:

```diff
- RPC=https://eth-sepolia.g.alchemy.com/v2/<key>
+ RPC=https://ethereum-sepolia-rpc.publicnode.com
```

Plus a one-line caption update ("via PublicNode + Alchemy RPC" → "via PublicNode (open RPC, no key needed)").

## Out of scope

Other docs with the same `<key>` placeholder pattern (`docs/proof/r13-deploy-runbook.md`, `docs/cli/reputation-broadcast.md`, etc.) predate PR #383's scan window and continue to pass — not touching them in this PR to keep the diff minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)