### PR TITLE
feat(0g-uploader): 6 edge case improvements + Playwright e2e spec

### DIFF
--- a/apps/marketing/public/zerog-uploader-runtime.js
+++ b/apps/marketing/public/zerog-uploader-runtime.js
@@ -4,6 +4,21 @@
 // no `'unsafe-inline'`). The component element exposes its constants
 // via `data-*` attrs; the runtime auto-binds every
 // `[data-zerog-uploader]` on the page at DOMContentLoaded.
+//
+// Edge cases handled inline (sister test suite at
+// `src/lib/zerog-uploader.test.mjs` covers the pure-helper layer):
+//   1. Non-JSON file        → "Not valid JSON: <parse err>"
+//   2. Empty file           → "File is empty."
+//   3. Valid JSON not capsule → "Missing top-level `schema` field…"
+//   4. localStorage quota   → success path still works; recent list
+//                              persistence shows quota warning + no list
+//   5. Popup blocked        → fallback panel reveals "Heads up" warning
+//                              with manual link; happy path unchanged
+//   6. Mobile drag-drop     → CSS swaps copy via @media (pointer: coarse);
+//                              runtime is unchanged (drop + click both work)
+
+const RECENT_STORAGE_KEY = "sbo3l.zerog.recent.v1";
+const RECENT_HISTORY_LIMIT = 5;
 
 function initOne(root) {
   const cfg = {
@@ -33,6 +48,11 @@ function initOne(root) {
   const hashValueEl = $(".zg-hash-value");
   const copyBtn = $(".zg-copy");
   const permalinkEl = $(".zg-permalink");
+  const popupBlockedEl = $(".zg-popup-blocked-warning");
+  const quotaWarnEl = $(".zg-quota-warning");
+  const recentEl = $(".zg-recent");
+  const recentListEl = $(".zg-recent-list");
+  const recentClearBtn = $(".zg-recent-clear");
 
   let currentFile = null;
 
@@ -72,7 +92,89 @@ function initOne(root) {
         ? "Source: manually pasted from 0G storage tool."
         : "Source: 0G SDK auto-upload.";
     setState("success");
+    persistAndRenderRecent(norm);
   }
+
+  // ---- recent-uploads localStorage persistence ------------------------
+  // Mirrors `src/lib/zerog-uploader.mjs::persistRecent` — duplicated here
+  // because CSP forbids importing modules from this static script. The
+  // sister test suite locks the contract both implementations honor.
+  function safeReadRecent() {
+    try {
+      const ls = window.localStorage;
+      if (!ls) return [];
+      const raw = ls.getItem(RECENT_STORAGE_KEY);
+      if (!raw) return [];
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return [];
+      return parsed.filter(
+        (e) => e && typeof e === "object" && typeof e.rootHash === "string" && typeof e.ts === "number",
+      );
+    } catch (_) {
+      return [];
+    }
+  }
+  function safeWriteRecent(entries) {
+    try {
+      const ls = window.localStorage;
+      if (!ls) return false;
+      ls.setItem(RECENT_STORAGE_KEY, JSON.stringify(entries));
+      return true;
+    } catch (_) {
+      return false;  // QuotaExceededError or unavailable — caller surfaces.
+    }
+  }
+  function persistAndRenderRecent(rootHash) {
+    let entries = safeReadRecent();
+    entries = entries.filter((e) => e.rootHash !== rootHash);
+    entries.unshift({ rootHash, ts: Date.now() });
+    if (entries.length > RECENT_HISTORY_LIMIT) entries = entries.slice(0, RECENT_HISTORY_LIMIT);
+    const persisted = safeWriteRecent(entries);
+    if (!persisted) {
+      // Show quota warning inline in the success card. The rootHash itself
+      // is still valid and visible — only the local history failed.
+      if (quotaWarnEl) quotaWarnEl.hidden = false;
+    } else {
+      if (quotaWarnEl) quotaWarnEl.hidden = true;
+    }
+    renderRecent(entries);
+  }
+  function renderRecent(entries) {
+    if (!recentEl || !recentListEl) return;
+    if (!entries || entries.length === 0) {
+      recentEl.hidden = true;
+      recentListEl.innerHTML = "";
+      return;
+    }
+    recentEl.hidden = false;
+    recentListEl.innerHTML = "";
+    for (const e of entries) {
+      const li = document.createElement("li");
+      const hash = document.createElement("a");
+      hash.className = "zg-recent-hash";
+      hash.href = cfg.storagescanFileUrl + "/" + e.rootHash;
+      hash.target = "_blank";
+      hash.rel = "noopener noreferrer";
+      hash.textContent = e.rootHash;
+      const time = document.createElement("span");
+      time.className = "zg-recent-time";
+      time.textContent = new Date(e.ts).toISOString().slice(0, 19).replace("T", " ");
+      li.appendChild(hash);
+      li.appendChild(time);
+      recentListEl.appendChild(li);
+    }
+  }
+  function clearRecentList() {
+    try {
+      window.localStorage && window.localStorage.removeItem(RECENT_STORAGE_KEY);
+    } catch (_) {
+      // unavailable — render an empty list anyway.
+    }
+    renderRecent([]);
+  }
+  // Hydrate the recent list on first paint if persisted entries exist.
+  renderRecent(safeReadRecent());
+  if (recentClearBtn) recentClearBtn.addEventListener("click", clearRecentList);
 
   async function pickFile(file) {
     setError(null);
@@ -202,11 +304,24 @@ function initOne(root) {
     } else {
       setStatus("indexer unreachable (" + probe.reason + ") — falling back");
     }
+    let popupBlocked = false;
     try {
-      window.open(cfg.storagescanToolUrl, "_blank", "noopener,noreferrer");
+      const winRef = window.open(cfg.storagescanToolUrl, "_blank", "noopener,noreferrer");
+      // window.open returns null when the popup is blocked. Some
+      // browsers return a stub window then close it; sample synchronously.
+      if (winRef === null || winRef === undefined) {
+        popupBlocked = true;
+      } else {
+        try {
+          if (winRef.closed) popupBlocked = true;
+        } catch (_) {
+          // Cross-origin closed access throws — popup DID open. Don't flag.
+        }
+      }
     } catch (_) {
-      // Popup blockers are non-fatal; the in-page link still works.
+      popupBlocked = true;
     }
+    if (popupBlockedEl) popupBlockedEl.hidden = !popupBlocked;
     fallbackEl.hidden = false;
     setState("fallback");
     uploadBtn.disabled = false;

--- a/apps/marketing/src/components/ZeroGUploader.astro
+++ b/apps/marketing/src/components/ZeroGUploader.astro
@@ -77,11 +77,13 @@ const MAX_FILE_BYTES = 1024 * 1024; // 1 MB — 0G testnet practical cap.
     </p>
   </header>
 
-  <div class="zg-drop" tabindex="0" role="button" aria-label="Drop or click to pick a capsule JSON">
+  <div class="zg-drop" tabindex="0" role="button" aria-label="Tap or drop a capsule JSON to upload">
     <input type="file" accept="application/json,.json" hidden />
     <div class="zg-drop-prompt">
-      <strong>Drag a capsule JSON here</strong>
-      <span>or click to pick a file (max 1 MB)</span>
+      <strong class="zg-drop-prompt-desktop">Drag a capsule JSON here</strong>
+      <strong class="zg-drop-prompt-mobile">Tap to pick a capsule JSON</strong>
+      <span class="zg-drop-help-desktop">or click to pick a file (max 1 MB)</span>
+      <span class="zg-drop-help-mobile">max 1 MB</span>
     </div>
     <div class="zg-drop-loaded" hidden>
       <strong class="zg-file-name"></strong>
@@ -101,6 +103,11 @@ const MAX_FILE_BYTES = 1024 * 1024; // 1 MB — 0G testnet practical cap.
 
   <div class="zg-fallback" hidden>
     <h3>0G SDK couldn't auto-push — manual fallback</h3>
+    <p class="zg-popup-blocked-warning" hidden>
+      <strong>Heads up:</strong> your browser blocked the new tab.
+      <a href={STORAGESCAN_TOOL_URL} target="_blank" rel="noopener noreferrer">Open the 0G storage tool</a>
+      manually (or allow popups for this site, then click <em>Push to 0G Storage</em> again).
+    </p>
     <ol>
       <li>We've opened the <a href={STORAGESCAN_TOOL_URL} target="_blank" rel="noopener noreferrer">0G storage tool</a> in a new tab.</li>
       <li>Drag the same file there and click <strong>Upload</strong>.</li>
@@ -136,7 +143,18 @@ const MAX_FILE_BYTES = 1024 * 1024; // 1 MB — 0G testnet practical cap.
     <p>
       Permalink: <a class="zg-permalink" target="_blank" rel="noopener noreferrer"></a>
     </p>
+    <p class="zg-quota-warning" hidden>
+      <em>Note:</em> couldn't save this rootHash to local history (browser
+      storage quota exceeded). The rootHash above still works as proof of
+      upload — just keep your own copy.
+    </p>
   </div>
+
+  <details class="zg-recent" hidden>
+    <summary>Recently uploaded (this browser only)</summary>
+    <ul class="zg-recent-list"></ul>
+    <button type="button" class="btn ghost zg-recent-clear">Clear history</button>
+  </details>
 </section>
 
 <style>
@@ -166,6 +184,74 @@ const MAX_FILE_BYTES = 1024 * 1024; // 1 MB — 0G testnet practical cap.
   }
   .zg-drop strong { display: block; font-size: 1em; margin-bottom: 0.3em; }
   .zg-drop span { color: var(--muted); font-size: 0.9em; }
+
+  /* Mobile + touch: swap "Drag …" copy for "Tap …". The desktop strings
+     are misleading on a touchscreen where dragging is impractical. The
+     `pointer: coarse` media query is the most reliable way to detect a
+     touch-primary device — viewport width alone misses tablets. */
+  .zg-drop-prompt-mobile, .zg-drop-help-mobile { display: none; }
+  @media (pointer: coarse) {
+    .zg-drop-prompt-desktop, .zg-drop-help-desktop { display: none; }
+    .zg-drop-prompt-mobile { display: block; }
+    .zg-drop-help-mobile { display: inline; }
+  }
+  .zg-popup-blocked-warning {
+    margin: 0 0 1em;
+    padding: 0.7em 1em;
+    background: #fff3cd;
+    border-left: 3px solid #ff9500;
+    border-radius: var(--r-sm);
+    font-size: 0.9em;
+  }
+  .zg-quota-warning {
+    margin-top: 0.8em;
+    padding: 0.5em 0.8em;
+    background: #fff3cd;
+    border-left: 3px solid #ff9500;
+    border-radius: var(--r-sm);
+    font-size: 0.85em;
+    color: #6b4500;
+  }
+  .zg-recent {
+    margin-top: 1.5em;
+    padding: 0.8em 1em;
+    background: var(--code-bg);
+    border-radius: var(--r-md);
+    border: 1px solid var(--border);
+    font-size: 0.9em;
+  }
+  .zg-recent summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--muted);
+  }
+  .zg-recent-list {
+    list-style: none;
+    padding: 0;
+    margin: 0.6em 0;
+  }
+  .zg-recent-list li {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.6em;
+    padding: 0.4em 0;
+    border-top: 1px solid var(--border);
+    font-family: var(--font-mono);
+    font-size: 0.8em;
+  }
+  .zg-recent-list li:first-child { border-top: none; }
+  .zg-recent-list .zg-recent-hash { word-break: break-all; }
+  .zg-recent-list .zg-recent-time { color: var(--muted); white-space: nowrap; }
+  .zg-recent-clear {
+    margin-top: 0.4em;
+    padding: 0.3em 0.7em;
+    border: 1px solid var(--border);
+    background: none;
+    border-radius: var(--r-sm);
+    font-size: 0.75em;
+    color: var(--muted);
+    cursor: pointer;
+  }
   .zg-drop-loaded {
     display: flex;
     align-items: center;

--- a/apps/marketing/src/lib/zerog-uploader.mjs
+++ b/apps/marketing/src/lib/zerog-uploader.mjs
@@ -101,3 +101,146 @@ export function bytesHuman(n) {
 }
 
 export const MAX_CAPSULE_BYTES = 1024 * 1024;
+
+/**
+ * localStorage key for the recently-uploaded rootHash list. Bump the
+ * suffix if the schema ever changes (today: array of `{rootHash, ts}`).
+ */
+export const RECENT_STORAGE_KEY = "sbo3l.zerog.recent.v1";
+
+/**
+ * Cap on persisted history. The key + each entry is ~120 bytes, so
+ * 5 entries is ~600 bytes — orders of magnitude under any browser
+ * quota even at the strictest 5 MB cap. Cap exists for UI density,
+ * not storage pressure.
+ */
+export const RECENT_HISTORY_LIMIT = 5;
+
+/**
+ * @typedef {{ rootHash: string, ts: number }} RecentEntry
+ */
+
+/**
+ * Persist a rootHash to the recently-uploaded list. Returns one of:
+ *   - `{ ok: true, entries }`
+ *   - `{ ok: false, reason: "quota" }` on QuotaExceededError
+ *   - `{ ok: false, reason: "unavailable" }` if localStorage isn't
+ *     accessible (private browsing, sandboxed iframe, etc.)
+ *   - `{ ok: false, reason: "format" }` if the rootHash fails validation
+ *
+ * Caller renders the recent list from the returned `entries` (when ok)
+ * or surfaces the failure reason inline (when not ok).
+ *
+ * @param {string} rootHash
+ * @param {Storage} [storage] — defaults to globalThis.localStorage
+ * @param {number} [now] — injection point for tests
+ * @returns {{ ok: true, entries: RecentEntry[] } | { ok: false, reason: "quota" | "unavailable" | "format" }}
+ */
+export function persistRecent(rootHash, storage, now) {
+  if (!isValidRootHash(rootHash)) {
+    return { ok: false, reason: "format" };
+  }
+  const store = storage ?? (typeof localStorage !== "undefined" ? localStorage : null);
+  if (!store) return { ok: false, reason: "unavailable" };
+
+  /** @type {RecentEntry[]} */
+  let existing = [];
+  try {
+    const raw = store.getItem(RECENT_STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        existing = parsed.filter(
+          (e) => e && typeof e === "object" && typeof e.rootHash === "string" && typeof e.ts === "number",
+        );
+      }
+    }
+  } catch (_) {
+    // Corrupt JSON in storage — discard, start fresh. Don't surface
+    // as an error to the caller; recovery is automatic.
+    existing = [];
+  }
+
+  const norm = rootHash.trim().toLowerCase();
+  // De-dup by hash; promote any prior entry to the front.
+  existing = existing.filter((e) => e.rootHash !== norm);
+  existing.unshift({ rootHash: norm, ts: now ?? Date.now() });
+  if (existing.length > RECENT_HISTORY_LIMIT) {
+    existing = existing.slice(0, RECENT_HISTORY_LIMIT);
+  }
+
+  try {
+    store.setItem(RECENT_STORAGE_KEY, JSON.stringify(existing));
+    return { ok: true, entries: existing };
+  } catch (e) {
+    // QuotaExceededError name varies across browsers (Safari uses
+    // "QuotaExceededError" / code 22; Firefox "NS_ERROR_DOM_QUOTA_REACHED";
+    // Chrome both). Any setItem throw under a normal call is effectively
+    // quota-related — treat uniformly.
+    return { ok: false, reason: "quota" };
+  }
+}
+
+/**
+ * Read the recently-uploaded list out of localStorage. Returns an empty
+ * array on missing key / corrupt JSON / unavailable storage.
+ *
+ * @param {Storage} [storage]
+ * @returns {RecentEntry[]}
+ */
+export function readRecent(storage) {
+  const store = storage ?? (typeof localStorage !== "undefined" ? localStorage : null);
+  if (!store) return [];
+  try {
+    const raw = store.getItem(RECENT_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (e) => e && typeof e === "object" && typeof e.rootHash === "string" && typeof e.ts === "number",
+    );
+  } catch (_) {
+    return [];
+  }
+}
+
+/**
+ * Clear the recently-uploaded list. Returns true on success, false on
+ * unavailable storage.
+ *
+ * @param {Storage} [storage]
+ * @returns {boolean}
+ */
+export function clearRecent(storage) {
+  const store = storage ?? (typeof localStorage !== "undefined" ? localStorage : null);
+  if (!store) return false;
+  try {
+    store.removeItem(RECENT_STORAGE_KEY);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+/**
+ * Detect a popup-blocked outcome from `window.open`. Returns true when
+ * the result is null/undefined OR when the returned window's `closed`
+ * flag is true immediately (some browsers return a stub window then
+ * close it on the next tick — sample after a short timeout when
+ * possible). For the synchronous check we just inspect what we got.
+ *
+ * @param {Window | null | undefined} winRef
+ * @returns {boolean}
+ */
+export function isPopupBlocked(winRef) {
+  if (winRef === null || winRef === undefined) return true;
+  // `closed` may be true synchronously when a popup is blocked silently.
+  try {
+    if (winRef.closed) return true;
+  } catch (_) {
+    // Cross-origin access can throw — that means the popup DID open
+    // (just on a different origin we can't inspect). Treat as not-blocked.
+    return false;
+  }
+  return false;
+}

--- a/apps/marketing/src/lib/zerog-uploader.test.mjs
+++ b/apps/marketing/src/lib/zerog-uploader.test.mjs
@@ -19,7 +19,48 @@ import {
   permalinkFor,
   bytesHuman,
   MAX_CAPSULE_BYTES,
+  RECENT_STORAGE_KEY,
+  RECENT_HISTORY_LIMIT,
+  persistRecent,
+  readRecent,
+  clearRecent,
+  isPopupBlocked,
 } from "./zerog-uploader.mjs";
+
+/**
+ * In-memory Storage stub that supports an `injectedThrowOnSetItem` flag
+ * for testing QuotaExceededError. Tests construct fresh instances so
+ * state doesn't leak between cases.
+ */
+function makeStorage(opts = {}) {
+  const map = new Map();
+  return {
+    getItem(k) {
+      return map.has(k) ? map.get(k) : null;
+    },
+    setItem(k, v) {
+      if (opts.throwOnSet) {
+        const e = new Error("QuotaExceededError");
+        e.name = "QuotaExceededError";
+        throw e;
+      }
+      map.set(k, String(v));
+    },
+    removeItem(k) {
+      map.delete(k);
+    },
+    get length() {
+      return map.size;
+    },
+    key(i) {
+      return Array.from(map.keys())[i] ?? null;
+    },
+    clear() {
+      map.clear();
+    },
+    _internal: map,
+  };
+}
 
 describe("isValidRootHash", () => {
   it("accepts a 32-byte 0x-prefixed lowercase hash", () => {
@@ -192,5 +233,168 @@ describe("simulated fallback flow — manual rootHash entry", () => {
   it("rejects a paste with stray prefix from a copy-paste mishap", () => {
     const sloppy = "rootHash: 0x" + "1".repeat(64);
     assert.equal(isValidRootHash(sloppy), false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// R20 edge cases (#436 batch B):
+//   1. non-JSON file        — covered by "Not valid JSON" suite above
+//   2. empty file           — covered by "File is empty" suite above
+//   3. valid JSON not capsule — covered by "Missing top-level schema" above
+//   4. localStorage quota   — new tests below
+//   5. popup blocked        — new tests below
+//   6. mobile drag-drop     — pure-CSS swap (no JS to test); the
+//      .astro template uses `@media (pointer: coarse)` to swap copy
+//      between desktop and touch primary devices.
+// ─────────────────────────────────────────────────────────────────────
+
+describe("edge case 4 — localStorage quota + persistence", () => {
+  it("rejects an invalid rootHash format before touching storage", () => {
+    const store = makeStorage();
+    const r = persistRecent("not-a-valid-hash", store);
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "format");
+    // Storage untouched.
+    assert.equal(store._internal.size, 0);
+  });
+
+  it("persists a fresh rootHash to an empty store", () => {
+    const store = makeStorage();
+    const h = "0x" + "a".repeat(64);
+    const r = persistRecent(h, store, 1700000000000);
+    assert.equal(r.ok, true);
+    assert.equal(r.entries.length, 1);
+    assert.equal(r.entries[0].rootHash, h);
+    assert.equal(r.entries[0].ts, 1700000000000);
+    // Storage now contains the serialized list.
+    assert.ok(store._internal.has(RECENT_STORAGE_KEY));
+  });
+
+  it("de-dupes by hash and promotes the entry to the front", () => {
+    const store = makeStorage();
+    const h1 = "0x" + "1".repeat(64);
+    const h2 = "0x" + "2".repeat(64);
+    persistRecent(h1, store, 1);
+    persistRecent(h2, store, 2);
+    const r = persistRecent(h1, store, 3);  // re-add h1
+    assert.equal(r.ok, true);
+    assert.equal(r.entries.length, 2);
+    assert.equal(r.entries[0].rootHash, h1);  // promoted to front
+    assert.equal(r.entries[0].ts, 3);          // with new timestamp
+    assert.equal(r.entries[1].rootHash, h2);
+  });
+
+  it("caps history at RECENT_HISTORY_LIMIT entries", () => {
+    const store = makeStorage();
+    for (let i = 0; i < RECENT_HISTORY_LIMIT + 3; i++) {
+      // Hex-encode i to get a unique 64-char hash per call.
+      const h = "0x" + i.toString(16).padStart(64, "0");
+      persistRecent(h, store, i);
+    }
+    const entries = readRecent(store);
+    assert.equal(entries.length, RECENT_HISTORY_LIMIT);
+    // Most recent (highest i) should be at the front.
+    const expectedFront = "0x" + (RECENT_HISTORY_LIMIT + 2).toString(16).padStart(64, "0");
+    assert.equal(entries[0].rootHash, expectedFront);
+  });
+
+  it("returns reason='quota' on QuotaExceededError without crashing", () => {
+    const store = makeStorage({ throwOnSet: true });
+    const h = "0x" + "a".repeat(64);
+    const r = persistRecent(h, store);
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "quota");
+  });
+
+  it("returns reason='unavailable' when storage is provided as undefined + no global localStorage", () => {
+    // Stash + restore the global so this test works regardless of
+    // Node/jsdom version (recent Node added experimental localStorage).
+    const orig = globalThis.localStorage;
+    try {
+      // @ts-expect-error — clearing for the duration of the test
+      delete globalThis.localStorage;
+      const r = persistRecent("0x" + "a".repeat(64), undefined);
+      assert.equal(r.ok, false);
+      assert.equal(r.reason, "unavailable");
+    } finally {
+      if (orig !== undefined) globalThis.localStorage = orig;
+    }
+  });
+
+  it("readRecent returns [] on missing key", () => {
+    assert.deepEqual(readRecent(makeStorage()), []);
+  });
+
+  it("readRecent recovers gracefully from corrupt JSON in storage", () => {
+    const store = makeStorage();
+    store.setItem(RECENT_STORAGE_KEY, "{not-valid-json");
+    assert.deepEqual(readRecent(store), []);
+  });
+
+  it("readRecent filters malformed entries (defensive)", () => {
+    const store = makeStorage();
+    // Mix of valid + malformed entries — only valid ones should survive.
+    store.setItem(
+      RECENT_STORAGE_KEY,
+      JSON.stringify([
+        { rootHash: "0x" + "a".repeat(64), ts: 1 },
+        { rootHash: 42, ts: 2 },           // wrong type
+        null,
+        "string-not-object",
+        { rootHash: "0x" + "b".repeat(64) },  // missing ts
+        { rootHash: "0x" + "c".repeat(64), ts: 3 },
+      ]),
+    );
+    const entries = readRecent(store);
+    assert.equal(entries.length, 2);
+    assert.equal(entries[0].rootHash, "0x" + "a".repeat(64));
+    assert.equal(entries[1].rootHash, "0x" + "c".repeat(64));
+  });
+
+  it("clearRecent removes the key + returns true on success", () => {
+    const store = makeStorage();
+    persistRecent("0x" + "a".repeat(64), store);
+    assert.equal(clearRecent(store), true);
+    assert.deepEqual(readRecent(store), []);
+  });
+
+  it("clearRecent returns false on unavailable storage", () => {
+    const orig = globalThis.localStorage;
+    try {
+      // @ts-expect-error — clearing for the duration of the test
+      delete globalThis.localStorage;
+      assert.equal(clearRecent(undefined), false);
+    } finally {
+      if (orig !== undefined) globalThis.localStorage = orig;
+    }
+  });
+});
+
+describe("edge case 5 — popup blocked detection", () => {
+  it("treats null return from window.open as blocked", () => {
+    assert.equal(isPopupBlocked(null), true);
+  });
+
+  it("treats undefined return as blocked", () => {
+    assert.equal(isPopupBlocked(undefined), true);
+  });
+
+  it("treats a stub-window with closed=true as blocked", () => {
+    assert.equal(isPopupBlocked({ closed: true }), true);
+  });
+
+  it("treats a real window stub with closed=false as not-blocked", () => {
+    assert.equal(isPopupBlocked({ closed: false }), false);
+  });
+
+  it("treats a cross-origin window (closed throws) as not-blocked", () => {
+    const crossOrigin = {
+      get closed() {
+        throw new Error("SecurityError: Blocked a frame with origin …");
+      },
+    };
+    // Cross-origin access throws — that means the popup DID open
+    // (just on a different origin we can't inspect). Don't flag.
+    assert.equal(isPopupBlocked(crossOrigin), false);
   });
 });

--- a/apps/marketing/tests/e2e/README.md
+++ b/apps/marketing/tests/e2e/README.md
@@ -1,0 +1,39 @@
+# `apps/marketing/tests/e2e`
+
+Playwright end-to-end specs for the marketing site. **NOT run in CI by default** — adding `@playwright/test` + Chromium binaries is ~700 MB of overhead and the marketing site is static-only Astro. The fast `node --test` suite at `src/lib/*.test.mjs` covers the helpers; this dir catches the few failure modes that only surface in a real browser.
+
+## What lives here
+
+- `zerog-uploader.spec.ts` — 7 specs covering the 6 R20 edge cases + a happy-path sanity:
+  1. Non-JSON file → "Not valid JSON" error
+  2. Empty file → "File is empty" error
+  3. Valid JSON missing `schema` → "Missing top-level `schema` field" error
+  4. localStorage quota exceeded → success card shows quota warning
+  5. Popup blocked → fallback panel shows inline guidance
+  6. Mobile copy swap → desktop strings hidden via `@media (pointer: coarse)`
+  7. Happy path → end-to-end manual rootHash flow
+
+## Run locally
+
+```bash
+cd apps/marketing
+npm install -D @playwright/test
+npx playwright install --with-deps chromium
+
+# Build the static site first; the spec defaults to file:// against dist/.
+npm run build
+
+npx playwright test tests/e2e/zerog-uploader.spec.ts
+```
+
+Or against the dev server:
+
+```bash
+cd apps/marketing
+npm run dev &
+BASE_URL=http://localhost:4321 npx playwright test tests/e2e/zerog-uploader.spec.ts
+```
+
+## When to add to CI
+
+If we start seeing real-browser regressions (CSP breaks, runtime drift between the .astro inline template + the pure-helper layer), promote this spec to a separate `playwright-e2e.yml` workflow that runs on a `marketing-changed` path filter. Until then, keep CI fast.

--- a/apps/marketing/tests/e2e/zerog-uploader.spec.ts
+++ b/apps/marketing/tests/e2e/zerog-uploader.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * ZeroGUploader Playwright e2e — exercises the 6 R20 edge cases through
+ * a real browser against the static-built /try page.
+ *
+ * NOT run in CI by default — the unit-shaped suite at
+ * `src/lib/zerog-uploader.test.mjs` (42 tests under `node --test`)
+ * locks the contract for the pure-helper layer (which the .astro
+ * runtime duplicates inline). This Playwright spec catches the few
+ * failure modes that only surface in a real browser:
+ *
+ *   - CSP blocks the runtime script (caught at first interaction)
+ *   - DOM event wiring drifts between Astro template + runtime
+ *   - touch-pointer media query doesn't actually swap the copy
+ *   - real localStorage QuotaExceededError surfaces the warning UI
+ *   - real popup-blocker behavior matches our detection
+ *
+ * Run locally:
+ *
+ *   cd apps/marketing
+ *   npm install -D @playwright/test
+ *   npx playwright install --with-deps chromium
+ *   npm run build
+ *   npx playwright test tests/e2e/zerog-uploader.spec.ts
+ *
+ * Or run against `npm run dev` by setting BASE_URL=http://localhost:4321
+ * before invoking playwright.
+ *
+ * Why no Playwright in package.json devDeps: adding @playwright/test +
+ * Chromium binaries is ~700 MB of CI overhead. The marketing site is
+ * static-only Astro and we keep CI fast by running `node --test` for
+ * the helpers + a manual Playwright spike when we touch the runtime.
+ */
+
+import { expect, test } from "@playwright/test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Resolve the static-built try page. Honors BASE_URL override (so the
+// spec works against `npm run dev` too).
+const TRY_URL =
+  process.env.BASE_URL !== undefined
+    ? `${process.env.BASE_URL}/try`
+    : `file://${path.resolve(__dirname, "../../dist/try/index.html")}`;
+
+const VALID_CAPSULE = JSON.stringify(
+  {
+    schema: "sbo3l.passport_capsule.v1",
+    version: 1,
+    request: { request_hash: "a".repeat(64) },
+    decision: { result: "allow" },
+    audit: { audit_event_id: "evt-test-001" },
+  },
+  null,
+  2,
+);
+const VALID_ROOT_HASH = "0x" + "a".repeat(64);
+
+async function pickFile(page: import("@playwright/test").Page, name: string, content: string) {
+  // Astro renders <input type="file" hidden> inside .zg-drop. Playwright
+  // can target it by selector even though it's hidden.
+  const input = page.locator(".zg-drop input[type='file']");
+  await input.setInputFiles({
+    name,
+    mimeType: name.endsWith(".json") ? "application/json" : "text/plain",
+    buffer: Buffer.from(content, "utf-8"),
+  });
+}
+
+test.describe("ZeroGUploader edge cases", () => {
+  test("[edge 1] non-JSON file shows parse error", async ({ page }) => {
+    await page.goto(TRY_URL);
+    await pickFile(page, "not-json.txt", "this is plain text, not JSON\n");
+    await expect(page.locator(".zg-error")).toContainText(/Not valid JSON/);
+    // Upload button stays disabled until a valid capsule is loaded.
+    await expect(page.locator(".zg-upload")).toBeDisabled();
+  });
+
+  test("[edge 2] empty file shows 'File is empty' error", async ({ page }) => {
+    await page.goto(TRY_URL);
+    await pickFile(page, "empty.json", "");
+    await expect(page.locator(".zg-error")).toContainText(/empty/i);
+  });
+
+  test("[edge 3] valid JSON missing schema field shows 'Missing top-level' error", async ({ page }) => {
+    await page.goto(TRY_URL);
+    await pickFile(page, "no-schema.json", JSON.stringify({ hello: "world" }));
+    await expect(page.locator(".zg-error")).toContainText(/Missing top-level `schema` field/);
+  });
+
+  test("[edge 4] localStorage quota exceeded surfaces warning in success card", async ({ page }) => {
+    await page.goto(TRY_URL);
+    // Stub localStorage.setItem to throw QuotaExceededError BEFORE any
+    // interactions. The runtime's safeWriteRecent catches and shows
+    // .zg-quota-warning; the rootHash itself stays valid + visible.
+    await page.evaluate(() => {
+      const orig = window.localStorage.setItem.bind(window.localStorage);
+      window.localStorage.setItem = (k: string, v: string) => {
+        if (k.startsWith("sbo3l.zerog.recent")) {
+          const e = new DOMException("Quota exceeded", "QuotaExceededError");
+          throw e;
+        }
+        orig(k, v);
+      };
+    });
+
+    await pickFile(page, "capsule.json", VALID_CAPSULE);
+    await expect(page.locator(".zg-error")).toBeHidden();
+    await page.locator(".zg-upload").click();
+    // Click through the fallback panel's manual rootHash flow to reach success.
+    await page.locator(".zg-manual-hash").fill(VALID_ROOT_HASH);
+    await page.locator(".zg-manual-submit").click();
+    await expect(page.locator(".zg-hash-value")).toHaveText(VALID_ROOT_HASH);
+    // Quota warning IS visible because persistAndRenderRecent failed.
+    await expect(page.locator(".zg-quota-warning")).toBeVisible();
+  });
+
+  test("[edge 5] popup blocked surfaces inline warning in fallback panel", async ({ page, context }) => {
+    // Block all popups for this context — the runtime's window.open
+    // call returns null, which our isPopupBlocked() catches.
+    await context.route("**/storagescan-galileo.0g.ai/**", (route) => route.abort());
+    await page.evaluate(() => {
+      // Replace window.open with a stub that returns null (simulates
+      // browser popup blocker).
+      window.open = () => null;
+    });
+
+    await page.goto(TRY_URL);
+    await pickFile(page, "capsule.json", VALID_CAPSULE);
+    await page.locator(".zg-upload").click();
+    // Fallback panel reveals + the popup-blocked warning shows.
+    await expect(page.locator(".zg-fallback")).toBeVisible();
+    await expect(page.locator(".zg-popup-blocked-warning")).toBeVisible();
+    await expect(page.locator(".zg-popup-blocked-warning")).toContainText(/blocked the new tab/);
+  });
+
+  test("[edge 6] mobile copy swap (pointer: coarse) hides desktop strings", async ({ browser }) => {
+    // Emulate a touch device so @media (pointer: coarse) takes effect.
+    const ctx = await browser.newContext({
+      hasTouch: true,
+      isMobile: true,
+      viewport: { width: 390, height: 844 }, // iPhone 14 Pro footprint
+    });
+    const page = await ctx.newPage();
+    await page.goto(TRY_URL);
+
+    // Mobile prompt is visible; desktop prompt is hidden via display: none.
+    await expect(page.locator(".zg-drop-prompt-mobile")).toBeVisible();
+    await expect(page.locator(".zg-drop-prompt-desktop")).toBeHidden();
+    await expect(page.locator(".zg-drop-prompt-mobile")).toHaveText(/Tap/);
+
+    await ctx.close();
+  });
+
+  test("happy path stays green (sanity — none of the new code regressed it)", async ({ page }) => {
+    await page.goto(TRY_URL);
+    await pickFile(page, "capsule.json", VALID_CAPSULE);
+    await expect(page.locator(".zg-error")).toBeHidden();
+    await expect(page.locator(".zg-upload")).toBeEnabled();
+    await page.locator(".zg-upload").click();
+    await expect(page.locator(".zg-fallback")).toBeVisible();
+    await page.locator(".zg-manual-hash").fill(VALID_ROOT_HASH);
+    await page.locator(".zg-manual-submit").click();
+    await expect(page.locator(".zg-hash-value")).toHaveText(VALID_ROOT_HASH);
+    await expect(page.locator(".zg-permalink")).toHaveAttribute(
+      "href",
+      `https://storagescan-galileo.0g.ai/file/${VALID_ROOT_HASH}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
R20 batch B follow-up to PR #399. Three of the six edge cases (#1-3 input handling) were already covered; the remaining three (#4 localStorage quota, #5 popup blocked, #6 mobile copy) are new code.

## Edge cases handled

| # | Case | Coverage |
|---|---|---|
| 1 | Non-JSON file | Existing — `Not valid JSON: <err>` |
| 2 | Empty file | Existing — `File is empty.` |
| 3 | Valid JSON, not capsule | Existing — `Missing top-level `schema` field…` |
| 4 | localStorage quota exceeded | **NEW** — `.zg-quota-warning` reveals; rootHash itself stays valid |
| 5 | Popup blocked | **NEW** — fallback panel reveals `.zg-popup-blocked-warning` with manual link |
| 6 | Mobile drag-drop confusion | **NEW** — `@media (pointer: coarse)` swaps "Drag" → "Tap" copy |

Plus a new `<details class="zg-recent">` section that renders the last 5 successfully-uploaded rootHashes from localStorage with a "Clear history" button.

## Code changes

- `apps/marketing/src/components/ZeroGUploader.astro` — dual-copy drop zone, popup-blocked + quota warnings, recent list section, CSS for all of the above
- `apps/marketing/src/lib/zerog-uploader.mjs` — new `persistRecent`, `readRecent`, `clearRecent`, `isPopupBlocked` helpers + `RECENT_STORAGE_KEY`/`RECENT_HISTORY_LIMIT` constants. Defensive against corrupt JSON, malformed entries, QuotaExceededError, missing `localStorage` global.
- `apps/marketing/public/zerog-uploader-runtime.js` — duplicates `persistAndRenderRecent` + `safeWriteRecent` inline (CSP forbids module imports from this static script). `handleUpload` now detects popup-blocked from `window.open`'s return.

## Tests

- `apps/marketing/src/lib/zerog-uploader.test.mjs` — **16 new test cases** under `node --test`. **26 → 42 tests, 0 failures.** Covers: format rejection, fresh persist, de-dup + LRU, history cap, QuotaExceededError, unavailable storage, corrupt JSON recovery, malformed-entry filtering, clear, popup-blocked detection (null / undefined / closed=true / closed=false / cross-origin throw).
- `apps/marketing/tests/e2e/zerog-uploader.spec.ts` — **7 Playwright specs** for real-browser regression coverage. NOT wired into CI (would add ~700 MB Chromium dep). `tests/e2e/README.md` documents local-run procedure + when to promote.

## Test plan
- [x] `apps/marketing && npm test` → **42/42 ✓** (was 26)
- [x] `apps/marketing && npm run typecheck` → unchanged 2 pre-existing errors; **0 new errors**
- [x] `apps/marketing && npm run build` → 47 pages in 4.32s ✓
- [x] Rendered HTML inspection → all new elements present in `dist/try.html`
- [ ] (optional, local-only) `npx playwright test tests/e2e/zerog-uploader.spec.ts` → 7/7

No new `package.json` deps. No CI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)