### PR TITLE
feat(i18n): SK + KO + JA — top 5 pages localised (trimmed pattern)

### DIFF
--- a/apps/marketing/src/i18n/en.json
+++ b/apps/marketing/src/i18n/en.json
@@ -6,13 +6,15 @@
     "cta_view_source": "View source",
     "cta_walk_demo": "Walk the demo",
     "cta_verify": "Verify a capsule yourself",
+    "cta_full_english": "Read full English version",
     "nav_features": "Features",
     "nav_proof": "Proof",
     "nav_demo": "Demo",
     "nav_docs": "Docs",
     "nav_github": "GitHub",
     "nav_quickstart": "Quickstart",
-    "footer_about": "SBO3L · ETHGlobal Open Agents 2026 submission"
+    "footer_about": "SBO3L · ETHGlobal Open Agents 2026 submission",
+    "partial_translation_note": "This translation covers only the headline sections. The full version with all technical detail is available in"
   },
   "index": {
     "lede": "SBO3L is the cryptographically verifiable trust layer for autonomous AI agents. Every action your agent takes — pay, swap, store, compute, coordinate — passes through SBO3L's policy boundary first. Output: a self-contained Passport capsule anyone can verify offline.",
@@ -32,6 +34,26 @@
   },
   "proof": {
     "h1": "Verify a Passport capsule",
-    "lede": "Paste or drop a capsule. All 6 strict-mode checks run in your browser via a WASM-compiled sbo3l-core. No data leaves the page — no upload, no API call, no analytics."
+    "lede": "Paste or drop a capsule. All 6 strict-mode checks run in your browser via a WASM-compiled sbo3l-core. No data leaves the page — no upload, no API call, no analytics.",
+    "section_what_checks": "What gets checked",
+    "what_checks_blurb": "A v2 capsule embeds the policy snapshot and audit segment. The verifier runs all 6 checks with no aux input: structural invariants, request hash recompute, policy hash recompute, receipt signature, audit chain, and audit event link. v1 capsules pass the structural and request-hash checks; the remaining four show as SKIPPED — that's an honest report, never a fake-OK."
+  },
+  "status": {
+    "h1": "What's live, what's mock, what's roadmap",
+    "lede": "An honest, surface-by-surface inventory of where SBO3L is end-to-end live, where the executor is mocked, and where the path is roadmap. Counters at the top match the rows below.",
+    "section_legend": "Legend",
+    "legend_blurb": "Each row is one user-facing surface. Live = end-to-end signed and verifiable. Mock = the contract or executor is intentionally a fake we own. Not yet = path designed, not yet wired."
+  },
+  "try_page": {
+    "h1": "Try SBO3L in 5 minutes",
+    "lede": "An eight-step sticky-scroll walkthrough: stand up the daemon, point an agent at it, watch a capsule emit, verify the capsule offline. No wallet, no API key, no SaaS account.",
+    "section_outcome": "What you walk away with",
+    "outcome_blurb": "By the end you have a running daemon, an agent making allowed and denied requests, and one signed Passport capsule on disk that you can hand to anyone for offline verification."
+  },
+  "keeperhub": {
+    "h1": "SBO3L × KeeperHub — guarded execution for cron agents",
+    "lede": "Drop SBO3L between any KeeperHub workflow and any cron agent. Every tick passes through the policy boundary; allowed ticks emit a signed Passport capsule that anyone can verify offline.",
+    "section_evidence": "Live evidence",
+    "evidence_blurb": "Workflow m4t4cnpmhv8qquce3bv3c on KeeperHub has been running cron ticks against the SBO3L policy boundary since April 2026. Five capsules from that run are downloadable on /kh-fleet — each verifies under all 6 strict-mode WASM checks on /proof."
   }
 }

--- a/apps/marketing/src/i18n/ja.json
+++ b/apps/marketing/src/i18n/ja.json
@@ -7,18 +7,57 @@
     "cta_view_source": "ソースを見る",
     "cta_walk_demo": "デモを見る",
     "cta_verify": "カプセルを自分で検証",
+    "cta_full_english": "完全な英語版を読む",
     "nav_features": "機能",
     "nav_proof": "証明",
     "nav_demo": "デモ",
     "nav_docs": "ドキュメント",
     "nav_github": "GitHub",
     "nav_quickstart": "クイックスタート",
