### PR TITLE
fix(sw): strip query from runtime cache key + bump SW_VERSION → v2

### DIFF
--- a/apps/marketing/public/sw.js
+++ b/apps/marketing/public/sw.js
@@ -17,7 +17,7 @@
 // Versioning: bumping SW_VERSION invalidates all caches on activate.
 // CSP: vercel.json allows worker-src 'self'; SW is same-origin.
 
-const SW_VERSION = "v1-2026-05-02";
+const SW_VERSION = "v2-2026-05-03";
 const SHELL_CACHE = `sbo3l-shell-${SW_VERSION}`;
 const RUNTIME_CACHE = `sbo3l-runtime-${SW_VERSION}`;
 
@@ -106,18 +106,28 @@ self.addEventListener("fetch", (event) => {
   // Network-first for HTML so users see updated pages when online; fall
   // back to cached shell if offline. Limit fallback to navigation
   // requests so JSON / data files don't get stale shells.
+  //
+  // Self-review fix (PR #501): the cache key is the URL pathname, not
+  // the full Request, so /proof?capsule_url=A and /proof?capsule_url=B
+  // and /proof?capsule_url=C all collapse onto a single cache entry
+  // for /proof. Without this, every distinct deep-link from /kh-fleet
+  // ("verify →" buttons) added an unbounded entry to the runtime cache.
+  // The runtime <script> on /proof reads window.location.search at
+  // execution time, so query-string variants don't need separate
+  // cached HTML — the canonical /proof shell handles them all.
   if (req.mode === "navigate" || (req.headers.get("accept") || "").includes("text/html")) {
+    const cacheKey = new Request(url.pathname, { method: "GET" });
     event.respondWith(
       fetch(req)
         .then((res) => {
           if (res && res.ok) {
             const copy = res.clone();
-            caches.open(RUNTIME_CACHE).then((c) => c.put(req, copy));
+            caches.open(RUNTIME_CACHE).then((c) => c.put(cacheKey, copy));
           }
           return res;
         })
         .catch(() =>
-          caches.match(req).then((cached) => cached || caches.match("/proof"))
+          caches.match(cacheKey).then((cached) => cached || caches.match("/proof"))
         )
     );
   }


### PR DESCRIPTION
## Summary

Self-review #3 — one more real bug in R22 PWA SW (after #491 + #500 fixes).

## Bug

Runtime navigation cache used the full \`Request\` as the key:

\`\`\`js
caches.open(RUNTIME_CACHE).then((c) => c.put(req, copy));
\`\`\`

Every distinct \`/proof?capsule_url=X\` URL became a separate cache entry. Each "verify →" click on /kh-fleet (5 links today, growing as more capsules ship) added a new entry. Result: **unbounded runtime-cache growth** tied to user navigation patterns, with no eviction.

## Why query strings don't need separate cached HTML

The runtime \`<script>\` on /proof reads \`window.location.search\` at **execution time**, not at cache-write time. The HTML body is identical regardless of \`?capsule_url=...\`. Vercel also ignores query strings for static routes, returning the same HTML for /foo and /foo?a=b.

## Fix

\`\`\`js
const cacheKey = new Request(url.pathname, { method: "GET" });
// ... cache.put(cacheKey, copy) ... cache.match(cacheKey)
\`\`\`

\`/proof?A\`, \`/proof?B\`, \`/proof?C\` all collapse onto a single \`/proof\` cache entry. Pages with different pathnames (\`/sk/proof\`, \`/kh-fleet\`, etc.) each still get their own entry as before.

\`SW_VERSION\` bumped \`v1-2026-05-02\` → \`v2-2026-05-03\` so existing clients re-build their cache from the corrected logic instead of inheriting any polluted v1 state.

## Test plan

- [x] Build clean
- [x] dist/sw.js contains \`cacheKey = new Request(url.pathname...)\` + \`cache.put(cacheKey, ...)\`
- [x] dist/sw.js no longer contains \`cache.put(req, copy)\` for navigation branch
- [ ] Manual: install PWA, click 5 different /kh-fleet "verify →" links, inspect Cache Storage in DevTools → only 1 \`/proof\` entry, not 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)