### PR TITLE
fix(self-review): Codex P1+P2 on R20 PRs #461 + #470

### DIFF
--- a/crates/sbo3l-core/tests/adversarial_capsule_fixtures.rs
+++ b/crates/sbo3l-core/tests/adversarial_capsule_fixtures.rs
@@ -34,8 +34,8 @@ fn corpus(name: &str) -> Value {
     p.push("test-corpus");
     p.push("passport");
     p.push(name);
-    let raw = std::fs::read_to_string(&p)
-        .unwrap_or_else(|e| panic!("read fixture {}: {e}", p.display()));
+    let raw =
+        std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read fixture {}: {e}", p.display()));
     serde_json::from_str(&raw).expect("fixture parses as JSON")
 }
 
@@ -60,7 +60,11 @@ fn corpus(name: &str) -> Value {
 fn v2_tampered_005_executor_evidence_drift_rejected_by_schema() {
     let v = corpus("v2_tampered_005_executor_evidence_drift.json");
     let err = verify_capsule(&v).expect_err("malformed executor_evidence must be rejected");
-    assert_eq!(err.code(), "capsule.schema_invalid", "unexpected error: {err}");
+    assert_eq!(
+        err.code(),
+        "capsule.schema_invalid",
+        "unexpected error: {err}"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sbo3l-server/tests/adversarial_http.rs
+++ b/crates/sbo3l-server/tests/adversarial_http.rs
@@ -61,7 +61,13 @@ async fn post_raw(
     let req = req.body(Body::from(body_bytes)).unwrap();
     let resp = app.oneshot(req).await.expect("server must not panic");
     let status = resp.status();
-    let bytes = resp.into_body().collect().await.unwrap().to_bytes().to_vec();
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes()
+        .to_vec();
     (status, bytes)
 }
 

--- a/docs/0g-integration.md
+++ b/docs/0g-integration.md
@@ -126,8 +126,8 @@ The backend also has a **`live_testnet_upload`** integration test gated behind
 
 ```bash
 ZEROG_TESTNET_LIVE=1 cargo test -p sbo3l-storage \
-  --test-threads=1 zerog_backend::tests::live_testnet_upload \
-  -- --nocapture
+  zerog_backend::tests::live_testnet_upload \
+  -- --test-threads=1 --nocapture
 ```
 
 ### Honest gaps

--- a/sdks/python/tests/test_sdk_conformance.py
+++ b/sdks/python/tests/test_sdk_conformance.py
@@ -52,7 +52,7 @@ def test_manifest_vector_count_pinned(manifest: dict) -> None:
     """Pin the corpus size — adding/removing a fixture must update
     both the manifest and this assertion together. Catches an
     accidental delete during refactors."""
-    assert len(manifest["vectors"]) == 19, (
+    assert len(manifest["vectors"]) == 24, (
         "manifest vector count drifted; update both the manifest and this constant"
     )
 

--- a/sdks/typescript/test/sdk_conformance.test.ts
+++ b/sdks/typescript/test/sdk_conformance.test.ts
@@ -63,7 +63,7 @@ describe("SDK conformance — TypeScript runner", () => {
   it("manifest vector count is pinned (sync with manifest.json)", () => {
     // Adding/removing a fixture must update both the manifest and
     // this assertion together.
-    expect(manifest.vectors.length).toBe(19);
+    expect(manifest.vectors.length).toBe(24);
   });
 
   it("typescript SDK matches every manifest vector (skipping known_drift)", () => {


### PR DESCRIPTION
## Summary

Two findings from Codex review on the R20 batch.

### P1 — TS + Python SDK conformance counts not synced (#470)

PR #470 expanded \`test-corpus/sdk-conformance/manifest.json\` from 19 to 24 vectors (added \`v2_tampered_005..009\`) and bumped the **Rust** conformance assertion to 24, but missed the parallel **TypeScript** and **Python** conformance suites. Their \`vectors.length == 19\` assertions made those CI jobs fail immediately.

- \`sdks/typescript/test/sdk_conformance.test.ts:66\`  19 → 24
- \`sdks/python/tests/test_sdk_conformance.py:55\`     19 → 24

Vectors 006-009 carry \`verify_ok: true\` (structural pass; only strict mode catches the tamper), so neither SDK needs a new \`known_drift\` entry — they handle the new fixtures the same way they handle 001-004.

### P2 — Wrong arg position in doc test command (#461)

\`docs/0g-integration.md\` showed \`cargo test -p sbo3l-storage --test-threads=1 ... -- --nocapture\`. \`--test-threads\` is a test-binary flag, not a Cargo flag — must come after the \`--\`. Operators trying to reproduce the live test path got \`unexpected argument '--test-threads'\` at step 1.

## Test plan
- [x] \`npx vitest run test/sdk_conformance.test.ts\` → 4/4 passed
- [x] \`python3 -m pytest tests/test_sdk_conformance.py::test_manifest_vector_count_pinned\` → 1 passed
- [x] Doc command reads correctly per Cargo's flag-vs-test-binary contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)