### PR TITLE
fix(truthfulness): drop Anthropic from all sponsor surfaces (sweep follow-up to #511)

### DIFF
--- a/apps/marketing/src/data/og-registry.ts
+++ b/apps/marketing/src/data/og-registry.ts
@@ -100,9 +100,15 @@ export const OG_PAGES: Record<string, OgPageMeta> = {
     variant: "sponsor",
   },
   "submission/anthropic": {
+    // Anthropic is NOT an ETHGlobal Open Agents 2026 sponsor track —
+    // they don't give a prize. The /submission/anthropic page is an
+    // SDK adapter integration story (the @sbo3l/anthropic npm package
+    // wraps Claude tool-use with policy receipts), so the OG card
+    // uses the "default" variant, not the "sponsor" variant. Avoids
+    // social-preview implying a bounty/prize relationship.
     title: "SBO3L × Anthropic",
     subtitle: "Claude tool-use signed receipts · single-line wrapAnthropic()",
-    variant: "sponsor",
+    variant: "default",
   },
 };
 

--- a/apps/marketing/src/pages/status.astro
+++ b/apps/marketing/src/pages/status.astro
@@ -36,6 +36,16 @@ const sections: { title: string; rows: Row[] }[] = [
         mock: null,
         notyet: null,
       },
+    ],
+  },
+  {
+    // AI provider SDK adapters are NOT ETHGlobal Open Agents 2026
+    // sponsor tracks (no bounty / no prize); they're tool integrations
+    // the project ships alongside the sponsor work. Split into their
+    // own section so the "Sponsor integrations" surface above does
+    // not imply Anthropic is a bounty-giving sponsor.
+    title: "AI provider SDK adapters",
+    rows: [
       {
         surface: "Anthropic Claude tool-use",
         live: "`@sbo3l/anthropic` published on npm. `examples/anthropic-research-agent/` runs end-to-end with `ANTHROPIC_API_KEY=…`.",

--- a/docs/dev3/mobile-device-uat-checklist.md
+++ b/docs/dev3/mobile-device-uat-checklist.md
@@ -37,7 +37,7 @@ For every page below: open the URL on phone, then run the steps. Mark ✅ pass /
 - [ ] CinematicDecision auto-plays after FCP; 6 scenes cycle without freezing
 - [ ] Primary CTA button "Start in 5 minutes" is comfortably tappable (≥ 44×44 px), visibly underlined or button-shaped
 - [ ] Tier cards (Tier 1 / Tier 2 / Tier 3) tap-navigate to /demo, /playground, /playground/live
-- [ ] Sponsor strip (KH, ENS, Uniswap, Anthropic) shows 4 cards in a grid; cards have brand motifs
+- [ ] Sponsor strip (KH, ENS, Uniswap) shows 3 cards in a grid; cards have brand motifs
 - [ ] KeyFlowDiagram renders (agent → daemon → executor with audit-log box below)
 - [ ] Footer links work; nothing overflows
 

--- a/docs/submission/backup-demo-video/scene-5-sponsor-wins.md
+++ b/docs/submission/backup-demo-video/scene-5-sponsor-wins.md
@@ -1,10 +1,19 @@
-# Scene 5 — Sponsor wins (static slide content)
+# Scene 5 — Sponsor wins + SDK reach (static slide content)
 
 > **Format:** paste this into one Keynote / Google Slides slide at 1920×1080.
 > **Hold time:** 15 s on camera.
-> **Layout suggestion:** two columns. Left column = sponsors (5 rows). Right
-> column = the four-number outro footer (881 / 13 / 25 / 9). Use the SBO3L
-> palette: bg `#0a0a0f`, accent `#4ad6a7`, fg `#e6e6ec`.
+> **Layout suggestion:** two columns. Left column = 4 ETHGlobal sponsor
+> tracks (KH, ENS, Uniswap, 0G) + 1 SDK adapter row (Anthropic) clearly
+> visually separated from the sponsor block. Right column = the four-
+> number outro footer (881 / 13 / 25 / 9). Use the SBO3L palette: bg
+> `#0a0a0f`, accent `#4ad6a7`, fg `#e6e6ec`.
+>
+> **Anthropic note for the recording:** Anthropic is NOT an ETHGlobal
+> Open Agents 2026 sponsor (no bounty / no prize). The Claude tool-use
+> adapter is real and shipped on npm, but it belongs in the "SDK reach"
+> bucket, not the sponsor bucket. The slide MUST visually separate them
+> (different sub-heading + a divider) so a viewer can't read it as
+> "Anthropic gives a prize."
 >
 > **Voice match:** these bullets mirror the per-bounty docs at
 > [`bounty-keeperhub.md`](../bounty-keeperhub.md), [`bounty-ens-most-creative-final.md`](../bounty-ens-most-creative-final.md),
@@ -65,7 +74,13 @@
 
 ---
 
-## Anthropic — Claude tool-use
+## SDK adapter (non-sponsor): Anthropic Claude tool-use
+
+> **Important visual cue when slidedesigning:** put this section
+> under its own sub-heading or divider so it's clearly separate
+> from the 4 sponsor blocks above. Anthropic does NOT sponsor Open
+> Agents 2026 — listing them under the sponsor block would be a
+> truthfulness defect.
 
 - `@sbo3l/anthropic` npm package — `sbo3lTool` Claude `Tool` definition +
   `runSbo3lToolUseLoop()` driver for multi-turn tool dispatch


### PR DESCRIPTION
## Summary
Follow-up sweep after #511 dropped Anthropic from the FE sponsor strip. Found 4 more surfaces still falsely framing Anthropic as an ETHGlobal Open Agents 2026 sponsor.

## Fixed surfaces

1. **`docs/dev3/mobile-device-uat-checklist.md:40`** — checked "Sponsor strip (KH, ENS, Uniswap, Anthropic) shows 4 cards"; post-#511 strip has 3. Updated.

2. **`apps/marketing/src/pages/status.astro:19,40`** — Anthropic Claude tool-use was under section title "Sponsor integrations". Split into a new "AI provider SDK adapters" section. Same row content preserved.

3. **`apps/marketing/src/data/og-registry.ts:105`** — `/submission/anthropic` OG card had `variant: "sponsor"`, rendering a sponsor-styled social-preview card. Changed to `variant: "default"`.

4. **`docs/submission/backup-demo-video/scene-5-sponsor-wins.md`** — backup-demo-video Scene 5 titled "Sponsor wins" listed Anthropic alongside KH/ENS/Uniswap/0G. Renamed scene to "Sponsor wins + SDK reach"; renamed Anthropic section to "SDK adapter (non-sponsor): Anthropic Claude tool-use"; added slide-design + recording notes that mandate visual separation.

## Intentionally NOT changed
- `/submission/anthropic` page itself stays reachable (real SDK adapter integration story, not a sponsorship claim)
- `@sbo3l/anthropic` adapter references in `/quickstarts`, `examples/`, README — accurate technical facts
- `bounty-anthropic.md` mentions in cross-reference lists — accurate documentation pointers

## Verification
- [x] `pnpm build` — 61 pages, 1.63s, clean
- [x] `/submission/anthropic` page still renders post variant change
- [x] `/status` renders both "Sponsor integrations" + new "AI provider SDK adapters" sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)