### PR TITLE
fix(dev4): R21 Codex review — 4 bug fixes (nudge script + simulator)

### DIFF
--- a/docs/dev4/mainnet-deploy-simulator-output.md
+++ b/docs/dev4/mainnet-deploy-simulator-output.md
@@ -59,8 +59,8 @@ read-back). Outputs to stdout + per-step logs in
   ✅ resolver flipped to 0x<NEW-OR-ADDRESS>
   STEP 2 gas estimate: 80000 (~ $0.02 simulator-side; ~$3.00 real-mainnet @ 50 gwei)
 
-  STEP 3: forge script RegisterMainnetFleet (60 subnames)
-  STEP 3 gas estimate: 3000000 (3M aggregate, 60×50K) (~ $0.60 simulator-side; ~$180.00 real-mainnet @ 50 gwei)
+  STEP 3: cast send setSubnodeRecord loop (60 subnames)
+  STEP 3 gas total: 3000000 (~ $0.60 simulator-side; ~$180.00 real-mainnet @ 50 gwei)
 
 [4/4] Final state spot-check (5 subnames)
   ✅ research.sbo3lagent.eth          resolver = 0x<NEW-OR-ADDRESS>

--- a/scripts/nudge-upstream-prs.sh
+++ b/scripts/nudge-upstream-prs.sh
@@ -79,12 +79,20 @@ for tuple in "${WATCH_TARGETS[@]}"; do
     echo
     echo "── $LABEL ($REPO#$NUMBER, kind=$KIND) ──────────────"
 
+    # Top-level discussion comments (this is where bumps post). Same
+    # endpoint shape for issues and PRs.
+    COMMENTS_ENDPOINT="repos/$REPO/issues/$NUMBER/comments"
+
+    # PR review-thread comments (line-anchored on the diff) live at
+    # a SEPARATE endpoint. For kind=pr, watch BOTH endpoints —
+    # otherwise maintainers responding via review threads stay
+    # invisible to this script. (Codex P2 on PR #484 caught this.)
     if [ "$KIND" = "pr" ]; then
         ENDPOINT="repos/$REPO/pulls/$NUMBER"
-        COMMENTS_ENDPOINT="repos/$REPO/issues/$NUMBER/comments"
+        REVIEW_COMMENTS_ENDPOINT="repos/$REPO/pulls/$NUMBER/comments"
     else
         ENDPOINT="repos/$REPO/issues/$NUMBER"
