### PR TITLE
feat(brand): SponsorCard replaces text-only SponsorLogos (R19 Wave 2 D7)

### DIFF
--- a/apps/marketing/src/components/SponsorCard.astro
+++ b/apps/marketing/src/components/SponsorCard.astro
@@ -1,0 +1,146 @@
+---
+// SponsorCard — single sponsor track card with brand-themed motif.
+// R19 Wave 2 Task C. Converted from /tmp/sbo3l-design-kit/assets/sponsor.jsx.
+//
+// Inline SVG, viewBox 240×140. One of four motifs ("keeperhub" /
+// "ens" / "uniswap" / "anthropic") rendered in the right column;
+// track name + subtitle + CTA in the left column. The whole card is
+// an <a> link to the per-bounty submission page.
+
+interface Props {
+  track: string;
+  subtitle: string;
+  motif: "keeperhub" | "ens" | "uniswap" | "anthropic";
+  href: string;
+}
+const { track, subtitle, motif, href } = Astro.props;
+---
+<a href={href} class="sponsor-card" aria-label={`${track} sponsor track`}>
+  <svg viewBox="0 0 240 140" class="card-svg">
+    <rect x="0" y="0" width="240" height="140" rx="6" class="card-bg" />
+    <rect x="0" y="0" width="3" height="140" class="card-accent-stripe" />
+
+    <!-- Header: SPONSOR TRACK -->
+    <text x="20" y="26" class="card-eyebrow">SPONSOR TRACK</text>
+    <line x1="20" y1="34" x2="60" y2="34" class="card-eyebrow-rule" />
+
+    <!-- Brand-themed motif on the right -->
+    <g transform="translate(190 70)" class="motif">
+      {motif === "keeperhub" && (
+        <g>
+          <path d="M 0 -22 L 20 -14 L 20 6 Q 20 22 0 28 Q -20 22 -20 6 L -20 -14 Z" fill="none" class="m-stroke-thick" />
+          <circle cx="-8" cy="-4" r="3" class="m-fill" />
+          <circle cx="8"  cy="-4" r="3" class="m-fill" />
+          <circle cx="0"  cy="14" r="3" class="m-fill" />
+          <line x1="-8" y1="-4" x2="0" y2="14" class="m-stroke-thin" />
+          <line x1="8"  y1="-4" x2="0" y2="14" class="m-stroke-thin" />
+          <line x1="-8" y1="-4" x2="8" y2="-4" class="m-stroke-thin" />
+        </g>
+      )}
+      {motif === "ens" && (
+        <g>
+          <rect x="-10" y="-26" width="20" height="14" rx="2" fill="none" class="m-stroke-thick" />
+          <text x="0" y="-16" text-anchor="middle" class="motif-label">.eth</text>
+          <line x1="0"   y1="-12" x2="0"   y2="-4" class="m-stroke-thin" />
+          <line x1="-18" y1="-4"  x2="18"  y2="-4" class="m-stroke-thin" />
+          <line x1="-18" y1="-4"  x2="-18" y2="2"  class="m-stroke-thin" />
+          <line x1="0"   y1="-4"  x2="0"   y2="2"  class="m-stroke-thin" />
+          <line x1="18"  y1="-4"  x2="18"  y2="2"  class="m-stroke-thin" />
+          <rect x="-26" y="2" width="16" height="14" rx="2" fill="none" class="m-stroke-thick" />
+          <rect x="-8"  y="2" width="16" height="14" rx="2" class="m-fill m-stroke-thick" />
+          <rect x="10"  y="2" width="16" height="14" rx="2" fill="none" class="m-stroke-thick" />
+          <text x="0" y="13" text-anchor="middle" class="motif-fill-label">sbo3l</text>
+        </g>
+      )}
+      {motif === "uniswap" && (
+        <g>
+          <path d="M -22 -8 L 18 -8 M 12 -14 L 18 -8 L 12 -2" fill="none" class="m-stroke-thick m-linecap" />
+          <path d="M 22 12 L -18 12 M -12 6 L -18 12 L -12 18" fill="none" class="m-stroke-thick m-linecap" />
+          <rect x="-7" y="-2" width="14" height="10" rx="1.5" class="m-fill" />
+          <path d="M -4 -2 L -4 -6 Q -4 -10 0 -10 Q 4 -10 4 -6 L 4 -2" fill="none" class="m-stroke-thick" />
+        </g>
+      )}
+      {motif === "anthropic" && (
+        <g>
+          <rect x="-24" y="-18" width="32" height="22" rx="3" fill="none" class="m-stroke-thick" />
+          <path d="M -10 4 L -8 10 L -2 4" fill="none" class="m-stroke-thick m-linejoin" />
+          <circle cx="-16" cy="-8" r="1.5" class="m-fill" />
+          <circle cx="-8"  cy="-8" r="1.5" class="m-fill" />
+          <circle cx="0"   cy="-8" r="1.5" class="m-fill" />
+          <rect x="12" y="-6" width="14" height="16" rx="2" fill="none" class="m-stroke-thick" />
+          <line x1="15" y1="-2" x2="23" y2="-2" class="m-stroke-thin" />
+          <line x1="15" y1="2"  x2="20" y2="2"  class="m-stroke-thin" />
+          <line x1="15" y1="6"  x2="23" y2="6"  class="m-stroke-thin" />
+        </g>
+      )}
+    </g>
+
+    <!-- Title + subtitle + CTA -->
+    <text x="20" y="70"  class="card-title">{track}</text>
+    <text x="20" y="92"  class="card-subtitle">{subtitle}</text>
+    <text x="20" y="118" class="card-cta">VIEW SUBMISSION →</text>
+  </svg>
+</a>
+
+<style>
+  .sponsor-card {
+    display: block;
+    text-decoration: none;
+    transition: transform 0.15s ease;
+  }
+  .sponsor-card:hover { transform: translateY(-2px); text-decoration: none; }
+  .sponsor-card:hover .card-bg { stroke: var(--accent); }
+
+  .card-svg { display: block; width: 100%; height: auto; }
+  .card-bg {
+    fill: var(--code-bg);
+    stroke: var(--border);
+    stroke-width: 1;
+    transition: stroke 0.15s ease;
+  }
+  .card-accent-stripe { fill: var(--accent); }
+
+  .card-eyebrow {
+    font-family: var(--font-mono, ui-monospace);
+    font-size: 9px;
+    fill: var(--muted);
+    letter-spacing: 2px;
+  }
+  .card-eyebrow-rule { stroke: var(--accent); stroke-width: 1; }
+
+  .card-title {
+    font-family: var(--font-mono, ui-monospace);
+    font-size: 20px;
+    fill: var(--fg);
+  }
+  .card-subtitle {
+    font-family: var(--font-mono, ui-monospace);
+    font-size: 10px;
+    fill: var(--muted);
+  }
+  .card-cta {
+    font-family: var(--font-mono, ui-monospace);
+    font-size: 9px;
+    fill: var(--accent);
+    letter-spacing: 1px;
+  }
+
+  /* Motif strokes/fills — inherit accent so dark/light theming flows */
+  .m-stroke-thick { stroke: var(--accent); stroke-width: 1.5; }
+  .m-stroke-thin  { stroke: var(--accent); stroke-width: 1; }
+  .m-linecap { stroke-linecap: round; stroke-linejoin: round; }
+  .m-linejoin { stroke-linejoin: round; }
+  .m-fill { fill: var(--accent); }
+
+  .motif-label {
+    font-family: var(--font-mono, ui-monospace);
+    font-size: 7px;
+    fill: var(--accent);
+  }
+  .motif-fill-label {
+    font-family: var(--font-mono, ui-monospace);
+    font-size: 7px;
+    font-weight: 700;
+    fill: var(--bg);
+  }
+</style>