-    "footer_about": "SBO3L · ETHGlobal Open Agents 2026 — 提出作品"
+    "footer_about": "SBO3L · ETHGlobal Open Agents 2026 — 提出作品",
+    "partial_translation_note": "この翻訳は主要セクションのみをカバーしています。すべての技術的詳細を含む完全版はこちらで入手可能です:"
   },
   "index": {
-    "lede": "SBO3L は自律型 AI エージェント向けの暗号学的に検証可能な信頼レイヤーです。エージェントが実行するすべてのアクション — 支払い、スワップ、ストレージ、計算、調整 — はまず SBO3L のポリシー境界を通過します。"
+    "lede": "SBO3L は自律型 AI エージェント向けの暗号学的に検証可能な信頼レイヤーです。エージェントが実行するすべてのアクション — 支払い、スワップ、ストレージ、計算、調整 — はまず SBO3L のポリシー境界を通過します。出力: 誰もがオフラインで検証できる自己完結型 Passport カプセル。",
+    "section_what_is": "SBO3L とは",
+    "section_what_blocks": "SBO3L がブロックするもの",
+    "section_evidence": "実稼働統合の証拠",
+    "section_arch": "アーキテクチャ",
+    "section_reproduce": "自分で再現する",
+    "section_resources": "リソース",
+    "what_is_blurb": "AI エージェント向けのローカル ポリシー + 予算 + 領収書 + 監査ファイアウォールを実装する Rust ワークスペース。許可 → スポンサー実行器へのルーティング (KeeperHub, Uniswap)。拒否 → 実行器は呼び出されません。すべての決定は、エージェントが公開した Ed25519 公開鍵のみを使って誰でもオフライン検証可能な Passport カプセルにラップできます。"
   },
   "submission": {
-    "h1": "自律型 AI エージェント向けの暗号学的に検証可能な信頼レイヤー。"
+    "eyebrow": "ETHGlobal Open Agents 2026 · 提出作品",
+    "h1": "自律型 AI エージェント向けの暗号学的に検証可能な信頼レイヤー。",
+    "judge_test_h2": "審査員テスト",
+    "judge_test_body": "上記のいかなる主張も、私たちの言葉だけで信じないでください。/proof にカプセルをドロップしてください。WebAssembly 検証器 — デーモン内部で動作する同じ Rust コードを wasm32 にコンパイルしたもの — が、ブラウザ内で 6 つの strict チェックすべてを実行します。アップロードなし、API 呼び出しなし、デーモンなし。6 つの緑色のチェック、または具体的な拒否理由。"
+  },
+  "proof": {
+    "h1": "Passport カプセルを検証",
+    "lede": "カプセルを貼り付けるかドロップしてください。6 つの strict モード チェックすべてが、WASM コンパイルされた sbo3l-core を介してブラウザ内で実行されます。データはページから一切出ません — アップロードなし、API 呼び出しなし、アナリティクスなし。",
+    "_TODO_JA_REVIEW": "Native Japanese reviewer: 'strict モード', 'WASM', 'Passport カプセル' kept in mixed Latin-Japanese (technical/brand terms).",
+    "section_what_checks": "検証される項目",
+    "what_checks_blurb": "v2 カプセルはポリシー スナップショットと監査セグメントを埋め込んでいます。検証器は補助入力なしに 6 つのチェックすべてを実行します: 構造的不変条件、リクエスト ハッシュ再計算、ポリシー ハッシュ再計算、領収書署名、監査チェーン、監査イベント リンク。v1 カプセルは構造とリクエスト ハッシュのチェックを通過し、残りの 4 つは SKIPPED として表示されます — これは誠実な報告であり、決して偽の OK ではありません。"
+  },
+  "status": {
+    "h1": "稼働中・モック・ロードマップ",
+    "lede": "表面ごとの誠実なインベントリ: SBO3L がエンドツーエンドで稼働している箇所、実行器がモックされている箇所、経路がロードマップである箇所。上部のカウンターは下の行と一致します。",
+    "section_legend": "凡例",
+    "legend_blurb": "各行は 1 つのユーザー向け表面です。Live = エンドツーエンドで署名され検証可能。Mock = 私たちが意図的に所有する偽のコントラクトまたは実行器。Not yet = 経路設計済み、未配線。",
+    "_TODO_JA_REVIEW": "Native Japanese reviewer: 'Live/Mock/Not yet' kept in English to mirror the truth-table headers."
+  },
+  "try_page": {
+    "h1": "5 分で SBO3L を試す",
+    "lede": "8 ステップの sticky-scroll ウォークスルー: デーモンを起動し、エージェントを向けさせ、カプセルが生成されるのを観察し、カプセルをオフライン検証する。ウォレットなし、API キーなし、SaaS アカウントなし。",
+    "section_outcome": "得られるもの",
+    "outcome_blurb": "終わると、稼働中のデーモン、許可と拒否のリクエストを行うエージェント、そして誰にでも渡してオフライン検証できる、ディスク上の署名済み Passport カプセル 1 つが手に入ります。"
+  },
+  "keeperhub": {
+    "h1": "SBO3L × KeeperHub — cron エージェント向けガード付き実行",
+    "lede": "任意の KeeperHub ワークフローと任意の cron エージェントの間に SBO3L を配置してください。すべてのティックがポリシー境界を通過します; 許可されたティックは、誰もがオフライン検証できる署名済み Passport カプセルを発行します。",
+    "section_evidence": "実稼働の証拠",
+    "evidence_blurb": "KeeperHub のワークフロー m4t4cnpmhv8qquce3bv3c は 2026 年 4 月から SBO3L のポリシー境界に対して cron ティックを実行してきました。その実行からの 5 つのカプセルが /kh-fleet でダウンロード可能です — 各カプセルは /proof の 6 つの strict モード WASM チェックすべてに合格します。",
+    "_TODO_JA_REVIEW": "Native Japanese reviewer: 'cron', 'ワークフロー', 'ティック' technical terms left as-is. 'KeeperHub' product name kept."
   }
 }

--- a/apps/marketing/src/i18n/ko.json
+++ b/apps/marketing/src/i18n/ko.json
@@ -7,13 +7,15 @@
     "cta_view_source": "소스 보기",
     "cta_walk_demo": "데모 둘러보기",
     "cta_verify": "캡슐 직접 검증하기",
+    "cta_full_english": "전체 영문 버전 읽기",
     "nav_features": "기능",
     "nav_proof": "증명",
     "nav_demo": "데모",
     "nav_docs": "문서",
     "nav_github": "GitHub",
     "nav_quickstart": "빠른 시작",
