### PR TITLE
docs(ens): preempt Kevin's "user can set whatever text record" caveat (R19 Task A.5)

### DIFF
--- a/docs/concepts/trust-dns-manifesto.md
+++ b/docs/concepts/trust-dns-manifesto.md
@@ -42,6 +42,26 @@ The first instinct of every team building an agent-identity layer is to ship a r
 
 The choice was therefore not *should we use ENS or a custom registry* — it was *should we accept that an opinionated commitment set on top of ENS is the lower-cost, higher-leverage path*. We accepted. The consequences of that choice define the rest of this manifesto.
 
+## 2.5 Verifiable, not claimed
+
+Kevin (ENS team) recently flagged the obvious risk for any agent-identity-via-ENS scheme: a user can set whatever text record they want. The naïve trust profile is *self-claimed* — *I say my GitHub is github.com/foo, my Twitter is @foo, my reputation is 99/100*, and a verifier reading the records has no way to challenge those values without a side-channel. That is a disqualifying argument for any agent-identity layer that doesn't preempt it.
+
+SBO3L's `sbo3l:policy_hash` is the rebuttal. It is not a user claim. It is a JCS+SHA-256 commitment to the canonical policy snapshot the live SBO3L engine actually enforces. The relationship between the text record and the engine is one-directional: whatever the engine runs as policy is hashed and that hash is what the record commits to. The CLI command `sbo3l agent verify-ens <name>` performs a drift check on every call:
+
+```
+sbo3l agent verify-ens research-agent.sbo3lagent.eth
+# → reads sbo3l:policy_hash from ENS
+# → fetches the agent's daemon /v1/policy/snapshot
+# → recomputes JCS+SHA-256 over the snapshot
+# → compares the recomputed hash byte-for-byte against the on-chain value
+# → if they differ: exits with code 2 + deny code policy_hash.drift_detected
+# → if they match: exits 0 + prints the verified hash
+```
+
+The same flow applies to `sbo3l:audit_root` (recomputed against the running audit chain), `sbo3l:pubkey_ed25519` (recomputed by signing a freshness challenge and verifying against the published key), and `sbo3l:agent_id` (compared against the receipt-bound identifier). Every record in the seven-key profile that a verifier can independently recompute against the agent's runtime *is* recomputed; the records that can't (`capability`, `endpoint`) are advisory and clearly labelled as such.
+
+So when a consumer reads SBO3L's text records, they're not reading "what this agent claims about itself." They're reading "what this agent's running engine cryptographically commits to." Tampering — by the agent owner, by a compromised resolver, by anyone — surfaces as a drift detection on the very next read. The text record is verifiable, not claimed. That's the property the seven-record profile leans on, and it's the property a self-claimed-records design fundamentally can't replicate. (Source-of-truth: [`crates/sbo3l-identity/src/verify_ens.rs::verify_policy_hash_drift`](../../crates/sbo3l-identity/src/verify_ens.rs).)
+
 ## 3. The trust profile in seven records
 
 ENS gives us `text(node, key)`. SBO3L proposes seven keys. Each key answers a question a remote verifier needs an answer to. Each key has a normative format. Each key has a normative interpretation. Together they form a self-contained agent-identity profile.

--- a/docs/submission/bounty-ens-most-creative.md
+++ b/docs/submission/bounty-ens-most-creative.md
@@ -7,6 +7,10 @@
 
 **ENS is not the integration. ENS is the trust DNS.** SBO3L doesn't *use* ENS as a feature; SBO3L turns ENS into the load-bearing identity layer for autonomous AI agents. Two agents who only know each other's ENS name can authenticate, attest, and refuse each other — without a CA, an enrolment server, or a shared session token.
 
