### PR TITLE
fix(marketing): mobile rendering improvements (R20 Task A)

### DIFF
--- a/apps/marketing/src/pages/proof.astro
+++ b/apps/marketing/src/pages/proof.astro
@@ -51,7 +51,9 @@ const initialCapsule = decodeCapsuleParam(Astro.url.searchParams.get("capsule"))
 
   <section class="verifier-pair">
     <div class="passport-side">
-      <PassportCapsule state="open" width={760} />
+      <div class="passport-frame">
+        <PassportCapsule state="open" width={760} />
+      </div>
       <p class="passport-caption">
         Visual reference: the SBO3L Passport spread. Left page carries
         agent identity + the six cryptographic check seals; right page
@@ -105,6 +107,19 @@ const initialCapsule = decodeCapsuleParam(Astro.url.searchParams.get("capsule"))
       align-items: start;
     }
     .passport-side { min-width: 0; }
+    /* R20 Task A: PassportCapsule shipped with explicit width=760
+       which renders >viewport on iPhone SE (375px). The frame
+       constrains it to 100% of the column and lets the SVG scale via
+       its viewBox + preserveAspectRatio. */
+    .passport-frame {
+      max-width: 100%;
+      overflow: hidden;
+    }
+    .passport-frame :global(svg) {
+      width: 100% !important;
+      height: auto !important;
+      max-width: 760px;
+    }
     .passport-caption {
       margin: 1em 0 0;
       color: var(--muted);

--- a/apps/marketing/src/pages/status.astro
+++ b/apps/marketing/src/pages/status.astro
@@ -239,26 +239,36 @@ const totalRows = sections.flatMap(s => s.rows).length;
     {sections.map((section) => (
       <section class="section">
         <h2>{section.title}</h2>
-        <table>
-          <thead>
-            <tr>
-              <th>Surface</th>
-              <th>Live</th>
-              <th>Mock</th>
-              <th>Not yet</th>
-            </tr>
-          </thead>
-          <tbody>
-            {section.rows.map((row) => (
+        {/*
+          R20 Task A: wrap the table in a horizontal-scroll container
+          so iPhone SE (375px wide) doesn't push the page horizontal
+          scrollbar onto the rest of the layout. role="region" +
+          tabindex="0" + aria-label make the scroll region keyboard-
+          reachable and screen-reader-discoverable. The .table-wrap-
+          shadow gradient on the right hints there's more to scroll.
+        */}
+        <div class="table-wrap" role="region" aria-label={`${section.title} truth table`} tabindex="0">
+          <table>
+            <thead>
               <tr>
-                <td><strong>{row.surface}</strong></td>
-                <td>{row.live ? <span class="cell live" set:html={row.live} /> : <span class="cell empty">—</span>}</td>
-                <td>{row.mock ? <span class="cell mock" set:html={row.mock} /> : <span class="cell empty">—</span>}</td>
-                <td>{row.notyet ? <span class="cell notyet" set:html={row.notyet} /> : <span class="cell empty">—</span>}</td>
+                <th>Surface</th>
+                <th>Live</th>
+                <th>Mock</th>
+                <th>Not yet</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {section.rows.map((row) => (
+                <tr>
+                  <td><strong>{row.surface}</strong></td>
+                  <td>{row.live ? <span class="cell live" set:html={row.live} /> : <span class="cell empty">—</span>}</td>
+                  <td>{row.mock ? <span class="cell mock" set:html={row.mock} /> : <span class="cell empty">—</span>}</td>
+                  <td>{row.notyet ? <span class="cell notyet" set:html={row.notyet} /> : <span class="cell empty">—</span>}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </section>
     ))}
 
@@ -374,6 +384,28 @@ const totalRows = sections.flatMap(s => s.rows).length;
     margin-bottom: 0.8em;
     line-height: 1.55;
   }
+  /* R20 Task A — horizontal-scroll table wrapper with right-edge
+     shadow hint. Outer container is keyboard-reachable; inner table
+     keeps its full width so cells with prose don't squeeze. */
+  .table-wrap {
+    position: relative;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    /* Reserve scroll-shadow space on the right so the gradient
+       doesn't overlap the last column. */
+    background:
+      linear-gradient(to right, var(--bg) 0%, transparent 8px),
+      linear-gradient(to right, transparent calc(100% - 8px), var(--bg) 100%),
+      linear-gradient(to right, transparent 0, rgba(74, 214, 167, 0.18) 100%) right / 24px 100% no-repeat;
+    background-attachment: local, local, scroll;
+  }
+  .table-wrap:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: var(--r-sm);
+  }
+  .table-wrap table { min-width: 760px; }
+
   @media (max-width: 720px) {
     table {
       font-size: 0.85em;
@@ -381,5 +413,6 @@ const totalRows = sections.flatMap(s => s.rows).length;
     th, td {
       padding: 0.5em;
     }
+    .table-wrap table { min-width: 640px; }
   }
 </style>


### PR DESCRIPTION
## Summary

Pre-empts Heidi UAT mobile test (iPhone SE 375×667 + iPad 768×1024). Code-side audit of the four pages most likely to fail.

| Surface | Fix |
|---|---|
| \`global.css\` \`.btn\` | \`min-height: 44px\` + flex centering — hits WCAG 2.5.5 enhanced target size at any viewport |
| \`/status\` truth tables | Wrap each \`<table>\` in a \`role=\"region\" tabindex=\"0\"\` scroll container with right-edge gradient hint; iPhone SE no longer horizontally scrolls the page, only the table |
| \`/proof\` PassportCapsule | New \`.passport-frame\` constrains the explicit width=760 SVG to 100% of column with viewBox-driven scaling |

## What's NOT in this PR

Pages already correct on mobile:
- \`/roadmap\` already stacks 3-col → 1 at 1100px
- \`/kh-fleet\` stacks 5-col grid → 1 at 900px; \`.exec-id\` has \`word-break: break-all\`
- Nav ⌘K pill already hidden at 640px
- \`/demo\` step 1 artifact-side panel already stacks at 640px

## Test plan

- [ ] iPhone SE emulator (Chrome DevTools): /status truth-table scrolls within its container, page itself doesn't horizontally scroll
- [ ] iPad (768px): /proof PassportCapsule fits in left column without overflow
- [ ] Tab through homepage: every \`.btn\` shows focus ring + has hit-area ≥44×44

🤖 Generated with [Claude Code](https://claude.com/claude-code)