### PR TITLE
fix(codex-r20): 4 codex P1/P2 from R20 PR reviews

### DIFF
--- a/apps/marketing/tests/e2e/zerog-uploader.spec.ts
+++ b/apps/marketing/tests/e2e/zerog-uploader.spec.ts
@@ -120,9 +120,14 @@ test.describe("ZeroGUploader edge cases", () => {
     // Block all popups for this context — the runtime's window.open
     // call returns null, which our isPopupBlocked() catches.
     await context.route("**/storagescan-galileo.0g.ai/**", (route) => route.abort());
-    await page.evaluate(() => {
-      // Replace window.open with a stub that returns null (simulates
-      // browser popup blocker).
+
+    // CRITICAL: install the stub via addInitScript BEFORE page.goto,
+    // not via page.evaluate. page.evaluate runs in the CURRENT document
+    // context — the override is discarded the moment we navigate.
+    // addInitScript registers the script to run on every new document
+    // load, so the stubbed window.open is what /try sees when its
+    // runtime calls it.
+    await page.addInitScript(() => {
       window.open = () => null;
     });
 

--- a/examples/langchain-keeperhub-demos/cross-agent-attestation.py
+++ b/examples/langchain-keeperhub-demos/cross-agent-attestation.py
@@ -57,13 +57,23 @@ def main() -> int:
     endpoint = os.environ.get("SBO3L_ENDPOINT", "http://localhost:8730")
     print(f"▶ daemon: {endpoint}")
 
+    # Both agents run as research-agent-01 — the only agent_id registered
+    # in the bundled reference policy. The delegation chain is then
+    # demonstrated by audit_event_id distinction (each call gets a fresh
+    # event id, regardless of agent_id) plus B's task_id explicitly
+    # encoding A's audit_event_id. To demo TWO distinct agent_ids in the
+    # same chain, register them in a custom policy and load via
+    # SBO3L_POLICY=/path/to/your-policy.json before starting sbo3l-server.
+    AGENT_A_ID = "research-agent-01"
+    AGENT_B_ID = "research-agent-01"
+
     with SBO3LClientSync(endpoint) as client:
         descriptor = sbo3l_keeperhub_tool(client=client)
 
         # --- Agent A: planner, headline call ---
-        print("\n=== agent A (researcher-01) — planner call ===")
+        print(f"\n=== agent A ({AGENT_A_ID}, role=planner) — headline call ===")
         a_aprp = base_aprp(
-            agent_id="researcher-01",
+            agent_id=AGENT_A_ID,
             intent="purchase_api_call",
             amount_usd="0.03",
         )
@@ -77,9 +87,9 @@ def main() -> int:
         a_request_hash = a_envelope["request_hash"]
 
         # --- Agent B: executor, derived call referencing A's attestation ---
-        print(f"\n=== agent B (executor-02) — derived from A's audit_event_id={a_audit_event_id[:24]}... ===")
+        print(f"\n=== agent B ({AGENT_B_ID}, role=executor) — derived from A's audit_event_id={a_audit_event_id[:24]}... ===")
         b_aprp = base_aprp(
-            agent_id="executor-02",
+            agent_id=AGENT_B_ID,
             intent="purchase_api_call",
             amount_usd="0.02",
         )

--- a/examples/langchain-keeperhub-demos/multi-step-research.py
+++ b/examples/langchain-keeperhub-demos/multi-step-research.py
@@ -70,7 +70,11 @@ def aprp(step: Step, agent_id: str) -> dict:
 
 def main() -> int:
     endpoint = os.environ.get("SBO3L_ENDPOINT", "http://localhost:8730")
-    agent_id = "multi-step-research-01"
+    # research-agent-01 is the only agent_id registered in the bundled
+    # reference policy; demos using a different id are denied before
+    # policy evaluation (auth.agent_not_found). Override via SBO3L_POLICY
+    # to a custom policy if you want a different label here.
+    agent_id = "research-agent-01"
     print(f"▶ daemon: {endpoint}")
     print(f"▶ agent: {agent_id}, budget: {BUDGET_USD} USD, plan: {len(PLAN)} steps")
 

--- a/examples/langchain-keeperhub-demos/observability.py
+++ b/examples/langchain-keeperhub-demos/observability.py
@@ -71,7 +71,10 @@ def setup_otel() -> "trace.Tracer | None":
 
 def aprp() -> dict:
     return {
-        "agent_id": "observable-agent-01",
+        # research-agent-01 is the only agent_id registered in the bundled
+        # reference policy. Demos using a different id are denied before
+        # policy evaluation (auth.agent_not_found). Override via SBO3L_POLICY.
+        "agent_id": "research-agent-01",
         "task_id": f"obs-{uuid.uuid4().hex[:8]}",
         "intent": "purchase_api_call",
         "amount": {"value": "0.05", "currency": "USD"},

--- a/examples/langchain-keeperhub-demos/retry-with-backoff.py
+++ b/examples/langchain-keeperhub-demos/retry-with-backoff.py
@@ -37,7 +37,10 @@ from sbo3l_sdk import SBO3LClientSync
 
 def aprp() -> dict:
     return {
-        "agent_id": "retry-demo-agent",
+        # research-agent-01 is the only agent_id registered in the bundled
+        # reference policy. Demos using a different id are denied before
+        # policy evaluation (auth.agent_not_found). Override via SBO3L_POLICY.
+        "agent_id": "research-agent-01",
         "task_id": f"retry-{uuid.uuid4().hex[:8]}",
         "intent": "purchase_api_call",
         "amount": {"value": "0.05", "currency": "USD"},
@@ -96,7 +99,22 @@ def main() -> int:
     print("▶ wrapper: max 3 attempts, base backoff 0.25s with jitter")
 
     with SBO3LClientSync(endpoint) as client:
-        descriptor = sbo3l_keeperhub_tool(client=client)
+        # Deterministic idempotency key for the whole submission lifecycle:
+        # if attempt 1 succeeds server-side but the response is lost
+        # (classic transient transport failure), attempt 2 carries the
+        # SAME idempotency key and the daemon recognises it as a replay
+        # — returns the stored decision without re-running policy or
+        # re-firing KH. Without this, attempt 2 would be a NEW submission
+        # with a new nonce, doubling the side effect.
+        #
+        # The key is derived from (agent_id + task_id + nonce) — all
+        # already in the APRP body — so every retry of the same APRP
+        # gets the same key, but distinct top-level invocations
+        # (different APRPs) get distinct keys.
+        def _idem(body: dict) -> str:
+            return f"{body['agent_id']}:{body['task_id']}:{body['nonce']}"
+
+        descriptor = sbo3l_keeperhub_tool(client=client, idempotency_key=_idem)
         envelope = with_retry(descriptor.func, json.dumps(aprp()))
 
     print("\n=== envelope ===")

--- a/examples/langchain-keeperhub-demos/simple-keepalive.py
+++ b/examples/langchain-keeperhub-demos/simple-keepalive.py
@@ -24,7 +24,11 @@ from sbo3l_sdk import SBO3LClientSync
 
 def aprp() -> dict:
     return {
-        "agent_id": "keepalive-agent-01",
+        # research-agent-01 is the only agent_id registered in the bundled
+        # reference policy. Demos that hardcode a different id are denied
+        # before policy evaluation (auth.agent_not_found). Use SBO3L_POLICY
+        # to load a custom policy if you want a different label here.
+        "agent_id": "research-agent-01",
         "task_id": f"keepalive-{uuid.uuid4().hex[:8]}",
         "intent": "purchase_api_call",
         "amount": {"value": "0.05", "currency": "USD"},

--- a/integrations/langchain-keeperhub-py/sbo3l_langchain_keeperhub/langchain_tool.py
+++ b/integrations/langchain-keeperhub-py/sbo3l_langchain_keeperhub/langchain_tool.py
@@ -92,9 +92,14 @@ class Sbo3lKeeperHubTool(BaseTool):  # type: ignore[misc, unused-ignore]
         return str(self._func(aprp_json))
 
     async def _arun(self, aprp_json: str, **_: Any) -> str:
-        # The underlying SBO3LClientSync is sync; invoking from async
-        # contexts is fine because LangChain's BaseTool wraps in a
-        # threadpool when no native _arun exists. We provide _arun
-        # explicitly so async agents don't need to fall through to the
-        # sync path via run_in_executor (slightly cleaner semantics).
-        return str(self._func(aprp_json))
+        # The underlying SBO3LClientSync.submit performs blocking httpx
+        # I/O. Calling self._func directly from _arun would stall the
+        # event loop and starve other async tools running concurrently
+        # in the same agent. asyncio.to_thread offloads the call to the
+        # default thread pool — same semantics as LangChain BaseTool's
+        # default _arun fallback when this method isn't overridden, but
+        # explicit so future maintainers don't accidentally re-introduce
+        # the blocking version.
+        import asyncio
+
+        return await asyncio.to_thread(self._func, aprp_json)


### PR DESCRIPTION
## Summary
4 codex review findings on the R20 batch (PRs #441, #445, merged #425) — all real, all fixed. A 5th finding was verified-already-fixed in PR #429.

## Bugs fixed

### P1 — PR #441 — demos use unregistered agent_ids
All 5 KH demos hardcoded `agent_id`s not in the bundled reference policy (`policies/reference_low_risk.json` registers only `research-agent-01`). README's startup uses `sbo3l-server` without `SBO3L_POLICY` override → demos would deny with `auth.agent_not_found` before policy evaluation. Reader sees 'broken' instead of 'allow-first happy path.'

**Fix:** Switched all 6 demo agent_ids to `research-agent-01`. Inline comments point at `SBO3L_POLICY` for callers wanting custom labels. `cross-agent-attestation` now demos delegation via `audit_event_id` distinction + role labels (both 'agents' use the same registered id).

### P2 — PR #441 — retry-with-backoff fresh idempotency key
Wrapper resubmitted the same APRP via `descriptor.func` but the descriptor was constructed without an `idempotency_key` callback, so each retry used a fresh key. If attempt 1 succeeded server-side but the response was lost (classic transient), attempt 2 was a NEW submission instead of a replay → nonce/conflict instead of safe recovery.

**Fix:** Passed deterministic `idempotency_key` callback deriving from `(agent_id + task_id + nonce)` — all already in the APRP body. Same APRP across retries → same key → daemon recognises replay.

### P2 — PR #445 — popup-blocked stub before navigation
Test replaced `window.open` via `page.evaluate()` BEFORE `page.goto()`. `page.evaluate` runs in the CURRENT document context — discarded on navigation. Test usually exercised the REAL `window.open` on `/try`, so the `.zg-popup-blocked-warning` assertion was environment-dependent.

**Fix:** Switched to `page.addInitScript()` which registers the stub on every new document load (including the goto'd `/try`). Inline comment explains the lifecycle gotcha.

### P2 — merged PR #425 — _arun blocks event loop
`Sbo3lKeeperHubTool._arun` called sync `self._func` directly, blocking the event loop on httpx I/O. Async agents running multiple tools concurrently would stall on each SBO3L call. The override effectively undid LangChain BaseTool's default `asyncio.to_thread` fallback.

**Fix:** Replaced direct call with `asyncio.to_thread(self._func, aprp_json)`. Same semantics as the default fallback but explicit so future maintainers don't re-introduce the blocking version.

## Verified-already-fixed (no action)

### P1 — merged PR #425 — KH tag patterns missing from push trigger
Codex flagged that `on.push.tags` doesn't include `langchain-keeperhub-{ts,py}-v*`. **Already fixed in PR #429 (commit 11253c0)** — both patterns present at lines 28 + 33 of `integrations-publish.yml` today. Codex finding was on PR #425's snapshot before the trigger fix shipped.

## Test plan
- [x] All 5 demo files: `python3 -c 'import ast; ast.parse(...)'` → ✓
- [x] `integrations/langchain-keeperhub-py && pytest -q` → **6/6 ✓**
- [x] `ruff check` → All checks passed ✓
- [x] `ruff format --check` → 4 files already formatted ✓
- [x] `mypy --strict sbo3l_langchain_keeperhub` → no issues ✓

No new dependencies. No CI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)