-        COMMENTS_ENDPOINT="repos/$REPO/issues/$NUMBER/comments"
+        REVIEW_COMMENTS_ENDPOINT=""
     fi
 
     META=$(gh api "$ENDPOINT" 2>/dev/null) || {
@@ -107,16 +115,40 @@ for tuple in "${WATCH_TARGETS[@]}"; do
         continue
     fi
 
-    # New comments in the last 24h?
-    NEW_COMMENT_COUNT=$(gh api "$COMMENTS_ENDPOINT" --paginate \
-        --jq '[.[] | select(.created_at > (now - 86400 | strftime("%Y-%m-%dT%H:%M:%SZ")))] | length' \
-        2>/dev/null || echo "0")
+    # `gh api --paginate --jq <expr>` runs the jq expression PER
+    # PAGE and concatenates results — so `... | length` prints
+    # multiple integers (one per page) instead of an aggregate. Use
+    # `--paginate --slurp` to gather all pages into one array, then
+    # `add | length` for a correct single integer. (Codex P2 on PR
+    # #484 caught this.)
+    count_recent_comments() {
+        local endpoint="$1"
+        gh api "$endpoint" --paginate --slurp \
+            --jq 'add // [] | [.[] | select(.created_at > (now - 86400 | strftime("%Y-%m-%dT%H:%M:%SZ")))] | length' \
+            2>/dev/null || echo "0"
+    }
+    list_recent_comments() {
+        local endpoint="$1"
+        gh api "$endpoint" --paginate --slurp \
+            --jq 'add // [] | .[] | select(.created_at > (now - 86400 | strftime("%Y-%m-%dT%H:%M:%SZ"))) | "       - \(.user.login): \(.body | .[0:120])"' \
+            2>/dev/null
+    }
+
+    # Sum across both endpoints (issue-style + review-thread, when
+    # applicable).
+    NEW_COMMENT_COUNT=$(count_recent_comments "$COMMENTS_ENDPOINT")
+    if [ -n "$REVIEW_COMMENTS_ENDPOINT" ]; then
+        REVIEW_COMMENT_COUNT=$(count_recent_comments "$REVIEW_COMMENTS_ENDPOINT")
+        NEW_COMMENT_COUNT=$((NEW_COMMENT_COUNT + REVIEW_COMMENT_COUNT))
+    fi
 
     if [ "$NEW_COMMENT_COUNT" -gt 0 ] 2>/dev/null; then
         echo "  → 🆕 $NEW_COMMENT_COUNT new comment(s) in last 24h"
         echo "  → recent commenters:"
-        gh api "$COMMENTS_ENDPOINT" --paginate \
-            --jq '.[] | select(.created_at > (now - 86400 | strftime("%Y-%m-%dT%H:%M:%SZ"))) | "       - \(.user.login): \(.body | .[0:120])"' 2>/dev/null
+        list_recent_comments "$COMMENTS_ENDPOINT"
+        if [ -n "$REVIEW_COMMENTS_ENDPOINT" ]; then
+            list_recent_comments "$REVIEW_COMMENTS_ENDPOINT"
+        fi
         NEW_ACTIVITY_FOUND=1
     else
         echo "  → no comments in last 24h"
@@ -126,8 +158,8 @@ for tuple in "${WATCH_TARGETS[@]}"; do
     if [ $BUMP = 1 ] && [ "$DAYS_SINCE_UPDATE" -ge "$QUIET_DAYS" ]; then
         # Avoid bump-spam: only bump if the most recent comment is NOT
         # already a B2JK-Industry bump within the last QUIET_DAYS.
-        LAST_BUMP_FROM_US=$(gh api "$COMMENTS_ENDPOINT" --paginate \
-            --jq '[.[] | select(.user.login == "B2JK-Industry" and (.body | startswith("Bumping this for visibility")))] | last | .created_at // empty' \
+        LAST_BUMP_FROM_US=$(gh api "$COMMENTS_ENDPOINT" --paginate --slurp \
+            --jq 'add // [] | [.[] | select(.user.login == "B2JK-Industry" and (.body | startswith("Bumping this for visibility")))] | last | .created_at // empty' \
             2>/dev/null || echo "")
 
         if [ -n "$LAST_BUMP_FROM_US" ]; then

--- a/scripts/simulate-mainnet-deploy.sh
+++ b/scripts/simulate-mainnet-deploy.sh
@@ -57,6 +57,22 @@ ANVIL_LOG=/tmp/sbo3l-simulator-anvil.log
 SIM_OUTPUT_DIR=/tmp/sbo3l-simulator-output
 mkdir -p "$SIM_OUTPUT_DIR"
 
+# Robust RPC redaction. Previous version assumed Alchemy's `/v2/`
+# segment and would leak Infura `/v3/<key>`, generic
+# `?apikey=<key>`, or QuickNode `/<token>/` cleartext (Codex P2 on
+# PR #486 caught this). Strip everything past the host, replace
+# with `/<redacted>`. Pure shell param expansion — no sed (BSD vs
+# GNU regex inconsistencies).
+redact_rpc() {
+    local url="$1"
+    local scheme="${url%%://*}"
+    local rest="${url#*://}"
+    local host_port="${rest%%/*}"
+    host_port="${host_port%%\?*}"
+    host_port="${host_port%%\#*}"
+    printf '%s://%s/<redacted>' "$scheme" "$host_port"
+}
+
 cleanup() {
     if [[ -n "$ANVIL_PID" ]]; then
         kill "$ANVIL_PID" 2>/dev/null || true
@@ -67,7 +83,7 @@ trap cleanup EXIT INT TERM
 
 echo "==================================================================="
 echo "  SBO3L mainnet deploy SIMULATOR — $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-echo "  upstream RPC:  ${MAINNET_RPC_URL%v2*}v2/<redacted>"
+echo "  upstream RPC:  $(redact_rpc "$MAINNET_RPC_URL")"
 echo "  fork port:     $ANVIL_PORT"
 echo "  output dir:    $SIM_OUTPUT_DIR"
 echo "==================================================================="
@@ -169,28 +185,59 @@ echo "  STEP 2 gas estimate: ${STEP2_GAS} (~ \$$(awk "BEGIN { printf \"%.2f\", $
 echo
 
 # ============================================================
-# STEP 3 — 60x setSubnodeRecord via the forge script
+# STEP 3 — 60x setSubnodeRecord via cast send loop
 # ============================================================
-echo "  STEP 3: forge script RegisterMainnetFleet (60 subnames)"
-FLEET_OUT=$(cd crates/sbo3l-identity/contracts && \
-    PRIVATE_KEY=$SIM_DEPLOYER_PK \
-    PARENT_NODE=$NODE \
-    RESOLVER_ADDRESS=$NEW_OR \
-    forge script script/RegisterMainnetFleet.s.sol \
-        --rpc-url "$LOCAL_RPC" \
-        --broadcast \
-        --slow \
-        --sender "$PARENT_OWNER" \
-        --unlocked \
-        2>&1 || true)
-echo "$FLEET_OUT" > "$SIM_OUTPUT_DIR/step3-fleet.log"
+#
+# WHY a cast loop instead of `forge script RegisterMainnetFleet`:
+# the forge script derives its broadcaster from
+# `vm.envUint("PRIVATE_KEY")` and asserts `parentOwner == deployer`
+# inside `setUp()`. With `--unlocked --sender PARENT_OWNER` the
+# foundry --sender flag does NOT bypass that assertion (the script
+# still derives the address from PRIVATE_KEY), so the script
+# reverts. cast send with `--unlocked --from PARENT_OWNER` against
+# the impersonated address bypasses the foundry script layer
+# entirely. (Codex P1 on PR #486 caught this.)
+echo "  STEP 3: cast send setSubnodeRecord loop (60 subnames)"
 
-# Estimate: each setSubnodeRecord ~50K gas → 60 × 50K = 3M.
-# anvil with --silent doesn't print per-tx gas; use the runbook's
-# documented 3M estimate. The "did the tx land" check is via the
-# verify step below.
-STEP3_GAS=3000000
-echo "  STEP 3 gas estimate: ${STEP3_GAS} (3M aggregate, 60×50K) (~ \$$(awk "BEGIN { printf \"%.2f\", $STEP3_GAS * 50 / 1e9 * 4000 }"))"
+# Build the same 60-label list RegisterMainnetFleet.s.sol uses
+# (50 numbered + 10 specialist). Keep this list in lock-step with
+# the .s.sol file when either changes.
+ALL_LABELS=()
+for i in $(seq 1 50); do
+    ALL_LABELS+=("agent-$(printf '%03d' "$i")")
+done
+ALL_LABELS+=(research trader auditor compliance treasury analytics reputation oracle messenger executor)
+
+FLEET_FAILS=0
+STEP3_GAS_TOTAL=0
+for label in "${ALL_LABELS[@]}"; do
+    LABEL_HASH=$(cast keccak "$label")
+    TX_OUT=$(cast send "$ENS_REGISTRY" \
+        "setSubnodeRecord(bytes32,bytes32,address,address,uint64)" \
+        "$NODE" "$LABEL_HASH" "$PARENT_OWNER" "$NEW_OR" 0 \
+        --from "$PARENT_OWNER" --unlocked \
+        --rpc-url "$LOCAL_RPC" --json 2>&1) || {
+        FLEET_FAILS=$((FLEET_FAILS + 1))
+        echo "$TX_OUT" >> "$SIM_OUTPUT_DIR/step3-fleet.log"
+        printf "    ❌ setSubnodeRecord %-20s failed (see step3-fleet.log)\n" "$label"
+        continue
+    }
+    TX_GAS=$(echo "$TX_OUT" | python3 -c "import sys,json; d=json.loads(sys.stdin.read() or '{}'); print(int(d.get('gasUsed','0xC350'),16))" 2>/dev/null || echo "50000")
+    STEP3_GAS_TOTAL=$((STEP3_GAS_TOTAL + TX_GAS))
+done
+
+if [ "$FLEET_FAILS" -gt 0 ]; then
+    echo "  ⚠️  STEP 3 had $FLEET_FAILS / ${#ALL_LABELS[@]} failures (full log: $SIM_OUTPUT_DIR/step3-fleet.log)"
+fi
+
+# Use measured total when available; fall back to 3M conservative
+# estimate (60 × 50K) if every tx failed and we have nothing.
+if [ "$STEP3_GAS_TOTAL" -eq 0 ]; then
+    STEP3_GAS=3000000
+else
+    STEP3_GAS=$STEP3_GAS_TOTAL
+fi
+echo "  STEP 3 gas total: ${STEP3_GAS} (~ \$$(awk "BEGIN { printf \"%.2f\", $STEP3_GAS * 50 / 1e9 * 4000 }"))"
 echo
 
 # ============================================================


### PR DESCRIPTION
## Summary
R21 self-review found 4 Codex bugs across PRs #484 (nudge script, Task B) and #486 (simulator, Task C). All four fixed in this PR.

| # | Bug | Severity | File |
|---|---|---|---|
| 1 | nudge script missed PR review-thread comments (only watched `/issues/N/comments`) | P2 | scripts/nudge-upstream-prs.sh |
| 2 | nudge script used `gh api --paginate --jq` which emits one length per page instead of aggregate | P2 | scripts/nudge-upstream-prs.sh |
| 3 | simulator STEP 3 forge-script call asserts `deployer == parentOwner` via `vm.envUint("PRIVATE_KEY")`; --sender doesn't bypass | P1 | scripts/simulate-mainnet-deploy.sh |
| 4 | simulator RPC redaction `${URL%v2*}v2/<redacted>` leaks Infura `/v3/`, QuickNode tokens, generic `?apikey=` | P2 | scripts/simulate-mainnet-deploy.sh |

### Fix 1 — review-thread comments
Added `REVIEW_COMMENTS_ENDPOINT` for `kind=pr`. Sum count across both `/issues/N/comments` (top-level discussion) and `/pulls/N/comments` (line-anchored review-thread).

### Fix 2 — paginated counting
Switched to `--paginate --slurp` + `add // [] | ... | length`. Helpers `count_recent_comments()` and `list_recent_comments()` factored to keep the loop readable.

### Fix 3 — STEP 3 cast loop
Replaced `forge script RegisterMainnetFleet.s.sol` with a `cast send setSubnodeRecord` loop using `--unlocked --from PARENT_OWNER`. Bypasses the foundry script's PRIVATE_KEY-derived deployer assertion entirely. Bonus: reports per-tx measured gas instead of a static 3M estimate.

### Fix 4 — robust RPC redaction
New `redact_rpc()` helper uses pure shell parameter expansion (no sed — BSD vs GNU regex inconsistencies on `[^/?#]` character class). Tested against Alchemy v2, Infura v3, QuickNode token, generic `?apikey=`, no-path PublicNode, and `host:port` URLs — all six redact correctly.

## Test plan
- [x] `bash -n scripts/nudge-upstream-prs.sh` — clean
- [x] `bash -n scripts/simulate-mainnet-deploy.sh` — clean
- [x] `redact_rpc` unit-tested against 6 URL shapes (all pass)
- [x] companion `docs/dev4/mainnet-deploy-simulator-output.md` updated to reflect new STEP 3 line format

🤖 Generated with [Claude Code](https://claude.com/claude-code)