### PR TITLE
fix(crates-publish): include sbo3l-anchor + bump 1.2.1 to 1.2.2

### DIFF
--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -1,7 +1,7 @@
-name: Publish 9 SBO3L crates to crates.io
+name: Publish 10 SBO3L crates to crates.io
 
 # Triggered by tagging the workspace with a version tag (`v0.1.0`,
-# `v0.2.0`, ...). The 9 crates are published in dependency order:
+# `v0.2.0`, ...). The 10 crates are published in dependency order:
 #
 #   1. sbo3l-core              (no internal deps)
 #   2. sbo3l-storage           (deps: sbo3l-core)
@@ -11,7 +11,8 @@ name: Publish 9 SBO3L crates to crates.io
 #   6. sbo3l-execution         (deps: sbo3l-core, sbo3l-keeperhub-adapter)
 #   7. sbo3l-server            (deps: sbo3l-core, sbo3l-policy, sbo3l-storage)
 #   8. sbo3l-mcp               (deps: 1-7)
-#   9. sbo3l-cli               (deps: 1-7)
+#   9. sbo3l-anchor            (deps: sbo3l-core, sbo3l-storage)
+#  10. sbo3l-cli               (deps: 1-9, including sbo3l-anchor)
 #
 # Each step waits ~30s for the crates.io index to propagate before
 # publishing the next dependent crate — necessary because subsequent
@@ -181,6 +182,24 @@ jobs:
       - name: wait for crates.io index propagation (sbo3l-mcp)
         run: sleep 30
 
+      # sbo3l-anchor must publish BEFORE sbo3l-cli — cli depends on it for the
+      # `sbo3l audit anchor` subcommand. Originally published manually at v1.2.0
+      # and missing from this workflow until v1.2.1 patch (UAT found that bumping
+      # workspace 1.2.0→1.2.1 broke sbo3l-cli publish because sbo3l-anchor 1.2.1
+      # didn't yet exist on crates.io).
+      - name: cargo package — sbo3l-anchor
+        run: cargo package -p sbo3l-anchor --allow-dirty
+      - name: attest provenance — sbo3l-anchor
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: target/package/sbo3l-anchor-${{ env.VERSION }}.crate
+      - name: cargo publish — sbo3l-anchor
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p sbo3l-anchor --no-verify
+      - name: wait for crates.io index propagation (sbo3l-anchor)
+        run: sleep 30
+
       - name: cargo package — sbo3l-cli
         run: cargo package -p sbo3l-cli --allow-dirty
       - name: attest provenance — sbo3l-cli
@@ -192,7 +211,7 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish -p sbo3l-cli --no-verify
 
-      - name: Upload all 9 .crate files + attestation bundles
+      - name: Upload all 10 .crate files + attestation bundles
         uses: actions/upload-artifact@v4
         with:
           name: sbo3l-crates-${{ env.VERSION }}-attested

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 license = "MIT"
 authors = ["Daniel Babjak <babjak_daniel@hotmail.com>"]
@@ -85,23 +85,23 @@ url = "2"
 # survives). The IP-4 standalone adapter
 # (`crates/sbo3l-keeperhub-adapter`) needs `sbo3l-core` to be
 # publishable, which means the version must be declared here.
-sbo3l-core = { path = "crates/sbo3l-core", version = "1.2.1" }
+sbo3l-core = { path = "crates/sbo3l-core", version = "1.2.2" }
 # Workspace dep declares `default-features = false` so per-member
 # `features = […]` and `default-features = false/true` overrides take
 # effect. Most members opt-in to the `budget` feature explicitly via
 # `features = ["budget"]` (server, cli, mcp, identity, research-agent);
 # the wasm-target playground crate uses default-off to skip the
 # rusqlite-backed budget tracker. R17 P1.
-sbo3l-policy = { path = "crates/sbo3l-policy", version = "1.2.1", default-features = false }
-sbo3l-storage = { path = "crates/sbo3l-storage", version = "1.2.1" }
-sbo3l-identity = { path = "crates/sbo3l-identity", version = "1.2.1" }
-sbo3l-execution = { path = "crates/sbo3l-execution", version = "1.2.1" }
-sbo3l-keeperhub-adapter = { path = "crates/sbo3l-keeperhub-adapter", version = "1.2.1" }
-sbo3l-mcp = { path = "crates/sbo3l-mcp", version = "1.2.1" }
-sbo3l-cli = { path = "crates/sbo3l-cli", version = "1.2.1" }
-sbo3l-server = { path = "crates/sbo3l-server", version = "1.2.1" }
-sbo3l-anchor = { path = "crates/sbo3l-anchor", version = "1.2.1" }
-sbo3l-playground = { path = "crates/sbo3l-playground", version = "1.2.1" }
+sbo3l-policy = { path = "crates/sbo3l-policy", version = "1.2.2", default-features = false }
+sbo3l-storage = { path = "crates/sbo3l-storage", version = "1.2.2" }
+sbo3l-identity = { path = "crates/sbo3l-identity", version = "1.2.2" }
+sbo3l-execution = { path = "crates/sbo3l-execution", version = "1.2.2" }
+sbo3l-keeperhub-adapter = { path = "crates/sbo3l-keeperhub-adapter", version = "1.2.2" }
+sbo3l-mcp = { path = "crates/sbo3l-mcp", version = "1.2.2" }
+sbo3l-cli = { path = "crates/sbo3l-cli", version = "1.2.2" }
+sbo3l-server = { path = "crates/sbo3l-server", version = "1.2.2" }
+sbo3l-anchor = { path = "crates/sbo3l-anchor", version = "1.2.2" }
+sbo3l-playground = { path = "crates/sbo3l-playground", version = "1.2.2" }
 
 [profile.release]
 lto = "thin"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 **With the CLI** (3 min, ~150MB Rust install):
 
 ```bash
-cargo install sbo3l-cli --version 1.2.1
+cargo install sbo3l-cli --version 1.2.2
 sbo3l agent verify-ens sbo3lagent.eth --network mainnet  # → 5 records resolved
 sbo3l doctor --extended                                  # → 7/7 contracts ok
 curl -s https://b2jk-industry.github.io/SBO3L-ethglobal-openagents-2026/capsule.json \

--- a/crates/sbo3l-keeperhub-adapter/Cargo.toml
+++ b/crates/sbo3l-keeperhub-adapter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbo3l-keeperhub-adapter"
-version = "1.2.1"
+version = "1.2.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Adds sbo3l-anchor to publish workflow + bumps to 1.2.2 for clean re-publish.