### PR TITLE
fix(ci): install-smoke + pypi-republish — 2 root causes from QA report (#495)

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -104,39 +104,64 @@ jobs:
     needs: build-daemon
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Per-entry `continue-on-error` via `matrix.allow_failure` — same
+    # mechanism the pip-smoke job uses for KH-plugin pip variants pending
+    # PyPI Trusted Publisher. Used here for npm packages whose 1.2.0
+    # tag-publish hasn't fired yet (the publish workflow fires on tag
+    # push, but a brand-new package's first tag is a manual step).
+    # Drop the `allow_failure: true` line on each entry once its first
+    # tag-publish lands and the registry serves @1.2.0.
+    continue-on-error: ${{ matrix.allow_failure || false }}
     strategy:
       fail-fast: false
       matrix:
-        package:
-          - "@sbo3l/sdk"
-          - "@sbo3l/0g-storage"
-          - "@sbo3l/marketplace"
-          - "@sbo3l/agentforce"
-          - "@sbo3l/anthropic"
-          - "@sbo3l/anthropic-computer-use"
-          - "@sbo3l/autogen"
-          - "@sbo3l/autogpt"
-          - "@sbo3l/babyagi"
-          - "@sbo3l/cohere-tools"
-          - "@sbo3l/copilot-studio"
-          - "@sbo3l/e2b"
-          - "@sbo3l/elizaos"
-          - "@sbo3l/elizaos-keeperhub"
-          - "@sbo3l/inngest"
-          - "@sbo3l/langchain"
-          - "@sbo3l/langchain-keeperhub"
-          - "@sbo3l/langflow"
-          - "@sbo3l/letta"
-          - "@sbo3l/mastra"
-          - "@sbo3l/modal"
-          - "@sbo3l/openai-assistants"
-          - "@sbo3l/perplexity"
-          - "@sbo3l/replicate"
-          - "@sbo3l/superagi"
-          - "@sbo3l/together"
-          - "@sbo3l/vellum"
-          - "@sbo3l/vercel-ai"
-          - "@sbo3l/vercel-ai-keeperhub"
+        # Each entry: `package` (required) + optional `allow_failure: true`.
+        # The matrix is `include`-only because mixing a `package` axis with
+        # per-entry `allow_failure` overrides via include-merging silently
+        # drops entries — same gotcha as pip-smoke below.
+        include:
+          - package: "@sbo3l/sdk"
+          - package: "@sbo3l/0g-storage"
+            # Pending first tag-publish on the existing v1.2.0 tag.
+            # Dev 1's package; will go live once anyone tags + pushes
+            # `0g-storage-ts-v1.2.0` per integrations-publish.yml.
+            allow_failure: true
+          - package: "@sbo3l/marketplace"
+          - package: "@sbo3l/agentforce"
+          - package: "@sbo3l/anthropic"
+          - package: "@sbo3l/anthropic-computer-use"
+          - package: "@sbo3l/autogen"
+          - package: "@sbo3l/autogpt"
+          - package: "@sbo3l/babyagi"
+          - package: "@sbo3l/cohere-tools"
+          - package: "@sbo3l/copilot-studio"
+          - package: "@sbo3l/e2b"
+          - package: "@sbo3l/elizaos"
+          - package: "@sbo3l/elizaos-keeperhub"
+            # Pending first tag-publish — R22-C cascade landed the
+            # package + matrix entry but no one tagged + pushed the
+            # `elizaos-keeperhub-ts-v1.2.0` release tag yet. Drop
+            # `allow_failure` once the registry serves @1.2.0.
+            allow_failure: true
+          - package: "@sbo3l/inngest"
+          - package: "@sbo3l/langchain"
+          - package: "@sbo3l/langchain-keeperhub"
+          - package: "@sbo3l/langflow"
+          - package: "@sbo3l/letta"
+          - package: "@sbo3l/mastra"
+          - package: "@sbo3l/modal"
+          - package: "@sbo3l/openai-assistants"
+          - package: "@sbo3l/perplexity"
+          - package: "@sbo3l/replicate"
+          - package: "@sbo3l/superagi"
+          - package: "@sbo3l/together"
+          - package: "@sbo3l/vellum"
+          - package: "@sbo3l/vercel-ai"
+          - package: "@sbo3l/vercel-ai-keeperhub"
+            # Pending first tag-publish — R22-D cascade landed the
+            # package + matrix entry but no one tagged + pushed the
+            # `vercel-ai-keeperhub-ts-v1.2.0` release tag yet.
+            allow_failure: true
     steps:
       - uses: actions/setup-node@v4
         with:
@@ -261,27 +286,9 @@ jobs:
           - package: sbo3l-sdk
           - package: sbo3l-langchain
           - package: sbo3l-langchain-keeperhub
-            # Pending PyPI publish — Trusted Publisher config blocker
-            # documented at docs/dev2/pypi-langchain-keeperhub-publish-blocker.md.
-            # The npm version IS live; only the PyPI half is pending.
-            # When Daniel completes the PyPI Trusted Publisher registration
-            # + the publish job lands, drop this `allow_failure` line.
-            allow_failure: true
           - package: sbo3l-autogen-keeperhub
-            # Pending first PyPI publish — Trusted Publisher registration
-            # required (same gating story as sbo3l-langchain-keeperhub
-            # above; once the publish workflow lands a v1.2.0 the entry
-            # flips to a hard requirement). Tracking the same
-            # docs/dev2/pypi-langchain-keeperhub-publish-blocker.md note.
-            allow_failure: true
           - package: sbo3l-crewai
           - package: sbo3l-crewai-keeperhub
-            # Pending first PyPI publish — once the publish workflow
-            # fires on the `crewai-keeperhub-py-v1.2.0` tag and the
-            # Trusted Publisher config is in place, drop this
-            # `allow_failure` line. Same precedent as
-            # `sbo3l-langchain-keeperhub` above.
-            allow_failure: true
           - package: sbo3l-llamaindex
           - package: sbo3l-langgraph
     steps:
@@ -396,10 +403,11 @@ jobs:
           echo "pip-smoke:   $pip"
           if [ "$cargo" = "success" ] && [ "$npm" = "success" ] && [ "$pip" = "success" ]; then
             echo "✅ install-smoke green: 1 cargo + 29 npm + 8 pip = 38 packages installed cleanly"
-            echo "   (Hard-required: 35. Allowed-to-fail today: 3 KH-plugin pip variants —"
-            echo "    sbo3l-langchain-keeperhub + sbo3l-autogen-keeperhub + sbo3l-crewai-keeperhub"
-            echo "    pending PyPI Trusted Publisher; see"
-            echo "    docs/dev2/pypi-langchain-keeperhub-publish-blocker.md.)"
+            echo "   (Hard-required: 35. Allowed-to-fail today: 3 npm packages pending"
+            echo "    first tag-publish — @sbo3l/0g-storage + @sbo3l/elizaos-keeperhub +"
+            echo "    @sbo3l/vercel-ai-keeperhub. Drop their allow_failure flags once each"
+            echo "    package's <id>-v1.2.0 tag is pushed and integrations-publish.yml"
+            echo "    serves the registry @1.2.0.)"
             exit 0
           fi
           echo "❌ install-smoke regression — one or more HARD-REQUIRED matrix jobs failed"

--- a/.github/workflows/pypi-republish-langchain-kh.yml
+++ b/.github/workflows/pypi-republish-langchain-kh.yml
@@ -101,7 +101,17 @@ jobs:
           set -euo pipefail
           # Verify the tag actually exists before dispatching — saves
           # a useless workflow run if someone deleted it accidentally.
-          if ! git ls-remote --tags --exit-code origin "refs/tags/${PUBLISH_TAG}" >/dev/null 2>&1; then
+          #
+          # We use `gh api repos/.../git/ref/tags/<tag>` instead of
+          # `git ls-remote` because there's no `actions/checkout@v4`
+          # step in this job — it runs lean to avoid a 5-second clone
+          # on every 30-min cron tick. The git API check works on both
+          # lightweight and annotated tags (a previous version that
+          # tried `git ls-remote origin` failed on a clean runner with
+          # no `origin` remote configured — the workflow hard-errored
+          # before getting to the dispatch and the tag-find logic was
+          # blamed when in reality the empty workspace was the bug).
+          if ! gh api "repos/${{ github.repository }}/git/ref/tags/${PUBLISH_TAG}" >/dev/null 2>&1; then
             echo "::error::tag ${PUBLISH_TAG} not found on origin — cannot dispatch publish workflow"
             exit 1
           fi


### PR DESCRIPTION
## Summary
Heidi (QA) flagged 3 failing workflows in #495. This PR fixes the **2 Dev 2-owned ones**; the third (Uptime probe transient crates.io API empty) self-recovers and isn't owned by Dev 2.

## Fix 1 — install-smoke: 3 npm packages pending first tag-publish

| Failing matrix entry | Why |
|---|---|
| `@sbo3l/elizaos-keeperhub` | R22-C package landed on main, no `elizaos-keeperhub-ts-v1.2.0` tag pushed yet → registry 404 |
| `@sbo3l/vercel-ai-keeperhub` | R22-D package landed on main, no `vercel-ai-keeperhub-ts-v1.2.0` tag pushed yet → registry 404 |
| `@sbo3l/0g-storage` | Dev 1 package landed on main, no `0g-storage-ts-v1.2.0` tag pushed yet → registry 404 |

`integrations-publish.yml` fires on tag push. Without a tag, no npm publish, registry is 404, install-smoke matrix job fails.

**Fix:**
- Convert npm-smoke matrix from flat list → include-style (same pattern pip-smoke already uses) so per-entry overrides work
- Add `continue-on-error: ${{ matrix.allow_failure || false }}` at the npm-smoke job level (mirror of pip-smoke)
- Mark the 3 pending entries with `allow_failure: true` + inline comment pointing at unblock condition (push the v1.2.0 tag, drop the flag)

**Bonus:** drop `allow_failure: true` from the 3 pip KH-plugin entries. **Re-probe at commit time shows ALL 3 PyPI packages live now** (`sbo3l-langchain-keeperhub`, `sbo3l-autogen-keeperhub`, `sbo3l-crewai-keeperhub` all return HTTP 200) — Daniel must have completed the Trusted Publisher registration in the last hour. Hard-require all 3 again so future yanks/registry corruption surface loud.

Updated summary line: **29 npm + 8 pip + 1 cargo = 38 total, 35 hard-required, 3 allowed-to-fail**.

## Fix 2 — pypi-republish-langchain-keeperhub: tag check on clean runner

**Failure log:**
```
::error::tag langchain-keeperhub-py-v1.2.0 not found on origin
```

Tag IS on origin (Heidi verified via `git ls-remote`). But the cron workflow has **NO `actions/checkout@v4` step** — it runs lean to avoid a 5-second clone every 30 min. Without checkout, there's no git repo + no `origin` remote; `git ls-remote --tags origin` exits non-zero because there's no remote to query.

Heidi attributed the failure to lightweight-vs-annotated tag handling. **Real bug is the missing checkout** — any git invocation in this workflow hard-errors. The lightweight-tag observation was a red herring.

**Fix:** replace `git ls-remote --tags --exit-code origin <tag>` with `gh api repos/.../git/ref/tags/<tag>` — uses the GitHub API directly (no checkout required), works on both lightweight and annotated tags, runs in ~100ms vs ~5s for a full clone. Inline comment captures the lifecycle reasoning so future maintainers don't re-introduce the regression.

## Test plan
- [x] YAML parses for both files
- [x] npm matrix: 29 entries (3 with allow_failure)
- [x] pip matrix: 8 entries (0 with allow_failure now — all live on PyPI)
- [x] PyPI live probe at commit time: all 3 KH-plugin pip variants HTTP 200 ✓
- [x] npm registry probe at commit time: 3 entries with allow_failure are HTTP 404 (correct) ✓

After merge:
- install-smoke goes green on next push (35 hard-required + 3 soft-fail visible in matrix view)
- `pypi-republish-langchain-keeperhub` next cron fire short-circuits via 'Already published — short-circuit' (no dispatch needed; package is live)
- 3 npm packages stay on allow_failure until tag-publish lands

## Related
- #495 — Heidi's CI failure report
- #435 — original PyPI Trusted Publisher blocker doc (now resolved)
- #458 — pypi-republish poller original PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)