### PR TITLE
fix(codex): R18 marketing review — mock-engine + nested main + kh-fleet links

### DIFF
--- a/apps/marketing/src/lib/playground/mock-engine.ts
+++ b/apps/marketing/src/lib/playground/mock-engine.ts
@@ -150,20 +150,30 @@ function evalDecision(aprp: AprpEnvelope, policy: PolicyParseResult): { outcome:
   }
 
   // Expired APRP — 60-second skew tolerance.
-  // Codex review fix (PR #353): the previous bound was hard-coded to
-  // 1714565000000 - 60_000 (the fixed scenario timestamp), so any APRP
-  // edited in 2026+ would always pass the expiry check. Use Date.now()
-  // so the 60s tolerance behaves like the real daemon. The seeded
-  // scenarios deliberately include `deny-aprp-expired` with a
-  // ts_ms 5 minutes in the past relative to the same fixed reference
-  // point, so it still denies via the path below for that scenario.
+  //
+  // Codex review history:
+  //   PR #353 — original bound hard-coded to SCENARIO_REF − 60s; any
+  //     2026+ edit silently passed the gate.
+  //   PR #353 fix in #359 — heuristic "within ±24h of SCENARIO_REF use
+  //     SCENARIO_REF baseline, else Date.now()". Codex flagged this:
+  //     a user-edited timestamp 23h after SCENARIO_REF is still 2024
+  //     time, but the heuristic baselines it against SCENARIO_REF and
+  //     accepts it as fresh.
+  //
+  // Final logic (this fix): a timestamp counts as "fresh" if it is
+  // within the skew tolerance of EITHER the seeded scenario reference
+  // OR the current wall clock. That accepts seeded fixtures (which
+  // sit exactly at SCENARIO_REF_MS) without accepting user-edited
+  // 2024 timestamps that drift outside the 60s tolerance, and
+  // accepts real-time edits (2026+ values within 60s of now) like a
+  // production daemon would.
   const SKEW_TOLERANCE_MS = 60_000;
   const SCENARIO_REF_MS = 1714565000000;
   if (typeof aprp.timestamp_ms === "number") {
-    const now = Date.now();
-    const isFromSeededScenario = Math.abs(aprp.timestamp_ms - SCENARIO_REF_MS) < 24 * 60 * 60 * 1000;
-    const baseline = isFromSeededScenario ? SCENARIO_REF_MS : now;
-    if (aprp.timestamp_ms < baseline - SKEW_TOLERANCE_MS) {
+    const ts = aprp.timestamp_ms;
+    const freshAgainstScenarioRef = Math.abs(ts - SCENARIO_REF_MS) <= SKEW_TOLERANCE_MS;
+    const freshAgainstWallClock   = Math.abs(ts - Date.now())   <= SKEW_TOLERANCE_MS;
+    if (!freshAgainstScenarioRef && !freshAgainstWallClock) {
       return { outcome: "deny", deny_code: "protocol.aprp_expired" };
     }
   }

--- a/apps/marketing/src/pages/kh-fleet.astro
+++ b/apps/marketing/src/pages/kh-fleet.astro
@@ -89,10 +89,20 @@ function fmtUtcDateTime(iso: string): string {
             <code class="exec-id">{row.execution_id}</code>
             <span class="agent">{row.agent_id}</span>
             <span class={`decision ${row.decision}`}>{row.decision}</span>
-            <a class="capsule-link" href={row.capsule_url}>verify capsule →</a>
+            <a class="capsule-link" href="/proof">verify capsule format →</a>
           </article>
         ))}
       </div>