-    "footer_about": "SBO3L · ETHGlobal Open Agents 2026 제출작"
+    "footer_about": "SBO3L · ETHGlobal Open Agents 2026 제출작",
+    "partial_translation_note": "이 번역은 핵심 섹션만 다룹니다. 모든 기술 세부사항을 포함한 전체 버전은 다음에서 확인할 수 있습니다:"
   },
   "index": {
     "lede": "SBO3L은 자율 AI 에이전트를 위한 암호학적으로 검증 가능한 신뢰 계층입니다. 에이전트가 수행하는 모든 작업 — 결제, 스왑, 저장, 연산, 조정 — 은 먼저 SBO3L의 정책 경계를 통과합니다. 결과물: 누구나 오프라인에서 검증할 수 있는 자기 완결형 Passport 캡슐.",
@@ -34,6 +36,28 @@
   "proof": {
     "h1": "Passport 캡슐 검증",
     "lede": "캡슐을 붙여넣거나 끌어다 놓으세요. 6가지 strict 모드 검사 모두 WASM으로 컴파일된 sbo3l-core를 통해 브라우저에서 실행됩니다. 어떤 데이터도 페이지를 떠나지 않습니다 — 업로드 없음, API 호출 없음, 분석 없음.",
-    "_TODO_KO_REVIEW": "Native Korean reviewer: 'strict 모드' is left in English-Korean mix; consider '엄격 모드' for full Korean. Same for 'WASM' (technical term, leave) and 'Passport 캡슐' (brand term, leave)."
+    "_TODO_KO_REVIEW": "Native Korean reviewer: 'strict 모드' is left in English-Korean mix; consider '엄격 모드' for full Korean. Same for 'WASM' (technical term, leave) and 'Passport 캡슐' (brand term, leave).",
+    "section_what_checks": "검증 항목",
+    "what_checks_blurb": "v2 캡슐은 정책 스냅샷과 감사 세그먼트를 포함합니다. 검증기는 보조 입력 없이 6가지 검사를 모두 실행합니다: 구조적 불변성, 요청 해시 재계산, 정책 해시 재계산, 영수증 서명, 감사 체인, 감사 이벤트 링크. v1 캡슐은 구조 검사와 요청-해시 검사를 통과하며, 나머지 4개는 SKIPPED로 표시됩니다 — 이는 정직한 보고이며 결코 거짓 OK가 아닙니다."
+  },
+  "status": {
+    "h1": "라이브, 모의(mock), 로드맵",
+    "lede": "표면별 정직한 인벤토리: SBO3L이 엔드투엔드로 라이브인 곳, 실행기가 모의된 곳, 경로가 로드맵인 곳. 상단 카운터는 아래 행과 일치합니다.",
+    "section_legend": "범례",
+    "legend_blurb": "각 행은 하나의 사용자 대면 표면입니다. Live = 엔드투엔드 서명되고 검증 가능. Mock = 우리가 의도적으로 만든 가짜 계약 또는 실행기. Not yet = 경로 설계됨, 아직 연결되지 않음.",
+    "_TODO_KO_REVIEW": "Native Korean reviewer: 'Live/Mock/Not yet' kept in English to mirror the truth-table headers."
+  },
+  "try_page": {
+    "h1": "5분 안에 SBO3L 시도하기",
+    "lede": "8단계 sticky-scroll 워크스루: 데몬 실행, 에이전트를 가리키기, 캡슐 발생 관찰, 캡슐을 오프라인 검증. 지갑 없음, API 키 없음, SaaS 계정 없음.",
+    "section_outcome": "얻게 되는 것",
+    "outcome_blurb": "끝나면 실행 중인 데몬, 허용 및 거부된 요청을 만드는 에이전트, 그리고 누구에게나 건네 오프라인 검증할 수 있는 디스크 상의 서명된 Passport 캡슐 1개를 갖게 됩니다."
+  },
+  "keeperhub": {
+    "h1": "SBO3L × KeeperHub — cron 에이전트를 위한 가드된 실행",
+    "lede": "임의의 KeeperHub 워크플로우와 임의의 cron 에이전트 사이에 SBO3L을 배치하세요. 모든 틱이 정책 경계를 통과합니다; 허용된 틱은 누구나 오프라인 검증할 수 있는 서명된 Passport 캡슐을 발생시킵니다.",
+    "section_evidence": "라이브 증거",
+    "evidence_blurb": "KeeperHub의 워크플로우 m4t4cnpmhv8qquce3bv3c는 2026년 4월부터 SBO3L 정책 경계에 대해 cron 틱을 실행해왔습니다. 해당 실행의 5개 캡슐을 /kh-fleet에서 다운로드할 수 있습니다 — 각 캡슐은 /proof의 6가지 strict 모드 WASM 검사를 모두 통과합니다.",
+    "_TODO_KO_REVIEW": "Native Korean reviewer: 'cron', 'workflow', 'tick' technical terms left in English. 'KeeperHub' is a product name and stays."
   }
 }

--- a/apps/marketing/src/i18n/sk.json
+++ b/apps/marketing/src/i18n/sk.json
@@ -6,13 +6,15 @@
     "cta_view_source": "Pozrieť zdroj",
     "cta_walk_demo": "Prejsť demo",
     "cta_verify": "Overte si kapsulu",
+    "cta_full_english": "Prečítať plnú anglickú verziu",
     "nav_features": "Funkcie",
     "nav_proof": "Dôkaz",
     "nav_demo": "Demo",
     "nav_docs": "Dokumentácia",
     "nav_github": "GitHub",
     "nav_quickstart": "Rýchly štart",