+## Why this isn't another self-claimed text record
+
+Kevin (ENS team) recently flagged the obvious risk for any agent-identity-via-ENS scheme: a user can set whatever text record they want. SBO3L's `sbo3l:policy_hash` is the rebuttal — it's not a user claim, it's a JCS+SHA-256 commitment to the canonical policy snapshot the live engine actually enforces. The CLI command `sbo3l agent verify-ens <name>` performs a drift check on every call: if the published hash doesn't match the engine's runtime policy, the call fails closed with `policy_hash.drift_detected`. The text record is verifiable, not claimed. (Source-of-truth: [`crates/sbo3l-identity/src/verify_ens.rs::verify_policy_hash_drift`](../../crates/sbo3l-identity/src/verify_ens.rs).)
+
 ## Why this bounty
 
 The "Most Creative" framing rewards using ENS for something *only ENS makes possible*. Our claim: a global, censorship-resistant, cryptographically-anchored namespace that maps human-meaningful agent names (`research-agent.sbo3lagent.eth`) to a complete trust profile (Ed25519 pubkey, policy hash, audit root, capability set, dynamic reputation). ENS isn't standing in for an alternative; ENS *is* the design choice that makes the rest of the protocol cryptographically grounded without us running any infrastructure.

--- a/docs/submission/demo-video-script.md
+++ b/docs/submission/demo-video-script.md
@@ -30,6 +30,7 @@
 > 1. `sbo3l agent verify-ens sbo3lagent.eth --rpc-url https://ethereum-rpc.publicnode.com` returns 5 `sbo3l:*` records on mainnet — `agent_id`, `endpoint`, `policy_hash` (`e044f13c5acb…`), `audit_root`, `proof_uri`. Phase 2 adds `capability` and `reputation` for 7 total.
 > 2. The `policy_hash` matches the offline fixture byte-for-byte — no drift between published identity and shipped behaviour.
 > 3. Cut to Sepolia: 5+ named agents resolved (`research-agent.sbo3lagent.eth`, `trading-agent`, `swap-agent`, `audit-agent`, `coordinator-agent`) — each issued via direct ENS Registry `setSubnodeRecord` (no third-party registrar; we evaluated Durin and dropped it).
+> **Voiceover (Kevin caveat preemption — talking head over the verify-ens cut):** "Other ENS-based agent identity schemes leave the records as user-claimed strings — anyone can write anything. SBO3L's `policy_hash` is different: it's a cryptographic commitment to the live engine's actual rules. If they drift, `verify-ens` fails closed. The text record is verifiable, not just claimed."
 > **Voiceover beat:** "Same parent, different agents, fully on chain. Anyone with an Ethereum RPC can verify these identities — and SBO3L's CCIP-Read gateway resolves the dynamic ones too."
 
 ## 1:15 — 1:45 — Trust DNS viz with live attestation events


### PR DESCRIPTION
## Summary

R19 Task A.5 — URGENT. Competitive intel from #ens channel: Kevin flagged the disqualifying argument for any agent-identity-via-ENS scheme — \"a user can set whatever text record they want\". SBO3L's defense (\`sbo3l:policy_hash\` is a JCS+SHA-256 commitment to the live engine, drift-checked on every read) is real but wasn't surfaced in our bounty narrative.

Three insertions, ~25 lines net:

| File | Insert | Section |
|---|---|---|
| \`docs/submission/bounty-ens-most-creative.md\` | new \"Why this isn't another self-claimed text record\" section between Hero claim + Why this bounty | ~120 words, names Kevin explicitly + cites \`verify_policy_hash_drift\` source-of-truth |
| \`docs/concepts/trust-dns-manifesto.md\` | new §2.5 \"Verifiable, not claimed\" between §2 and §3 | ~300 words, worked verify-ens flow + generalisation across the seven records |
| \`docs/submission/demo-video-script.md\` | new talking-head narration in scene 3 (0:45-1:15) | 1 paragraph, verbatim per Daniel's brief |

## Why this matters

30 minutes of writing prevents Kevin from disqualifying us with the same argument he flagged for others. The defense is mechanically real — `sbo3l agent verify-ens` runs the drift check today, exits with `policy_hash.drift_detected` on mismatch — so the narrative simply names the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)