### PR TITLE
docs(kh-bf): 5 more issues + amplifier KH-BF-A3 closure

### DIFF
--- a/docs/proof/kh-builder-feedback-2026-05-03.md
+++ b/docs/proof/kh-builder-feedback-2026-05-03.md
@@ -73,10 +73,41 @@ Direct links (no GitHub login required — `author:@me` would have only resolved
   - [PR #406](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/406) — consumer shape for KH-cli#56
 - [Re-read round 1 evidence](../submission/bounty-keeperhub-builder-feedback.md) — original 5 issues (#47–#51) that started the cumulative submission.
 
-Filtered listings (link to a search anyone can run; uses explicit author):
-- [All 10 SBO3L-filed issues on KeeperHub/cli](https://github.com/KeeperHub/cli/issues?q=is%3Aissue+author%3AB2JK-Industry)
-- [All 5 KH-BF draft PRs on this repo](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pulls?q=is%3Apr+author%3AB2JK-Industry+%22kh-bf-additional%22)
+Filtered listings (link to a search anyone can run; uses explicit author). Both listings cover all 15 issues across rounds 1+2+3 and the 5 round-2 companion draft PRs:
+- [All SBO3L-filed issues on KeeperHub/cli](https://github.com/KeeperHub/cli/issues?q=is%3Aissue+author%3AB2JK-Industry)
+- [All KH-BF draft PRs on this repo](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pulls?q=is%3Apr+author%3AB2JK-Industry+%22kh-bf-additional%22)
 
 ## Sponsor-specific value prop
 
 We want KH to win with us. Every issue in this round has a paired implementation commitment from our side. Five round-2 issues × five draft PRs = ten distinct contracts where SBO3L commits to landing the consumer-side change as soon as KH ships the upstream platform change. That's a higher commitment density than vendor-SDK feedback usually carries and it's the thing the Builder Feedback bounty is designed to reward.
+
+---
+
+## Round 3 (2026-05-03 evening) — KH-BF-A3 amplifier closure
+
+5 MORE concrete asks filed (each ≤ 200 words), bringing total filed feedback to **15 issues + 5 reference PRs** on KeeperHub/cli — clears the KH-BF-A3 amplifier threshold (15+ issues).
+
+| Issue | Subject |
+|---|---|
+| [KeeperHub/cli#58](https://github.com/KeeperHub/cli/issues/58) | HMAC-SHA256 webhook signature verification (`X-KeeperHub-Signature`) |
+| [KeeperHub/cli#59](https://github.com/KeeperHub/cli/issues/59) | Workflow versioning (per-revision IDs) + back-compat policy |
+| [KeeperHub/cli#60](https://github.com/KeeperHub/cli/issues/60) | Publish JSON Schema for webhook 2xx response envelope |
+| [KeeperHub/cli#61](https://github.com/KeeperHub/cli/issues/61) | `X-KeeperHub-RateLimit-*` headers on every webhook response |
+| [KeeperHub/cli#62](https://github.com/KeeperHub/cli/issues/62) | Document webhook delivery guarantees (semantics + ordering + dedup) |
+
+### Why these 5
+
+Round 2 covered **post-integration concerns** (error catalog, fixture suite, SLO, schema versioning, payload size). Round 3 covers **production-grade reliability concerns**: signing for reverse-direction webhooks, workflow revision pinning for upgrade safety, response schema for parser stability, rate-limit telemetry for client pacing, and delivery-guarantees documentation for queue-backed integrations. Each is a single platform change KH can land in any order; together they define the reliability contract a production agent fleet needs.
+
+### Cumulative totals (rounds 1 + 2 + 3)
+
+| Metric | R1 | R2 | R3 | Total |
+|---|---|---|---|---|
+| Issues on `KeeperHub/cli` | 5 (#47–#51) | 5 (#52–#56) | 5 (#58–#62) | **15** |
+| Companion draft PRs | 0 | 5 (#402–#406) | 0 (R3 issues are doc-only asks) | **5** |
+| Adapter line refs cited | 6 | 9 | 1 (#60 cites lib.rs:316-319) | 16 |
+
+### Updated filtered listings
+
+- [All 15 SBO3L-filed issues on KeeperHub/cli](https://github.com/KeeperHub/cli/issues?q=is%3Aissue+author%3AB2JK-Industry)
+- [All 5 KH-BF draft PRs on this repo](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pulls?q=is%3Apr+author%3AB2JK-Industry+%22kh-bf-additional%22)


### PR DESCRIPTION
## Summary
Round 3 of the KeeperHub Builder Feedback amplifier work. **5 NEW issues filed on KeeperHub/cli** (#58–#62), each ≤200 words. Brings total filed feedback to **15 issues + 5 reference PRs** — clears the **KH-BF-A3 amplifier threshold (15+ filed asks)**.

## 5 NEW issues (this round)

| Issue | Subject |
|---|---|
| [KeeperHub/cli#58](https://github.com/KeeperHub/cli/issues/58) | HMAC-SHA256 webhook signature verification (`X-KeeperHub-Signature`) |
| [KeeperHub/cli#59](https://github.com/KeeperHub/cli/issues/59) | Workflow versioning (per-revision IDs) + back-compat policy |
| [KeeperHub/cli#60](https://github.com/KeeperHub/cli/issues/60) | Publish JSON Schema for webhook 2xx response envelope |
| [KeeperHub/cli#61](https://github.com/KeeperHub/cli/issues/61) | `X-KeeperHub-RateLimit-*` headers on every webhook response |
| [KeeperHub/cli#62](https://github.com/KeeperHub/cli/issues/62) | Document webhook delivery guarantees (semantics + ordering + dedup) |

## Why these 5

- **R1** (#47–#51): "couldn't get it working at all" frictions — token prefix, envelope schema, executionId lookup, sbo3l_* fields, idempotency dedup
- **R2** (#52–#56): post-integration concerns — error catalog, fixture suite, SLO publication, schema versioning, payload size
- **R3** (#58–#62): production-grade reliability concerns — signing for reverse-direction webhooks, revision pinning for upgrade safety, response schema for parser stability, rate-limit telemetry, delivery guarantees doc

Each is a single platform change KH can land in any order; together they define the reliability contract a production agent fleet needs.

## Cumulative totals (R1 + R2 + R3)

| Metric | R1 | R2 | R3 | Total |
|---|---|---|---|---|
| Issues on `KeeperHub/cli` | 5 | 5 | 5 | **15** |
| Companion draft PRs | 0 | 5 | 0 | **5** |
| Adapter line refs cited | 6 | 9 | 1 | 16 |

## What's in this PR

A single doc edit at `docs/proof/kh-builder-feedback-2026-05-03.md` — appends an "R3" section + corrects a stale "10 issues" filtered link to be count-agnostic (so it stays accurate as future rounds add more).

## Test plan
- [x] All 5 R3 KH issues live: [#58](https://github.com/KeeperHub/cli/issues/58), [#59](https://github.com/KeeperHub/cli/issues/59), [#60](https://github.com/KeeperHub/cli/issues/60), [#61](https://github.com/KeeperHub/cli/issues/61), [#62](https://github.com/KeeperHub/cli/issues/62)
- [x] Cumulative `author:B2JK-Industry` listing on KeeperHub/cli now shows **15 issues**
- [x] All 15 issue links in the doc resolve

## Related
- #407 — round 1+2 KH-BF docs
- #402–#406 — round 2 companion draft PRs (intentionally remain DRAFT as KH-BF-A2 evidence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)