### PR TITLE
fix(R22 self-review #2): a11y label-in-name + SW robustness + layout dead zone

### DIFF
--- a/apps/marketing/public/sw.js
+++ b/apps/marketing/public/sw.js
@@ -33,14 +33,22 @@ const SHELL_ASSETS = [
 ];
 
 self.addEventListener("install", (event) => {
+  // Self-review fix (PR #496): cache.addAll() is all-or-nothing — a
+  // single 404 in SHELL_ASSETS would leave the cache empty and
+  // offline mode broken. Use per-asset cache.add() wrapped in
+  // allSettled so individual failures don't kill the rest. Logged
+  // for observability when one drifts.
   event.waitUntil(
     caches.open(SHELL_CACHE).then((cache) =>
-      cache.addAll(SHELL_ASSETS).catch((err) => {
-        // Best-effort prefetch — if one asset 404s we still install the SW
-        // and rely on runtime caching. Logging only.
-        // eslint-disable-next-line no-console
-        console.warn("[sbo3l-sw] shell prefetch partial:", err);
-      })
+      Promise.allSettled(
+        SHELL_ASSETS.map((url) =>
+          cache.add(url).catch((err) => {
+            // eslint-disable-next-line no-console
+            console.warn(`[sbo3l-sw] shell asset failed: ${url}`, err);
+            return null;
+          })
+        )
+      )
     )
   );
   self.skipWaiting();

--- a/apps/marketing/src/pages/kh-fleet.astro
+++ b/apps/marketing/src/pages/kh-fleet.astro
@@ -280,7 +280,13 @@ sbo3l passport verify capsule.json</code></pre>
   .footnote p { line-height: 1.65; margin: 0; max-width: 820px; }
   .footnote code { background: var(--code-bg); padding: 0.05em 0.4em; border-radius: 3px; font-size: 0.92em; }
 
-  @media (max-width: 1100px) {
+  /* Self-review (PR #496): the 7-column grid's intrinsic width is
+     ~1133px (12+18+11+5+13+4em fixed ≈ 1008px + 6 × 1em gaps ≈ 96px
+     + 0.9em row padding × 2 ≈ 29px). Below 1133px the row overflows
+     its container before the @media collapse to 1-col kicks in.
+     Lifting the breakpoint to 1200px closes the dead zone and keeps
+     a comfortable margin around medium-laptop viewports (1280px+). */
+  @media (max-width: 1200px) {
     .row { grid-template-columns: 1fr; gap: 0.3em; }
     .row .ts::before { content: "ts: "; color: var(--muted); }
     .row .agent::before { content: "agent: "; color: var(--muted); }

--- a/apps/marketing/src/pages/proof.astro
+++ b/apps/marketing/src/pages/proof.astro
@@ -5,32 +5,13 @@ import PassportCapsule from "~/components/PassportCapsule.astro";
 
 const githubRepoUrl = "https://github.com/B2JK-Industry/SBO3L-ethglobal-openagents-2026";
 
-// PassportCapsule "open" spread is rendered alongside the WASM verifier
-// as a visual reference for what a verified capsule looks like. The
-// `verifiedChecks` prop is empty by default — when the user pastes a
-// capsule and clicks Verify, JS could update this view, but at SSR
-// time we render the unverified state. /proof is build-time static
-// so the visual is a reference card, not a live status.
-//
-// Codex review fix (PR #392): /kh-fleet "verify capsule →" links pass
-// `?capsule=...` query strings. Read the param here and pre-fill the
-// PassportVerifier so the deep-links actually populate the textarea.
-// We accept either:
-//   - raw JSON (rare; only short capsules fit in URL bounds)
-//   - base64url-encoded JSON (standard; matches `passport export --base64`)
-// The decode is best-effort — malformed input leaves the textarea
-// empty and the user gets the standard idle state.
-function decodeCapsuleParam(raw: string | null): string {
-  if (!raw) return "";
-  if (raw.trim().startsWith("{")) return raw;
-  try {
-    const padded = raw.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(raw.length / 4) * 4, "=");
-    return atob(padded);
-  } catch {
-    return "";
-  }
-}
-const initialCapsule = decodeCapsuleParam(Astro.url.searchParams.get("capsule"));
+// /proof is build-time static (output: 'static'). The deep-link
+// `?capsule=…` and `?capsule_url=…` parsing happens at runtime in the
+// inline <script> below — Astro.url.searchParams in this frontmatter
+// is empty at build time, so any decoding here would be dead. The
+// previous frontmatter `decodeCapsuleParam` + `initialCapsule` const
+// were removed in R22 self-review (PR #496) — they computed nothing
+// and the result was never passed to <PassportVerifier />.
 ---
 <BaseLayout
   title="SBO3L — Verify a Passport capsule in your browser"
@@ -48,7 +29,7 @@ const initialCapsule = decodeCapsuleParam(Astro.url.searchParams.get("capsule"))
       crate yourself.
     </p>
     <p class="install-row">
-      <button id="pwa-install-btn" class="install-btn" hidden type="button" aria-label="Install SBO3L Verify as an app">
+      <button id="pwa-install-btn" class="install-btn" hidden type="button">
         <span aria-hidden="true">⤓</span> Install as offline-capable app
       </button>
       <span id="pwa-install-status" class="install-status" hidden role="status"></span>


### PR DESCRIPTION
## Summary

Second self-review pass on R22, prompted by **"so there are no errors anywhere in your work?"** — there were four. Found by running real Lighthouse against the live deployed \`/proof\` and tracing layout math against the post-#491 7-column \`/kh-fleet\` grid.

## What it does

### 1. A11y — Lighthouse \`label-content-name-mismatch\` (P1, real bug on production)

The PWA install button from #491 had \`aria-label="Install SBO3L Verify as an app"\` while the visible text read **"Install as offline-capable app"**. The two don't match → WCAG 2.5.3 "Label in Name" violation. Voice-control users can't tap the button by saying its visible text. Audit score 0.

**Fix:** drop the aria-label entirely; the visible text is a clear accessible name on its own.

### 2. SW robustness — bug-in-waiting

\`sw.js\` used \`cache.addAll(SHELL_ASSETS)\` which is all-or-nothing — a single 404 in the 8-asset list would empty the cache and break offline mode. Currently all 8 return 200, but brittle.

**Fix:** \`Promise.allSettled\` over per-asset \`cache.add()\`, individual failures now log + skip without poisoning the rest.

### 3. Dead code — \`proof.astro\` frontmatter

\`decodeCapsuleParam\` function + \`initialCapsule\` const left over from before the codex #415 runtime fix. \`/proof\` is build-time static so frontmatter \`Astro.url.searchParams\` is empty at build — they computed nothing and were never passed to \`<PassportVerifier>\`.

**Fix:** removed; comment block points at the runtime \`<script>\` as authoritative.

### 4. Layout dead zone — /kh-fleet 7-column grid

PR #491 added a REAL badge column. Grid intrinsic width grew from ~1008px (6 cols) to ~1133px (7 cols: \`12+18+11+5+13+4em\` ≈ 1008px + 6×1em gaps ≈ 96px + 0.9em padding ×2 ≈ 29px). Mobile-collapse \`@media\` kicked in at ≤ 1100px → **32px dead zone (1101-1132px)** where rows overflowed.

**Fix:** lifted breakpoint to ≤ 1200px, closing the dead zone with a comfortable margin around 1280px laptops.

## Build

61 pages, no errors. Inline-script hashes unchanged from #491 (no fix modifies scripted code paths). CSP still covers all 7 inline scripts in built dist.

## Test plan

- [x] Build clean
- [x] Lighthouse \`label-content-name-mismatch\` passes after aria-label drop (verified locally)
- [x] /kh-fleet at 1101-1199px now collapses to single column (mobile pattern) instead of overflowing
- [ ] Manual: voice-control "Install as offline-capable app" → button activates
- [ ] Manual: real-device install flow still works (visible text didn't change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)