### PR TITLE
ci: PyPI auto-republish poller for langchain-keeperhub-py

### DIFF
--- a/.github/workflows/pypi-republish-langchain-kh.yml
+++ b/.github/workflows/pypi-republish-langchain-kh.yml
@@ -1,0 +1,115 @@
+name: pypi-republish-langchain-keeperhub
+
+# Auto-republish poller for sbo3l-langchain-keeperhub@1.2.0.
+#
+# Why this exists:
+#   The npm half (@sbo3l/langchain-keeperhub@1.2.0) is live on the npm
+#   registry. The PyPI half is blocked on a one-time Daniel-side PyPI
+#   Trusted Publisher registration (~5 min, doc'd at
+#   docs/dev2/pypi-langchain-keeperhub-publish-blocker.md). Once that
+#   registration completes, the existing langchain-keeperhub-py-v1.2.0
+#   tag needs the publish workflow re-fired to actually push to PyPI.
+#
+# What this workflow does:
+#   Every 30 min (during the submission window), checks if
+#   sbo3l-langchain-keeperhub==1.2.0 has appeared on PyPI. If NOT,
+#   re-fires `Integrations publish` on the existing v1.2.0 tag via
+#   workflow_dispatch. If YES, logs and exits — no action.
+#
+# Self-termination:
+#   The workflow is idempotent — it's safe to keep running indefinitely
+#   after publish succeeds (the gating step short-circuits without
+#   firing the publish workflow). After 7+ days of consecutive success
+#   we'll open a follow-up PR to delete this workflow file as cleanup.
+#   The post-success job-summary line below is the signal the cleanup
+#   PR's autogen script greps for.
+#
+# Permissions: actions:write needed to dispatch the publish workflow.
+# Other permissions kept minimal.
+
+on:
+  schedule:
+    # Every 30 min, off the half-hour to dodge runner-cold-start congestion.
+    - cron: "13,43 * * * *"
+  workflow_dispatch:
+    inputs:
+      force_dispatch:
+        description: "Re-fire publish workflow even if PyPI already shows the package as live"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  actions: write  # dispatch `Integrations publish`
+
+concurrency:
+  # Only one poll at a time — successive cron fires queue rather than
+  # double-dispatch the publish workflow.
+  group: pypi-republish-langchain-kh
+  cancel-in-progress: false
+
+env:
+  PKG: sbo3l-langchain-keeperhub
+  PKG_VERSION: "1.2.0"
+  PUBLISH_WORKFLOW: integrations-publish.yml
+  PUBLISH_TAG: langchain-keeperhub-py-v1.2.0
+
+jobs:
+  poll-and-republish:
+    name: poll PyPI + dispatch on miss
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check PyPI for ${{ env.PKG }}@${{ env.PKG_VERSION }}
+        id: probe
+        run: |
+          set -euo pipefail
+          url="https://pypi.org/pypi/${PKG}/${PKG_VERSION}/json"
+          # -o /dev/null discards body; -w writes status code.
+          # Don't pass -f (fail-on-non-200) — we WANT to inspect 404 vs 200.
+          status=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+          echo "PyPI probe HTTP status: $status"
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          if [ "$status" = "200" ]; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          elif [ "$status" = "404" ]; then
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          else
+            # Treat 5xx / network issues as "unknown" — don't dispatch
+            # speculatively (could double-publish if PyPI responded 5xx
+            # mid-publish), don't claim success either.
+            echo "published=unknown" >> "$GITHUB_OUTPUT"
+            echo "::warning::PyPI returned unexpected status $status; treating as unknown — no dispatch this cycle"
+          fi
+
+      - name: Already published — short-circuit
+        if: steps.probe.outputs.published == 'true' && inputs.force_dispatch != true
+        run: |
+          echo "✅ ${PKG}@${PKG_VERSION} already on PyPI — no action."
+          echo "AUTOPUBLISH_SUCCESS_MARKER=${PKG}@${PKG_VERSION}-live" >> "$GITHUB_ENV"
+          # The marker line below is what the eventual cleanup-PR
+          # generator greps for in workflow run logs to count
+          # consecutive successes (target: 7+ days = ~336 runs).
+          echo "::notice::AUTOPUBLISH_SUCCESS_MARKER=${PKG}@${PKG_VERSION}-live"
+
+      - name: Re-fire publish workflow on existing tag
+        if: steps.probe.outputs.published == 'false' || inputs.force_dispatch == true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Verify the tag actually exists before dispatching — saves
+          # a useless workflow run if someone deleted it accidentally.
+          if ! git ls-remote --tags --exit-code origin "refs/tags/${PUBLISH_TAG}" >/dev/null 2>&1; then
+            echo "::error::tag ${PUBLISH_TAG} not found on origin — cannot dispatch publish workflow"
+            exit 1
+          fi
+          echo "▶ ${PKG}@${PKG_VERSION} not on PyPI — dispatching ${PUBLISH_WORKFLOW} on tag ${PUBLISH_TAG}"
+          gh workflow run "${PUBLISH_WORKFLOW}" --ref "${PUBLISH_TAG}"
+          echo "::notice::Dispatched ${PUBLISH_WORKFLOW} on ${PUBLISH_TAG}. Track at: https://github.com/${{ github.repository }}/actions/workflows/${PUBLISH_WORKFLOW}"
+
+      - name: Unknown PyPI state — log + skip
+        if: steps.probe.outputs.published == 'unknown'
+        run: |
+          echo "⚠ PyPI status unknown (HTTP ${{ steps.probe.outputs.status }}); skipping this cycle. Next cron fires in ~30 min."


