### PR TITLE
docs(blog): KH composability long-form post + /learn page (KH-A1)

### DIFF
--- a/apps/marketing/src/data/learn-articles.ts
+++ b/apps/marketing/src/data/learn-articles.ts
@@ -431,6 +431,143 @@ const trustDnsManifestoHtml = `
 </p>
 `;
 
+const keeperhubComposabilityHtml = `
+<p>
+  A research agent sees a paid API endpoint, decides "this is worth $0.05,"
+  and reaches for a tool to fire the payment. Two things have to happen
+  between intent and execution:
+</p>
+<ol>
+  <li><strong>Decide:</strong> is this payment authorized? Within budget? Recipient allowlisted? Right chain? Right risk class?</li>
+  <li><strong>Execute:</strong> translate the authorized intent into a signed transaction (or a webhook, or an x402 call) and dispatch it.</li>
+</ol>
+<p>
+  Most "agent payment" stacks today try to do both in one product.
+  SBO3L doesn't. KeeperHub doesn't. Together they form the cleanest
+  composition we've shipped — a policy boundary that emits a signed
+  receipt, and an execution layer that consumes the receipt and
+  actually fires the call.
+</p>
+
+<h2>1. Why two products beat one monolith</h2>
+<p>
+  The decision layer is the boundary between "what the agent wants to
+  do" and "what the operator allows the agent to do." Its audience is
+  the operator: a CFO, a compliance officer, an SRE on call. They edit
+  YAML to express budget caps, allowlist providers, set risk thresholds.
+  They want the policy engine auditable, deterministic, slow-moving.
+</p>
+<p>
+  The execution layer is the bridge between "an authorized payment
+  intent" and "the rails it actually settles on." Its audience is the
+  workflow developer wiring KeeperHub up to a Stripe webhook, an x402
+  endpoint, a Uniswap router, a Discord bot. They want flexibility,
+  fast-evolving, integration-rich.
+</p>
+<p>
+  Bundle them and you compromise both. The decision engine starts
+  shipping integrations to chase the latest payment rail. The execution
+  layer starts adding policy DSLs to chase compliance reviews. Both get
+  worse at their core jobs. Split them and each grows on its own clock —
+  <em>if</em> the contract between them is right.
+</p>
+
+<h2>2. The signed receipt as the contract</h2>
+<p>
+  When SBO3L decides on an APRP (Agent Payment Request Protocol body),
+  it emits a 14-field <code>PolicyReceipt</code>. Three things make it
+  the right contract:
+</p>
+<ol>
+  <li><strong>Content-addressable.</strong> The <code>request_hash</code> pins the exact APRP bytes that were decided on. KeeperHub can re-derive the hash from the body it receives and refuse to execute on mismatch. No "agent edited the request between decision and execution" attack.</li>
+  <li><strong>Offline-verifiable.</strong> Anyone with the policy signer's public key can verify the Ed25519 signature without contacting SBO3L. KH verifies before executing. An auditor reading the audit log months later verifies too. No "trust SBO3L" step.</li>
+  <li><strong>Carries the audit pointer.</strong> <code>audit_event_id</code> references a node in SBO3L's hash-chained audit log. KH echoes this ID back on its execution row, giving an auditor a single ID to walk both directions.</li>
+</ol>
+<p>
+  This receipt is the only thing the two layers exchange. SBO3L doesn't
+  know what KeeperHub's webhook URL is. KeeperHub doesn't know what
+  policy YAML SBO3L is running. Each side evolves freely as long as
+  the receipt schema holds.
+</p>
+
+<h2>3. Five integration paths (IP-1..IP-5)</h2>
+<p>
+  Once you have a receipt-as-contract, the next question is: how tight
+  can the composition get? Five paths, each independently shippable:
+</p>
+<ul>
+  <li><strong>IP-1 — sbo3l_* upstream-proof envelope fields.</strong> SBO3L's KH adapter posts the receipt's <code>request_hash</code> + <code>policy_hash</code> + <code>policy_version</code> + <code>audit_event_id</code> + <code>signature_hex</code> as five optional <code>sbo3l_*</code> fields alongside the workflow body. KH stores them. <strong>Shipped on the SBO3L side</strong>; pending KH-side schema adoption.</li>
+  <li><strong>IP-2 — Public submission/result envelope JSON Schema.</strong> A Draft 2020-12 schema documenting the bidirectional wire shape. Adapter authors stop reverse-engineering responses from <code>curl -v</code>.</li>
+  <li><strong>IP-3 — keeperhub.lookup_execution MCP tool.</strong> Symmetric MCP tool letting auditors query execution status + run-log + sbo3l_* fields without raw HTTP plumbing. <strong>Shipped on the SBO3L side</strong> as <code>sbo3l.audit_lookup</code>.</li>
+  <li><strong>IP-4 — Standalone sbo3l-keeperhub-adapter Rust crate.</strong> Any third-party agent framework can <code>cargo add sbo3l-keeperhub-adapter</code> with no transitive dependency on the SBO3L policy engine. <strong>Shipped at v1.2.0 on crates.io.</strong></li>
+  <li><strong>IP-5 — SBO3L Passport capsule URI on the execution row.</strong> A single optional string column — the URI to a self-contained verifiable bundle (APRP + receipt + audit segment + executor evidence + verification metadata). Capsule schema + verifier shipped; pending KH-side column adoption.</li>
+</ul>
+<p>
+  Stacking all five gives end-to-end offline auditability of every
+  KeeperHub execution that flowed through SBO3L. Two different products,
+  one verifiable trail.
+</p>
+
+<h2>4. End-to-end demo</h2>
+<p>Five lines in TypeScript:</p>
+<pre><code>import { SBO3LClient } from "@sbo3l/sdk";
+import { sbo3lKeeperHubTool } from "@sbo3l/langchain-keeperhub";
+
+const client = new SBO3LClient({ endpoint: "http://localhost:8730" });
+const tool = sbo3lKeeperHubTool({ client });
+// pass \`tool\` (or wrap as DynamicTool) into your LangChain agent's tool list</code></pre>
+<p>What happens when the agent calls <code>tool.func(JSON.stringify(aprp))</code>:</p>
+<ol>
+  <li>POST to SBO3L daemon at <code>/v1/payment-requests</code> with the APRP body</li>
+  <li>SBO3L decides allow / deny / requires_human against the policy + budget + nonce + provider trust list</li>
+  <li>On allow: SBO3L's <code>executor_callback</code> hands the signed receipt to the daemon-side KeeperHub adapter</li>
+  <li>KH adapter POSTs the IP-1 envelope to the workflow webhook, captures <code>executionId</code></li>
+  <li>Tool returns <code>{decision, kh_workflow_id_advisory, kh_execution_ref, audit_event_id, request_hash, policy_hash, deny_code}</code></li>
+</ol>
+
+<h2>5. The 15 issues we filed on KeeperHub/cli</h2>
+<p>
+  Building the composition end-to-end surfaced 15 concrete, actionable
+  asks. We filed them all on
+  <a href="https://github.com/KeeperHub/cli/issues?q=is%3Aissue+author%3AB2JK-Industry">KeeperHub/cli</a>:
+</p>
+<ul>
+  <li><strong>Round 1 (#47–#51)</strong> — couldn't-get-it-working frictions: token-prefix split, envelope schema, executionId lookup, sbo3l_* fields adoption, idempotency-key dedup.</li>
+  <li><strong>Round 2 (#52–#56)</strong> — post-integration concerns: HTTP error code catalog, public mock fixture suite, webhook timeout SLO, schema versioning headers, max payload size.</li>
+  <li><strong>Round 3 (#58–#62)</strong> — production-grade reliability: HMAC-SHA256 signature, workflow versioning + back-compat, response envelope JSON Schema, rate-limiting headers, delivery guarantees doc.</li>
+</ul>
+<p>
+  Each issue carries a worked reproduction, a citation to the exact
+  line in our adapter where the friction surfaces, and a proposed
+  shape for the fix. Five have <strong>companion draft PRs</strong> on
+  our repo showing the consumer-side adapter change ready to ship the
+  day KH lands the upstream contract.
+</p>
+
+<h2>6. Looking forward — joint roadmap</h2>
+<ul>
+  <li><strong>Phase 1:</strong> IP-1 + IP-2 land on KeeperHub. A workflow author opts into <code>sbo3l_*</code> envelope fields with one checkbox. The submission/result schema is published. Adapters across the ecosystem standardise.</li>
+  <li><strong>Phase 2:</strong> IP-3 + IP-5 ship. Vendor-neutral MCP tool surface for execution lookup. Capsule URI column on the execution row makes "show me the proof" a one-click download.</li>
+  <li><strong>Phase 3:</strong> Multi-tenant trust DNS. Every agent gets its own ENS name; trust commitments behind each name (policy hash, signing key, deployer attestation) resolve from a single DNS-style query.</li>
+</ul>
+<p>
+  This isn't a replacement for either product. It's a clean composition
+  where each layer keeps doing what it's best at, and the contract
+  between them carries enough cryptographic proof to satisfy the most
+  paranoid auditor.
+</p>
+<p>
+  If you're shipping an agent today, you already have an unsolved
+  gate-then-execute problem. Start with the composition.
+</p>
+
+<p>
+  <strong>
+    <a href="https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026/blob/main/docs/proof/blog-keeperhub-composability.md">Full long-form version →</a>
+  </strong>
+</p>
+`;
+
 export const ARTICLES: Article[] = [
   {
     slug: "tier-architecture",
@@ -479,6 +616,14 @@ export const ARTICLES: Article[] = [
     reading_min: 22,
     audience: "ENS standards reviewers, ERC-8004 implementers, agent-platform architects",
     body_html: trustDnsManifestoHtml.trim(),
+  },
+  {
+    slug: "keeperhub-composability",
+    title: "Don't give your agent a wallet. Don't make KeeperHub guess what's authorized either.",
+    description: "Composing SBO3L's policy boundary with KeeperHub's execution layer. Why two products beat one monolith, the signed receipt as the contract, IP-1..IP-5, end-to-end demo, the 15 issues we filed, joint roadmap.",
+    reading_min: 8,
+    audience: "Agent-platform engineers + KeeperHub workflow authors evaluating end-to-end safety",
+    body_html: keeperhubComposabilityHtml.trim(),
   },
 ];
 

--- a/docs/proof/blog-keeperhub-composability.md
+++ b/docs/proof/blog-keeperhub-composability.md
@@ -1,0 +1,181 @@
+# Don't give your agent a wallet. Don't make KeeperHub guess what's authorized either.
+
+> **Composing SBO3L's policy boundary with KeeperHub's execution layer.**
+>
+> *For: agent-platform engineers + KeeperHub workflow authors evaluating end-to-end safety.*
+
+---
+
+A research agent sees a paid API endpoint, decides "this is worth $0.05," and reaches for a tool to fire the payment. Two things have to happen between intent and execution:
+
+1. **Decide:** is this payment authorized? Within budget? Recipient allowlisted? Right chain? Right risk class?
+2. **Execute:** translate the authorized intent into a signed transaction (or a webhook, or an x402 call) and dispatch it.
+
+Most "agent payment" stacks today try to do both in one product. SBO3L doesn't. KeeperHub doesn't. Together they form the cleanest composition we've shipped — a policy boundary that emits a signed receipt, and an execution layer that consumes the receipt and actually fires the call.
+
+This post walks through the composition: why two products beat one monolith, what the receipt contract between them looks like, and the five integration paths (IP-1..IP-5) that compose them tighter still. By the end you'll be able to wire `@sbo3l/langchain-keeperhub` into your own agent in five lines and reason about every byte of evidence the round-trip emits.
+
+---
+
+## 1. The composability story — agent intent → SBO3L decide → KH execute
+
+Why split the decision and the execution into two products?
+
+Because they have **different audiences** and **different operational contracts**.
+
+The decision layer is the boundary between "what the agent wants to do" and "what the operator allows the agent to do." Its audience is the operator: a CFO, a compliance officer, an SRE on call. They edit YAML to express budget caps, allowlist providers, set risk thresholds. They want the policy engine to be auditable, deterministic, and slow-moving. They want every decision logged in a tamper-evident way. They don't want it coupled to whichever execution backend is in fashion this quarter.
+
+The execution layer is the bridge between "an authorized payment intent" and "the rails it actually settles on." Its audience is the developer of the workflow: someone wiring KeeperHub up to a Stripe webhook, an x402 endpoint, a Uniswap router, a Discord bot. They want the execution layer to be flexible, fast-evolving, integration-rich. They want first-class support for the latest workflow runner, not a slow decision engine slowing them down.
+
+Bundle them and you compromise both. The decision engine starts shipping integrations to chase the latest payment rail. The execution layer starts adding policy DSLs to chase compliance reviews. Both products get worse at their core jobs.
+
+Split them and each can grow on its own clock — *if* the contract between them is right.
+
+---
+
+## 2. The signed receipt as the contract between layers
+
+The contract is a **signed PolicyReceipt**.
+
+When SBO3L decides on an APRP (Agent Payment Request Protocol body), it emits a 14-field receipt:
+
+```json
+{
+  "receipt_type": "sbo3l.policy_receipt.v1",
+  "version": 1,
+  "agent_id": "research-agent-01",
+  "decision": "allow",
+  "deny_code": null,
+  "matched_rule_id": "allow-low-risk-x402-keeperhub",
+  "request_hash": "c0bd2fab…",     // 32-byte SHA-256 of canonicalised APRP
+  "policy_hash": "e044f13c…",      // hash of the policy YAML that decided
+  "policy_version": 1,
+  "audit_event_id": "evt-01HTAW…",  // ULID into the hash-chained audit log
+  "execution_ref": null,           // populated by the executor on success
+  "issued_at": "2026-04-29T10:00:00Z",
+  "expires_at": null,
+  "signature": {
+    "algorithm": "ed25519",
+    "key_id": "decision-signer-v1",
+    "signature_hex": "1f…128 chars…"
+  }
+}
+```
+
+Three things about this receipt make it the right contract:
+
+1. **It's content-addressable.** The `request_hash` pins the exact APRP bytes that were decided on. KeeperHub can re-derive the hash from the body it receives and refuse to execute if it doesn't match. No "the agent edited the request between decision and execution" attack.
+
+2. **It's offline-verifiable.** Anyone with the policy signer's public key can verify the signature without contacting SBO3L. KH can verify before executing. An auditor reading the audit log months later can verify too. There's no "trust SBO3L" step.
+
+3. **It carries the audit pointer.** `audit_event_id` references a node in SBO3L's hash-chained Ed25519 audit log. KH can echo this ID back on its execution row, giving an auditor a single ID to walk both directions: the decision side and the execution side, end-to-end.
+
+This receipt is the only thing the two layers exchange. SBO3L doesn't know what KeeperHub's webhook URL is. KeeperHub doesn't know what policy YAML SBO3L is running. Each side evolves freely as long as the receipt schema holds.
+
+---
+
+## 3. The 5 IP paths (re-explained from scratch)
+
+Once you have a receipt-as-contract, the next question is: how tight can the composition get? Five paths, each independently shippable:
+
+**IP-1 — `sbo3l_*` upstream-proof envelope fields on the workflow webhook.**
+SBO3L's KH adapter posts the signed receipt's `request_hash`, `policy_hash`, `policy_version`, `audit_event_id`, and `signature_hex` as five optional `sbo3l_*` fields alongside whatever other body the workflow expects. KH stores them. An auditor reading a KH execution row sees the cryptographic link upstream without having to query SBO3L. Status today: **shipped on the SBO3L side** as `sbo3l_keeperhub_adapter::build_envelope`. Pending KH-side schema adoption (issue [KeeperHub/cli#50](https://github.com/KeeperHub/cli/issues/50)).
+
+**IP-2 — Public submission/result envelope JSON Schema.**
+A Draft 2020-12 schema that documents the bidirectional wire shape. Adapter authors stop reverse-engineering response payloads from `curl -v`. Status: filed as issue [KeeperHub/cli#48](https://github.com/KeeperHub/cli/issues/48); SBO3L's adapter validates against the schema once published.
+
+**IP-3 — `keeperhub.lookup_execution(execution_id)` MCP tool.**
+A symmetric MCP tool that lets a downstream auditor query an execution's status + run-log + sbo3l_* fields without raw HTTP plumbing. Status: **shipped on the SBO3L side** as `sbo3l.audit_lookup` in `sbo3l-mcp`; pending KH-side MCP tool definition (issue [KeeperHub/cli#49](https://github.com/KeeperHub/cli/issues/49)).
+
+**IP-4 — Standalone `sbo3l-keeperhub-adapter` Rust crate.**
+Any third-party agent framework can `cargo add sbo3l-keeperhub-adapter` and get a `GuardedExecutor` that posts the IP-1 envelope, with no transitive dependency on `sbo3l-server`, `sbo3l-policy`, or `sbo3l-storage`. Status: **shipped** at `crates/sbo3l-keeperhub-adapter/`, [live on crates.io at v1.2.0](https://crates.io/crates/sbo3l-keeperhub-adapter).
+
+**IP-5 — SBO3L Passport capsule URI on the execution row.**
+A single optional string column on KH's execution table — the URI to a self-contained verifiable bundle (APRP + receipt + audit segment + executor evidence + verification metadata). With this column, an auditor can reconstruct everything offline from one URL. Status: **capsule schema + verifier shipped** on the SBO3L side; pending KH-side column adoption.
+
+Stacking all five gives end-to-end offline auditability of every KeeperHub execution that flowed through SBO3L. An auditor with the right keys can reconstruct who authorized what, under which policy, when, and where the audit chain says it sits — without trusting any single party. Two different products, one verifiable trail.
+
+---
+
+## 4. End-to-end demo
+
+Five lines in TypeScript:
+
+```ts
+import { SBO3LClient } from "@sbo3l/sdk";
+import { sbo3lKeeperHubTool } from "@sbo3l/langchain-keeperhub";
+
+const client = new SBO3LClient({ endpoint: "http://localhost:8730" });
+const tool = sbo3lKeeperHubTool({ client });
+// pass `tool` (or wrap as DynamicTool) into your LangChain agent's tool list
+```
+
+What happens when the agent calls `tool.func(JSON.stringify(aprp))`:
+
+1. **POST to SBO3L daemon** at `/v1/payment-requests` with the APRP body
+2. **SBO3L decides** allow / deny / requires_human against the loaded policy + budget + nonce + provider trust list
+3. **On allow:** SBO3L's `executor_callback` hands the signed receipt to the daemon-side KeeperHub adapter (`SBO3L_KEEPERHUB_WEBHOOK_URL` + `SBO3L_KEEPERHUB_TOKEN` env-var-configured)
+4. **KH adapter POSTs the IP-1 envelope** to the workflow webhook, captures `executionId`
+5. **Tool returns** `{decision, kh_workflow_id_advisory, kh_execution_ref, audit_event_id, request_hash, policy_hash, deny_code}`
+
+The signed envelope on the wire (curl trace, real values redacted):
+
+```http
+POST /api/workflows/m4t4cnpmhv8qquce3bv3c/webhook HTTP/1.1
+Host: app.keeperhub.com
+Authorization: Bearer wfb_<token>
+Content-Type: application/json
+
+{
+  "agent_id": "research-agent-01",
+  "intent": "purchase_api_call",
+  "sbo3l_request_hash": "c0bd2fab…",
+  "sbo3l_policy_hash": "e044f13c…",
+  "sbo3l_policy_version": 1,
+  "sbo3l_audit_event_id": "evt-01HTAW…",
+  "sbo3l_signature_hex": "1f…"
+}
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{ "executionId": "kh-01HTAWX5K3R8YV9NQB7C6P2DGZ" }
+```
+
+That's the full round-trip. A single `curl` capture proves SBO3L decided, KH executed, and the receipt connects them.
+
+---
+
+## 5. The 15 GitHub issues — what we'd want KeeperHub to adopt
+
+Building the composition end-to-end surfaced 15 concrete, actionable asks on the KeeperHub side. We filed them all on [KeeperHub/cli](https://github.com/KeeperHub/cli/issues?q=is%3Aissue+author%3AB2JK-Industry):
+
+**Round 1 (#47–#51)** — couldn't-get-it-working frictions: token-prefix split, envelope schema, executionId lookup, sbo3l_* fields adoption, idempotency-key dedup.
+
+**Round 2 (#52–#56)** — post-integration concerns: HTTP error code catalog, public mock fixture suite, webhook timeout SLO publication, schema versioning headers, max payload size documentation.
+
+**Round 3 (#58–#62)** — production-grade reliability concerns: HMAC-SHA256 signature for reverse-direction webhooks, workflow versioning + back-compat policy, response envelope JSON Schema, rate-limiting headers, delivery guarantees documentation.
+
+Each issue carries a worked reproduction (`curl` invocation or unit test), a citation to the exact line in our adapter where the friction surfaces, and a proposed shape for the fix. Five of them have **companion draft PRs** on our repo showing the consumer-side adapter change ready to ship the day KH lands the upstream contract.
+
+The fastest unlock for the broader adapter ecosystem: **#48** (envelope schema, R1) + **#52** (error catalog, R2) + **#55** (schema-version header, R2). Three docs/platform changes that together unblock every subsequent adapter author.
+
+---
+
+## 6. Looking forward — joint product roadmap
+
+Post-hackathon, three directions worth pursuing together:
+
+**Phase 1 — IP-1 + IP-2 land on KeeperHub.** A workflow author can opt into the `sbo3l_*` envelope fields with one checkbox. The submission/result envelope JSON Schema is published. Adapters across the ecosystem (Devendra's `langchain-keeperhub`, ours, future ones) standardise on the schema instead of reverse-engineering it.
+
+**Phase 2 — IP-3 + IP-5 ship.** The MCP tool surface for `keeperhub.lookup_execution` lets agents and auditors query in a vendor-neutral way. The Passport capsule URI column on the execution row makes "show me the proof" a one-click download from the KH UI.
+
+**Phase 3 — Multi-tenant trust DNS.** Every agent that runs through SBO3L → KH gets its own ENS name (e.g. `research-agent-01.sbo3lagent.eth`). A workflow author looking at their execution log sees agent names, not opaque IDs. The trust commitments behind each name (policy hash, signing key, deployer attestation) are resolvable from a single DNS-style query.
+
+This isn't a replacement for either product. It's a clean composition where each layer keeps doing what it's best at, and the contract between them carries enough cryptographic proof to satisfy the most paranoid auditor.
+
+If you're shipping an agent today, you already have an unsolved gate-then-execute problem. Start with the composition. Compose more later.
+
+---
+
+*Written by Daniel Babjak ([@B2JK-Industry](https://github.com/B2JK-Industry)) for ETHGlobal Open Agents 2026. Companion to the [SBO3L → KeeperHub Builder Feedback submission](../submission/bounty-keeperhub-builder-feedback.md). Code: [`@sbo3l/langchain-keeperhub`](https://www.npmjs.com/package/@sbo3l/langchain-keeperhub) (npm), [`sbo3l-langchain-keeperhub`](https://pypi.org/project/sbo3l-langchain-keeperhub/) (PyPI — pending Trusted Publisher registration), [`sbo3l-keeperhub-adapter`](https://crates.io/crates/sbo3l-keeperhub-adapter) (crates.io). All 15 KH issues + 5 companion draft PRs catalogued in [docs/proof/kh-builder-feedback-2026-05-03.md](kh-builder-feedback-2026-05-03.md).*


### PR DESCRIPTION
## Summary
Closes the **KH-A1 amplifier** (joint blog with Luca on KeeperHub + SBO3L composability). Luca going dark for engineering questions per loop 5 intel — workaround is a SOLO post polished enough that he could co-sign post-submission.

**Title:** *Don't give your agent a wallet. Don't make KeeperHub guess what's authorized either. Composing SBO3L's policy boundary with KeeperHub's execution layer.*

**Length:** 1700 words (target 1500–2000) across 6 sections per the brief.

## What ships

| Surface | Path | Purpose |
|---|---|---|
| Marketing /learn page | `apps/marketing/src/data/learn-articles.ts` (new entry) | Renders at `/learn/keeperhub-composability` via the existing `[slug].astro` route. Same content collection as the other 6 articles. |
| Judge-facing markdown | `docs/proof/blog-keeperhub-composability.md` | Full 1700-word version for judges skimming `docs/`. Cross-links back to the kh-builder-feedback evidence doc. |

## Note on `.mdx` vs HTML-string-in-TS

The spec asked for `.mdx`, but the existing `/learn` collection deliberately uses HTML-string-in-TS — the file's own header comment explains the choice: *"Adding @astrojs/mdx for 4 articles is the wrong tradeoff — 28 KB of React + scheduler hydration just to render markdown."* I followed that pattern to stay consistent with the 6 neighbour articles and ship under the existing bundle budget. The full markdown lives at `docs/proof/blog-keeperhub-composability.md` for anyone who wants the source-of-truth.

## Sections

1. **The composability story** — agent intent → SBO3L decide → KH execute — why two products beat one monolith (different audiences, different operational contracts)
2. **The signed receipt as the contract** — three properties of `PolicyReceipt` (content-addressable, offline-verifiable, audit-pointer-carrying) that make it the right wire shape between the layers
3. **The 5 IP paths** — IP-1 envelope fields / IP-2 JSON Schema / IP-3 MCP tool / IP-4 standalone crate / IP-5 capsule URI — re-explained for a fresh reader
4. **End-to-end demo** — 5-line TS snippet + a real curl trace of the IP-1 envelope on the wire
5. **The 15 GitHub issues we filed** across 3 rounds — what we'd want KeeperHub to adopt + the 3 fastest ecosystem unlocks (#48 + #52 + #55)
6. **Looking forward** — joint product roadmap (Phase 1: IP-1+IP-2, Phase 2: IP-3+IP-5, Phase 3: multi-tenant trust DNS)

## Test plan
- [x] `apps/marketing && npm run build` → **48 pages** (was 47)
- [x] `/learn/keeperhub-composability` rendered with "Composing SBO3L's policy boundary" body present in HTML
- [x] `npm run typecheck` → 13 pre-existing errors, **0 new errors** in `learn-articles.ts`
- [x] All cross-links in the markdown (15 KH issues, 5 draft PRs, npm/PyPI/crates URLs) resolve

## Related
- #407 — round 1+2 KH-BF docs
- #456 — round 3 KH-BF (KH-BF-A3 closure, 5 more issues)
- [`@sbo3l/langchain-keeperhub`](https://www.npmjs.com/package/@sbo3l/langchain-keeperhub) (npm v1.2.0 live)
- [`sbo3l-keeperhub-adapter`](https://crates.io/crates/sbo3l-keeperhub-adapter) (crates.io v1.2.0 live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)