### PR TITLE
fix(integrations): handle both langchain-core typed/untyped

### DIFF
--- a/integrations/langchain-keeperhub-py/sbo3l_langchain_keeperhub/langchain_tool.py
+++ b/integrations/langchain-keeperhub-py/sbo3l_langchain_keeperhub/langchain_tool.py
@@ -35,7 +35,7 @@ class _Sbo3lKeeperHubInput(BaseModel):
     )
 
 
-class Sbo3lKeeperHubTool(BaseTool):  # type: ignore[misc]
+class Sbo3lKeeperHubTool(BaseTool):  # type: ignore[misc, unused-ignore]
     """LangChain BaseTool that gates KeeperHub execution through SBO3L.
 
     Construct with an SBO3L client (`SBO3LClientSync` recommended for


### PR DESCRIPTION
Final mypy fix — # type: ignore[misc, unused-ignore]