-    "footer_about": "SBO3L · ETHGlobal Open Agents 2026 — odovzdaný projekt"
+    "footer_about": "SBO3L · ETHGlobal Open Agents 2026 — odovzdaný projekt",
+    "partial_translation_note": "Tento preklad pokrýva iba kľúčové sekcie. Plná verzia so všetkými technickými detailmi je dostupná v"
   },
   "index": {
     "lede": "SBO3L je kryptograficky overiteľná dôveryhodná vrstva pre autonómnych AI agentov. Každá akcia, ktorú agent vykoná — platba, swap, uloženie, výpočet, koordinácia — najprv prejde cez politickú hranicu SBO3L. Výstup: samostatná Passport kapsula, ktorú ktokoľvek overí offline.",
@@ -32,6 +34,26 @@
   },
   "proof": {
     "h1": "Overiť Passport kapsulu",
-    "lede": "Vložte alebo pretiahnite kapsulu. Všetkých 6 striktných kontrol prebieha vo vašom prehliadači cez WASM-kompilovaný sbo3l-core. Žiadne dáta neopúšťajú stránku — bez uploadov, bez API volaní, bez analytiky."
+    "lede": "Vložte alebo pretiahnite kapsulu. Všetkých 6 striktných kontrol prebieha vo vašom prehliadači cez WASM-kompilovaný sbo3l-core. Žiadne dáta neopúšťajú stránku — bez uploadov, bez API volaní, bez analytiky.",
+    "section_what_checks": "Čo sa kontroluje",
+    "what_checks_blurb": "Kapsula v2 obsahuje snímku politiky a audit segment. Overovač spúšťa všetkých 6 kontrol bez pomocných vstupov: štrukturálne invarianty, prepočet hash požiadavky, prepočet hash politiky, podpis potvrdenky, audit reťaz a prepojenie audit udalosti. Kapsuly v1 prejdú štrukturálnou a request-hash kontrolou; zvyšné štyri sú označené ako SKIPPED — to je čestné hlásenie, nikdy falošné OK."
+  },
+  "status": {
+    "h1": "Čo je živé, čo mock, čo roadmap",
+    "lede": "Čestná inventarizácia povrch-po-povrchu: kde je SBO3L kompletne live, kde je vykonávateľ mockovaný a kde je cesta roadmap. Počítadlá hore zodpovedajú riadkom dolu.",
+    "section_legend": "Legenda",
+    "legend_blurb": "Každý riadok je jeden užívateľsky viditeľný povrch. Live = end-to-end podpísané a overiteľné. Mock = kontrakt alebo vykonávateľ je zámerne fake, ktorý vlastníme. Zatiaľ nie = cesta navrhnutá, ešte nie zapojená."
+  },
+  "try_page": {
+    "h1": "Vyskúšajte SBO3L za 5 minút",
+    "lede": "Osemkrokový sticky-scroll návod: spustite daemon, namierte naň agenta, sledujte vznik kapsuly, overte kapsulu offline. Bez peňaženky, bez API kľúča, bez SaaS účtu.",
+    "section_outcome": "Čo si odnesiete",
+    "outcome_blurb": "Na konci máte bežiaci daemon, agenta robiaceho povolené aj zamietnuté požiadavky a jednu podpísanú Passport kapsulu na disku, ktorú môžete dať komukoľvek na offline overenie."
+  },
+  "keeperhub": {
+    "h1": "SBO3L × KeeperHub — strážená exekúcia pre cron agentov",
+    "lede": "Vložte SBO3L medzi ľubovoľný KeeperHub workflow a ľubovoľného cron agenta. Každý tick prejde cez politickú hranicu; povolené ticky vyrábajú podpísanú Passport kapsulu, ktorú ktokoľvek overí offline.",
+    "section_evidence": "Živé dôkazy",
+    "evidence_blurb": "Workflow m4t4cnpmhv8qquce3bv3c na KeeperHub beží cron tickmi cez politickú hranicu SBO3L od apríla 2026. Päť kapsúl z tohto behu je stiahnuteľných na /kh-fleet — každá prejde všetkými 6 striktnými WASM kontrolami na /proof."
   }
 }

--- a/apps/marketing/src/pages/ja/index.astro
+++ b/apps/marketing/src/pages/ja/index.astro
@@ -1,0 +1,54 @@
+---
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import NumberStrip from "~/components/NumberStrip.astro";
+import ArchDiagram from "~/components/ArchDiagram.astro";
+import LocaleSwitcher from "~/components/LocaleSwitcher.astro";
+import { t } from "~/i18n";
+
+const locale = "ja" as const;
+const githubRepoUrl = "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026";
+---
+<BaseLayout
+  title={`SBO3L — ${t("common.tagline_part1", locale)} ${t("common.tagline_part2", locale)}`}
+  lang="ja"
+>
+  <section class="hero">
+    <LocaleSwitcher current="ja" basePath="/" />
+    <h1>{t("common.tagline_part1", locale)}<br />{t("common.tagline_part2", locale)}</h1>
+    <p class="lede">{t("index.lede", locale)}</p>
+    <div class="cta">
+      <a class="btn primary" href={`${githubRepoUrl}/blob/main/QUICKSTART.md`}>{t("common.cta_start", locale)}</a>
+      <a class="btn ghost" href={githubRepoUrl}>{t("common.cta_view_source", locale)}</a>
+    </div>
+  </section>
+
+  <NumberStrip />
+
+  <section class="panel">
+    <h2>{t("index.section_what_is", locale)}</h2>
+    <p>{t("index.what_is_blurb", locale)}</p>
+  </section>
+
+  <section class="panel">
+    <h2>{t("index.section_arch", locale)}</h2>
+    <ArchDiagram size="compact" />
+  </section>
+
+  <section class="panel">
+    <p>
+      <em>{t("common.partial_translation_note", locale)} <a href="/">{t("common.cta_full_english", locale)}</a>.</em>
+    </p>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero { max-width: var(--max); margin: 4em auto 3em; padding: 0 1.5em; }
+  .hero h1 {
+    font-size: var(--fs-4); font-weight: 700; line-height: 1.3;
+    margin: 0.5em 0 0.7em;
+    /* Japanese glyphs render slightly larger; tighten line-height vs en/sk */
+    word-break: keep-all;
+  }
+  .hero .lede { font-size: var(--fs-2); color: var(--muted); margin-bottom: 1.5em; max-width: 700px; line-height: 1.7; }
+  .cta { display: flex; gap: 1em; flex-wrap: wrap; }
+</style>

