### PR TITLE
fix(self-review): Codex P1+P2 findings on CCIP-Read follow (PR #446)

### DIFF
--- a/crates/sbo3l-identity/src/ccip_read.rs
+++ b/crates/sbo3l-identity/src/ccip_read.rs
@@ -292,17 +292,23 @@ fn u256_be(n: u64) -> [u8; 32] {
     out
 }
 
-/// CCIP-Read end-to-end follow: gateway GET → decode response →
+/// CCIP-Read end-to-end follow: gateway request → decode response →
 /// callback `eth_call` on the OffchainResolver → unwrap the inner
 /// `bytes` return, which is the ABI-encoded payload the original
 /// `text(node, key)` / `addr(node)` would have returned (i.e. an
 /// ABI-encoded `(string)` for `text`, or a 32-byte address word for
 /// `addr`).
 ///
-/// Tries the gateway URLs in order, treating any 4xx HTTP status as
-/// a "skip + try next" signal (per EIP-3668). 5xx and transport
-/// errors short-circuit without trying further URLs — those signal a
-/// real outage, not a "wrong gateway" condition.
+/// Per EIP-3668 §"Client Lookup Protocol":
+///
+/// * **HTTP method.** If the URL template contains the `{data}`
+///   placeholder, use GET (params in URL). Otherwise POST a JSON
+///   body `{"sender":"0x..","data":"0x.."}`. Both forms are
+///   compliant; the resolver picks per-URL.
+/// * **Retry classification.** 4xx responses are *terminal* for that
+///   lookup — the gateway has authoritative data and is rejecting,
+///   so trying another gateway won't help. 5xx and transport errors
+///   trigger trying the next URL in the list.
 ///
 /// Returns the inner-result bytes. Use [`decode_string_result`] to
 /// pull a string out of a `text(node, key)` follow.
@@ -318,8 +324,22 @@ pub fn follow_offchain_lookup<T: JsonRpcTransport>(
 
     let mut last_error: Option<RpcError> = None;
     for template in &lookup.urls {
+        let has_data_placeholder = template.contains("{data}");
         let url = substitute_gateway_url(template, &lookup.sender, &lookup.call_data);
-        match transport.http_get(&url) {
+
+        let body_result = if has_data_placeholder {
+            transport.http_get(&url)
+        } else {
+            let body = serde_json::json!({
+                "sender": format!("0x{}", hex::encode(lookup.sender)),
+                "data": format!("0x{}", hex::encode(&lookup.call_data)),
+            })
+            .to_string()
+            .into_bytes();
+            transport.http_post_json(&url, &body)
+        };
+
+        match body_result {
             Ok(body) => {
                 let parsed = decode_gateway_response_body(&body)
                     .map_err(|e| RpcError::Decode(format!("gateway body {url}: {e}")))?;
@@ -361,9 +381,13 @@ pub fn follow_offchain_lookup<T: JsonRpcTransport>(
                     .map_err(|e| RpcError::Decode(format!("callback {sender_hex}: {e}")));
             }
             Err(e) => {
-                let is_4xx = matches!(&e, RpcError::Http(msg) if msg.contains("status 4"));
+                // EIP-3668 §"Client Lookup Protocol": 4xx is
+                // authoritative-rejection from the gateway and
+                // terminates this lookup; 5xx (and transport
+                // failures) trigger trying the next URL.
+                let is_4xx = is_http_4xx(&e);
                 last_error = Some(e);
-                if !is_4xx {
+                if is_4xx {
                     break;
                 }
                 // Else fall through and try the next URL in the list.
@@ -372,6 +396,25 @@ pub fn follow_offchain_lookup<T: JsonRpcTransport>(
     }
     Err(last_error
         .unwrap_or_else(|| RpcError::Http("CCIP-Read: all gateway URLs exhausted".into())))
+}
+
+/// Detect a 4xx HTTP status from the error string the live transport
+/// produces (`"status 4xx"`). The trait-level error is opaque, so we
+/// match on the standardised substring rather than parameterising
+/// every transport with a status code accessor.
+fn is_http_4xx(e: &RpcError) -> bool {
+    if let RpcError::Http(msg) = e {
+        // Live transport formats: "...: status 404 Not Found".
+        // Match digit immediately after "status ".
+        if let Some(idx) = msg.find("status ") {
+            let tail = &msg[idx + "status ".len()..];
+            let mut iter = tail.chars();
+            return matches!(iter.next(), Some('4'))
+                && iter.next().is_some_and(|c| c.is_ascii_digit())
+                && iter.next().is_some_and(|c| c.is_ascii_digit());
+        }
+    }
+    false
 }
 
 /// Decode an ABI-encoded `(bytes)` tuple — the outer shape returned
@@ -409,6 +452,180 @@ pub fn decode_string_result(result_bytes: &[u8]) -> Result<String, CcipError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
+
+    /// Local minimal fake — covers just enough of `JsonRpcTransport`
+    /// to drive `follow_offchain_lookup` end-to-end. The richer
+    /// fixture in `ens_live::tests` exercises the resolver-side
+    /// dispatch; this one focuses on the EIP-3668 client semantics
+    /// (GET vs POST, 4xx vs 5xx).
+    struct FollowFake {
+        get_responses: RefCell<Vec<Result<Vec<u8>, RpcError>>>,
+        post_responses: RefCell<Vec<Result<Vec<u8>, RpcError>>>,
+        eth_call_responses: RefCell<Vec<Result<String, RpcError>>>,
+        http_log: RefCell<Vec<String>>,
+    }
+
+    impl FollowFake {
+        fn new() -> Self {
+            Self {
+                get_responses: RefCell::new(Vec::new()),
+                post_responses: RefCell::new(Vec::new()),
+                eth_call_responses: RefCell::new(Vec::new()),
+                http_log: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl JsonRpcTransport for FollowFake {
+        fn eth_call(&self, _to: &str, _data: &str) -> Result<String, RpcError> {
+            self.eth_call_responses
+                .borrow_mut()
+                .pop()
+                .unwrap_or_else(|| Err(RpcError::Decode("fake: no eth_call scripted".into())))
+        }
+        fn http_get(&self, url: &str) -> Result<Vec<u8>, RpcError> {
+            self.http_log.borrow_mut().push(format!("GET {url}"));
+            self.get_responses
+                .borrow_mut()
+                .pop()
+                .unwrap_or_else(|| Err(RpcError::Http(format!("fake: no GET scripted for {url}"))))
+        }
+        fn http_post_json(&self, url: &str, body: &[u8]) -> Result<Vec<u8>, RpcError> {
+            self.http_log.borrow_mut().push(format!(
+                "POST {url} body={}",
+                std::str::from_utf8(body).unwrap_or("<non-utf8>")
+            ));
+            self.post_responses
+                .borrow_mut()
+                .pop()
+                .unwrap_or_else(|| Err(RpcError::Http(format!("fake: no POST scripted for {url}"))))
+        }
+    }
+
+    fn build_lookup(urls: &[&str]) -> OffchainLookup {
+        OffchainLookup {
+            sender: [0x11u8; 20],
+            urls: urls.iter().map(|s| s.to_string()).collect(),
+            call_data: vec![0xaa, 0xbb],
+            callback_selector: [0xb4, 0xa8, 0x5b, 0x71],
+            extra_data: vec![0xcc],
+        }
+    }
+
+    /// EIP-3668 §"Client Lookup Protocol" (Codex P1 review on PR
+    /// #446): when the URL template contains `{data}`, use HTTP GET.
+    /// `follow_offchain_lookup` should *only* hit `http_get` on this
+    /// path, never `http_post_json`.
+    #[test]
+    fn follow_uses_get_when_url_has_data_placeholder() {
+        let fake = FollowFake::new();
+        // Push a 4xx so the follow terminates without invoking the
+        // callback eth_call — keeps the test focused on dispatch.
+        fake.get_responses
+            .borrow_mut()
+            .push(Err(RpcError::Http("GET ...: status 404 Not Found".into())));
+        let lookup = build_lookup(&["https://gw.test/api/{sender}/{data}.json"]);
+        let _ = follow_offchain_lookup(&fake, &lookup);
+        let log = fake.http_log.borrow();
+        assert_eq!(log.len(), 1, "exactly one HTTP attempt");
+        assert!(log[0].starts_with("GET "), "got: {log:?}");
+    }
+
+    /// EIP-3668: when the URL template lacks `{data}`, the client
+    /// MUST POST `{"sender":"0x..","data":"0x.."}`. (Codex P1 review
+    /// on PR #446 — previously we always GET-ed.)
+    #[test]
+    fn follow_uses_post_when_url_lacks_data_placeholder() {
+        let fake = FollowFake::new();
+        fake.post_responses
+            .borrow_mut()
+            .push(Err(RpcError::Http("POST ...: status 404 Not Found".into())));
+        // Template has only {sender} → POST.
+        let lookup = build_lookup(&["https://gw.test/api/{sender}/lookup"]);
+        let _ = follow_offchain_lookup(&fake, &lookup);
+        let log = fake.http_log.borrow();
+        assert_eq!(log.len(), 1, "exactly one HTTP attempt");
+        assert!(log[0].starts_with("POST "), "got: {log:?}");
+        assert!(
+            log[0].contains(r#""sender":"0x"#),
+            "missing sender: {log:?}"
+        );
+        assert!(
+            log[0].contains(r#""data":"0xaabb""#),
+            "missing data: {log:?}"
+        );
+    }
+
+    /// EIP-3668: 4xx responses are *terminal* — the gateway has
+    /// authoritative data and is rejecting. Don't try the next URL.
+    /// (Codex P2 review on PR #446 flagged the inverted policy.)
+    #[test]
+    fn follow_does_not_retry_after_4xx() {
+        let fake = FollowFake::new();
+        // Push *two* 404s, but we expect only the first to be
+        // consumed (4xx terminates).
+        fake.get_responses.borrow_mut().push(Err(RpcError::Http(
+            "GET https://gw2.test/...: status 404 Not Found".into(),
+        )));
+        fake.get_responses.borrow_mut().push(Err(RpcError::Http(
+            "GET https://gw1.test/...: status 404 Not Found".into(),
+        )));
+        let lookup = build_lookup(&[
+            "https://gw1.test/api/{sender}/{data}.json",
+            "https://gw2.test/api/{sender}/{data}.json",
+        ]);
+        let err = follow_offchain_lookup(&fake, &lookup).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("404"), "expected 404 in surfaced error: {msg}");
+        assert_eq!(
+            fake.http_log.borrow().len(),
+            1,
+            "must NOT try next URL after a 4xx"
+        );
+    }
+
+    /// EIP-3668: 5xx responses + transport errors trigger the next
+    /// URL. (Codex P2 review on PR #446 flagged the inverted policy.)
+    #[test]
+    fn follow_retries_next_url_after_5xx() {
+        let fake = FollowFake::new();
+        // Pre-populate post-stack-pop order: first GET (gw1) =
+        // 502, second GET (gw2) = success.
+        let success_body = serde_json::json!({
+            "data": "0x",
+            "ttl": 60,
+        })
+        .to_string()
+        .into_bytes();
+        fake.get_responses.borrow_mut().push(Ok(success_body));
+        fake.get_responses.borrow_mut().push(Err(RpcError::Http(
+            "GET https://gw1.test/...: status 502 Bad Gateway".into(),
+        )));
+        // The success path then tries to decode a callback eth_call.
+        // We don't care about the callback in this test (it'll fail
+        // on empty `0x`); we just want to confirm we tried both
+        // URLs.
+        fake.eth_call_responses
+            .borrow_mut()
+            .push(Err(RpcError::Decode("test stub".into())));
+
+        let lookup = build_lookup(&[
+            "https://gw1.test/api/{sender}/{data}.json",
+            "https://gw2.test/api/{sender}/{data}.json",
+        ]);
+        let _ = follow_offchain_lookup(&fake, &lookup);
+        let log = fake.http_log.borrow();
+        assert_eq!(log.len(), 2, "should try both URLs after 5xx");
+        assert!(
+            log[0].contains("gw1.test"),
+            "first attempt should be gw1: {log:?}"
+        );
+        assert!(
+            log[1].contains("gw2.test"),
+            "second attempt should be gw2 after 5xx: {log:?}"
+        );
+    }
 
     #[test]
     fn offchain_lookup_selector_matches_keccak() {
@@ -529,6 +746,31 @@ mod tests {
         buf.extend(std::iter::repeat_n(0u8, pad));
         let decoded = decode_single_bytes_tuple(&buf).unwrap();
         assert_eq!(decoded, payload);
+    }
+
+    #[test]
+    fn is_http_4xx_recognises_404_but_not_5xx_or_transport() {
+        assert!(is_http_4xx(&RpcError::Http(
+            "GET https://x: status 404 Not Found".into()
+        )));
+        assert!(is_http_4xx(&RpcError::Http(
+            "POST https://x: status 410 Gone".into()
+        )));
+        assert!(is_http_4xx(&RpcError::Http(
+            "GET https://x: status 451 Unavailable For Legal Reasons".into()
+        )));
+        // 5xx must not match (gateway-outage retry path).
+        assert!(!is_http_4xx(&RpcError::Http(
+            "GET https://x: status 500 Internal Server Error".into()
+        )));
+        assert!(!is_http_4xx(&RpcError::Http(
+            "GET https://x: status 503 Service Unavailable".into()
+        )));
+        // Plain transport failure (no "status N" substring) must
+        // NOT be classified as 4xx — those are retry-next-URL.
+        assert!(!is_http_4xx(&RpcError::Http("connection refused".into())));
+        // Other RpcError variants don't classify either.
+        assert!(!is_http_4xx(&RpcError::Decode("garbage".into())));
     }
 
     #[test]

--- a/crates/sbo3l-identity/src/ens_live.rs
+++ b/crates/sbo3l-identity/src/ens_live.rs
@@ -103,6 +103,16 @@ pub trait JsonRpcTransport {
             "JsonRpcTransport::http_get not implemented for this transport".into(),
         ))
     }
+
+    /// POST a CCIP-Read gateway URL with a JSON body — required by
+    /// EIP-3668 when the URL template does NOT contain `{data}`. The
+    /// body shape is `{ "sender": "0x..", "data": "0x.." }`. Default
+    /// impl errors out; live transport implements it.
+    fn http_post_json(&self, _url: &str, _body: &[u8]) -> Result<Vec<u8>, RpcError> {
+        Err(RpcError::Http(
+            "JsonRpcTransport::http_post_json not implemented for this transport".into(),
+        ))
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -242,6 +252,25 @@ impl JsonRpcTransport for ReqwestTransport {
         resp.bytes()
             .map(|b| b.to_vec())
             .map_err(|e| RpcError::Http(format!("CCIP gateway body {url}: {e}")))
+    }
+
+    fn http_post_json(&self, url: &str, body: &[u8]) -> Result<Vec<u8>, RpcError> {
+        let resp = self
+            .client
+            .post(url)
+            .header("content-type", "application/json")
+            .body(body.to_vec())
+            .send()
+            .map_err(|e| RpcError::Http(format!("CCIP gateway POST {url}: {e}")))?;
+        if !resp.status().is_success() {
+            return Err(RpcError::Http(format!(
+                "CCIP gateway POST {url}: status {}",
+                resp.status()
+            )));
+        }
+        resp.bytes()
+            .map(|b| b.to_vec())
+            .map_err(|e| RpcError::Http(format!("CCIP gateway POST body {url}: {e}")))
     }
 }
 
@@ -500,6 +529,25 @@ fn call_text_via_ensip10<T: JsonRpcTransport>(
                     "ENSIP-10 resolver {resolver_addr} reverted with non-OffchainLookup data: {e}"
                 ))
             })?;
+            // EIP-3668 sender-check (Codex P1): the lookup's `sender`
+            // MUST equal the resolver address we just called.
+            // Otherwise a resolver could bubble an OffchainLookup
+            // from a *nested* call to an attacker-controlled
+            // contract, and we'd issue gateway requests + a callback
+            // `eth_call` against that untrusted address. The spec
+            // requires the client to refuse in that case (see EIP-3668
+            // §"Client Lookup Protocol", "Verify that sender is the
+            // address of a contract the client is currently
+            // resolving").
+            let resolver_lower = resolver_addr.trim_start_matches("0x").to_ascii_lowercase();
+            let sender_lower = hex::encode(lookup.sender);
+            if resolver_lower != sender_lower {
+                return Err(RpcError::Decode(format!(
+                    "EIP-3668 sender mismatch: resolver is 0x{resolver_lower}, \
+                     OffchainLookup.sender is 0x{sender_lower} — refusing to follow \
+                     a nested-call lookup pointing at an unrelated address"
+                )));
+            }
             let inner_bytes = crate::ccip_read::follow_offchain_lookup(transport, &lookup)?;
             decode_string_from_inner(&inner_bytes)
         }
@@ -812,7 +860,7 @@ mod tests {
         }
 
         fn http_get(&self, url: &str) -> Result<Vec<u8>, RpcError> {
-            self.http_calls.borrow_mut().push(url.to_string());
+            self.http_calls.borrow_mut().push(format!("GET {url}"));
             let mut script = self.http_scripted.borrow_mut();
             let pos = script
                 .iter()
@@ -821,6 +869,25 @@ mod tests {
                 Some(i) => script.remove(i).1,
                 None => Err(RpcError::Http(format!(
                     "FakeTransport: no http_get expectation for {url}"
+                ))),
+            }
+        }
+
+        fn http_post_json(&self, url: &str, body: &[u8]) -> Result<Vec<u8>, RpcError> {
+            // Record both the URL and the body so tests can assert
+            // that the JSON envelope (`{sender,data}`) is correct.
+            self.http_calls.borrow_mut().push(format!(
+                "POST {url} body={}",
+                std::str::from_utf8(body).unwrap_or("<non-utf8>")
+            ));
+            let mut script = self.http_scripted.borrow_mut();
+            let pos = script
+                .iter()
+                .position(|(prefix, _)| url.starts_with(prefix));
+            match pos {
+                Some(i) => script.remove(i).1,
+                None => Err(RpcError::Http(format!(
+                    "FakeTransport: no http_post_json expectation for {url}"
                 ))),
             }
         }
@@ -1271,6 +1338,60 @@ mod tests {
             .resolve_raw_text("sbo3lagent.eth", "sbo3l:agent_id")
             .unwrap();
         assert_eq!(v.as_deref(), Some("research-agent-01"));
+    }
+
+    /// EIP-3668 sender-check (Codex P1 review on PR #446): if the
+    /// OffchainLookup's `sender` doesn't match the resolver address
+    /// we just called, refuse to follow. Otherwise an attacker-
+    /// controlled inner contract could reroute the gateway request +
+    /// callback `eth_call` to an unrelated address.
+    #[test]
+    fn resolve_raw_text_rejects_offchain_lookup_with_mismatched_sender() {
+        let transport = FakeTransport::new();
+        let resolver_addr = "0x87e99508c222c6e419734cacbb6781b8d282b1f6";
+        let attacker_sender_bytes = {
+            let mut a = [0u8; 20];
+            // Different from `resolver_addr`.
+            hex::decode_to_slice("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", &mut a).unwrap();
+            a
+        };
+
+        transport.expect(
+            ENS_REGISTRY_ADDRESS,
+            "0x0178b8bf",
+            Ok(abi_encode_address_response(
+                "87e99508c222c6e419734cacbb6781b8d282b1f6",
+            )),
+        );
+        let true_word = format!("0x{}{}", "00".repeat(31), "01");
+        transport.expect(resolver_addr, "0x01ffc9a7", Ok(true_word));
+
+        let urls = vec!["https://gateway.test/api/{sender}/{data}.json"];
+        let inner_call_data = encode_text_call(&[0u8; 32], "sbo3l:agent_id");
+        let callback_selector = [0xb4, 0xa8, 0x5b, 0x71];
+        let extra_data = inner_call_data.clone();
+        let revert_bytes = abi_encode_offchain_lookup_revert(
+            &attacker_sender_bytes, // <-- mismatch
+            &urls,
+            &inner_call_data,
+            &callback_selector,
+            &extra_data,
+        );
+        transport.expect(
+            resolver_addr,
+            "0x9061b923",
+            Err(RpcError::Reverted { data: revert_bytes }),
+        );
+
+        let resolver = LiveEnsResolver::new(transport, EnsNetwork::Sepolia);
+        let err = resolver
+            .resolve_raw_text("research-agent.sbo3lagent.eth", "sbo3l:agent_id")
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("EIP-3668 sender mismatch"),
+            "expected sender-mismatch error, got: {msg}"
+        );
     }
 
     /// `find_resolver` walks parent names when the leaf has no


### PR DESCRIPTION
## Summary

Three Codex findings on the verify-ens CCIP-Read implementation that shipped in #446. All three are **EIP-3668 conformance issues** — the original implementation worked against our own gateway but diverged from the spec on three points.

| # | Sev | Issue | Fix |
|---|---|---|---|
| 1 | **P1** | OffchainLookup follow doesn't check `sender == resolver` | Added sender-mismatch guard in `call_text_via_ensip10` |
| 2 | **P1** | Always GET, even when URL template lacks `{data}` | Added `http_post_json` to transport; dispatch on `{data}` presence |
| 3 | **P2** | Retry policy inverted: retried on 4xx, stopped on 5xx | Flipped: 4xx terminal, 5xx + transport try next URL |

### P1 — Sender check (EIP-3668 §"Client Lookup Protocol")

A resolver could bubble an `OffchainLookup` from a *nested* call to an attacker-controlled contract; without the sender check, the client would issue gateway requests + a callback `eth_call` against that untrusted address. `call_text_via_ensip10` now compares `lookup.sender` against the resolver address (lowercase, prefix-stripped) and refuses to follow on mismatch.

### P1 — POST fallback when `{data}` is absent

EIP-3668: `{data}` in URL template → GET (data in URL); `{data}` absent → POST with JSON body `{"sender":"0x..","data":"0x.."}`. The previous always-GET path wouldn't resolve against POST-only gateway templates (common for short URLs). Added `JsonRpcTransport::http_post_json` (default impl errors; `ReqwestTransport` implements it). Our own gateway template still uses GET — no change to live behaviour.

### P2 — Retry-class inversion

Previous policy: retry on 4xx, stop on 5xx. Spec policy: 4xx is *terminal* for that lookup (gateway has authoritative data + is rejecting; trying another gateway won't help); 5xx + transport errors trigger trying the next URL. Without this fix, transient 502s short-circuited and "404 not found" burned through every gateway's quota in turn.

## Tests

6 new unit tests (215 → 221 total, all green):
- `is_http_4xx_recognises_404_but_not_5xx_or_transport` — boundary check on the new helper
- `follow_uses_get_when_url_has_data_placeholder` / `follow_uses_post_when_url_lacks_data_placeholder` — dispatch
- `follow_does_not_retry_after_4xx` / `follow_retries_next_url_after_5xx` — retry policy
- `resolve_raw_text_rejects_offchain_lookup_with_mismatched_sender` — sender check

## Live verification

\`\`\`
$ SBO3L_SEPOLIA_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/... \\
  cargo test -p sbo3l-identity --test ccip_read_sepolia_live -- --include-ignored
running 2 tests
test research_agent_subname_resolves_via_ccip_read ... ok
test research_agent_endpoint_record_resolves_via_ccip_read ... ok
test result: ok. 2 passed; 0 failed
\`\`\`

The legitimate single-resolver path still works because our `OffchainResolver.resolve(name, data)` correctly sets `sender = address(this)` in the OffchainLookup revert.

## Test plan
- [x] cargo test -p sbo3l-identity (221 lib tests pass)
- [x] cargo clippy --all-targets -- -D warnings (clean)
- [x] cargo fmt --all -- --check (clean)
- [x] Live Sepolia integration test (research-agent.sbo3lagent.eth)
- [ ] Re-run Codex review on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)