### PR TITLE
docs(uat): fix codex P1 + factual error — Bug #2 closure scope + UTC timestamps

### DIFF
--- a/docs/proof/final-uat-pre-submit.md
+++ b/docs/proof/final-uat-pre-submit.md
@@ -133,14 +133,18 @@ node -e "console.log(Object.keys(require('@sbo3l/anthropic')))"
 | `npm test` from integration leaf dir (vitest hoisting) | 🟢 Low | Dev 2 | Follow-up; not user-facing |
 | `/submission/<slug>` for erc-8004/privy/sbe | 🟢 Low | Dev 3 | Optional; only 4 of 7 speculated slugs are deployed today |
 
-## Round 2 — pending Daniel's mainnet OR redeploy
+## Round 2 — pending Daniel's NÁVOD 1 (mainnet Phase 2 setText + Sepolia OR redeploy)
+
+> **Scope clarification (corrected post-codex P1):** there is no "mainnet OR" — the OffchainResolver is a **Sepolia-only** contract; the mainnet apex `sbo3lagent.eth` uses the regular `PublicResolver` and stores its `sbo3l:*` records directly on chain. NÁVOD 1 is two independent pieces:
+> 1. **Mainnet:** Phase 2 setText calls to add `sbo3l:pubkey_ed25519` + `sbo3l:capabilities` to the apex.
+> 2. **Sepolia:** OR redeploy with the canonical URL template (the actual Bug #2 fix).
 
 Will re-run when Daniel completes NÁVOD 1:
 
-1. `sbo3l agent verify-ens sbo3lagent.eth --network mainnet` → expect `verdict: PASS` with **all 7+ records non-empty** (including new `sbo3l:pubkey_ed25519` and `sbo3l:capabilities`)
-2. Confirm `sbo3l:endpoint` is **NOT localhost** any more (was bug #3)
-3. Decode the new OffchainResolver `urls(0)` → expect well-formed `{sender}/{data}.json`
-4. Live CCIP-Read flow: cast a real ENSIP-25 request against the new resolver, confirm gateway signs response correctly
+1. `sbo3l agent verify-ens sbo3lagent.eth --network mainnet` → expect `verdict: PASS` with **all 7+ records non-empty** (including new `sbo3l:pubkey_ed25519` and `sbo3l:capabilities` from the mainnet Phase 2 setText calls)
+2. Confirm `sbo3l:endpoint` on mainnet is **NOT localhost** any more (was bug #3)
+3. Decode the **new Sepolia OR** `urls(0)` → expect well-formed `{sender}/{data}.json` (the actual Bug #2 fix happens on Sepolia, not mainnet)
+4. Live CCIP-Read flow: cast a real ENSIP-25 request against the new Sepolia resolver, confirm gateway signs response correctly
 
 ## Round 3 — pending Daniel's demo video
 

--- a/docs/proof/uat-round-1.5-2026-05-03.md
+++ b/docs/proof/uat-round-1.5-2026-05-03.md
@@ -34,7 +34,7 @@ For each R18 PR landing on main, run the targeted check from Daniel's R18 brief,
 
 ## Cascade snapshot at session start
 
-Open R18 PRs at 2026-05-03 ~00:10 UTC:
+Open R18 PRs at 2026-05-02 ~22:10 UTC:
 
 - #383 [agent/dev4/sepolia-or-redeploy-task-a] — fix(deploy): Task A — pin canonical URL template + probe tests
 - #384 [agent/dev1/doctor-extended] — feat(cli): sbo3l doctor --extended — Sepolia contract liveness probes
@@ -43,7 +43,7 @@ Both auto-merge armed. Will verify post-merge.
 
 ## Per-PR verification entries
 
-### Batch 1 — verified 2026-05-03 ~00:50 UTC
+### Batch 1 — verified 2026-05-02 ~22:50 UTC
 
 Five R18 PRs landed in the same 80-second window:
 
@@ -65,7 +65,7 @@ This PR is Task A of a three-PR sequence (A/B/C). Task B = #390 (deploy + regist
 
 **Note:** the PR body has a typo in the new OR address — it shows `0x87e99508Ad7DdaBcdf67C50ad5cFC18906bDb1f6` (capital letters in middle) but the actual deploy script + onchain reality is `0x87e99508c222c6e419734cacbb6781b8d282b1f6`. The deploy + onchain state are correct; only the PR body display is wrong. Filing minor doc-fix follow-up.
 
-**Bug status:** Heidi's UAT-1 Bug #2 (malformed gateway URL onchain) is now **FIXED on Sepolia**. The mainnet apex `sbo3lagent.eth` still points at the OLD OR (`0x7c69…A8c3`); pinning the new addr in `contracts.rs` + updating mainnet ENS record is Task C (pending).
+**Bug status:** Heidi's UAT-1 Bug #2 (malformed gateway URL onchain) is now **FIXED on Sepolia** (the only network where the OffchainResolver is deployed). The mainnet apex `sbo3lagent.eth` uses a regular `PublicResolver` (`0xF29100983E058B709F3D539b0c765937B804AC15`) and stores text records directly on chain — it does **not** depend on the OR, so there is no mainnet-side OR fix needed. Remaining Task C work: pin the new Sepolia OR address in `crates/sbo3l-identity/src/contracts.rs` so `sbo3l doctor --extended` probes the new deployment instead of the orphaned old one.
 
 #### #386 — Dev 1 PR2 — P-marker cleanup ✅ PASS — **Bug #5 FIXED**
 
@@ -99,14 +99,14 @@ All four help texts free of `P[0-9]+\.[0-9]+` markers. Heidi's UAT-1 Bug #5 full
 
 All three brief requirements met.
 
-### Batch 1 verdict — all 5 PASS, 2 UAT-1 bugs closed (#2, #5)
+### Batch 1 verdict — all 5 PASS, Bug #5 fully closed; Bug #2 closed on the network it actually lives on
 
 R18 batch 1 lands a major chunk of Heidi's UAT-1 follow-ups:
-- Bug #2 fixed on Sepolia (#390 Task B; mainnet update pending Task C)
-- Bug #5 fixed (#386)
-- Plus operational upgrades (#384 doctor extension; #392 live KH dashboard) and deploy-script regression guard (#383)
+- **Bug #5 fully fixed** (#386)
+- **Bug #2 fixed on Sepolia** (#390 Task B) — Sepolia is the only network where the OR is deployed; mainnet apex uses `PublicResolver` directly and was never affected by Bug #2. Remaining Task C work: bump the inlined OR address in `contracts.rs` so `sbo3l doctor --extended` probes the new deployment.
+- Plus operational upgrades (#384 doctor extension; #392 live KH dashboard) and deploy-script regression guard (#383).
 
-Task C (contracts.rs pin + mainnet ENS update + doc memory updates) is the remaining piece for full Bug #2 closure.
+Task C (contracts.rs pin + judge-facing doc memory updates) is the remaining piece for the doctor-side closure.
 
 ### Open R18 PRs at batch 1 close
 
@@ -116,7 +116,7 @@ Task C (contracts.rs pin + mainnet ENS update + doc memory updates) is the remai
 
 Batch 2 verification fires when these land.
 
-### Batch 2 — verified 2026-05-03 ~01:30 UTC — **regression bug found**
+### Batch 2 — verified 2026-05-02 ~23:25 UTC — **regression bug found**
 
 8 R18 PRs landed in a 25-second window:
 


### PR DESCRIPTION
## Summary

Codex review on PR #400 surfaced 2 P1 issues. Self-audit found a 3rd factual error on the same theme. All fixed.

| # | Type | What | Fix |
|---|---|---|---|
| 1 | Codex P1 | Impossible-future timestamps in uat-round-1.5 (CEST written as UTC) | 3 timestamps corrected to actual UTC |
| 2 | Codex P1 | Verdict said "Bug #2 closed" while body said Sepolia-only | Reframed verdict to honest scope |
| 3 | Self-audit factual | "mainnet OR redeploy pending" is wrong — there is no mainnet OR (mainnet apex uses PublicResolver) | Reframed Bug #2 scope across both docs with explicit "scope clarification" callout |

## Detail on #3

The OffchainResolver is a **Sepolia-only** contract. Mainnet apex \`sbo3lagent.eth\` uses \`PublicResolver 0xF29100983E058B709F3D539b0c765937B804AC15\` and stores its \`sbo3l:*\` records directly on chain — no CCIP-Read indirection.

NÁVOD 1 is **two independent pieces**, not one mainnet OR redeploy:
1. **Mainnet:** Phase 2 setText calls to add \`sbo3l:pubkey_ed25519\` + \`sbo3l:capabilities\` to the apex
2. **Sepolia:** OR redeploy with canonical URL — the actual Bug #2 fix

Both docs now reflect this with an explicit "scope clarification (corrected post-codex P1)" callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)