### PR TITLE
fix(codex-r18): 1 P1 + 2 P2 from R18 PR reviews

### DIFF
--- a/apps/marketing/public/zerog-uploader-runtime.js
+++ b/apps/marketing/public/zerog-uploader-runtime.js
@@ -1,0 +1,276 @@
+// ZeroGUploader runtime — companion to
+// `src/components/ZeroGUploader.astro`. Lives as a static asset so it
+// loads under Vercel's CSP (`script-src 'self' 'wasm-unsafe-eval'`,
+// no `'unsafe-inline'`). The component element exposes its constants
+// via `data-*` attrs; the runtime auto-binds every
+// `[data-zerog-uploader]` on the page at DOMContentLoaded.
+
+function initOne(root) {
+  const cfg = {
+    storagescanToolUrl: root.dataset.storagescanToolUrl,
+    storagescanFileUrl: root.dataset.storagescanFileUrl,
+    indexerProbeUrl: root.dataset.indexerProbeUrl,
+    probeTimeoutMs: Number(root.dataset.probeTimeoutMs) || 5000,
+    maxFileBytes: Number(root.dataset.maxFileBytes) || 1024 * 1024,
+  };
+
+  const $ = (sel) => root.querySelector(sel);
+  const drop = $(".zg-drop");
+  const fileInput = drop.querySelector('input[type="file"]');
+  const promptEl = $(".zg-drop-prompt");
+  const loadedEl = $(".zg-drop-loaded");
+  const fileNameEl = $(".zg-file-name");
+  const fileMetaEl = $(".zg-file-meta");
+  const clearBtn = $(".zg-clear");
+  const errEl = $(".zg-error");
+  const uploadBtn = $(".zg-upload");
+  const statusEl = $(".zg-status");
+  const fallbackEl = $(".zg-fallback");
+  const manualHashInput = $(".zg-manual-hash");
+  const manualSubmitBtn = $(".zg-manual-submit");
+  const successEl = $(".zg-success");
+  const successSrcEl = $(".zg-success-source");
+  const hashValueEl = $(".zg-hash-value");
+  const copyBtn = $(".zg-copy");
+  const permalinkEl = $(".zg-permalink");
+
+  let currentFile = null;
+
+  function setError(msg) {
+    if (msg) {
+      errEl.textContent = msg;
+      errEl.hidden = false;
+    } else {
+      errEl.textContent = "";
+      errEl.hidden = true;
+    }
+  }
+  function setStatus(s) {
+    statusEl.textContent = s;
+  }
+  function setState(s) {
+    root.dataset.state = s;
+  }
+  function bytesHuman(n) {
+    if (n < 1024) return n + " B";
+    if (n < 1024 * 1024) return (n / 1024).toFixed(1) + " KB";
+    return (n / (1024 * 1024)).toFixed(2) + " MB";
+  }
+  function isHex32(s) {
+    // 0G Storage rootHash is 32 bytes (64 hex chars), 0x-prefixed.
+    return /^0x[0-9a-fA-F]{64}$/.test(s.trim());
+  }
+  function showSuccess(rootHash, source) {
+    successEl.hidden = false;
+    const norm = rootHash.trim().toLowerCase();
+    hashValueEl.textContent = norm;
+    const url = cfg.storagescanFileUrl + "/" + norm;
+    permalinkEl.textContent = url;
+    permalinkEl.href = url;
+    successSrcEl.textContent =
+      source === "manual"
+        ? "Source: manually pasted from 0G storage tool."
+        : "Source: 0G SDK auto-upload.";
+    setState("success");
+  }
+
+  async function pickFile(file) {
+    setError(null);
+    successEl.hidden = true;
+    fallbackEl.hidden = true;
+    if (!file) return;
+    if (file.size > cfg.maxFileBytes) {
+      setError("File too large (" + bytesHuman(file.size) + "). 0G testnet practical cap is 1 MB.");
+      return;
+    }
+    let text;
+    try {
+      text = await file.text();
+    } catch (e) {
+      setError("Could not read file: " + (e && e.message ? e.message : String(e)));
+      return;
+    }
+    if (!text || !text.trim()) {
+      setError("File is empty.");
+      return;
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch (e) {
+      setError("Not valid JSON: " + (e && e.message ? e.message : String(e)));
+      return;
+    }
+    if (!parsed || typeof parsed !== "object") {
+      setError("JSON root must be an object (got " + (parsed === null ? "null" : typeof parsed) + ").");
+      return;
+    }
+    if (typeof parsed.schema !== "string" || !parsed.schema) {
+      setError(
+        "Missing top-level `schema` field — this doesn't look like a SBO3L Passport capsule (expected schema like `sbo3l.passport_capsule.v1`)."
+      );
+      return;
+    }
+    currentFile = file;
+    promptEl.hidden = true;
+    loadedEl.hidden = false;
+    fileNameEl.textContent = file.name;
+    fileMetaEl.textContent = "(" + bytesHuman(file.size) + ", schema=" + parsed.schema + ")";
+    uploadBtn.disabled = false;
+    setStatus("ready");
+    setState("ready");
+  }
+
+  function clearFile() {
+    currentFile = null;
+    fileInput.value = "";
+    promptEl.hidden = false;
+    loadedEl.hidden = true;
+    fileNameEl.textContent = "";
+    fileMetaEl.textContent = "";
+    uploadBtn.disabled = true;
+    setError(null);
+    setStatus("idle");
+    setState("idle");
+    successEl.hidden = true;
+    fallbackEl.hidden = true;
+  }
+
+  drop.addEventListener("click", () => {
+    if (!currentFile) fileInput.click();
+  });
+  drop.addEventListener("keydown", (e) => {
+    if ((e.key === "Enter" || e.key === " ") && !currentFile) {
+      e.preventDefault();
+      fileInput.click();
+    }
+  });
+  drop.addEventListener("dragover", (e) => {
+    e.preventDefault();
+    drop.classList.add("zg-drag");
+  });
+  drop.addEventListener("dragleave", () => {
+    drop.classList.remove("zg-drag");
+  });
+  drop.addEventListener("drop", (e) => {
+    e.preventDefault();
+    drop.classList.remove("zg-drag");
+    const f = e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files[0];
+    if (f) void pickFile(f);
+  });
+  fileInput.addEventListener("change", (e) => {
+    const f = e.target.files && e.target.files[0];
+    if (f) void pickFile(f);
+  });
+  clearBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    clearFile();
+  });
+
+  // Probe: 5s AbortController against the 0G indexer. CORS may block the
+  // response read, but we only care whether the request resolves vs. times
+  // out. `mode: "no-cors"` returns an opaque response on success.
+  async function probeIndexer() {
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort("timeout"), cfg.probeTimeoutMs);
+    try {
+      await fetch(cfg.indexerProbeUrl, {
+        method: "GET",
+        mode: "no-cors",
+        signal: ac.signal,
+        cache: "no-store",
+      });
+      clearTimeout(timer);
+      return { ok: true };
+    } catch (e) {
+      clearTimeout(timer);
+      const reason = ac.signal.aborted
+        ? "timeout after " + cfg.probeTimeoutMs + "ms"
+        : (e && e.message ? e.message : "network error");
+      return { ok: false, reason };
+    }
+  }
+
+  async function handleUpload() {
+    if (!currentFile) return;
+    setError(null);
+    uploadBtn.disabled = true;
+    setStatus("probing 0G indexer…");
+    const probe = await probeIndexer();
+    if (probe.ok) {
+      setStatus("indexer reachable — handing off to manual web tool");
+    } else {
+      setStatus("indexer unreachable (" + probe.reason + ") — falling back");
+    }
+    try {
+      window.open(cfg.storagescanToolUrl, "_blank", "noopener,noreferrer");
+    } catch (_) {
+      // Popup blockers are non-fatal; the in-page link still works.
+    }
+    fallbackEl.hidden = false;
+    setState("fallback");
+    uploadBtn.disabled = false;
+  }
+
+  uploadBtn.addEventListener("click", () => void handleUpload());
+
+  manualSubmitBtn.addEventListener("click", () => {
+    const v = manualHashInput.value.trim();
+    if (!v) {
+      setError("Paste the rootHash from the 0G storage tool first.");
+      return;
+    }
+    if (!isHex32(v)) {
+      setError("rootHash must be 0x-prefixed 32-byte hex (66 chars total). Got " + v.length + " chars.");
+      return;
+    }
+    setError(null);
+    showSuccess(v, "manual");
+    setStatus("manual rootHash accepted");
+  });
+
+  manualHashInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      manualSubmitBtn.click();
+    }
+  });
+
+  copyBtn.addEventListener("click", async () => {
+    const v = hashValueEl.textContent || "";
+    if (!v) return;
+    try {
+      await navigator.clipboard.writeText(v);
+      copyBtn.classList.add("zg-copied");
+      const orig = copyBtn.textContent;
+      copyBtn.textContent = "Copied";
+      setTimeout(() => {
+        copyBtn.classList.remove("zg-copied");
+        copyBtn.textContent = orig;
+      }, 1500);
+    } catch (_) {
+      // Fallback for browsers without clipboard API — select the hash.
+      const range = document.createRange();
+      range.selectNode(hashValueEl);
+      const sel = window.getSelection();
+      if (sel) {
+        sel.removeAllRanges();
+        sel.addRange(range);
+      }
+    }
+  });
+}
+
+function bindAll() {
+  document.querySelectorAll("[data-zerog-uploader]").forEach((root) => {
+    if (root.dataset.zerogBound === "1") return;
+    root.dataset.zerogBound = "1";
+    initOne(root);
+  });
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", bindAll);
+} else {
+  bindAll();
+}

