### PR TITLE
fix(ci): install-smoke npm matrix — allow_failure for the 3 just-shipped packages

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -104,39 +104,62 @@ jobs:
     needs: build-daemon
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Per-entry `continue-on-error` via `matrix.allow_failure`. Same
+    # pattern as the PyPI matrix below — used for packages that are
+    # EXPECTED to 404 on the registry today because the publish workflow
+    # is pending Daniel-side action (token provision, GitHub-Actions
+    # tag-push race, etc.). When the blocker clears and the package
+    # goes live, drop the `allow_failure: true` line for that entry in
+    # a follow-up PR.
+    continue-on-error: ${{ matrix.allow_failure || false }}
     strategy:
       fail-fast: false
       matrix:
-        package:
-          - "@sbo3l/sdk"
-          - "@sbo3l/0g-storage"
-          - "@sbo3l/marketplace"
-          - "@sbo3l/agentforce"
-          - "@sbo3l/anthropic"
-          - "@sbo3l/anthropic-computer-use"
-          - "@sbo3l/autogen"
-          - "@sbo3l/autogpt"
-          - "@sbo3l/babyagi"
-          - "@sbo3l/cohere-tools"
-          - "@sbo3l/copilot-studio"
-          - "@sbo3l/e2b"
-          - "@sbo3l/elizaos"
-          - "@sbo3l/elizaos-keeperhub"
-          - "@sbo3l/inngest"
-          - "@sbo3l/langchain"
-          - "@sbo3l/langchain-keeperhub"
-          - "@sbo3l/langflow"
-          - "@sbo3l/letta"
-          - "@sbo3l/mastra"
-          - "@sbo3l/modal"
-          - "@sbo3l/openai-assistants"
-          - "@sbo3l/perplexity"
-          - "@sbo3l/replicate"
-          - "@sbo3l/superagi"
-          - "@sbo3l/together"
-          - "@sbo3l/vellum"
-          - "@sbo3l/vercel-ai"
-          - "@sbo3l/vercel-ai-keeperhub"
+        # Each entry: `package` (required) + optional `allow_failure: true`.
+        # `include`-only form because mixing a `package` axis with per-entry
+        # overrides via include-merging silently drops entries when GitHub
+        # Actions evaluates the cross-product.
+        include:
+          - package: "@sbo3l/sdk"
+          - package: "@sbo3l/0g-storage"
+            # Pending first npm publish — shipped via #480 (R22 Task B);
+            # publish-on-tag workflow hasn't fired yet. Drop this line
+            # once `npm view @sbo3l/0g-storage version` returns 1.2.0.
+            allow_failure: true
+          - package: "@sbo3l/marketplace"
+          - package: "@sbo3l/agentforce"
+          - package: "@sbo3l/anthropic"
+          - package: "@sbo3l/anthropic-computer-use"
+          - package: "@sbo3l/autogen"
+          - package: "@sbo3l/autogpt"
+          - package: "@sbo3l/babyagi"
+          - package: "@sbo3l/cohere-tools"
+          - package: "@sbo3l/copilot-studio"
+          - package: "@sbo3l/e2b"
+          - package: "@sbo3l/elizaos"
+          - package: "@sbo3l/elizaos-keeperhub"
+            # Pending first npm publish — shipped via #477 (R22 Dev 2 KH
+            # adapter set, ElizaOS variant). Same gating story as
+            # @sbo3l/0g-storage above.
+            allow_failure: true
+          - package: "@sbo3l/inngest"
+          - package: "@sbo3l/langchain"
+          - package: "@sbo3l/langchain-keeperhub"
+          - package: "@sbo3l/langflow"
+          - package: "@sbo3l/letta"
+          - package: "@sbo3l/mastra"
+          - package: "@sbo3l/modal"
+          - package: "@sbo3l/openai-assistants"
+          - package: "@sbo3l/perplexity"
+          - package: "@sbo3l/replicate"
+          - package: "@sbo3l/superagi"
+          - package: "@sbo3l/together"
+          - package: "@sbo3l/vellum"
+          - package: "@sbo3l/vercel-ai"
+          - package: "@sbo3l/vercel-ai-keeperhub"
+            # Pending first npm publish — shipped via #478 (R22 Dev 2 KH
+            # adapter set, Vercel-AI variant). Same gating story.
+            allow_failure: true
     steps:
       - uses: actions/setup-node@v4
         with:
@@ -396,10 +419,14 @@ jobs:
           echo "pip-smoke:   $pip"
           if [ "$cargo" = "success" ] && [ "$npm" = "success" ] && [ "$pip" = "success" ]; then
             echo "✅ install-smoke green: 1 cargo + 29 npm + 8 pip = 38 packages installed cleanly"
-            echo "   (Hard-required: 35. Allowed-to-fail today: 3 KH-plugin pip variants —"
-            echo "    sbo3l-langchain-keeperhub + sbo3l-autogen-keeperhub + sbo3l-crewai-keeperhub"
-            echo "    pending PyPI Trusted Publisher; see"
-            echo "    docs/dev2/pypi-langchain-keeperhub-publish-blocker.md.)"
+            echo "   (Hard-required: 32. Allowed-to-fail today:"
+            echo "      3 KH-plugin pip variants — sbo3l-langchain-keeperhub +"
+            echo "        sbo3l-autogen-keeperhub + sbo3l-crewai-keeperhub —"
+            echo "        pending PyPI Trusted Publisher; see"
+            echo "        docs/dev2/pypi-langchain-keeperhub-publish-blocker.md."
+            echo "      3 npm variants — @sbo3l/0g-storage + @sbo3l/elizaos-keeperhub +"
+            echo "        @sbo3l/vercel-ai-keeperhub — pending first npm publish from"
+            echo "        R22 Task B (#480) + R22 Dev 2 KH-adapter set (#477, #478).)"
             exit 0
           fi
           echo "❌ install-smoke regression — one or more HARD-REQUIRED matrix jobs failed"


### PR DESCRIPTION
## Summary

Daniel's screenshot showed 4 install-smoke failures: 3 npm packages + 1 summary check. Root cause: npm matrix doesn't have the per-entry \`allow_failure\` mechanism the PyPI matrix already uses.

## Heidi probe of all 29 npm packages (11:00 UTC)

26/29 live at 1.2.0. The 3 still-404 ones are the just-shipped packages whose npm publish workflow is pending:

| Package | Shipped via | Why 404 today |
|---|---|---|
| \`@sbo3l/0g-storage\` | #480 (R22 Task B) | publish-on-tag pending |
| \`@sbo3l/elizaos-keeperhub\` | #477 (R22 Dev 2 KH set) | publish pending |
| \`@sbo3l/vercel-ai-keeperhub\` | #478 (R22 Dev 2 KH set) | publish pending |

## Fix

- Convert npm matrix from flat \`package:\` list to \`include:\` form (same shape as PyPI matrix)
- Add \`continue-on-error: \${{ matrix.allow_failure || false }}\` at job level (same precedent)
- Tag the 3 currently-404 packages with \`allow_failure: true\` + per-entry comment explaining the gate
- Bump the summary message to reflect the new "Hard-required: 32. Allowed-to-fail: 3 pip + 3 npm" counts

## Drop pattern

When npm publish fires for any of the 3, drop that entry's \`allow_failure: true\` in a follow-up PR — re-asserts the hard requirement so any future regression surfaces loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)