--- a/apps/marketing/src/pages/ja/proof.astro
+++ b/apps/marketing/src/pages/ja/proof.astro
@@ -1,0 +1,39 @@
+---
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import LocaleSwitcher from "~/components/LocaleSwitcher.astro";
+import { t } from "~/i18n";
+
+const locale = "ja" as const;
+---
+<BaseLayout
+  title={`SBO3L — ${t("proof.h1", locale)}`}
+  description={t("proof.lede", locale)}
+  lang="ja"
+>
+  <section class="hero">
+    <LocaleSwitcher current="ja" basePath="/proof" />
+    <h1>{t("proof.h1", locale)}</h1>
+    <p class="lede">{t("proof.lede", locale)}</p>
+    <div class="cta">
+      <a class="btn primary" href="/proof">{t("common.cta_verify", locale)}</a>
+    </div>
+  </section>
+
+  <section class="panel">
+    <h2>{t("proof.section_what_checks", locale)}</h2>
+    <p>{t("proof.what_checks_blurb", locale)}</p>
+  </section>
+
+  <section class="panel">
+    <p>
+      <em>{t("common.partial_translation_note", locale)} <a href="/proof">{t("common.cta_full_english", locale)}</a>.</em>
+    </p>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero { max-width: var(--max); margin: 4em auto 3em; padding: 0 1.5em; }
+  .hero h1 { font-size: var(--fs-4); font-weight: 700; line-height: 1.3; margin: 0.5em 0 0.7em; word-break: keep-all; }
+  .hero .lede { font-size: var(--fs-2); color: var(--muted); margin-bottom: 1.5em; max-width: 700px; line-height: 1.7; }
+  .cta { display: flex; gap: 1em; flex-wrap: wrap; }
+</style>

--- a/apps/marketing/src/pages/ja/status.astro
+++ b/apps/marketing/src/pages/ja/status.astro
@@ -1,0 +1,35 @@
+---
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import LocaleSwitcher from "~/components/LocaleSwitcher.astro";
+import { t } from "~/i18n";
+
+const locale = "ja" as const;
+---
+<BaseLayout
+  title={`SBO3L — ${t("status.h1", locale)}`}
+  description={t("status.lede", locale)}
+  lang="ja"
+>
+  <section class="hero">
+    <LocaleSwitcher current="ja" basePath="/status" />
+    <h1>{t("status.h1", locale)}</h1>
+    <p class="lede">{t("status.lede", locale)}</p>
+  </section>
+
+  <section class="panel">
+    <h2>{t("status.section_legend", locale)}</h2>
+    <p>{t("status.legend_blurb", locale)}</p>
+  </section>
+
+  <section class="panel">
+    <p>
+      <em>{t("common.partial_translation_note", locale)} <a href="/status">{t("common.cta_full_english", locale)}</a>.</em>
+    </p>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero { max-width: var(--max); margin: 4em auto 3em; padding: 0 1.5em; }
+  .hero h1 { font-size: var(--fs-4); font-weight: 700; line-height: 1.3; margin: 0.5em 0 0.7em; word-break: keep-all; }
+  .hero .lede { font-size: var(--fs-2); color: var(--muted); margin-bottom: 1.5em; max-width: 700px; line-height: 1.7; }
+</style>

--- a/apps/marketing/src/pages/ja/submission/keeperhub.astro
+++ b/apps/marketing/src/pages/ja/submission/keeperhub.astro
@@ -1,0 +1,40 @@
+---
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import LocaleSwitcher from "~/components/LocaleSwitcher.astro";
+import { t } from "~/i18n";
+
+const locale = "ja" as const;
+---
+<BaseLayout
+  title={`SBO3L — ${t("keeperhub.h1", locale)}`}
+  description={t("keeperhub.lede", locale)}
+  lang="ja"
+>
+  <section class="hero">
+    <LocaleSwitcher current="ja" basePath="/submission/keeperhub" />
+    <h1>{t("keeperhub.h1", locale)}</h1>
+    <p class="lede">{t("keeperhub.lede", locale)}</p>
+    <div class="cta">
+      <a class="btn primary" href="/kh-fleet">/kh-fleet →</a>
+      <a class="btn ghost" href="/proof">/proof →</a>
+    </div>
+  </section>
+
+  <section class="panel">
+    <h2>{t("keeperhub.section_evidence", locale)}</h2>
+    <p>{t("keeperhub.evidence_blurb", locale)}</p>
+  </section>
+
+  <section class="panel">
+    <p>
+      <em>{t("common.partial_translation_note", locale)} <a href="/submission/keeperhub">{t("common.cta_full_english", locale)}</a>.</em>
+    </p>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero { max-width: var(--max); margin: 4em auto 3em; padding: 0 1.5em; }
+  .hero h1 { font-size: var(--fs-4); font-weight: 700; line-height: 1.3; margin: 0.5em 0 0.7em; word-break: keep-all; }
+  .hero .lede { font-size: var(--fs-2); color: var(--muted); margin-bottom: 1.5em; max-width: 700px; line-height: 1.7; }
+  .cta { display: flex; gap: 1em; flex-wrap: wrap; }
+</style>

--- a/apps/marketing/src/pages/ja/try.astro
+++ b/apps/marketing/src/pages/ja/try.astro
@@ -1,0 +1,39 @@
+---
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import LocaleSwitcher from "~/components/LocaleSwitcher.astro";
+import { t } from "~/i18n";
+
+const locale = "ja" as const;
+---
+<BaseLayout
+  title={`SBO3L — ${t("try_page.h1", locale)}`}
+  description={t("try_page.lede", locale)}
+  lang="ja"
+>
+  <section class="hero">
+    <LocaleSwitcher current="ja" basePath="/try" />
+    <h1>{t("try_page.h1", locale)}</h1>
+    <p class="lede">{t("try_page.lede", locale)}</p>
+    <div class="cta">
+      <a class="btn primary" href="/try">{t("common.cta_walk_demo", locale)}</a>
+    </div>
+  </section>
+
+  <section class="panel">
+    <h2>{t("try_page.section_outcome", locale)}</h2>
+    <p>{t("try_page.outcome_blurb", locale)}</p>
+  </section>
+
+  <section class="panel">
+    <p>
+      <em>{t("common.partial_translation_note", locale)} <a href="/try">{t("common.cta_full_english", locale)}</a>.</em>
+    </p>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero { max-width: var(--max); margin: 4em auto 3em; padding: 0 1.5em; }
+  .hero h1 { font-size: var(--fs-4); font-weight: 700; line-height: 1.3; margin: 0.5em 0 0.7em; word-break: keep-all; }
+  .hero .lede { font-size: var(--fs-2); color: var(--muted); margin-bottom: 1.5em; max-width: 700px; line-height: 1.7; }
+  .cta { display: flex; gap: 1em; flex-wrap: wrap; }
+</style>

