### PR TITLE
fix(integrations): inline type:ignore[misc] (mypy unblock)

### DIFF
--- a/integrations/langchain-keeperhub-py/pyproject.toml
+++ b/integrations/langchain-keeperhub-py/pyproject.toml
@@ -57,23 +57,15 @@ files = ["sbo3l_langchain_keeperhub"]
 
 # langchain-core ships no PEP 561 type stubs (issue
 # langchain-ai/langchain#9131). mypy --strict can't resolve
-# `from langchain_core.tools import BaseTool` without them. Two-part
-# mitigation:
-#   1. ignore_missing_imports for the langchain.* namespace so the
-#      [import-not-found] error goes away.
-#   2. set disallow_subclassing_any=false on the same scope so the
-#      [misc] "Class cannot subclass BaseTool (has type Any)" error
-#      stops firing when our Sbo3lKeeperHubTool subclasses the now-Any
-#      BaseTool. Without this the strict subclass-Any rule still bites
-#      even after the import is suppressed.
+# `from langchain_core.tools import BaseTool` without them, so we mark
+# the namespace as untyped. The [misc] "Class cannot subclass BaseTool
+# (has type Any)" error on the Sbo3lKeeperHubTool class is suppressed
+# inline via `# type: ignore[misc]` rather than disabling the rule
+# globally — that way OTHER subclass-Any cases in our code still get
+# flagged.
 [[tool.mypy.overrides]]
 module = ["langchain_core.*", "langchain.*"]
 ignore_missing_imports = true
-
-# Apply the subclass-Any tolerance to OUR module (not the upstream
-# one — module-level override doesn't propagate to subclasses defined
-# in our code).
-disallow_subclassing_any = false
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/integrations/langchain-keeperhub-py/sbo3l_langchain_keeperhub/langchain_tool.py
+++ b/integrations/langchain-keeperhub-py/sbo3l_langchain_keeperhub/langchain_tool.py
@@ -35,7 +35,7 @@ class _Sbo3lKeeperHubInput(BaseModel):
     )
 
 
-class Sbo3lKeeperHubTool(BaseTool):
+class Sbo3lKeeperHubTool(BaseTool):  # type: ignore[misc]
     """LangChain BaseTool that gates KeeperHub execution through SBO3L.
 
     Construct with an SBO3L client (`SBO3LClientSync` recommended for


### PR DESCRIPTION
Surgical fix vs PR #431's broader override that didn't apply on CI.