### PR TITLE
fix(marketing): a11y WCAG 2.1 AA compliance (R20 Task B)

### DIFF
--- a/apps/marketing/src/components/Nav.astro
+++ b/apps/marketing/src/components/Nav.astro
@@ -5,18 +5,30 @@ const githubRepoUrl = "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagen
 // Docs site lives on Vercel via apps/docs (Starlight). Fallback to GitHub
 // repo /docs tree when sbo3l-docs.vercel.app isn't yet deployed by Daniel.
 const docsUrl = "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/tree/main/docs";
+
+// R20 Task B (WCAG 2.4.8): mark the nav link matching the current page
+// with aria-current="page" so screen readers announce "current page,
+// link, Proof" instead of "link, Proof". Pure server-side derivation
+// from Astro.url.pathname; no JS hydration cost.
+const path = Astro.url?.pathname ?? "/";
+function isCurrent(href: string): boolean {
+  if (href === "/") return path === "/" || path === "";
+  if (href.startsWith("http")) return false;
+  return path === href || path.startsWith(href + "/");
+}
+const ariaCurrent = (href: string): "page" | undefined => isCurrent(href) ? "page" : undefined;
 ---
 <header role="banner">
   <nav aria-label="Primary">
-    <a href="/" class="brand" aria-label="SBO3L home">
+    <a href="/" class="brand" aria-label="SBO3L home" aria-current={ariaCurrent("/")}>
       <Logo variant="lockup" height={32} />
     </a>
     <div class="links">
       <a href={githubRepoUrl} rel="noopener">GitHub</a>
-      <a href="/proof">Proof</a>
-      <a href="/status">Status</a>
-      <a href="/kh-fleet">KH-fleet</a>
-      <a href="/roadmap">Roadmap</a>
+      <a href="/proof"    aria-current={ariaCurrent("/proof")}>Proof</a>
+      <a href="/status"   aria-current={ariaCurrent("/status")}>Status</a>
+      <a href="/kh-fleet" aria-current={ariaCurrent("/kh-fleet")}>KH-fleet</a>
+      <a href="/roadmap"  aria-current={ariaCurrent("/roadmap")}>Roadmap</a>
       <a href={`${githubRepoUrl}/blob/main/QUICKSTART.md`} rel="noopener">Quickstart</a>
       <a href={docsUrl} class="search-hint" data-docs-url={docsUrl} aria-label="Search docs (Cmd+K)">
         <span aria-hidden="true">⌘K</span>
@@ -73,6 +85,12 @@ const docsUrl = "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-202
     color: var(--muted);
   }
   .search-hint:hover { color: var(--fg); border-color: var(--accent); text-decoration: none; }
+  /* R20 Task B (WCAG 2.4.8): visual + screen-reader hint for the
+     current page in the nav. */
+  .links a[aria-current="page"] {
+    color: var(--accent);
+    border-bottom: 1px solid var(--accent);
+  }
   .sr-only {
     position: absolute;
     width: 1px;

--- a/apps/marketing/src/components/ZeroGUploader.astro
+++ b/apps/marketing/src/components/ZeroGUploader.astro
@@ -159,10 +159,20 @@ const MAX_FILE_BYTES = 1024 * 1024; // 1 MB — 0G testnet practical cap.
     cursor: pointer;
     transition: border-color 0.15s, background 0.15s;
   }
-  .zg-drop:hover, .zg-drop:focus, .zg-drop.zg-drag {
+  .zg-drop:hover, .zg-drop.zg-drag {
     border-color: var(--accent);
     background: var(--code-bg);
-    outline: none;
+  }
+  /* R20 Task B: previous rule killed `outline` on `:focus`, removing
+     the keyboard ring entirely (border-color change alone isn't
+     reliable for users with reduced color sensitivity). Restored a
+     2px accent outline on `:focus-visible` so keyboard tabs ring but
+     mouse clicks don't. */
+  .zg-drop:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-color: var(--accent);
+    background: var(--code-bg);
   }
   .zg-drop strong { display: block; font-size: 1em; margin-bottom: 0.3em; }
   .zg-drop span { color: var(--muted); font-size: 0.9em; }


### PR DESCRIPTION
## Summary

Code-side a11y audit. 3 real WCAG 2.1 violations + 1 defensive enhancement.

| WCAG | Severity | Fix |
|---|---|---|
| 1.4.3 Contrast (AA) | P1 | \`/status .cell.empty\` placeholder \"—\" was rendered in --border (#2a2a3a) on --bg (#0a0a0f) → ~2.3:1, below the 4.5:1 minimum. Switched to --muted (#9999a8, ~7.5:1) with opacity 0.55. |
| 2.4.7 Focus visible (AA) | P2 | \`.zg-drop:focus { outline: none }\` killed the keyboard ring; restored 2px accent outline via \`:focus-visible\` so keyboard tabs ring but mouse clicks don't. |
| 2.4.8 Location (AAA) | enhancement | Nav links now carry \`aria-current=\"page\"\` (server-derived from Astro.url.pathname); screen readers announce \"current page, link, X\". Visual: matching link gets accent color + bottom border. |

## Audited and clean

- All accent / muted / fg combinations against bg + code-bg pass AA across the dark theme palette
- All `<img>` tags have alt text
- All form inputs have label wrappers or aria-label
- Decorative SVGs (Cinematic scenes, KeyFlow membrane) carry `aria-hidden="true"`; meaningful SVGs have `role="img"` + `<title>` + `<desc>`
- `prefers-reduced-motion` honored on Cinematic + KeyFlow + Hero animations
- Skip-link in BaseLayout works
- Cmd+K shortcut keyboard-only by construction

## Verification

\`pnpm --filter @sbo3l/marketing build\` — 47 pages, zero errors.

## Test plan

- [ ] Run axe-core on /status → contrast violation gone
- [ ] Tab through homepage / /try / /proof — every interactive element rings on keyboard focus
- [ ] Screen reader on /status announces "current page, link, Status" in nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)