### PR TITLE
fix: bump 1.2.0 → 1.2.1 — re-publishes sbo3l-cli with doctor --extended flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 license = "MIT"
 authors = ["Daniel Babjak <babjak_daniel@hotmail.com>"]
@@ -85,23 +85,23 @@ url = "2"
 # survives). The IP-4 standalone adapter
 # (`crates/sbo3l-keeperhub-adapter`) needs `sbo3l-core` to be
 # publishable, which means the version must be declared here.
-sbo3l-core = { path = "crates/sbo3l-core", version = "1.2.0" }
+sbo3l-core = { path = "crates/sbo3l-core", version = "1.2.1" }
 # Workspace dep declares `default-features = false` so per-member
 # `features = […]` and `default-features = false/true` overrides take
 # effect. Most members opt-in to the `budget` feature explicitly via
 # `features = ["budget"]` (server, cli, mcp, identity, research-agent);
 # the wasm-target playground crate uses default-off to skip the
 # rusqlite-backed budget tracker. R17 P1.
-sbo3l-policy = { path = "crates/sbo3l-policy", version = "1.2.0", default-features = false }
-sbo3l-storage = { path = "crates/sbo3l-storage", version = "1.2.0" }
-sbo3l-identity = { path = "crates/sbo3l-identity", version = "1.2.0" }
-sbo3l-execution = { path = "crates/sbo3l-execution", version = "1.2.0" }
-sbo3l-keeperhub-adapter = { path = "crates/sbo3l-keeperhub-adapter", version = "1.2.0" }
-sbo3l-mcp = { path = "crates/sbo3l-mcp", version = "1.2.0" }
-sbo3l-cli = { path = "crates/sbo3l-cli", version = "1.2.0" }
-sbo3l-server = { path = "crates/sbo3l-server", version = "1.2.0" }
-sbo3l-anchor = { path = "crates/sbo3l-anchor", version = "1.2.0" }
-sbo3l-playground = { path = "crates/sbo3l-playground", version = "1.2.0" }
+sbo3l-policy = { path = "crates/sbo3l-policy", version = "1.2.1", default-features = false }
+sbo3l-storage = { path = "crates/sbo3l-storage", version = "1.2.1" }
+sbo3l-identity = { path = "crates/sbo3l-identity", version = "1.2.1" }
+sbo3l-execution = { path = "crates/sbo3l-execution", version = "1.2.1" }
+sbo3l-keeperhub-adapter = { path = "crates/sbo3l-keeperhub-adapter", version = "1.2.1" }
+sbo3l-mcp = { path = "crates/sbo3l-mcp", version = "1.2.1" }
+sbo3l-cli = { path = "crates/sbo3l-cli", version = "1.2.1" }
+sbo3l-server = { path = "crates/sbo3l-server", version = "1.2.1" }
+sbo3l-anchor = { path = "crates/sbo3l-anchor", version = "1.2.1" }
+sbo3l-playground = { path = "crates/sbo3l-playground", version = "1.2.1" }
 
 [profile.release]
 lto = "thin"

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 **With the CLI** (3 min, ~150MB Rust install):
 
 ```bash
-cargo install sbo3l-cli --version 1.2.0
+cargo install sbo3l-cli --version 1.2.1
 sbo3l agent verify-ens sbo3lagent.eth --network mainnet  # → 5 records resolved
-sbo3l doctor --extended                                  # → 6/6 contracts ok
+sbo3l doctor --extended                                  # → 7/7 contracts ok
 curl -s https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/capsule.json \
   | sbo3l passport verify --path /dev/stdin              # → crypto verify: ok
 ```

--- a/crates/sbo3l-keeperhub-adapter/Cargo.toml
+++ b/crates/sbo3l-keeperhub-adapter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbo3l-keeperhub-adapter"
-version = "1.2.0"
+version = "1.2.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
UAT found published sbo3l-cli v1.2.0 lacks --extended (PR #384 landed after publish). Trust crack on first README walkthrough. Bump triggers crates-publish workflow on v1.2.1 tag.