### PR TITLE
fix(marketing): drop false Anthropic-sponsor claim from FE

### DIFF
--- a/apps/marketing/src/components/SponsorLogos.astro
+++ b/apps/marketing/src/components/SponsorLogos.astro
@@ -1,15 +1,21 @@
 ---
-// Sponsor track strip — links each ETHGlobal sponsor to our submission
-// page for that bounty.
+// Sponsor track strip — links each ETHGlobal Open Agents 2026 sponsor
+// to our submission page for that bounty.
 //
-// R19 Wave 2 Task C: replaced the prior text-only grid (4 plain
-// <a><strong/>name) with 4 SponsorCard SVG cards (240×140 each, brand
-// motif on the right, accent stripe on the left). Cards are still
+// R19 Wave 2 Task C: replaced the prior text-only grid (plain
+// <a><strong/>name) with SponsorCard SVG cards (240×140 each, brand
+// motif on the right, accent stripe on the left). Cards are
 // inline-SVG, no third-party images — keeps the marketing CSP clean
-// (img-src 'self'). Adoption matches the brief ordering.
+// (img-src 'self').
 //
-// Sponsor list deliberately matches the same 4 tracks the previous
-// component shipped — KH, ENS-Most-Creative, Uniswap, Anthropic.
+// 2026-05-03: removed Anthropic from the strip. Anthropic is NOT an
+// ETHGlobal Open Agents 2026 sponsor track — placing them under
+// "Live sponsor integrations" would falsely imply a prize-giving
+// relationship. The Claude tool-use ADAPTER (`@sbo3l/anthropic`) is
+// real and stays documented in /quickstarts + /status as an SDK
+// integration; the standalone /submission/anthropic page also stays
+// reachable but is no longer linked from this sponsor surface.
+//
 // Other tracks (0G, ENS-AI-Agents) live on their own /submission
 // pages but are intentionally not in this surface; that decision
 // was made when this component first shipped to avoid implying
@@ -17,11 +23,10 @@
 
 import SponsorCard from "~/components/SponsorCard.astro";
 
-const sponsors: { track: string; subtitle: string; motif: "keeperhub" | "ens" | "uniswap" | "anthropic"; href: string }[] = [
+const sponsors: { track: string; subtitle: string; motif: "keeperhub" | "ens" | "uniswap"; href: string }[] = [
   { track: "KeeperHub", subtitle: "Live workflow + signed receipts",  motif: "keeperhub", href: "/submission/keeperhub" },
   { track: "ENS",       subtitle: "sbo3lagent.eth + Trust DNS",       motif: "ens",       href: "/submission/ens-most-creative" },
   { track: "Uniswap",   subtitle: "Sepolia QuoterV2 + MEV guard",     motif: "uniswap",   href: "/submission/uniswap" },
-  { track: "Anthropic", subtitle: "Claude tool-use receipts",         motif: "anthropic", href: "/submission/anthropic" },
 ];
 ---
 <section class="sponsors" aria-label="ETHGlobal Open Agents 2026 sponsor tracks">

--- a/apps/marketing/src/pages/roadmap.astro
+++ b/apps/marketing/src/pages/roadmap.astro
@@ -40,7 +40,7 @@ const shipped: RoadmapItem[] = [
   },
   {
     title: "Sponsor live integrations",
-    blurb: "Live KeeperHub workflow + Sepolia QuoterV2 + Sepolia AnchorRegistry + Anthropic tool-use receipts. 7 sponsor pages on /submission/<slug>; status truth-table at /status.",
+    blurb: "Live KeeperHub workflow + Sepolia QuoterV2 + Sepolia AnchorRegistry. Per-track submission pages on /submission/<slug>; status truth-table at /status.",
   },
   {
     title: "ERC-8004 IdentityRegistry",


### PR DESCRIPTION
## Summary
Daniel flagged the marketing site implies Anthropic is an ETHGlobal Open Agents 2026 sponsor track giving a prize. They are **not** a sponsor of this hackathon; the prior FE state risked a truthfulness mark-down from judges or partners.

## What changed

**`SponsorLogos.astro`** — removed the 4th card ("Anthropic — Claude tool-use receipts"). The section title is "Live sponsor integrations" with aria-label "ETHGlobal Open Agents 2026 sponsor tracks" — Anthropic listed there was the false claim. Strip now shows only the 3 real bounty sponsors: KeeperHub, ENS, Uniswap.

**`roadmap.astro`** — Sponsor-live-integrations blurb dropped "Anthropic tool-use receipts" and the "7 sponsor pages" count (which was conflating SDK adapter pages with sponsor bounty pages). Replaced with neutral "per-track submission pages on /submission/<slug>".

## Intentionally NOT changed
- `/submission/anthropic` page stays reachable — it's an SDK adapter integration story (`@sbo3l/anthropic` wraps Claude tool-use with policy receipts, real and live on npm), not a sponsorship claim. Just no longer linked from the sponsor surface.
- `/quickstarts` and `/status` adapter references stay — accurate descriptions of a real npm package + real example app.
- `ens-most-creative-final.md` listing "Anthropic SDK" alongside other AI provider SDKs stays — accurate technical statement.

## Verification
- [x] `pnpm build` succeeds: 61 pages, 1.84s
- [x] `dist/index.html` sponsor strip links: keeperhub, ens-most-creative, uniswap (3, not 4 — Anthropic gone as intended)
- [x] `/submission/anthropic` page still renders (adapter story preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)