+      <p class="rows-footnote">
+        Codex review fix (PR #392): row links go to <a href="/proof">/proof</a>
+        with no query string today — pre-filling the verifier from a row's
+        <code>execution_id</code> requires the daemon's
+        <code>/v1/capsules/&lt;id&gt;</code> retrieval endpoint, which is
+        roadmap. The proof page now also accepts a
+        <code>?capsule=&lt;base64url&gt;</code> query parameter for direct
+        sharing of capsule JSON, so once retrieval lands, deep-linking
+        each row works without a UI change.
+      </p>
     </section>
 
     <section class="cta-card">
@@ -205,6 +215,15 @@ sbo3l-server &amp;
   .decision.deny  { background: rgba(248, 113, 113, 0.15); color: #f87171; }
   .capsule-link { color: var(--accent); text-decoration: none; font-size: 0.85em; text-align: right; }
   .capsule-link:hover { text-decoration: underline; }
+  .rows-footnote {
+    margin-top: 1em;
+    color: var(--muted);
+    font-size: 0.84em;
+    line-height: 1.55;
+    max-width: 760px;
+  }
+  .rows-footnote code { background: var(--code-bg); padding: 0.05em 0.35em; border-radius: 3px; font-size: 0.95em; }
+  .rows-footnote a { color: var(--accent); }
 
   .cta-card {
     background: var(--code-bg);

--- a/apps/marketing/src/pages/proof.astro
+++ b/apps/marketing/src/pages/proof.astro
@@ -3,6 +3,26 @@ import BaseLayout from "~/layouts/BaseLayout.astro";
 import PassportVerifier from "~/components/PassportVerifier.astro";
 
 const githubRepoUrl = "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026";
+
+// Codex review fix (PR #392): /kh-fleet "verify capsule →" links pass
+// `?capsule=...` query strings. Read the param here and pre-fill the
+// PassportVerifier so the deep-links actually populate the textarea.
+// We accept either:
+//   - raw JSON (rare; only short capsules fit in URL bounds)
+//   - base64url-encoded JSON (standard; matches `passport export --base64`)
+// The decode is best-effort — malformed input leaves the textarea
+// empty and the user gets the standard idle state.
+function decodeCapsuleParam(raw: string | null): string {
+  if (!raw) return "";
+  if (raw.trim().startsWith("{")) return raw;
+  try {
+    const padded = raw.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(raw.length / 4) * 4, "=");
+    return atob(padded);
+  } catch {
+    return "";
+  }
+}
+const initialCapsule = decodeCapsuleParam(Astro.url.searchParams.get("capsule"));
 ---
 <BaseLayout
   title="SBO3L — Verify a Passport capsule in your browser"
@@ -21,7 +41,7 @@ const githubRepoUrl = "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagen
     </p>
   </section>
 
-  <PassportVerifier />
+  <PassportVerifier initialCapsule={initialCapsule} />
 
   <section class="docs">
     <h2>What gets checked</h2>

--- a/apps/marketing/src/pages/roadmap.astro
+++ b/apps/marketing/src/pages/roadmap.astro
@@ -135,7 +135,7 @@ const future: RoadmapItem[] = [
   description="What is shipped from this hackathon submission, what's blocking a production v1, and what comes after that."
   ogTitle="SBO3L roadmap"
 >
-  <main class="roadmap">
+  <article class="roadmap">
     <header>
       <p class="eyebrow">Roadmap · companion to <a href="/status">/status</a></p>
       <h1>From hackathon submission to production v1 — and beyond</h1>
@@ -221,7 +221,7 @@ const future: RoadmapItem[] = [
         statement.
       </p>
     </section>
-  </main>
+  </article>
 </BaseLayout>
 
 <style>


### PR DESCRIPTION
## Summary

3 review-flagged bugs from PRs **#359, #380, #392**.

| Original PR | Severity | Fix |
|---|---|---|
| #359 | P1 | mock-engine APRP expiry — fresh iff within 60s of EITHER seeded ref OR wall clock; previous ±24h heuristic accepted user-edited 2024 timestamps |
| #380 | P2 | /roadmap nested \`<main>\` → \`<article>\` (BaseLayout already wraps with main) |
| #392 | P2 | /kh-fleet rows linked to broken \`?capsule=<id>\`; now link to flat /proof + /proof reads \`?capsule=<base64url\\|json>\` query param into PassportVerifier's \`initialCapsule\` prop |

## Verification

\`pnpm --filter @sbo3l/marketing build\` — 47 pages, zero errors.

## Test plan

- [ ] /proof?capsule=<base64url-of-real-capsule-json> pre-fills verifier
- [ ] /proof?capsule={raw-json} also works (best-effort)
- [ ] /roadmap renders without nested main (axe-core: zero landmark warnings)
- [ ] /kh-fleet rows link to /proof, footnote visible, no broken query strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)