### PR TITLE
fix(codex): R18 hosted-app review — actionable downgrade + retriable webhook

### DIFF
--- a/apps/hosted-app/app/api/billing/webhook/route.ts
+++ b/apps/hosted-app/app/api/billing/webhook/route.ts
@@ -66,14 +66,28 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session): Promis
 async function handleSubscriptionChange(sub: Stripe.Subscription): Promise<NextResponse> {
   const tenantUuid = sub.metadata?.tenant_uuid;
   if (!tenantUuid) {
+    // Subs created outside our exact Checkout flow have no metadata —
+    // they're not ours to handle. 200 + ignored stops Stripe retries
+    // for events we'll never act on.
     console.warn("[stripe] subscription change missing tenant_uuid metadata — ignored", { subId: sub.id });
     return NextResponse.json({ received: true, ignored: true, reason: "missing_tenant_metadata" });
   }
   const priceId = sub.items.data[0]?.price.id;
   const tier = priceId ? tierFromPriceId(priceId) : null;
   if (!tier) {
-    console.warn("[stripe] subscription change with unknown price — ignored", { tenantUuid, priceId });
-    return NextResponse.json({ received: true, ignored: true, reason: "unknown_price", priceId });
+    // Codex review fix (PR #360 follow-up): the previous handler
+    // returned 2xx + ignored on unknown priceId for tenant-bound
+    // subs, which permanently dropped the tier-change signal on a
+    // transient deploy/mapping mismatch (e.g. price IDs not yet
+    // synced after a Stripe rotation). Tenant-bound events MUST
+    // remain retriable so the eventual catch-up read of the price
+    // mapping resolves them. Return 503 — Stripe retries with
+    // exponential backoff for ≤3 days.
+    console.error("[stripe] subscription change with unknown priceId for tenant-bound event — RETRY", { tenantUuid, priceId });
+    return NextResponse.json(
+      { error: "unknown_price_for_tenant", priceId, tenant: tenantUuid, hint: "price ID not in tierFromPriceId mapping; check STRIPE_PRICE_* env config or the deploy bundle" },
+      { status: 503 },
+    );
   }
   console.log("[stripe] subscription.changed", { tenantUuid, tier, status: sub.status });
   return NextResponse.json({ received: true, tenant: tenantUuid, tier });

--- a/apps/hosted-app/app/t/[tenant]/admin/billing/PortalButton.tsx
+++ b/apps/hosted-app/app/t/[tenant]/admin/billing/PortalButton.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+
+interface Props {
+  tenantSlug: string;
+  label: string;
+}
+
+// Codex review fix (PR #360): the previous billing page replaced the
+// broken downgrade button with static "Downgrade via Customer Portal"
+// text — admins had no actionable path. This button POSTs to
+// /api/billing/portal and redirects to the Stripe-hosted Customer
+// Portal where the admin can change plan, update payment method,
+// or cancel. The portal handles tier transitions on the existing
+// subscription correctly (vs Checkout which would create a duplicate).
+
+export function PortalButton({ tenantSlug, label }: Props): JSX.Element {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onClick = async (): Promise<void> => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/billing/portal", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ tenant_slug: tenantSlug }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.detail ?? body.error ?? `HTTP ${res.status}`);
+      }
+      const { url } = (await res.json()) as { url: string };
+      window.location.href = url;
+    } catch (e) {
+      setError((e as Error).message);
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <button onClick={onClick} disabled={busy} className="ghost" style={{ width: "100%", fontSize: "0.85em" }}>
+        {busy ? "Redirecting…" : label}
+      </button>
+      {error && <p style={{ color: "#f87171", fontSize: "0.75em", marginTop: "0.4em" }}>{error}</p>}
+    </>
+  );
+}

--- a/apps/hosted-app/app/t/[tenant]/admin/billing/page.tsx
+++ b/apps/hosted-app/app/t/[tenant]/admin/billing/page.tsx
@@ -4,6 +4,7 @@ import { auth } from "@/auth";
 import { tenantBySlug, userHasAccessTo } from "@/lib/tenants";
 import { billingForTenant, TIER_LIMITS, fmtNumber, type Tier } from "@/lib/tenant-billing";
 import { UpgradeButton } from "./UpgradeButton";
+import { PortalButton } from "./PortalButton";
 
 interface Props { params: Promise<{ tenant: string }> }
 
@@ -105,12 +106,16 @@ export default async function TenantBillingPage({ params }: Props): Promise<JSX.
                   their existing subscription). Upgrades remain on
                   Checkout where new-subscription semantics are correct.
                 */}
+                {/*
+                  Codex review fix (PR #360 follow-up): the previous
+                  "Downgrade via Customer Portal" was static text
+                  with no actionable button. Now wired to <PortalButton/>
+                  which POSTs to /api/billing/portal and redirects.
+                */}
                 {isCurrent ? (
                   <span style={{ fontSize: "0.85em", color: "var(--accent)" }}>● current plan</span>
                 ) : limits.monthly_usd < TIER_LIMITS[billing.tier].monthly_usd ? (
-                  <span style={{ fontSize: "0.78em", color: "var(--muted)" }}>
-                    Downgrade via Customer Portal
-                  </span>
+                  <PortalButton tenantSlug={slug} label="Downgrade in Customer Portal" />
                 ) : (
                   <UpgradeButton
                     tenantSlug={slug}


### PR DESCRIPTION
## Summary

2 review-flagged bugs from PR **#360**.

| Severity | Fix |
|---|---|
| P1 | New \`PortalButton.tsx\` wires the previously-static \"Downgrade via Customer Portal\" copy into an actual POST to \`/api/billing/portal\` (already-shipped endpoint). Admins on paid tiers can now initiate downgrades; portal handles existing-subscription tier change correctly. |
| P2 | Webhook \`handleSubscriptionChange\` returns 503 (retriable) instead of 2xx ignored when a tenant-bound event has an unmapped priceId. Transient deploy/mapping mismatches now resolve via Stripe's retry backoff (≤3 days) instead of silently dropping the tier-change signal forever. Missing-metadata path stays 2xx ignored (genuinely not ours). |

## Verification

Touched files typecheck clean. Pre-existing repo-wide errors (JSX namespace, missing \`./roles\`, Stripe API version drift) are out of scope for this PR.

## Test plan

- [ ] Admin clicks \"Downgrade in Customer Portal\" → redirected to Stripe portal
- [ ] Stripe CLI: \`stripe trigger customer.subscription.updated\` with metadata.tenant_uuid + unmapped priceId → 503 with descriptive hint, retried by Stripe
- [ ] Same event without metadata.tenant_uuid → 200 + ignored:true (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)