### PR TITLE
fix(og): strip .html suffix from slug + fall back to default for unregistered slugs

### DIFF
--- a/apps/marketing/src/layouts/BaseLayout.astro
+++ b/apps/marketing/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import Nav from "~/components/Nav.astro";
 import Footer from "~/components/Footer.astro";
 import { isLocale, isRtlLocale, DEFAULT_LOCALE, type Locale } from "~/i18n";
+import { OG_PAGES } from "~/data/og-registry";
 import "~/styles/global.css";
 
 interface Props {
@@ -26,9 +27,26 @@ const {
 // /og/[...slug].svg.ts is the static-generator endpoint that emits one SVG per
 // registry entry (variants: default / proof / status / roadmap / playground /
 // sponsor). Fall back to /og-default.svg if the slug isn't registered yet.
-const rawSlug = (Astro.url?.pathname ?? "/").replace(/^\/+|\/+$/g, "");
-const slug = rawSlug === "" ? "default" : rawSlug;
-const resolvedOgImage = ogImage ?? `/og/${slug}.svg`;
+//
+// Self-review fix (R22 round 4): astro.config has `build.format: 'file'`,
+// so Astro.url.pathname for /pages/proof.astro at SSR time is
+// `/proof.html`, not `/proof`. The slug-strip below previously produced
+// `proof.html` → resolved og URL `/og/proof.html.svg` → 404 in
+// production (the OG endpoint emits `/og/proof.svg`). Every EN page
+// except `/` had a broken og:image URL — link previews on social /
+// Slack / Discord lost their imagery. Strip the trailing `.html` so
+// the slug matches the OG registry keys.
+const rawSlug = (Astro.url?.pathname ?? "/")
+  .replace(/^\/+|\/+$/g, "")
+  .replace(/\.html$/, "");
+const candidateSlug = rawSlug === "" ? "default" : rawSlug;
+// Only emit /og/<slug>.svg if the slug is a known OG_PAGES entry — every
+// other path (like locale homepages /sk, /ko, /ja, or pages without a
+// registered OG variant) falls back to the default SVG. The endpoint
+// only generates one file per OG_PAGES key; an unknown slug would 404
+// in production. Explicit `ogImage` prop wins over both.
+const ogSlug = candidateSlug in OG_PAGES ? candidateSlug : "default";
+const resolvedOgImage = ogImage ?? `/og/${ogSlug}.svg`;
 
 // Self-review fix: derive lang + dir from Astro.currentLocale rather than
 // trusting the prop default. The previous default of `lang = "en"` meant


### PR DESCRIPTION
## Summary

R22 round-4 audit. Pre-existing P2 bug: **every EN page except \`/\` had a broken og:image URL (404)** in production. Verified via curl. Same Codex P2 pattern flagged on PR #487 for *locale subpages*, but the underlying derivation bug in BaseLayout was never closed for EN root pages.

## Two bugs in one derivation

\`\`\`js
const rawSlug = (Astro.url?.pathname ?? "/").replace(/^\/+|\/+$/g, "");
const slug = rawSlug === "" ? "default" : rawSlug;
const resolvedOgImage = ogImage ?? \`/og/\${slug}.svg\`;
\`\`\`

1. **\`build.format: 'file'\`** → SSR pathname is \`/proof.html\`, not \`/proof\` → produced \`/og/proof.html.svg\` (404).
2. The OG endpoint only generates files for slugs in \`OG_PAGES\`. Locale homepages \`/sk\`, \`/ko\`, \`/ja\` had no entry → \`/og/sk.svg\` etc would 404 even with bug #1 fixed.

## Curl-verified production state

\`\`\`
/                       og=/og/default.svg              → 200 ✓
/proof                  og=/og/proof.html.svg           → 404
/kh-fleet               og=/og/kh-fleet.html.svg        → 404
/try                    og=/og/try.html.svg             → 404
/status                 og=/og/status.html.svg          → 404
/roadmap                og=/og/roadmap.html.svg         → 404
/demo                   og=/og/demo.html.svg            → 404
/playground             og=/og/playground.html.svg      → 404
/compare                og=/og/compare.html.svg         → 404
/learn                  og=/og/learn.html.svg           → 404
/marketplace            og=/og/marketplace.html.svg     → 404
/submission/keeperhub   og=/og/submission/keeperhub.html.svg → 404
/submission/uniswap     og=/og/submission/uniswap.html.svg   → 404
/submission/anthropic   og=/og/submission/anthropic.html.svg → 404
/playground/live        og=/og/playground/live.html.svg → 404
/sk                     og=/og/sk.html.svg              → 404
/ko                     og=/og/ko.html.svg              → 404
\`\`\`

Link previews on social / Slack / Discord / Twitter for those ~14 routes lost their imagery — production-visible defect.

## Fix

1. Strip trailing \`.html\` from derived slug so it matches OG_PAGES keys.
2. Import OG_PAGES + check membership; fall back to \`default\` if slug not registered. Explicit \`ogImage\` prop still wins.

## Verified after fix (local build, dist inspection)

\`\`\`
/                                       og=/og/default.svg ✓
/proof, /kh-fleet, /status, /try, …     og=/og/<slug>.svg  ✓
/sk, /ko, /ja                           og=/og/default.svg ✓
/sk/proof, /ja/submission/keeperhub …   explicit prop, unchanged ✓
\`\`\`

12 / 12 sampled pages now resolve to existing files in \`dist/og/\`.

## Test plan

- [x] Build clean (61 pages)
- [x] dist sample of 12 pages all have og:image pointing at existing /og/*.svg
- [ ] Manual: paste /proof URL into Slack/Discord/Twitter — preview image now renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)