--- a/apps/marketing/src/pages/ko/proof.astro
+++ b/apps/marketing/src/pages/ko/proof.astro
@@ -1,0 +1,39 @@
+---
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import LocaleSwitcher from "~/components/LocaleSwitcher.astro";
+import { t } from "~/i18n";
+
+const locale = "ko" as const;
+---
+<BaseLayout
+  title={`SBO3L — ${t("proof.h1", locale)}`}
+  description={t("proof.lede", locale)}
+  lang="ko"
+>
+  <section class="hero">
+    <LocaleSwitcher current="ko" basePath="/proof" />
+    <h1>{t("proof.h1", locale)}</h1>
+    <p class="lede">{t("proof.lede", locale)}</p>
+    <div class="cta">
+      <a class="btn primary" href="/proof">{t("common.cta_verify", locale)}</a>
+    </div>
+  </section>
+
+  <section class="panel">
+    <h2>{t("proof.section_what_checks", locale)}</h2>
+    <p>{t("proof.what_checks_blurb", locale)}</p>
+  </section>
+
+  <section class="panel">
+    <p>
+      <em>{t("common.partial_translation_note", locale)} <a href="/proof">{t("common.cta_full_english", locale)}</a>.</em>
+    </p>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero { max-width: var(--max); margin: 4em auto 3em; padding: 0 1.5em; }
+  .hero h1 { font-size: var(--fs-4); font-weight: 700; line-height: 1.3; margin: 0.5em 0 0.7em; word-break: keep-all; }
+  .hero .lede { font-size: var(--fs-2); color: var(--muted); margin-bottom: 1.5em; max-width: 700px; line-height: 1.6; }
+  .cta { display: flex; gap: 1em; flex-wrap: wrap; }
+</style>

--- a/apps/marketing/src/pages/ko/status.astro
+++ b/apps/marketing/src/pages/ko/status.astro
@@ -1,0 +1,35 @@
+---
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import LocaleSwitcher from "~/components/LocaleSwitcher.astro";
+import { t } from "~/i18n";
+
+const locale = "ko" as const;
+---
+<BaseLayout
+  title={`SBO3L — ${t("status.h1", locale)}`}
+  description={t("status.lede", locale)}
+  lang="ko"
+>
+  <section class="hero">
+    <LocaleSwitcher current="ko" basePath="/status" />
+    <h1>{t("status.h1", locale)}</h1>
+    <p class="lede">{t("status.lede", locale)}</p>
+  </section>
+
+  <section class="panel">
+    <h2>{t("status.section_legend", locale)}</h2>
+    <p>{t("status.legend_blurb", locale)}</p>
+  </section>
+
+  <section class="panel">
+    <p>
+      <em>{t("common.partial_translation_note", locale)} <a href="/status">{t("common.cta_full_english", locale)}</a>.</em>
+    </p>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero { max-width: var(--max); margin: 4em auto 3em; padding: 0 1.5em; }
+  .hero h1 { font-size: var(--fs-4); font-weight: 700; line-height: 1.3; margin: 0.5em 0 0.7em; word-break: keep-all; }
+  .hero .lede { font-size: var(--fs-2); color: var(--muted); margin-bottom: 1.5em; max-width: 700px; line-height: 1.6; }
+</style>

--- a/apps/marketing/src/pages/ko/submission/keeperhub.astro
+++ b/apps/marketing/src/pages/ko/submission/keeperhub.astro
@@ -1,0 +1,40 @@
+---
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import LocaleSwitcher from "~/components/LocaleSwitcher.astro";
+import { t } from "~/i18n";
+
+const locale = "ko" as const;
+---
+<BaseLayout
+  title={`SBO3L — ${t("keeperhub.h1", locale)}`}
+  description={t("keeperhub.lede", locale)}
+  lang="ko"
+>
+  <section class="hero">
+    <LocaleSwitcher current="ko" basePath="/submission/keeperhub" />
+    <h1>{t("keeperhub.h1", locale)}</h1>
+    <p class="lede">{t("keeperhub.lede", locale)}</p>
+    <div class="cta">
+      <a class="btn primary" href="/kh-fleet">/kh-fleet →</a>
+      <a class="btn ghost" href="/proof">/proof →</a>
+    </div>
+  </section>
+
+  <section class="panel">
+    <h2>{t("keeperhub.section_evidence", locale)}</h2>
+    <p>{t("keeperhub.evidence_blurb", locale)}</p>
+  </section>
+
+  <section class="panel">
+    <p>
+      <em>{t("common.partial_translation_note", locale)} <a href="/submission/keeperhub">{t("common.cta_full_english", locale)}</a>.</em>
+    </p>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero { max-width: var(--max); margin: 4em auto 3em; padding: 0 1.5em; }
+  .hero h1 { font-size: var(--fs-4); font-weight: 700; line-height: 1.3; margin: 0.5em 0 0.7em; word-break: keep-all; }
+  .hero .lede { font-size: var(--fs-2); color: var(--muted); margin-bottom: 1.5em; max-width: 700px; line-height: 1.6; }
+  .cta { display: flex; gap: 1em; flex-wrap: wrap; }
+</style>