--- a/apps/marketing/src/components/SponsorLogos.astro
+++ b/apps/marketing/src/components/SponsorLogos.astro
@@ -1,18 +1,27 @@
 ---
 // Sponsor track strip — links each ETHGlobal sponsor to our submission
-// page for that bounty. Image-free + text-only on purpose: the marketing
-// site's CSP doesn't allow third-party img domains, and judges don't
-// need to see a logo to know what KeeperHub is.
+// page for that bounty.
+//
+// R19 Wave 2 Task C: replaced the prior text-only grid (4 plain
+// <a><strong/>name) with 4 SponsorCard SVG cards (240×140 each, brand
+// motif on the right, accent stripe on the left). Cards are still
+// inline-SVG, no third-party images — keeps the marketing CSP clean
+// (img-src 'self'). Adoption matches the brief ordering.
+//
+// Sponsor list deliberately matches the same 4 tracks the previous
+// component shipped — KH, ENS-Most-Creative, Uniswap, Anthropic.
+// Other tracks (0G, ENS-AI-Agents) live on their own /submission
+// pages but are intentionally not in this surface; that decision
+// was made when this component first shipped to avoid implying
+// coverage where the integration is documentation-only.
 
-// Sponsor tracks with shipped + verified live integrations only. Tracks
-// without a shipped integration are documented in
-// docs/submission/PHASE-3-FINAL-STATUS.md and not surfaced here to avoid
-// implying false coverage.
-const sponsors = [
-  { name: "KeeperHub",  href: "/submission/keeperhub",         role: "Live workflow + signed receipts" },
-  { name: "ENS",        href: "/submission/ens-most-creative", role: "sbo3lagent.eth + Trust DNS" },
-  { name: "Uniswap",    href: "/submission/uniswap",           role: "Sepolia QuoterV2 + MEV guard" },
-  { name: "Anthropic",  href: "/submission/anthropic",         role: "Claude tool-use receipts" },
+import SponsorCard from "~/components/SponsorCard.astro";
+
+const sponsors: { track: string; subtitle: string; motif: "keeperhub" | "ens" | "uniswap" | "anthropic"; href: string }[] = [
+  { track: "KeeperHub", subtitle: "Live workflow + signed receipts",  motif: "keeperhub", href: "/submission/keeperhub" },
+  { track: "ENS",       subtitle: "sbo3lagent.eth + Trust DNS",       motif: "ens",       href: "/submission/ens-most-creative" },
+  { track: "Uniswap",   subtitle: "Sepolia QuoterV2 + MEV guard",     motif: "uniswap",   href: "/submission/uniswap" },
+  { track: "Anthropic", subtitle: "Claude tool-use receipts",         motif: "anthropic", href: "/submission/anthropic" },
 ];
 ---
 <section class="sponsors" aria-label="ETHGlobal Open Agents 2026 sponsor tracks">
@@ -21,16 +30,11 @@ const sponsors = [
     Each track has a working production-shape integration with signed
     receipts. Click through for the per-track submission narrative + live URLs.
   </p>
-  <ul class="grid">
+  <div class="grid">
     {sponsors.map((s) => (
-      <li>
-        <a href={s.href}>
-          <strong>{s.name}</strong>
-          <span class="role">{s.role}</span>
-        </a>
-      </li>
+      <SponsorCard track={s.track} subtitle={s.subtitle} motif={s.motif} href={s.href} />
     ))}
-  </ul>
+  </div>
 </section>
 
 <style>
@@ -38,24 +42,8 @@ const sponsors = [
   .title { font-size: var(--fs-3); font-weight: 700; margin: 0 0 0.3em; }
   .subtitle { color: var(--muted); margin: 0 0 1.2em; max-width: 700px; font-size: 0.95em; }
   .grid {
-    list-style: none;
-    padding: 0;
-    margin: 0;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: 0.8em;
   }
-  .grid a {
-    display: block;
-    padding: 1em 1.2em;
-    background: var(--code-bg);
-    border: 1px solid var(--border);
-    border-radius: var(--r-md);
-    color: var(--fg);
-    text-decoration: none;
-    transition: border-color 0.15s, transform 0.15s;
-  }
-  .grid a:hover { border-color: var(--accent); transform: translateY(-2px); text-decoration: none; }
-  .grid strong { display: block; font-size: 1.05em; margin-bottom: 0.25em; }
-  .grid .role { color: var(--muted); font-size: 0.85em; }
 </style>


### PR DESCRIPTION
## Summary

R19 Wave 2 Task C. New \`SponsorCard.astro\` (240×140 inline SVG, brand-themed motif per track) replaces the 4 text-only cards in the existing \`SponsorLogos.astro\`.

### Motifs (one per track)

| Track | Motif |
|---|---|
| KeeperHub | shield with 3 connected workflow nodes |
| ENS | namespace tree (.eth → 3 child slots, sbo3l filled) |
| Uniswap | bidirectional swap arrows around central lock icon |
| Anthropic | conversation bubble (3 dots) + tool-bracket icon |

### What's preserved

- Same 4 tracks with same hrefs (no nav regression)
- Inline SVG only (no third-party image domains, CSP stays clean)
- 4-card grid auto-fit; bumped minimum from 200 → 220 to fit the 240-wide card aspect ratio

### Verification

\`pnpm --filter @sbo3l/marketing build\` — 47 pages, zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)