--- a/apps/marketing/src/components/ZeroGUploader.astro
+++ b/apps/marketing/src/components/ZeroGUploader.astro
@@ -30,10 +30,15 @@
 // storagescan-galileo URL opens in a new tab (window.open) so it
 // bypasses the iframe frame-src restriction entirely.
 //
-// Component is a pure Astro island with `is:inline` script — matches
-// the convention set by PassportVerifier.astro. Marketing site has no
-// React/Vitest infra (it's static-only Astro 5), so this ships without
-// either; equivalent behavior is exercised manually via the dev server.
+// Component is a pure Astro island. The runtime lives at
+// `public/zerog-uploader-runtime.js` and is loaded via `<script src=…>`
+// rather than `is:inline` — Vercel's CSP is `script-src 'self'
+// 'wasm-unsafe-eval'` (no `'unsafe-inline'`), so any inline script is
+// blocked in production. Constants the runtime needs (storagescan URLs,
+// indexer probe URL, timeout, max file bytes) flow through `data-*`
+// attributes on the root element. Multiple instances on a page each get
+// their own `id`; the runtime auto-binds every `[data-zerog-uploader]`
+// at DOMContentLoaded.
 
 interface Props {
   /// Optional id for the inline component instance, used when mounting
@@ -50,7 +55,17 @@ const PROBE_TIMEOUT_MS = 5000;
 const MAX_FILE_BYTES = 1024 * 1024; // 1 MB — 0G testnet practical cap.
 ---
 
-<section class="zg-uploader" id={id} data-state="idle">
+<section
+  class="zg-uploader"
+  id={id}
+  data-state="idle"
+  data-zerog-uploader
+  data-storagescan-tool-url={STORAGESCAN_TOOL_URL}
+  data-storagescan-file-url={STORAGESCAN_FILE_URL}
+  data-indexer-probe-url={INDEXER_PROBE_URL}
+  data-probe-timeout-ms={String(PROBE_TIMEOUT_MS)}
+  data-max-file-bytes={String(MAX_FILE_BYTES)}
+>
   <header class="zg-head">
     <h2>Upload a Passport capsule to 0G Storage</h2>
     <p class="lede">
@@ -275,310 +290,4 @@ const MAX_FILE_BYTES = 1024 * 1024; // 1 MB — 0G testnet practical cap.
   .zg-permalink { font-family: var(--font-mono); font-size: 0.85em; word-break: break-all; }
 </style>
 
-<script
-  is:inline
-  define:vars={{
-    id,
-    STORAGESCAN_TOOL_URL,
-    STORAGESCAN_FILE_URL,
-    INDEXER_PROBE_URL,
-    PROBE_TIMEOUT_MS,
-    MAX_FILE_BYTES,
-  }}
->
-  // ZeroGUploader runtime — DOM-scoped to the component instance so
-  // multiple uploaders on one page don't collide.
-  (function init() {
-    const root = document.getElementById(id);
-    if (!root) return;
-
-    const $ = (sel) => root.querySelector(sel);
-    const drop = $(".zg-drop");
-    const fileInput = drop.querySelector('input[type="file"]');
-    const promptEl = $(".zg-drop-prompt");
-    const loadedEl = $(".zg-drop-loaded");
-    const fileNameEl = $(".zg-file-name");
-    const fileMetaEl = $(".zg-file-meta");
-    const clearBtn = $(".zg-clear");
-    const errEl = $(".zg-error");
-    const uploadBtn = $(".zg-upload");
-    const statusEl = $(".zg-status");
-    const fallbackEl = $(".zg-fallback");
-    const manualHashInput = $(".zg-manual-hash");
-    const manualSubmitBtn = $(".zg-manual-submit");
-    const successEl = $(".zg-success");
-    const successSrcEl = $(".zg-success-source");
-    const hashValueEl = $(".zg-hash-value");
-    const copyBtn = $(".zg-copy");
-    const permalinkEl = $(".zg-permalink");
-
-    let currentFile = null;
-
-    // ---- helpers --------------------------------------------------------
-
-    function setError(msg) {
-      if (msg) {
-        errEl.textContent = msg;
-        errEl.hidden = false;
-      } else {
-        errEl.textContent = "";
-        errEl.hidden = true;
-      }
-    }
-
-    function setStatus(s) {
-      statusEl.textContent = s;
-    }
-
-    function setState(s) {
-      root.dataset.state = s;
-    }
-
-    function bytesHuman(n) {
-      if (n < 1024) return n + " B";
-      if (n < 1024 * 1024) return (n / 1024).toFixed(1) + " KB";
-      return (n / (1024 * 1024)).toFixed(2) + " MB";
-    }
-
-    function isHex32(s) {
-      // 0G Storage rootHash is 32 bytes (64 hex chars), 0x-prefixed.
-      // Loose-validate format only — the hash is its own proof.
-      return /^0x[0-9a-fA-F]{64}$/.test(s.trim());
-    }
-
-    function showSuccess(rootHash, source) {
-      successEl.hidden = false;
-      const norm = rootHash.trim().toLowerCase();
-      hashValueEl.textContent = norm;
-      const url = STORAGESCAN_FILE_URL + "/" + norm;
-      permalinkEl.textContent = url;
-      permalinkEl.href = url;
-      successSrcEl.textContent =
-        source === "manual"
-          ? "Source: manually pasted from 0G storage tool."
-          : "Source: 0G SDK auto-upload.";
-      setState("success");
-    }
-
-    // ---- file pickup + validation ---------------------------------------
-
-    async function pickFile(file) {
-      setError(null);
-      successEl.hidden = true;
-      fallbackEl.hidden = true;
-
-      if (!file) return;
-      if (file.size > MAX_FILE_BYTES) {
-        setError("File too large (" + bytesHuman(file.size) + "). 0G testnet practical cap is 1 MB.");
-        return;
-      }
-
-      let text;
-      try {
-        text = await file.text();
-      } catch (e) {
-        setError("Could not read file: " + (e && e.message ? e.message : String(e)));
-        return;
-      }
-
-      if (!text || !text.trim()) {
-        setError("File is empty.");
-        return;
-      }
-
-      let parsed;
-      try {
-        parsed = JSON.parse(text);
-      } catch (e) {
-        setError("Not valid JSON: " + (e && e.message ? e.message : String(e)));
-        return;
-      }
-
-      if (!parsed || typeof parsed !== "object") {
-        setError("JSON root must be an object (got " + (parsed === null ? "null" : typeof parsed) + ").");
-        return;
-      }
-
-      if (typeof parsed.schema !== "string" || !parsed.schema) {
-        setError(
-          "Missing top-level `schema` field — this doesn't look like a SBO3L Passport capsule (expected schema like `sbo3l.passport_capsule.v1`)."
-        );
-        return;
-      }
-
-      currentFile = file;
-      promptEl.hidden = true;
-      loadedEl.hidden = false;
-      fileNameEl.textContent = file.name;
-      fileMetaEl.textContent = "(" + bytesHuman(file.size) + ", schema=" + parsed.schema + ")";
-      uploadBtn.disabled = false;
-      setStatus("ready");
-      setState("ready");
-    }
-
-    function clearFile() {
-      currentFile = null;
-      fileInput.value = "";
-      promptEl.hidden = false;
-      loadedEl.hidden = true;
-      fileNameEl.textContent = "";
-      fileMetaEl.textContent = "";
-      uploadBtn.disabled = true;
-      setError(null);
-      setStatus("idle");
-      setState("idle");
-      successEl.hidden = true;
-      fallbackEl.hidden = true;
-    }
-
-    // ---- drag-drop wiring -----------------------------------------------
-
-    drop.addEventListener("click", () => {
-      if (!currentFile) fileInput.click();
-    });
-    drop.addEventListener("keydown", (e) => {
-      if ((e.key === "Enter" || e.key === " ") && !currentFile) {
-        e.preventDefault();
-        fileInput.click();
-      }
-    });
-
-    drop.addEventListener("dragover", (e) => {
-      e.preventDefault();
-      drop.classList.add("zg-drag");
-    });
-    drop.addEventListener("dragleave", () => {
-      drop.classList.remove("zg-drag");
-    });
-    drop.addEventListener("drop", (e) => {
-      e.preventDefault();
-      drop.classList.remove("zg-drag");
-      const f = e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files[0];
-      if (f) void pickFile(f);
-    });
-
-    fileInput.addEventListener("change", (e) => {
-      const f = e.target.files && e.target.files[0];
-      if (f) void pickFile(f);
-    });
-
-    clearBtn.addEventListener("click", (e) => {
-      e.stopPropagation();
-      clearFile();
-    });
-
-    // ---- 0G primary path: liveness probe + handoff ----------------------
-    //
-    // We probe the indexer's HEAD reachability with a 5s AbortController
-    // timeout. If reachable, we still fall back to the manual web tool
-    // because uploading via the SDK requires a private key signer; the
-    // manual UI handles wallet connection in its own context. If the
-    // probe fails, we surface that as the explicit reason in the
-    // fallback panel and proceed identically.
-
-    async function probeIndexer() {
-      const ac = new AbortController();
-      const timer = setTimeout(() => ac.abort("timeout"), PROBE_TIMEOUT_MS);
-      try {
-        // CORS may block a real fetch response read, but we only care
-        // whether the request resolves vs. times out. `mode: "no-cors"`
-        // returns an opaque response on success — enough signal.
-        await fetch(INDEXER_PROBE_URL, {
-          method: "GET",
-          mode: "no-cors",
-          signal: ac.signal,
-          cache: "no-store",
-        });
-        clearTimeout(timer);
-        return { ok: true };
-      } catch (e) {
-        clearTimeout(timer);
-        const reason =
-          ac.signal.aborted
-            ? "timeout after " + PROBE_TIMEOUT_MS + "ms"
-            : (e && e.message ? e.message : "network error");
-        return { ok: false, reason };
-      }
-    }
-
-    async function handleUpload() {
-      if (!currentFile) return;
-      setError(null);
-      uploadBtn.disabled = true;
-      setStatus("probing 0G indexer…");
-
-      const probe = await probeIndexer();
-      if (probe.ok) {
-        setStatus("indexer reachable — handing off to manual web tool");
-      } else {
-        setStatus("indexer unreachable (" + probe.reason + ") — falling back");
-      }
-
-      // Open the storagescan tool in a new tab and reveal the manual
-      // panel with the rootHash paste field. Same UX whether the probe
-      // succeeded or timed out — only the inline status text differs.
-      try {
-        window.open(STORAGESCAN_TOOL_URL, "_blank", "noopener,noreferrer");
-      } catch (_) {
-        // Popup blockers are non-fatal; the in-page link still works.
-      }
-
-      fallbackEl.hidden = false;
-      setState("fallback");
-      uploadBtn.disabled = false;
-    }
-
-    uploadBtn.addEventListener("click", () => void handleUpload());
-
-    // ---- manual rootHash submit -----------------------------------------
-
-    manualSubmitBtn.addEventListener("click", () => {
-      const v = manualHashInput.value.trim();
-      if (!v) {
-        setError("Paste the rootHash from the 0G storage tool first.");
-        return;
-      }
-      if (!isHex32(v)) {
-        setError("rootHash must be 0x-prefixed 32-byte hex (66 chars total). Got " + v.length + " chars.");
-        return;
-      }
-      setError(null);
-      showSuccess(v, "manual");
-      setStatus("manual rootHash accepted");
-    });
-
-    manualHashInput.addEventListener("keydown", (e) => {
-      if (e.key === "Enter") {
-        e.preventDefault();
-        manualSubmitBtn.click();
-      }
-    });
-
-    // ---- copy-to-clipboard ----------------------------------------------
-
-    copyBtn.addEventListener("click", async () => {
-      const v = hashValueEl.textContent || "";
-      if (!v) return;
-      try {
-        await navigator.clipboard.writeText(v);
-        copyBtn.classList.add("zg-copied");
-        const orig = copyBtn.textContent;
-        copyBtn.textContent = "Copied";
-        setTimeout(() => {
-          copyBtn.classList.remove("zg-copied");
-          copyBtn.textContent = orig;
-        }, 1500);
-      } catch (_) {
-        // Older browsers without clipboard API — select the hash text
-        // manually as a degraded affordance.
-        const range = document.createRange();
-        range.selectNode(hashValueEl);
-        const sel = window.getSelection();
-        if (sel) {
-          sel.removeAllRanges();
-          sel.addRange(range);
-        }
-      }
-    });
-  })();
-</script>
+<script type="module" src="/zerog-uploader-runtime.js"></script>

--- a/docs/proof/kh-builder-feedback-2026-05-03.md
+++ b/docs/proof/kh-builder-feedback-2026-05-03.md
@@ -57,9 +57,25 @@ We've now filed 10 distinct issues + 5 draft PRs across two rounds, every one de
 
 ## Verification checklist for judges
 
-- [Open the 5 round-2 KH issues](https://github.com/KeeperHub/cli/issues?q=is%3Aissue+author%3A%40me+%2352..%2356) — each has reproduction commands, line-ref'd friction, and proposed fix shape.
-- [Open the 5 companion draft PRs](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pulls?q=is%3Apr+author%3A%40me+%22kh-bf-additional%22) — each carries the proposed adapter-side diff as a doc-only file under `docs/keeperhub-consumer-shape-proposals/`.
-- [Re-read round 1 evidence](../submission/bounty-keeperhub-builder-feedback.md) — original 5 issues that started the cumulative submission.
+Direct links (no GitHub login required — `author:@me` would have only resolved for the signed-in viewer):
+
+- The 5 round-2 KH issues:
+  - [KeeperHub/cli#52](https://github.com/KeeperHub/cli/issues/52) — HTTP error code catalog + retry semantics
+  - [KeeperHub/cli#53](https://github.com/KeeperHub/cli/issues/53) — public mock fixture suite / Docker image
+  - [KeeperHub/cli#54](https://github.com/KeeperHub/cli/issues/54) — webhook timeout SLO publication
+  - [KeeperHub/cli#55](https://github.com/KeeperHub/cli/issues/55) — schema-version headers
+  - [KeeperHub/cli#56](https://github.com/KeeperHub/cli/issues/56) — max payload size documentation
+- The 5 companion draft PRs on this repo:
+  - [PR #402](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/402) — consumer shape for KH-cli#52
+  - [PR #403](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/403) — consumer shape for KH-cli#53
+  - [PR #404](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/404) — consumer shape for KH-cli#54
+  - [PR #405](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/405) — consumer shape for KH-cli#55
+  - [PR #406](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/406) — consumer shape for KH-cli#56
+- [Re-read round 1 evidence](../submission/bounty-keeperhub-builder-feedback.md) — original 5 issues (#47–#51) that started the cumulative submission.
+
+Filtered listings (link to a search anyone can run; uses explicit author):
+- [All 10 SBO3L-filed issues on KeeperHub/cli](https://github.com/KeeperHub/cli/issues?q=is%3Aissue+author%3AB2JK-Industry)
+- [All 5 KH-BF draft PRs on this repo](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pulls?q=is%3Apr+author%3AB2JK-Industry+%22kh-bf-additional%22)
 
 ## Sponsor-specific value prop
 

--- a/docs/quickstart/keeperhub-with-langchain.md
+++ b/docs/quickstart/keeperhub-with-langchain.md
@@ -111,7 +111,7 @@ python3 -m venv .venv && .venv/bin/pip install -e ../../sdks/python -e ../../int
 .venv/bin/python -m sbo3l_langchain_demo.keeperhub_smoke
 ```
 
-The `keeperhub_tool()` factory in `sbo3l_langchain_demo.keeperhub_tool` returns a tool descriptor whose envelope explicitly carries `kh_workflow_id` + `kh_execution_ref` keys (named for the LLM to branch on, vs inferring from `execution_ref`'s `kh-` prefix). 6 pytest cases cover allow / deny / workflow-id-override / invalid-input paths against a mocked daemon.
+The `keeperhub_tool()` factory in `sbo3l_langchain_demo.keeperhub_tool` returns a tool descriptor whose envelope explicitly carries `kh_workflow_id_advisory` + `kh_execution_ref` keys (named for the LLM to branch on, vs inferring from `execution_ref`'s `kh-` prefix). The `_advisory` suffix on `kh_workflow_id_advisory` is intentional: today the daemon's env-configured webhook URL is the source of truth for actual routing, so the tool surfaces the caller's *intended* workflow for context tagging rather than misrepresenting it as a routing override. 6 pytest cases cover allow / deny / workflow-id-context / invalid-input paths against a mocked daemon.
 
 ## Next
 

--- a/examples/langchain-py-research-agent/README.md
+++ b/examples/langchain-py-research-agent/README.md
@@ -67,19 +67,19 @@ Expected output (with `SBO3L_KEEPERHUB_WEBHOOK_URL` + `SBO3L_KEEPERHUB_TOKEN` se
 ▶ tool: sbo3l_keeperhub_payment_request
   envelope:
     decision: "allow"
-    kh_workflow_id: "m4t4cnpmhv8qquce3bv3c"
+    kh_workflow_id_advisory: "m4t4cnpmhv8qquce3bv3c"
     kh_execution_ref: "kh-01HTAWX5..."
     audit_event_id: "evt-..."
     ...
 
 ✓ allow + KH executed — kh_execution_ref=kh-01HTAWX5...
-  workflow=m4t4cnpmhv8qquce3bv3c
+  workflow_advisory=m4t4cnpmhv8qquce3bv3c
   audit_event_id=evt-...
 ```
 
 Without webhook env vars on the daemon, the KH adapter falls back to `local_mock` — the demo still prints a `kh-<ULID>` ref (with `mock=true` evidence in the receipt) so the wire path is visible end-to-end.
 
-The wrapper (`sbo3l_langchain_demo.keeperhub_tool.keeperhub_tool`) returns a `kh_execution_ref` field explicitly named for the LLM to branch on, plus the workflow id surfaced for context. Useful in agent code that needs to reason "did KH execute?" without inferring from `execution_ref`'s prefix.
+The wrapper (`sbo3l_langchain_demo.keeperhub_tool.keeperhub_tool`) returns a `kh_execution_ref` field explicitly named for the LLM to branch on, plus a `kh_workflow_id_advisory` field carrying the *intended* workflow target (this value is NOT used for routing — the daemon's env config is the source of truth; see `keeperhub_tool` docstring). Useful for context tagging in audit trails.
 
 ## Tests
 

--- a/examples/langchain-py-research-agent/sbo3l_langchain_demo/keeperhub_smoke.py
+++ b/examples/langchain-py-research-agent/sbo3l_langchain_demo/keeperhub_smoke.py
@@ -47,7 +47,7 @@ def main() -> int:
         ref = envelope.get("kh_execution_ref")
         if ref:
             print(f"\n✓ allow + KH executed — kh_execution_ref={ref}")
-            print(f"  workflow={envelope.get('kh_workflow_id')}")
+            print(f"  workflow_advisory={envelope.get('kh_workflow_id_advisory')}")
             print(f"  audit_event_id={envelope.get('audit_event_id')}")
             return 0
         print(

--- a/examples/langchain-py-research-agent/sbo3l_langchain_demo/keeperhub_tool.py
+++ b/examples/langchain-py-research-agent/sbo3l_langchain_demo/keeperhub_tool.py
@@ -18,7 +18,7 @@ Wire path:
   5. Tool returns:
        {
          "decision": "allow" | "deny" | "requires_human",
-         "kh_workflow_id": "<workflow id from env or default>",
+         "kh_workflow_id_advisory": "<advisory tag — daemon env routes the actual call>",
          "kh_execution_ref": "kh-01HTAWX5..." | None,
          "audit_event_id": "evt-...",
          "request_hash": "...", "policy_hash": "...",
@@ -53,7 +53,7 @@ from sbo3l_sdk import SBO3LClientSync
 
 
 #: Live KeeperHub workflow id verified end-to-end on 2026-04-30.
-#: Override per-call via `kh_workflow_id` arg, or globally via
+#: Override per-call via `workflow_id` arg (advisory only — see docstring), or globally via
 #: `SBO3L_KEEPERHUB_WORKFLOW_ID` env on the agent process (advisory —
 #: the daemon ultimately decides which webhook URL it POSTs to).
 DEFAULT_KH_WORKFLOW_ID = "m4t4cnpmhv8qquce3bv3c"
@@ -78,7 +78,7 @@ _DEFAULT_DESCRIPTION = (
     "policy decision. On allow, the SBO3L daemon's KeeperHub adapter executes "
     "the payment by POSTing the IP-1 envelope to a KeeperHub workflow webhook "
     "and returns the captured executionId as kh_execution_ref. Input MUST be a "
-    "JSON-stringified APRP. Returns: {decision, kh_workflow_id, "
+    "JSON-stringified APRP. Returns: {decision, kh_workflow_id_advisory, "
     "kh_execution_ref, audit_event_id, request_hash, policy_hash, deny_code}. "
     "On deny, branch on deny_code."
 )
@@ -93,9 +93,19 @@ def keeperhub_tool(
 ) -> KeeperHubToolDescriptor:
     """Build the KH-flavored LangChain tool descriptor.
 
+    `workflow_id` is **advisory only** — it is reported back in the
+    envelope under `kh_workflow_id_advisory` so the agent / audit log
+    can record which workflow the caller intended, but the SBO3L
+    daemon's KH adapter routes per its own `SBO3L_KEEPERHUB_WEBHOOK_URL`
+    env var (the per-call workflow_id is NOT injected into the APRP
+    body and the daemon does NOT receive it). If the caller's
+    `workflow_id` doesn't match what the daemon is configured for, the
+    actual KH execution will land on the daemon-configured workflow,
+    not the caller's. Use this field for context tagging only; do not
+    rely on it as a routing override.
+
     `workflow_id` defaults to `DEFAULT_KH_WORKFLOW_ID` (the live workflow
-    verified during the ETHGlobal Open Agents 2026 submission). Override
-    per-instance for a different KH workflow (e.g. staging / your own).
+    verified during the ETHGlobal Open Agents 2026 submission).
 
     Wire it into LangChain via:
 
@@ -161,7 +171,13 @@ def keeperhub_tool(
         return json.dumps(
             {
                 "decision": r.get("decision"),
-                "kh_workflow_id": kh_workflow_id,
+                # Renamed from `kh_workflow_id` to make the contract
+                # honest: this value is the caller's intended target,
+                # NOT the workflow the daemon actually routed to. The
+                # daemon-configured webhook URL (env-var-driven) is the
+                # source of truth for actual routing — see the
+                # `keeperhub_tool` docstring + KeeperHub/cli#52.
+                "kh_workflow_id_advisory": kh_workflow_id,
                 # `kh_execution_ref` is None on deny / requires_human, OR on
                 # allow when the daemon's KH adapter ran in local_mock with
                 # no webhook configured but failed to populate execution_ref

--- a/examples/langchain-py-research-agent/test_keeperhub_demo.py
+++ b/examples/langchain-py-research-agent/test_keeperhub_demo.py
@@ -91,7 +91,7 @@ def test_allow_envelope_surfaces_kh_execution_ref(httpx_mock: HTTPXMock) -> None
 
     assert out["decision"] == "allow"
     assert out["kh_execution_ref"] == KH_EXECUTION_REF
-    assert out["kh_workflow_id"] == DEFAULT_KH_WORKFLOW_ID
+    assert out["kh_workflow_id_advisory"] == DEFAULT_KH_WORKFLOW_ID
     assert out["audit_event_id"] == "evt-01HTAWX5K3R8YV9NQB7C6P2DGR"
     assert out["request_hash"] == "c0bd2fab" * 8
     assert out["deny_code"] is None
@@ -108,9 +108,9 @@ def test_deny_envelope_does_not_surface_execution_ref(httpx_mock: HTTPXMock) -> 
     assert out["decision"] == "deny"
     # execution_ref must be None on deny — daemon never asks the KH adapter to run.
     assert out["kh_execution_ref"] is None
-    # workflow_id is still surfaced for context (the agent needs to know which
-    # workflow was *attempted* even though execution didn't happen).
-    assert out["kh_workflow_id"] == DEFAULT_KH_WORKFLOW_ID
+    # advisory workflow id is still surfaced for context (the agent needs to
+    # know which workflow was *intended* even though execution didn't happen).
+    assert out["kh_workflow_id_advisory"] == DEFAULT_KH_WORKFLOW_ID
     assert out["deny_code"] == "policy.amount_over_limit"
 
 
@@ -123,7 +123,7 @@ def test_workflow_id_override(httpx_mock: HTTPXMock) -> None:
         descriptor = keeperhub_tool(client=c, workflow_id=custom_workflow)
         out = json.loads(descriptor.func(json.dumps(aprp)))
 
-    assert out["kh_workflow_id"] == custom_workflow
+    assert out["kh_workflow_id_advisory"] == custom_workflow
 
 
 def test_invalid_input_returns_error_envelope() -> None:


### PR DESCRIPTION
## Summary
Three codex review findings on the R18 wave (PRs #395, #399, #407) — all real, all fixed.

## Bugs fixed

### P1 — PR #399 — CSP-violating inline script in ZeroGUploader.astro
Vercel CSP is `script-src 'self' 'wasm-unsafe-eval'` (no `'unsafe-inline'`). The `is:inline` runtime would be blocked in production — file pick / probe / fallback / copy clipboard wouldn't work.

**Fix:** Extracted runtime to `apps/marketing/public/zerog-uploader-runtime.js` served as a static asset under `script-src 'self'`. Constants flow through `data-*` attrs on the section root. Auto-binds every `[data-zerog-uploader]` at `DOMContentLoaded`.

### P2 — PR #395 — `workflow_id` never reaches daemon in keeperhub_tool
The constructor's `workflow_id` arg was reported back as `kh_workflow_id` in the envelope, suggesting per-call routing override. Reality: the daemon's KH adapter routes per its own `SBO3L_KEEPERHUB_WEBHOOK_URL` env var; the per-call value is NEVER injected into the APRP body. Result: misleading audit/context data when callers passed a different `workflow_id` than what the daemon was configured for.

**Fix:** Renamed envelope key to `kh_workflow_id_advisory` (suffix makes the contract honest). Expanded docstring to explicitly call out *advisory only — daemon env routes the actual call*. Updated 4 callers (3 test asserts, smoke print, README, docs quickstart).

### P2 — PR #407 — `author:@me` URLs in KH-BF evidence doc
GitHub search queries with `author:@me` only resolve for the signed-in viewer. Random judges see 0 or unrelated results.

**Fix:** Replaced both filtered-search links with direct issue/PR links (one bullet per item). Kept filtered-search links as a secondary affordance with explicit `author:B2JK-Industry` for users who want a generated listing.

## Test plan
- [x] `apps/marketing && npm run build` → 47 pages in 1.04s ✓
- [x] `apps/marketing && npm test` → 26/26 ✓
- [x] Rendered HTML inspected: `data-*` attrs present, `<script type="module" src="/zerog-uploader-runtime.js">` (no inline)
- [x] `examples/langchain-py-research-agent && pytest -q` → 8/8 ✓ (after `kh_workflow_id_advisory` rename)
- [x] Evidence doc: verified all 10 direct links resolve without login

No new dependencies. No behavioral change in the langchain demo wire path (`workflow_id` was never being routed; the rename just makes the contract honest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)