--- a/apps/marketing/src/pages/ko/try.astro
+++ b/apps/marketing/src/pages/ko/try.astro
@@ -1,0 +1,39 @@
+---
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import LocaleSwitcher from "~/components/LocaleSwitcher.astro";
+import { t } from "~/i18n";
+
+const locale = "ko" as const;
+---
+<BaseLayout
+  title={`SBO3L — ${t("try_page.h1", locale)}`}
+  description={t("try_page.lede", locale)}
+  lang="ko"
+>
+  <section class="hero">
+    <LocaleSwitcher current="ko" basePath="/try" />
+    <h1>{t("try_page.h1", locale)}</h1>
+    <p class="lede">{t("try_page.lede", locale)}</p>
+    <div class="cta">
+      <a class="btn primary" href="/try">{t("common.cta_walk_demo", locale)}</a>
+    </div>
+  </section>
+
+  <section class="panel">
+    <h2>{t("try_page.section_outcome", locale)}</h2>
+    <p>{t("try_page.outcome_blurb", locale)}</p>
+  </section>
+
+  <section class="panel">
+    <p>
+      <em>{t("common.partial_translation_note", locale)} <a href="/try">{t("common.cta_full_english", locale)}</a>.</em>
+    </p>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero { max-width: var(--max); margin: 4em auto 3em; padding: 0 1.5em; }
+  .hero h1 { font-size: var(--fs-4); font-weight: 700; line-height: 1.3; margin: 0.5em 0 0.7em; word-break: keep-all; }
+  .hero .lede { font-size: var(--fs-2); color: var(--muted); margin-bottom: 1.5em; max-width: 700px; line-height: 1.6; }
+  .cta { display: flex; gap: 1em; flex-wrap: wrap; }
+</style>

--- a/apps/marketing/src/pages/sk/proof.astro
+++ b/apps/marketing/src/pages/sk/proof.astro
@@ -1,0 +1,38 @@
+---
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import LocaleSwitcher from "~/components/LocaleSwitcher.astro";
+import { t } from "~/i18n";
+
+const locale = "sk" as const;
+---
+<BaseLayout
+  title={`SBO3L — ${t("proof.h1", locale)}`}
+  description={t("proof.lede", locale)}
+>
+  <section class="hero">
+    <LocaleSwitcher current="sk" basePath="/proof" />
+    <h1>{t("proof.h1", locale)}</h1>
+    <p class="lede">{t("proof.lede", locale)}</p>
+    <div class="cta">
+      <a class="btn primary" href="/proof">{t("common.cta_verify", locale)}</a>
+    </div>
+  </section>
+
+  <section class="panel">
+    <h2>{t("proof.section_what_checks", locale)}</h2>
+    <p>{t("proof.what_checks_blurb", locale)}</p>
+  </section>
+
+  <section class="panel">
+    <p>
+      <em>{t("common.partial_translation_note", locale)} <a href="/proof">{t("common.cta_full_english", locale)}</a>.</em>
+    </p>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero { max-width: var(--max); margin: 4em auto 3em; padding: 0 1.5em; }
+  .hero h1 { font-size: var(--fs-4); font-weight: 700; line-height: 1.2; margin: 0.5em 0 0.7em; }
+  .hero .lede { font-size: var(--fs-2); color: var(--muted); margin-bottom: 1.5em; max-width: 700px; }
+  .cta { display: flex; gap: 1em; flex-wrap: wrap; }
+</style>

--- a/apps/marketing/src/pages/sk/status.astro
+++ b/apps/marketing/src/pages/sk/status.astro
@@ -1,0 +1,34 @@
+---
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import LocaleSwitcher from "~/components/LocaleSwitcher.astro";
+import { t } from "~/i18n";
+
+const locale = "sk" as const;
+---
+<BaseLayout
+  title={`SBO3L — ${t("status.h1", locale)}`}
+  description={t("status.lede", locale)}
+>
+  <section class="hero">
+    <LocaleSwitcher current="sk" basePath="/status" />
+    <h1>{t("status.h1", locale)}</h1>
+    <p class="lede">{t("status.lede", locale)}</p>
+  </section>
+
+  <section class="panel">
+    <h2>{t("status.section_legend", locale)}</h2>
+    <p>{t("status.legend_blurb", locale)}</p>
+  </section>
+
+  <section class="panel">
+    <p>
+      <em>{t("common.partial_translation_note", locale)} <a href="/status">{t("common.cta_full_english", locale)}</a>.</em>
+    </p>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero { max-width: var(--max); margin: 4em auto 3em; padding: 0 1.5em; }
+  .hero h1 { font-size: var(--fs-4); font-weight: 700; line-height: 1.2; margin: 0.5em 0 0.7em; }
+  .hero .lede { font-size: var(--fs-2); color: var(--muted); margin-bottom: 1.5em; max-width: 700px; }
+</style>

--- a/apps/marketing/src/pages/sk/submission/keeperhub.astro
+++ b/apps/marketing/src/pages/sk/submission/keeperhub.astro
@@ -1,0 +1,39 @@
+---
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import LocaleSwitcher from "~/components/LocaleSwitcher.astro";
+import { t } from "~/i18n";
+
+const locale = "sk" as const;
+---
+<BaseLayout
+  title={`SBO3L — ${t("keeperhub.h1", locale)}`}
+  description={t("keeperhub.lede", locale)}
+>
+  <section class="hero">
+    <LocaleSwitcher current="sk" basePath="/submission/keeperhub" />
+    <h1>{t("keeperhub.h1", locale)}</h1>
+    <p class="lede">{t("keeperhub.lede", locale)}</p>
+    <div class="cta">
+      <a class="btn primary" href="/kh-fleet">/kh-fleet →</a>
+      <a class="btn ghost" href="/proof">/proof →</a>
+    </div>
+  </section>
+
+  <section class="panel">
+    <h2>{t("keeperhub.section_evidence", locale)}</h2>
+    <p>{t("keeperhub.evidence_blurb", locale)}</p>
+  </section>
+
+  <section class="panel">
+    <p>
+      <em>{t("common.partial_translation_note", locale)} <a href="/submission/keeperhub">{t("common.cta_full_english", locale)}</a>.</em>
+    </p>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero { max-width: var(--max); margin: 4em auto 3em; padding: 0 1.5em; }
+  .hero h1 { font-size: var(--fs-4); font-weight: 700; line-height: 1.2; margin: 0.5em 0 0.7em; }
+  .hero .lede { font-size: var(--fs-2); color: var(--muted); margin-bottom: 1.5em; max-width: 700px; }
+  .cta { display: flex; gap: 1em; flex-wrap: wrap; }
+</style>

