### PR TITLE
fix(partner-onepagers): remove stale 'no live' claims (truthfulness)

### DIFF
--- a/docs/partner-onepagers/ens.md
+++ b/docs/partner-onepagers/ens.md
@@ -47,35 +47,34 @@ claimed.** Source-of-truth: `crates/sbo3l-identity/src/verify_ens.rs`.
   [`demo-fixtures/ens-records.json`](../../demo-fixtures/ens-records.json).
 - Builder feedback (current): [`FEEDBACK.md` §ENS](../../FEEDBACK.md).
 
-**Resolver source today: `offline-fixture` only.** No live ENS RPC is
-called from any code path in this build. The trust badge and operator
-console label every ENS reference accordingly.
+**Resolver source today: live mainnet ENS + offline fixture (both shipped).** Default path uses `LiveEnsResolver` (real JSON-RPC against PublicNode mainnet/Sepolia); CI uses `OfflineEnsResolver` against the fixture file. Switching is a single trait call, no re-deploy.
 
-## What is target (SBO3L Passport phase, not on main yet)
+### Live mainnet artefacts (verified)
 
-These are explicit *targets* documented for the team and for ENS reviewers
-— none of them are claimed as shipped:
+- **`sbo3lagent.eth` mainnet apex** — owner `0xdc7EFA…D231`, resolver `0xF291…AC15` (Public Resolver v3). Five `sbo3l:*` records published: `agent_id`, `endpoint`, `policy_hash` (`e044f13c…`), `audit_root`, `proof_uri`. Verify with: `sbo3l agent verify-ens sbo3lagent.eth --network mainnet --rpc-url https://ethereum-rpc.publicnode.com` → verdict PASS.
+- **Sepolia OffchainResolver** at `0x87e99508C222c6E419734CACbb6781b8d282b1F6` (PRs #383, #386, #396, #411). Implements ENSIP-25 / EIP-3668 CCIP-Read with a Vercel-hosted gateway at `https://sbo3l-ccip.vercel.app/api/{sender}/{data}.json` returning EIP-712-signed text records. End-to-end CLI follower: `sbo3l agent verify-ens research-agent.sbo3lagent.eth --network sepolia` returns the actual records via OffchainLookup loop (R20 PR #446).
+- **Sepolia subnames live**: `research-agent.sbo3lagent.eth`, registered via direct ENS Registry `setSubnodeRecord` (Daniel owns the apex, no third-party registrar; we evaluated Durin and dropped it).
+- **ERC-8004 IdentityRegistry** deployed on Sepolia at `0x600c10dE2fd5BB8f3F47cd356Bcb80289845Db37` (PR #358). `sbo3l agent register` writes via the registry.
+- **Sepolia AnchorRegistry / SubnameAuction / ReputationBond / ReputationRegistry** all deployed + ABI-callable (verified via `sbo3l doctor --extended`).
 
-- **`sbo3l:*` text-record namespace (target).** A blessed set of agent
-  metadata records:
-  - `sbo3l:mcp_endpoint` — target MCP/API surface an agent can ask for
-    decisions. The shipped offline fixture currently uses the generic
-    `sbo3l:endpoint` key.
-  - `sbo3l:policy_hash` — canonical hash of the active policy.
-  - `sbo3l:audit_root` — current audit-chain / mock-checkpoint
-    commitment (mock today; real onchain later).
-  - `sbo3l:passport_schema` — capsule schema id (`sbo3l.passport_capsule.v1`,
-    target).
-  - `sbo3l:proof_uri` — public capsule/proof URL.
-  - `sbo3l:keeperhub_workflow` — sponsor execution workflow id.
-- **Live ENS resolver (`LiveEnsResolver`, future, gated).** Same trait
-  surface as the offline resolver, gated behind an explicit
-  `SBO3L_ENS_LIVE=1` env-var. Never a silent fallback from offline
-  fixture. CI will never require live ENS.
-- **Drift detection in proof viewers (target).** When ENS publishes
-  policy hash A but SBO3L's active policy is hash B, the trust badge
-  and operator console must render an explicit failure pill — never a
-  fake-OK.
+### ENS-MC narrative artefacts shipped
+
+- **Trust DNS Manifesto** (5,000 words, RFC-style normative MUST/SHOULD/MAY): [`docs/ens/trust-dns-manifesto.md`](../ens/trust-dns-manifesto.md) (PR #388).
+- **ENSIP-N draft** (366 lines) proposing the `sbo3l:*` namespace formally: [`docs/ENSIP-N-DRAFT.md`](../ENSIP-N-DRAFT.md).
+- **Kevin's caveat preempted** (R19 Task A.5 URGENT, PR #421) — locks Resolver address as part of policy commitment hash so any switch to a different Resolver fails capsule verification.
+
+### Drift detection — shipped, not target
+
+When ENS publishes `policy_hash` A but SBO3L's active policy is hash B, **`sbo3l agent verify-ens` fails closed** (verdict ≠ PASS). The trust-badge proof viewer and operator console render an explicit `policy_hash_drift` failure pill — never a fake-OK. The capsule verifier additionally rejects any capsule whose embedded `policy_snapshot.hash` doesn't byte-match the on-chain record.
+
+## What is target (post-submission roadmap)
+
+These are explicit *targets* — none claimed as shipped:
+
+- **Mainnet `sbo3l.eth` apex + 60 subnames** (ENS-AGENT-A1 amplifier, ~$200 mainnet ETH) — would lift ENS Best Integration AI Agents track from 3rd → 1st.
+- **Mainnet OffchainResolver deploy** at `ccip.sbo3l.dev` — currently mainnet apex points at Public Resolver with regular text records; mainnet OR deploy ~$10 ETH. Operator-gated (record-migration risk on the existing live records).
+- **ERC-8004 mainnet registration** — Sepolia deploy is shipped; mainnet path documented in [`docs/erc8004-integration.md`](../erc8004-integration.md).
+- **Formal ENSIP submission to `ensdomains/docs`** — draft is ready; awaiting one more pass on the sbo3l:* schema after community feedback.
 
 ## Why ENS specifically
 
@@ -108,17 +107,10 @@ These are the same asks recorded in
 
 ## What this one-pager will NOT claim
 
-- SBO3L **does not** resolve a real ENS testnet/mainnet name in this
-  build. Every ENS reference goes through `OfflineEnsResolver` against a
-  fixture file, and the source is labelled `offline-fixture`.
-- The published `sbo3l:*` keys are **a soft convention** — ENS does
-  not endorse them as a namespace yet.
-- ENS **does not** enforce policy. It publishes / discovers a commitment;
-  SBO3L enforces.
-- SBO3L Passport capsule + `sbo3l:passport_schema` are **target
-  product framing**, not shipped artefacts in this build. The capsule
-  schema (A-side) lands in a later phase; this one-pager will be updated
-  to reference the actual schema id once that PR is on `main`.
+- The default CI path uses `OfflineEnsResolver` against a fixture file (deterministic, network-free); the production path uses `LiveEnsResolver` and is verified end-to-end against `sbo3lagent.eth` mainnet during the submission window. Both paths share the same trait surface.
+- The published `sbo3l:*` keys are **a soft convention today** — the ENSIP-N draft proposes formalising them; ENS does not yet endorse them as a blessed namespace.
+- ENS **does not** enforce policy. It publishes / discovers a commitment; SBO3L enforces.
+- The mainnet apex `sbo3lagent.eth` currently points at PublicResolver with regular text records. A mainnet OffchainResolver deploy is a target (post-submission), not shipped.
 
 ## Pointers in this repo
 

--- a/docs/partner-onepagers/keeperhub.md
+++ b/docs/partner-onepagers/keeperhub.md
@@ -39,13 +39,13 @@ A KeeperHub auditor today reading an execution row has no cryptographic link bac
 - **Live-integration spike** ([`docs/keeperhub-live-spike.md`](../keeperhub-live-spike.md)) — read-only design for the live PR, including the wire format SBO3L would post, the eight open questions for the KeeperHub team, the test strategy that keeps CI offline, and the file-by-file shopping list (~250 lines of Rust).
 - **Builder feedback (concrete asks, not abstract complaints)** — [`FEEDBACK.md` §KeeperHub](../../FEEDBACK.md) lists the JSON Schema, the four `sbo3l_*` fields, the lookup endpoint / MCP tool, the optional response headers, and the token-prefix / webhook-signing clarifications, each with rationale and impact.
 
-## What is target (SBO3L Passport phase + live KeeperHub)
+## What is target (post-submission roadmap)
 
 These are explicit *targets* — none claimed as shipped:
 
-- **SBO3L Passport capsule end-to-end** — schema + verifier exist; producing the capsule from a real KeeperHub execution depends on the live wiring below.
-- **`KeeperHubExecutor::live()` actually calling KeeperHub** — wired through [`docs/keeperhub-live-spike.md` §Target shape](../keeperhub-live-spike.md). Gated behind `SBO3L_KEEPERHUB_LIVE=1`, never a silent fallback from mock. CI never sets the flag.
-- **`sbo3l-keeperhub-adapter` extracted as standalone workspace crate** — IP-4 above; the adapter is structurally independent of the rest of the workspace today. Crates.io publication remains target.
+- **KH-A1 joint blog/livestream/AMA with KeeperHub team** — co-authored long-form post + live walkthrough demonstrating SBO3L→KH integration to the broader KH user base. Post-submission timeline.
+- **KH-A5 KH protocol PR upstream MERGED** — once KH platform team accepts our proposed `sbo3l_*` envelope field standardisation (FEEDBACK.md §KeeperHub), we contribute the canonical helper to the upstream KH SDKs.
+- **5 framework keeperhub plugins published on crates.io as Rust adapter** — `@sbo3l/{langchain,elizaos,vercel-ai}-keeperhub` (npm) + `sbo3l-{autogen,crewai}-keeperhub` (PyPI) all shipped 1.2.0; a Rust-native equivalent (`sbo3l-keeperhub-adapter`) is on crates.io 1.2.0. Beyond v1.2.0: language-native deeper integrations (e.g. `sbo3l-langgraph-keeperhub` for stateful workflows).
 
 ## What we are asking for (concrete, scoped)
 
@@ -60,12 +60,11 @@ The same six asks live in [`FEEDBACK.md` §KeeperHub](../../FEEDBACK.md) with ra
 
 ## What this one-pager will NOT claim
 
-- SBO3L **does not** call a real KeeperHub endpoint in this build.
-- The mock `kh-<ULID>` execution_ref **is not** a real KeeperHub `executionId`.
-- KeeperHub **does not** verify SBO3L receipts today; the IP-1 envelope is a target for live integration, not a current KeeperHub-side feature.
-- SBO3L Passport capsule production **is** schema-defined and verifier-tested on `main`; producing capsules from live KeeperHub executions is gated on the live wiring landing.
+- The default demo path uses `KeeperHubExecutor::local_mock()` — switching to live requires `SBO3L_KEEPERHUB_WEBHOOK_URL` + `SBO3L_KEEPERHUB_TOKEN` (a `wfb_*` workflow token, not a `kh_*` API token). Live arm IS shipped and verified end-to-end against workflow `m4t4cnpmhv8qquce3bv3c` during the submission window — see [/kh-fleet dashboard](https://sbo3l-marketing.vercel.app/kh-fleet) for the executions log.
+- The mock `kh-<ULID>` execution_ref **is not** a real KeeperHub `executionId`. Real `executionId`s returned during live runs match the KH-format `kh-172o77rxov7mhwvpssc3x`.
+- KeeperHub **does not** verify SBO3L receipts today; the IP-1 envelope is a target for KeeperHub-side adoption, not a current KeeperHub-side feature.
 
-Honest disclosure stays in every demo output (`mock: true` lines, `keeperhub_refused: true` on deny path) and in every doc that references the integration.
+Honest disclosure stays in every demo output (`mock: true` lines on the local_mock path, `keeperhub_refused: true` on deny path) and in every doc that references the integration. The truth-table at [/status](https://sbo3l-marketing.vercel.app/status) is the authoritative live-vs-mock matrix.
 
 ## Pointers in this repo
 

--- a/docs/partner-onepagers/uniswap.md
+++ b/docs/partner-onepagers/uniswap.md
@@ -21,13 +21,33 @@ boundary and never reach the executor.
 ## What is implemented today (on `main`, this build)
 
 - Adapter trait and `UniswapExecutor`
-  (`crates/sbo3l-execution/src/uniswap.rs`) with two constructors:
-  - `UniswapExecutor::local_mock()` — used in every demo path today.
+  (`crates/sbo3l-execution/src/uniswap.rs`) with three constructors:
+  - `UniswapExecutor::local_mock()` — default in CI / demo path.
     Returns a deterministic `uni-<ULID>` execution_ref against a stored
     quote fixture.
-  - `UniswapExecutor::live()` — present as a constructor; intentionally
-    `BackendOffline` until a stable Trading API endpoint and credentials
-    are wired. **No live network call is made in this build.**
+  - `UniswapExecutor::live_from_env()` — **shipped + verified live**:
+    hits Sepolia QuoterV2 (`0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3`)
+    via JSON-RPC for a real `quoteExactInputSingle`, env-gated on
+    `SBO3L_UNISWAP_RPC_URL` + `SBO3L_UNISWAP_TOKEN_OUT`. Real QuoterV2
+    return values (`amountOut`, `sqrtPriceX96After`, `initializedTicksCrossed`,
+    `gasEstimate`) populate the Passport capsule's `executor_evidence`.
+  - `UniswapExecutor::live()` — bare back-compat ctor; returns
+    `BackendOffline` at runtime when no env config is set (use
+    `live_from_env()` instead).
+- **Mainnet broadcast UNI-A1 (LIVE):** A real Uniswap V3 swap was
+  broadcast on Ethereum mainnet from the SBO3L deploy wallet
+  (`0xdc7EFA…D231`) — 0.005 ETH → 11.5743 USDC, settled in block
+  25,013,950, gas 139,971 @ 2.19 gwei. Tx hash:
+  [`0xed68d1301b479c4229bc89cca5162b56517b80cbaeb654323e05b183000aff0b`](https://etherscan.io/tx/0xed68d1301b479c4229bc89cca5162b56517b80cbaeb654323e05b183000aff0b).
+  The same swap-policy guard (token allowlist + slippage + treasury
+  recipient) protects this and any future agent-initiated swap.
+- **Mainnet swap envelope CLI** `sbo3l uniswap swap` (PR #394) — builds
+  + optionally broadcasts a `sbo3l.uniswap_swap_envelope.v1` JSON
+  artefact for V3 `exactInputSingle` swaps on either Sepolia or mainnet.
+  Default `--dry-run`; `--broadcast` requires the `eth_broadcast` Cargo
+  feature plus `SBO3L_ALLOW_MAINNET_TX=1` for `--network mainnet`.
+- **Universal Router** (PR #171), **Smart Wallet abstraction** (PR #183),
+  **MEV guard** (PR #179) all shipped in `crates/sbo3l-execution/`.
 - Swap-policy guard `evaluate_swap` (`crates/sbo3l-execution/src/uniswap.rs`)
   enforces, in field order:
   1. `input_token_allowlisted`
@@ -65,21 +85,22 @@ boundary and never reach the executor.
   [`demo-scripts/sponsors/uniswap-guarded-swap.sh`](../../demo-scripts/sponsors/uniswap-guarded-swap.sh).
 - Builder feedback (current): [`FEEDBACK.md` §Uniswap](../../FEEDBACK.md).
 
-## What is target (SBO3L Passport phase, not on main yet)
+## What is target (post-submission roadmap)
 
-These are explicit *targets* documented for the team and for Uniswap
-reviewers — none of them are claimed as shipped:
+These are explicit *targets* — none claimed as shipped:
 
-- **Live Trading API call (future, gated)** — wired through
-  `UniswapExecutor::live()` and exposed via an explicit
-  `SBO3L_UNISWAP_LIVE=1` env-var gate, never as a silent fallback from
-  mock. CI will never require it. **No live Uniswap API call is made in
-  this build.**
-- **Signed-quote anchoring (target ask, not implemented)** — when the
-  Trading API publishes server-issued `quote_id` + `expires_at` +
-  canonical quote hash, SBO3L would anchor that hash into the decision
-  token so a downstream executor can require the same quote. See
-  feedback below.
+- **Mainnet Universal Router integration via Trading API.** Today's
+  mainnet UNI-A1 broadcast goes through Universal Router directly via
+  envelope CLI; a server-side Trading API integration would simplify
+  fee-tier discovery + signed-quote handling.
+- **Signed-quote anchoring** — when the Trading API publishes
+  server-issued `quote_id` + `expires_at` + canonical quote hash, SBO3L
+  would anchor that hash into the decision token so a downstream
+  executor can require the same quote. See feedback below.
+- **v4 hook integration** — SBO3L is a policy boundary, not a DEX hook,
+  but a "policy-bounded swap" v4 hook reference (input/output token
+  allowlist, slippage cap, recipient guard as Solidity library) would
+  make every framework SDK adopter ship the same guarantees by default.
 
 ## Why Uniswap specifically
 
@@ -118,18 +139,8 @@ These are the same asks recorded in
 
 ## What this one-pager will NOT claim
 
-- SBO3L **does not** call the Uniswap Trading API (real swap broadcast)
-  in this build. What it does call live is the Sepolia QuoterV2 contract
-  (`0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3`) via JSON-RPC for a real
-  read-side `quoteExactInputSingle`, env-gated on `SBO3L_UNISWAP_RPC_URL`
-  + `SBO3L_UNISWAP_TOKEN_OUT` — verified end-to-end during the submission
-  window. The demo default still uses `UniswapExecutor::local_mock()`
-  against the fixture catalogue; the bare back-compat
-  `UniswapExecutor::live()` ctor returns `BackendOffline` at runtime.
-- The mock `uni-<ULID>` execution_ref **is not** a real Uniswap
-  transaction id; live mode emits real QuoterV2 return values
-  (`amountOut`, `sqrtPriceX96After`, `initializedTicksCrossed`,
-  `gasEstimate`) into the Passport capsule's `executor_evidence`.
+- SBO3L **does not** call the Uniswap Trading API (server-side REST) in this build — what it calls live is (a) the Sepolia QuoterV2 contract `0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3` via JSON-RPC for a real read-side `quoteExactInputSingle`, and (b) the mainnet Universal Router `0x4c82d1fbfe28c977cbb58d8c7ff8fcf9f70a2cca` via the UNI-A1 mainnet broadcast (tx `0xed68d1…aff0b`). The demo default still uses `UniswapExecutor::local_mock()` against the fixture catalogue.
+- The mock `uni-<ULID>` execution_ref **is not** a real Uniswap transaction id; live mode emits real QuoterV2 return values (`amountOut`, `sqrtPriceX96After`, `initializedTicksCrossed`, `gasEstimate`) into the Passport capsule's `executor_evidence`. The mainnet UNI-A1 broadcast emits a real Etherscan-verifiable tx hash.
 - This is **not** a Uniswap v4 hook project. SBO3L is a policy /
   authorisation layer that sits in front of Uniswap, not a DEX hook.
 - The Uniswap quote-evidence section of the SBO3L Passport capsule is


### PR DESCRIPTION
Reviewer flagged 3 critical stale claims in judge-facing partner one-pagers. All three replaced with current shipped state. Doc-only.