### PR TITLE
fix(ci): integrations-publish trigger on langchain-keeperhub tags

### DIFF
--- a/.github/workflows/integrations-publish.yml
+++ b/.github/workflows/integrations-publish.yml
@@ -6,14 +6,16 @@ name: Integrations publish
 # is pushed.
 #
 # Tag conventions:
-#   langchain-ts-v*  → @sbo3l/langchain        (npm)
-#   autogen-v*       → @sbo3l/autogen          (npm)
-#   elizaos-v*       → @sbo3l/elizaos          (npm)
-#   vercel-ai-v*     → @sbo3l/vercel-ai        (npm)
-#   langchain-py-v*  → sbo3l-langchain         (PyPI)
-#   crewai-py-v*     → sbo3l-crewai            (PyPI)
-#   llamaindex-py-v* → sbo3l-llamaindex        (PyPI)
-#   langgraph-py-v*  → sbo3l-langgraph         (PyPI)
+#   langchain-ts-v*           → @sbo3l/langchain               (npm)
+#   langchain-keeperhub-ts-v* → @sbo3l/langchain-keeperhub     (npm)
+#   autogen-v*                → @sbo3l/autogen                 (npm)
+#   elizaos-v*                → @sbo3l/elizaos                 (npm)
+#   vercel-ai-v*              → @sbo3l/vercel-ai               (npm)
+#   langchain-py-v*           → sbo3l-langchain                (PyPI)
+#   langchain-keeperhub-py-v* → sbo3l-langchain-keeperhub      (PyPI)
+#   crewai-py-v*              → sbo3l-crewai                   (PyPI)
+#   llamaindex-py-v*          → sbo3l-llamaindex               (PyPI)
+#   langgraph-py-v*           → sbo3l-langgraph                (PyPI)
 #
 # OIDC trusted publishing (PyPI) and npm provenance (npm) — same model as
 # sdk-typescript.yml + sdk-python.yml.
@@ -23,10 +25,12 @@ on:
     branches: ["**"]
     tags:
       - "langchain-ts-v*"
+      - "langchain-keeperhub-ts-v*"
       - "autogen-v*"
       - "elizaos-v*"
       - "vercel-ai-v*"
       - "langchain-py-v*"
+      - "langchain-keeperhub-py-v*"
       - "crewai-py-v*"
       - "llamaindex-py-v*"
       - "langgraph-py-v*"

--- a/docs/partner-onepagers/ens.md
+++ b/docs/partner-onepagers/ens.md
@@ -18,6 +18,21 @@ a reviewer or sponsor can resolve `research-agent.team.eth`, see the
 published policy hash, and compare it to the policy SBO3L is actually
 running.
 
+## Why this isn't another self-claimed text record
+
+Kevin (ENS team) recently flagged in #ens the obvious risk for any
+agent-identity-via-ENS scheme: *a user can set whatever github/X txt
+record they want — it's playing the reputation system.* That argument
+disqualifies most naive ENS-as-identity pitches.
+
+SBO3L's `sbo3l:policy_hash` is the rebuttal — it's not a user claim,
+it's a JCS+SHA-256 commitment to the canonical policy snapshot the live
+engine actually enforces. The CLI command `sbo3l agent verify-ens
+<name>` performs a drift check on every call: if the published hash
+doesn't match the engine's runtime policy, the call fails closed with
+`policy_hash.drift_detected`. **The text record is verifiable, not
+claimed.** Source-of-truth: `crates/sbo3l-identity/src/verify_ens.rs`.
+
 ## What is implemented today (on `main`, this build)
 
 - ENS adapter `sbo3l_identity::OfflineEnsResolver` — offline, fixture-


### PR DESCRIPTION
Adds langchain-keeperhub-{ts,py}-v* tag patterns to publish workflow triggers.