--- a/apps/marketing/src/pages/sk/try.astro
+++ b/apps/marketing/src/pages/sk/try.astro
@@ -1,0 +1,38 @@
+---
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import LocaleSwitcher from "~/components/LocaleSwitcher.astro";
+import { t } from "~/i18n";
+
+const locale = "sk" as const;
+---
+<BaseLayout
+  title={`SBO3L — ${t("try_page.h1", locale)}`}
+  description={t("try_page.lede", locale)}
+>
+  <section class="hero">
+    <LocaleSwitcher current="sk" basePath="/try" />
+    <h1>{t("try_page.h1", locale)}</h1>
+    <p class="lede">{t("try_page.lede", locale)}</p>
+    <div class="cta">
+      <a class="btn primary" href="/try">{t("common.cta_walk_demo", locale)}</a>
+    </div>
+  </section>
+
+  <section class="panel">
+    <h2>{t("try_page.section_outcome", locale)}</h2>
+    <p>{t("try_page.outcome_blurb", locale)}</p>
+  </section>
+
+  <section class="panel">
+    <p>
+      <em>{t("common.partial_translation_note", locale)} <a href="/try">{t("common.cta_full_english", locale)}</a>.</em>
+    </p>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero { max-width: var(--max); margin: 4em auto 3em; padding: 0 1.5em; }
+  .hero h1 { font-size: var(--fs-4); font-weight: 700; line-height: 1.2; margin: 0.5em 0 0.7em; }
+  .hero .lede { font-size: var(--fs-2); color: var(--muted); margin-bottom: 1.5em; max-width: 700px; }
+  .cta { display: flex; gap: 1em; flex-wrap: wrap; }
+</style>


### PR DESCRIPTION
## Summary

R22 PR1. Brings SK + KO + JA from "homepage only, partial" to **top 5 judge-visible pages, trimmed-translation pattern** matching the existing \`/sk/index.astro\` + \`/ko/index.astro\` shape.

## Pages added (13 total)

| Locale | New pages |
|---|---|
| SK | proof, status, try, submission/keeperhub |
| KO | proof, status, try, submission/keeperhub |
| JA | **index** (was missing), proof, status, try, submission/keeperhub |

Each per-locale page covers: hero (eyebrow + h1 + lede + CTA), one substantive section, then a closing block linking to the English original ("read full English version") for technical content. **Mirrors the existing \`/sk/index.astro\` + \`/ko/index.astro\` pattern** — translated landing-card depth, not full duplication of code-heavy verifier / status-table content. Honest framing via \`common.partial_translation_note\` (translated per locale).

## i18n dictionary expansions

- \`en.json\`: added \`proof.section_what_checks\`, \`proof.what_checks_blurb\`, \`status.*\`, \`try_page.*\`, \`keeperhub.*\`, \`common.cta_full_english\`, \`common.partial_translation_note\`
- \`sk.json\`: **native Slovak** translations for all new keys (Daniel can sign off)
- \`ko.json\` + \`ja.json\`: best-effort translations following the existing \`_TODO_<LOCALE>_REVIEW_*\` convention. Brand terms (\"Passport 캡슐\", \"Passport カプセル\"), technical terms (\"strict mode\", \"WASM\", \"cron\", \"tick\"), and product names (KeeperHub) kept in established mixed-script form

## Build verification

\`npm run build\` produces 61 pages. All 13 new locale routes resolve to authored pages with translated h1, **not en-fallback redirects**:

\`\`\`
/sk/proof.html              9569B  h1="Overiť Passport kapsulu"
/sk/status.html             9129B  h1="Čo je živé, čo mock, čo roadmap"
/sk/try.html                9204B  h1="Vyskúšajte SBO3L za 5 minút"
/sk/submission/keeperhub    9874B  h1="SBO3L × KeeperHub — strážená exekúcia…"
/ko/proof.html              9790B  h1="Passport 캡슐 검증"
/ko/status.html             9214B  h1="라이브, 모의(mock), 로드맵"
/ko/try.html                9331B  h1="5분 안에 SBO3L 시도하기"
/ko/submission/keeperhub   10105B  h1="SBO3L × KeeperHub — cron 에이전트…"
/ja.html (was redirect)   10000+B  real JA homepage
/ja/proof.html             10085B  h1="Passport カプセルを検証"
/ja/status.html             9385B  h1="稼働中・モック・ロードマップ"
/ja/try.html                9551B  h1="5 分で SBO3L を試す"
/ja/submission/keeperhub   10288B  h1="SBO3L × KeeperHub — cron エージェント…"
\`\`\`

## Honest scope

This is **"trimmed translation"** not "full content parity". The technical verifier / status-table / 8-step walkthrough content stays English. **Full content parity for a hackathon submission would require ~2400 lines of native translation across 3 languages**, only one of which (SK) Daniel can sign off on without external reviewer time. The closing-block fallback ("read full English version") is the pattern the existing \`/sk/index.astro\` + \`/ko/index.astro\` already shipped, so this PR widens the surface 5× without changing the depth contract.

## Test plan

- [x] \`npm run build\` clean — 61 pages built
- [x] All 13 new locale URLs render with translated h1, not en fallback
- [x] \`<html lang="ko">\` / \`lang="ja">\` set correctly via lang prop
- [x] LocaleSwitcher per page passes correct \`basePath\`
- [ ] Native KO/JA reviewer sweep (follow-up; \`_TODO_<LOCALE>_REVIEW_*\` markers in JSON guide where to look)

🤖 Generated with [Claude Code](https://claude.com/claude-code)