### PR DESCRIPTION
## Summary
Auto-republish poller that fires the existing `langchain-keeperhub-py-v1.2.0` tag through `Integrations publish` every 30 min until `sbo3l-langchain-keeperhub@1.2.0` appears on PyPI. Closes the loop on the [#435 Trusted Publisher blocker](https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/pull/435) — once Daniel completes the ~5-min PyPI registration, the next cron fire (≤30 min later) lands the publish without any human re-tag.

## Behavior

- **Cron:** `13,43 * * * *` — every 30 min, off the half-hour
- **`workflow_dispatch`** with optional `force_dispatch` input for ad-hoc re-firing
- Probes `https://pypi.org/pypi/sbo3l-langchain-keeperhub/1.2.0/json`:
  - **HTTP 200** (published) → short-circuit + log success marker
  - **HTTP 404** (not published) → verify tag exists, then `gh workflow run integrations-publish.yml --ref langchain-keeperhub-py-v1.2.0`
  - **HTTP 5xx / network** → unknown; skip this cycle (don't double-publish on transient PyPI 5xx)

## Self-termination

Idempotent — safe to keep running indefinitely after publish succeeds. The success path emits a notice with marker `AUTOPUBLISH_SUCCESS_MARKER=<pkg>@<ver>-live` for the eventual cleanup-PR generator to grep against (target: 7+ days of consecutive success → ~336 marker hits → open auto-PR to delete this workflow file).

## Why a separate workflow vs reusing the existing one

The existing `integrations-publish.yml` fires on tag push or manual dispatch. We don't want to push a new tag (would break the contract that `v1.2.0` is the immutable v1.2.0). We don't want a human dispatching every 30 min. A focused poller workflow is the cleanest separation of concerns.

## Permissions
- `contents: read` (minimal; just to query repo for tag existence)
- `actions: write` (needed to dispatch the publish workflow via `gh workflow run`)

## Test plan
- [x] YAML parses; matrix-free; single job, single cron
- [ ] After merge: first scheduled fire shows `PyPI probe HTTP status: 404` → dispatches `integrations-publish` → publish job fails on Trusted Publisher (expected today), workflow exits cleanly
- [ ] After Daniel completes Trusted Publisher: next cron fire (within 30 min) re-dispatches → publish succeeds → subsequent cron fires log `already published` notice without re-dispatching

## Related
- #435 — docs(dev2): PyPI Trusted Publisher blocker for langchain-keeperhub-py
- #438 — ci(install-smoke): conditional skip for sbo3l-langchain-keeperhub (PyPI pending) — drop the `allow_failure: true` once this poller's first success lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)